### PR TITLE
feat(asyncapi-plugin): clone source spec to service folder by active …

### DIFF
--- a/packages/eventcatalog-plugin-generator-asyncapi/src/__tests__/plugin.spec.ts
+++ b/packages/eventcatalog-plugin-generator-asyncapi/src/__tests__/plugin.spec.ts
@@ -622,5 +622,22 @@ describe('eventcatalog-plugin-generator-asyncapi', () => {
         <NodeGraph />`);
       });
     });
+
+    describe('asyncapi service with spec file rendering', () => {
+      it('asyncapi service with spec file in service catalog', async () => {
+        const options: AsyncAPIPluginOptions = {
+          pathToSpec: [path.join(__dirname, './assets/valid-asyncapi-v3.yml')],
+          renderAsyncAPI: true,
+        };
+
+        await plugin(pluginContext, options);
+
+        // just wait for files to be there in time.
+        await new Promise((r) => setTimeout(r, 200));
+
+        const result = fs.readFileSync(path.join(process.env.PROJECT_DIR, 'services/Account Service V3', 'asyncapi.yml'), 'utf-8');
+        expect(result).not.toBeNull();
+      });
+    });
   });
 });

--- a/packages/eventcatalog-plugin-generator-asyncapi/src/types.ts
+++ b/packages/eventcatalog-plugin-generator-asyncapi/src/types.ts
@@ -4,6 +4,7 @@ export type AsyncAPIPluginOptions = {
   externalAsyncAPIUrl?: string;
   renderMermaidDiagram?: boolean;
   renderNodeGraph?: boolean;
+  renderAsyncAPI?: boolean;
   domainName?: string;
   domainSummary?: string;
 };

--- a/packages/eventcatalog-utils/src/__tests__/utils.spec.ts
+++ b/packages/eventcatalog-utils/src/__tests__/utils.spec.ts
@@ -744,6 +744,7 @@ describe('eventcatalog-utils', () => {
         ---
         <NodeGraph />`);
       });
