### PR TITLE
feat(asyncapi-plugin): support externalLinks, owner and domain name from…

### DIFF
--- a/packages/eventcatalog-plugin-generator-asyncapi/package.json
+++ b/packages/eventcatalog-plugin-generator-asyncapi/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "dependencies": {
     "@asyncapi/avro-schema-parser": "^3.0.7",
-    "@asyncapi/parser": "^3.0.1",
+    "@asyncapi/parser": "^3.0.14",
     "@eventcatalog/utils": "^0.2.2",
     "chalk": "^4.1.2",
     "front-matter": "^4.0.2",
@@ -33,11 +33,11 @@
     "node": ">=14"
   },
   "devDependencies": {
-    "@types/node-fetch": "2.6.7",
     "@eventcatalog/types": "0.4.2",
     "@types/fs-extra": "^9.0.13",
     "@types/json2md": "^1.5.1",
     "@types/lodash.merge": "^4.6.7",
+    "@types/node-fetch": "2.6.7",
     "@types/yamljs": "^0.2.31"
   }
 }

--- a/packages/eventcatalog-plugin-generator-asyncapi/src/__tests__/assets/valid-asyncapi-v3-with-domain-tag.yml
+++ b/packages/eventcatalog-plugin-generator-asyncapi/src/__tests__/assets/valid-asyncapi-v3-with-domain-tag.yml
@@ -1,14 +1,11 @@
 asyncapi: 3.0.0
 info:
-  title: Account Service V3
+  title: Account Service V3 In Domain 
   version: 1.0.0
   description: This service is in charge of processing user signups
   tags:
-    - name: owner
-      description: myteam
-  externalDocs:
-    description: Find more info here
-    url: 'https://example.com'
+    - name: domain
+      description: My Domain
 
 channels:
   userSignedup:

