### PR TITLE
feat(core): adding preview and start commands to eventcatalog

### DIFF
--- a/.changeset/small-lobsters-bake.md
+++ b/.changeset/small-lobsters-bake.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+feat(core): adding preview and start commands to eventcatalog

--- a/bin/eventcatalog.ts
+++ b/bin/eventcatalog.ts
@@ -113,4 +113,37 @@ program
     copyFolder(join(core, 'dist'), join(dir, 'dist'));
   });
 
+const previewCatalog = () => {
+  copyCore();
+
+  // Copy the config and styles
+  copyFolder(join(dir, 'public'), join(core, 'public'));
+  copyFile(join(dir, 'eventcatalog.config.js'), join(core, 'eventcatalog.config.js'));
+  copyFile(join(dir, 'eventcatalog.styles.css'), join(core, 'eventcatalog.styles.css'));
+
+  execSync(`PROJECT_DIR='${dir}' CATALOG_DIR='${core}' npm run preview`, {
+    cwd: core,
+    stdio: 'inherit',
+  });
+
+  // // everything is built make sure its back in the users project directory
+  copyFolder(join(core, 'dist'), join(dir, 'dist'));
+};
+
+program
+  .command('preview')
+  .description('Serves the contents of your eventcatalog build directory')
+  .action((options) => {
+    console.log('Starting preview of your build...');
+    previewCatalog();
+  });
+
+program
+  .command('start')
+  .description('Serves the contents of your eventcatalog build directory')
+  .action((options) => {
+    console.log('Starting preview of your build...');
+    previewCatalog();
+  });
+
 program.parse();


### PR DESCRIPTION
Adding two new commands `preview` and `start`.

These commands allow users to preview their build directory locally.