+      
 
       it('takes a given service and markdown content and returns the generated markdown file', () => {
         const service = {
@@ -798,6 +799,36 @@ describe('eventcatalog-utils', () => {
             - dBoyne
         ---
         <NodeGraph />`);
+      });
+
+      it('takes a given service and generates markdown with a AsyncApi', () => {
+        const service = {
+          name: 'My Service',
+          summary: 'This is summary for my service',
+          repository: {
+            url: 'https://github.com/boyney123/eventcatalog',
+            language: 'JavaScript',
+          },
+          owners: ['dBoyne'],
+        };
+
+        const result = buildServiceMarkdownForCatalog(service, {
+          renderMermaidDiagram: false,
+          renderNodeGraph: false,
+          renderAsyncAPI: true,
+        });
+
+        expect(result).toMatchMarkdown(`
+        ---
+        name: 'My Service'
+        summary: 'This is summary for my service'
+        repository:
+            url: 'https://github.com/boyney123/eventcatalog'
+            language: JavaScript
+        owners:
+            - dBoyne
+        ---
+        <AsyncAPI />`);
       });
     });
 

--- a/packages/eventcatalog-utils/src/service-markdown-builder.ts
+++ b/packages/eventcatalog-utils/src/service-markdown-builder.ts
@@ -1,0 +1,39 @@
+import YAML from 'yamljs';
+import json2md from 'json2md';
+import { Event, Service, Domain } from '@eventcatalog/types';
+
+type Content = Array<{ mermaid?: boolean; schema?: boolean; nodeGraph?: boolean; asyncAPI?: boolean }>;
+export default ({
+  frontMatterObject,
+  customContent,
+  includeSchemaComponent = false,
+  renderMermaidDiagram = false,
+  renderNodeGraph = true,
+  renderAsyncAPI = false,
+}: {
+  frontMatterObject: Service | Event | Domain;
+  customContent?: string;
+  includeSchemaComponent?: boolean;
+  renderMermaidDiagram?: boolean;
+  renderNodeGraph?: boolean;
+  renderAsyncAPI?: boolean;
+}) => {
+  const customJSON2MD = (content: any) => {
+    json2md.converters.mermaid = (render) => (render ? '<Mermaid />' : '');
+    json2md.converters.schema = (render) => (render ? '<Schema />' : '');
+    json2md.converters.nodeGraph = (render) => (render ? '<NodeGraph />' : '');
+    json2md.converters.asyncAPI = (render) => (render  ? '<AsyncAPI />' : '');
+    return json2md(content);
+  };
+
+  const content: Content = [
+    { mermaid: renderMermaidDiagram }, 
+    { nodeGraph: renderNodeGraph }, 
+    { schema: includeSchemaComponent },
+    { asyncAPI: renderAsyncAPI }];
+
+  return `---
+${YAML.stringify(frontMatterObject)}---
+${customContent || customJSON2MD(content)}`;
+};
+

--- a/packages/eventcatalog-utils/src/services.ts
+++ b/packages/eventcatalog-utils/src/services.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import fs from 'fs-extra';
 import matter from 'gray-matter';
 import { Service } from '@eventcatalog/types';
-import buildMarkdownFile from './markdown-builder';
+import buildMarkdownFile from './service-markdown-builder';
 
 import { FunctionInitInterface, WriteServiceToCatalogInterface, WriteServiceToCatalogInterfaceReponse } from './types';
 
@@ -18,12 +18,13 @@ const readMarkdownFile = (pathToFile: string) => {
 
 export const buildServiceMarkdownForCatalog =
   () =>
-  (service: Service, { markdownContent, renderMermaidDiagram = false, renderNodeGraph = true }: any = {}) =>
+  (service: Service, { markdownContent, renderMermaidDiagram = false, renderNodeGraph = true, renderAsyncAPI = false }: any = {}) =>
     buildMarkdownFile({
       frontMatterObject: service,
       customContent: markdownContent,
       renderMermaidDiagram,
       renderNodeGraph,
+      renderAsyncAPI,
     });
 
 export const getAllServicesFromCatalog =
@@ -58,7 +59,12 @@ export const writeServiceToCatalog =
   ({ catalogDirectory }: FunctionInitInterface) =>
   (service: Service, options?: WriteServiceToCatalogInterface): WriteServiceToCatalogInterfaceReponse => {
     const { name: serviceName } = service;
-    const { useMarkdownContentFromExistingService = true, renderMermaidDiagram = false, renderNodeGraph = true } = options || {};
+    const { 
+      useMarkdownContentFromExistingService = true, 
+      renderMermaidDiagram = false, 
+      renderNodeGraph = true, 
+      renderAsyncAPI = false } = options || {};
+      
     let markdownContent;
 
     if (!serviceName) throw new Error('No `name` found for given service');
@@ -73,6 +79,7 @@ export const writeServiceToCatalog =
       useMarkdownContentFromExistingService,
       renderMermaidDiagram,
       renderNodeGraph,
+      renderAsyncAPI,
     });
 
     fs.ensureDirSync(path.join(catalogDirectory, 'services', service.name));

--- a/packages/eventcatalog-utils/src/types.ts
+++ b/packages/eventcatalog-utils/src/types.ts
@@ -6,6 +6,7 @@ export interface WriteServiceToCatalogInterface {
   useMarkdownContentFromExistingService?: boolean;
   renderMermaidDiagram?: boolean;
   renderNodeGraph?: boolean;
+  renderAsyncAPI?: boolean;
 }
 
 export interface WriteServiceToCatalogInterfaceReponse {


### PR DESCRIPTION
This closes https://github.com/boyney123/eventcatalog/issues/518

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://github.com/boyney123/eventcatalog/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

When using AsyncApi plugin generator as part of generated documentation there is an interest in having the async API spec render as part of service page

### Have you read the [Contributing Guidelines on pull requests](https://github.com/boyney123/eventcatalog/blob/master/CONTRIBUTING.md#pull-requests)?

YES