--- a/packages/eventcatalog-plugin-generator-asyncapi/src/__tests__/plugin.spec.ts
+++ b/packages/eventcatalog-plugin-generator-asyncapi/src/__tests__/plugin.spec.ts
@@ -107,6 +107,8 @@ describe('eventcatalog-plugin-generator-asyncapi', () => {
         `---
           name: 'Account Service'
           summary: 'This service is in charge of processing user signups'
+          externalLinks: []
+          owners: []
           ---
 
           <NodeGraph />`
@@ -148,6 +150,10 @@ describe('eventcatalog-plugin-generator-asyncapi', () => {
         `---
           name: 'Account Service V3'
           summary: 'This service is in charge of processing user signups'
+          externalLinks:
+            - {label: 'Find more info here', url: 'https://example.com'}
+          owners:
+            - myteam
           ---
 
           <NodeGraph />`
@@ -201,6 +207,8 @@ describe('eventcatalog-plugin-generator-asyncapi', () => {
           `---
             name: 'Account Service'
             summary: 'This service is in charge of processing user signups'
+            externalLinks: []
+            owners: []
             ---
 
             <NodeGraph />`
@@ -209,6 +217,8 @@ describe('eventcatalog-plugin-generator-asyncapi', () => {
           `---
           name: 'Users Service'
           summary: 'This service is in charge of users'
+          externalLinks: []
+          owners: []
           ---
 
           <NodeGraph />`
@@ -217,6 +227,10 @@ describe('eventcatalog-plugin-generator-asyncapi', () => {
           `---
             name: 'Account Service V3'
             summary: 'This service is in charge of processing user signups'
+            externalLinks:
+              - {label: 'Find more info here', url: 'https://example.com'}
+            owners:
+              - myteam
             ---
 
             <NodeGraph />`
@@ -225,6 +239,8 @@ describe('eventcatalog-plugin-generator-asyncapi', () => {
           `---
             name: 'Users Service V3'
             summary: 'This service is in charge of processing user signups'
+            externalLinks: []
+            owners: []
             ---
 
             <NodeGraph />`
@@ -467,6 +483,8 @@ describe('eventcatalog-plugin-generator-asyncapi', () => {
             `---
             name: 'Account Service'
             summary: 'This service is in charge of processing user signups'
+            externalLinks: []
+            owners: []
             ---
 
             <NodeGraph />`
@@ -476,11 +494,12 @@ describe('eventcatalog-plugin-generator-asyncapi', () => {
 
       describe('In domain AsyncAPI parsing', () => {
         it('Creates a domain with contained services and events when domain options are set', async () => {
+          const domainName = 'My Domain';
           const options: AsyncAPIPluginOptions = {
-            pathToSpec: path.join(__dirname, './assets/valid-asyncapi.yml'),
+            pathToSpec: path.join(__dirname, './assets/valid-asyncapi-v3-with-domain-tag.yml'),
             renderMermaidDiagram: false,
             renderNodeGraph: true,
-            domainName: 'My Domain',
+            domainName,
             domainSummary: 'A summary of my domain.',
           };
 
@@ -491,11 +510,11 @@ describe('eventcatalog-plugin-generator-asyncapi', () => {
 
           const { getDomainFromCatalog } = utils({ catalogDirectory: process.env.PROJECT_DIR });
           const { getEventFromCatalog, getServiceFromCatalog } = utils({
-            catalogDirectory: path.join(process.env.PROJECT_DIR, 'domains', options.domainName),
+            catalogDirectory: path.join(process.env.PROJECT_DIR, 'domains', domainName),
           });
 
           const { raw: eventFile } = getEventFromCatalog('UserSignedUp');
-          const { raw: serviceFile } = getServiceFromCatalog('Account Service');
+          const { raw: serviceFile } = getServiceFromCatalog('Account Service V3 In Domain');
           const { raw: domainFile } = getDomainFromCatalog('My Domain');
 
           expect(eventFile).toMatchMarkdown(`
@@ -504,7 +523,7 @@ describe('eventcatalog-plugin-generator-asyncapi', () => {
               summary: null
               version: 1.0.0
               producers:
-                  - 'Account Service'
+                  - 'Account Service V3 In Domain'
               consumers: []
               externalLinks: []
               badges: []
@@ -516,8 +535,69 @@ describe('eventcatalog-plugin-generator-asyncapi', () => {
 
           expect(serviceFile).toMatchMarkdown(
             `---
-            name: 'Account Service'
+            name: 'Account Service V3 In Domain'
             summary: 'This service is in charge of processing user signups'
+            externalLinks: []
+            owners: []
+            ---
+
+            <NodeGraph />`
+          );
+
+          expect(domainFile).toMatchMarkdown(`
+            ---
+            name: 'My Domain'
+            summary: 'A summary of my domain.'
+            ---
+
+            <NodeGraph />
+          `);
+        });
+        it('Creates a domain with contained services and events when Spec has a domain Tag and domainName Option not present', async () => {
+          const domainName = 'My Domain';
+          const options: AsyncAPIPluginOptions = {
+            pathToSpec: path.join(__dirname, './assets/valid-asyncapi-v3-with-domain-tag.yml'),
+            renderMermaidDiagram: false,
+            renderNodeGraph: true,
+            domainSummary: 'A summary of my domain.',
+          };
+
+          await plugin(pluginContext, options);
+
+          // just wait for files to be there in time.
+          await new Promise((r) => setTimeout(r, 200));
+
+          const { getDomainFromCatalog } = utils({ catalogDirectory: process.env.PROJECT_DIR });
+          const { getEventFromCatalog, getServiceFromCatalog } = utils({
+            catalogDirectory: path.join(process.env.PROJECT_DIR, 'domains', domainName),
+          });
+
+          const { raw: eventFile } = getEventFromCatalog('UserSignedUp');
+          const { raw: serviceFile } = getServiceFromCatalog('Account Service V3 In Domain');
+          const { raw: domainFile } = getDomainFromCatalog(domainName);
+
+          expect(eventFile).toMatchMarkdown(`
+            ---
+              name: UserSignedUp
+              summary: null
+              version: 1.0.0
+              producers:
+                  - 'Account Service V3 In Domain'
+              consumers: []
+              externalLinks: []
+              badges: []
+            ---
+
+            <NodeGraph />
+            <Schema />
+            `);
+
+          expect(serviceFile).toMatchMarkdown(
+            `---
+            name: 'Account Service V3 In Domain'
+            summary: 'This service is in charge of processing user signups'
+            externalLinks: []
+            owners: []
             ---
 
             <NodeGraph />`
@@ -572,6 +652,8 @@ describe('eventcatalog-plugin-generator-asyncapi', () => {
         ---
         name: ResultsDataService
         summary: 'Results API'
+        externalLinks: []
+        owners: []
         ---
         <NodeGraph /> `);
       });
@@ -616,6 +698,8 @@ describe('eventcatalog-plugin-generator-asyncapi', () => {
         ---
         name: PersonUpateService
         summary: ""
+        externalLinks: []
+        owners: []
         ---
 
 

--- a/scripts/start-catalog-locally.js
+++ b/scripts/start-catalog-locally.js
@@ -7,7 +7,7 @@ const eventCatalogDir = path.join(__dirname, '../packages/eventcatalog');
 const projectDIR = path.join(__dirname, '../examples/basic');
 
 fs.copyFileSync(path.join(projectDIR, 'eventcatalog.config.js'), path.join(eventCatalogDir, 'eventcatalog.config.js'));
-fs.copyFileSync(path.join(projectDIR, 'eventcatalog.styles.css'), path.join(eventCatalogLibDir, 'eventcatalog.styles.css'));
+fs.copyFileSync(path.join(projectDIR, 'eventcatalog.styles.css'), path.join(eventCatalogDir, 'eventcatalog.styles.css'));
 
 execSync(`PROJECT_DIR=${projectDIR} npm run scripts:move-schema-for-download`, {
   cwd: eventCatalogDir,

--- a/yarn.lock
+++ b/yarn.lock
@@ -187,7 +187,32 @@
     ajv-errors "^3.0.0"
     ajv-formats "^2.1.1"
 
-"@asyncapi/parser@^3.0.1", "@asyncapi/parser@^3.0.6":
+"@asyncapi/parser@^3.0.14":
+  version "3.0.14"
+  resolved "https://registry.yarnpkg.com/@asyncapi/parser/-/parser-3.0.14.tgz#9596ceafe24353af7722e04e6c009a2d6efdcdef"
+  integrity sha512-tC2gmKkw28PWWMcGUXHQjTfVftiZdr+FQtsfapaHh36spX9uwe13iYzkcTyCkwSJAHibtg7wvStuHsiufP8xng==
+  dependencies:
+    "@asyncapi/specs" "^6.6.0"
+    "@openapi-contrib/openapi-schema-to-json-schema" "~3.2.0"
+    "@stoplight/json" "^3.20.2"
+    "@stoplight/json-ref-readers" "^1.2.2"
+    "@stoplight/json-ref-resolver" "^3.1.5"
+    "@stoplight/spectral-core" "^1.16.1"
+    "@stoplight/spectral-functions" "^1.7.2"
+    "@stoplight/spectral-parsers" "^1.0.2"
+    "@stoplight/spectral-ref-resolver" "^1.0.3"
+    "@stoplight/types" "^13.12.0"
+    "@types/json-schema" "^7.0.11"
+    "@types/urijs" "^1.19.19"
+    ajv "^8.11.0"
+    ajv-errors "^3.0.0"
+    ajv-formats "^2.1.1"
+    avsc "^5.7.5"
+    js-yaml "^4.1.0"
+    jsonpath-plus "^7.2.0"
+    node-fetch "2.6.7"
+
+"@asyncapi/parser@^3.0.6":
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/@asyncapi/parser/-/parser-3.0.6.tgz#f5593895094683c52b70376f65c888ceae9446f2"
   integrity sha512-oHTaeXG9DOdBlBZ90xCSPCl3kT5XE851+Rxn47bMfG05Z48csZ1o9wFUl/SzQt+L8HgplFeQG4n/7EJHYOlcWQ==
@@ -240,6 +265,13 @@
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/@asyncapi/specs/-/specs-6.4.0.tgz#6021a472582815c6e51447c46fb1e43cf4d09544"
   integrity sha512-hTw0xF09i+eoSGP8LKo6aM+XOkvWsgV7kYpFHXd45VX9RcVZl5cADFIYDnPZkd52WaDJ4S+8Nrwkt/1vDb6SrQ==
+  dependencies:
+    "@types/json-schema" "^7.0.11"
+
+"@asyncapi/specs@^6.6.0":
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/@asyncapi/specs/-/specs-6.7.1.tgz#f8b9795d66bf9d9d3e91cc9b00e8181ed2f27ae4"
+  integrity sha512-jEaW2vgAwD9GboCdO/TI1zN2k+iowL8YFYwiZwTIr4U4KDmsgo3BLypScl6Jl4+IvY9RdsWE67nuzVX7jooiqQ==
   dependencies:
     "@types/json-schema" "^7.0.11"
 
@@ -21887,7 +21919,12 @@ trim-trailing-lines@^1.0.0:
   resolved "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.4.tgz"
   integrity sha512-rjUWSqnfTNrjbB9NQWfPMH/xRK1deHeGsHoVfpxJ++XeYXE0d6B1En37AHfw3jtfTU7dzMzZL2jjpe8Qb5gLIQ==
 
-trim@0.0.1, trim@0.0.3, trim@=0.0.3:
+trim@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
+  integrity sha512-YzQV+TZg4AxpKxaTHK3c3D+kRDCGVEE7LemdlQZoQXn0iennk10RsIoY6ikzAqJTc9Xjl9C1/waHom/J86ziAQ==
+
+trim@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.3.tgz#05243a47a3a4113e6b49367880a9cca59697a20b"
   integrity sha512-h82ywcYhHK7veeelXrCScdH7HkWfbIT1D/CgYO+nmDarz3SGNssVBMws6jU16Ga60AJCRAvPV6w6RLuNerQqjg==


### PR DESCRIPTION
## Motivation
This closes #518 

The goal of this PR is to automate the discovery of extra useful information from Asyncapi spec while generating Domain, Service, and events. this helps to remove the extra manual markdown work.

By providing the following spec info object
```yaml
asyncapi: 3.0.0
info:
  title: Account Service V3 In Domain 
  version: 1.0.0
  description: This service is in charge of processing user signups
  tags:
    - name: domain
      description: My Domain
    - name: owner
      description: myteam
  externalDocs:
    description: Find more info here
    url: 'https://example.com'
```

The service generated markdown will be 
```markdown
          ---
          name: 'Account Service V3'
          summary: 'This service is in charge of processing user signups'
          externalLinks:
            - {label: 'Find more info here', url: 'https://example.com'}
          owners:
            - myteam
          ---

          <NodeGraph />`
```
 
And the DomainName `My Domain` will be considered if no domainName is provided by plugin options


### Have you read the [Contributing Guidelines on pull requests](https://github.com/boyney123/eventcatalog/blob/master/CONTRIBUTING.md#pull-requests)?

YES