### PR TITLE
feat(core): Renders names for services side bars and also links to services from domains fixed

### DIFF
--- a/.changeset/wet-readers-pump.md
+++ b/.changeset/wet-readers-pump.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+feat(core): Renders names for services side bars and also links to services from domains fixed

--- a/src/components/SideBars/DomainSideBar.astro
+++ b/src/components/SideBars/DomainSideBar.astro
@@ -19,7 +19,7 @@ const serviceList = services.map((p) => ({
   label: p.data.id,
   badge: p.collection,
   tag: `v${p.data.version}`,
-  href: `/docs/${p.collection}/${p.data.id}`,
+  href: `/docs/${p.collection}/${p.data.id}/${p.data.version}`,
 }));
 
 const ownersList = owners.map((o) => ({

--- a/src/components/SideBars/ServiceSideBar.astro
+++ b/src/components/SideBars/ServiceSideBar.astro
@@ -19,14 +19,14 @@ const ownersRaw = service.data?.owners || [];
 const owners = await Promise.all(ownersRaw.map((o) => getEntry(o)));
 
 const sendsList = sends.map((p) => ({
-  label: p.data.id,
+  label: p.data.name,
   badge: p.collection,
   color: p.collection === 'events' ? 'orange' : 'blue',
   tag: `v${p.data.version}`,
   href: `/docs/${p.collection}/${p.data.id}/${p.data.version}`,
 }));
 const receivesList = receives.map((p) => ({
-  label: p.data.id,
+  label: p.data.name,
   badge: p.collection,
   color: p.collection === 'events' ? 'orange' : 'blue',
   tag: `v${p.data.version}`,


### PR DESCRIPTION
Fixed #549 and #553

