### PR TITLE
fix(core): core folder now copied on buld

### DIFF
--- a/.changeset/little-spies-decide.md
+++ b/.changeset/little-spies-decide.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix(core): core folder now copied on buld

--- a/bin/eventcatalog.ts
+++ b/bin/eventcatalog.ts
@@ -98,7 +98,6 @@ program
   .command('build')
   .description('Run build of EventCatalog')
   .action((options) => {
-
     console.log('Building EventCatalog...');
 
     copyCore();

--- a/bin/eventcatalog.ts
+++ b/bin/eventcatalog.ts
@@ -98,6 +98,11 @@ program
   .command('build')
   .description('Run build of EventCatalog')
   .action((options) => {
+
+    console.log('Building EventCatalog...');
+
+    copyCore();
+
     // Copy the config and styles
     copyFolder(join(dir, 'public'), join(core, 'public'));
     copyFile(join(dir, 'eventcatalog.config.js'), join(core, 'eventcatalog.config.js'));


### PR DESCRIPTION
Fixes #532

EventCatalog build command was not copying over the required files for a build, breaking CI/CD integrations.