### PR TITLE
feat(core): added ability to hide resources in sidebar

### DIFF
--- a/.changeset/serious-sloths-retire.md
+++ b/.changeset/serious-sloths-retire.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+feat(core): added ability to hide resources in sidebar

--- a/examples/default/eventcatalog.config.js
+++ b/examples/default/eventcatalog.config.js
@@ -12,7 +12,22 @@ export default {
   docs: {
     sidebar: {
       // Should the sub heading be rendered in the docs sidebar?
-      showPageHeadings: true
+      showPageHeadings: true,
+      services: {
+        visible: true
+      },
+      messages: {
+        visible: true
+      },
+      domains: {
+        visible: true
+      },
+      teams: {
+        visible: true
+      },
+      users: {
+        visible: true
+      }
     }
   }
 }

--- a/src/components/DocsNavigation.astro
+++ b/src/components/DocsNavigation.astro
@@ -5,7 +5,7 @@ import { getEvents } from '@utils/events';
 import { getServices } from '@utils/services/services';
 import { getTeams } from '@utils/teams';
 import { getUsers } from '@utils/users';
-import config from '@eventcatalog';
+import config, { type CatalogConfig } from '@eventcatalog';
 
 const events = await getEvents({ getAllVersions: false });
 const commands = await getCommands({ getAllVersions: false });
@@ -18,8 +18,24 @@ const messages = [...events, ...commands];
 
 const allData = [ ...domains, ...services, ...messages, ...teams, ...users];
 
+const eventCatalogConfig = config as CatalogConfig;
+const { services: servicesConfig, domains: domainsConfig, messages: messagesConfig, teams: teamsConfig, users: usersConfig, showPageHeadings = true  } = eventCatalogConfig?.docs?.sidebar || {};
+
+const getConfigValue = (obj: any, key:string, defaultValue: any) => {
+  return obj?.[key] ?? defaultValue;
+}
+
+const visibleCollections = {
+  events: getConfigValue(messagesConfig, 'visible', true),
+  commands: getConfigValue(messagesConfig, 'visible', true),
+  domains: getConfigValue(domainsConfig, 'visible', true),
+  services: getConfigValue(servicesConfig, 'visible', true),
+  teams: getConfigValue(teamsConfig, 'visible', true),
+  users: getConfigValue(usersConfig, 'visible', true),
+};
+
 const fetchHeadings = allData.map(async (item) => {
-  const renderHeadings = config?.docs?.sidebar?.showPageHeadings ?? true;
+  const renderHeadings = showPageHeadings;
   const headings = renderHeadings ? await item.render() : { headings: []};
   return {
     ...item,
@@ -41,6 +57,7 @@ const sideNav = withHeadings.reduce((acc, item) => {
     label: item.data.name,
     version: item.collection === 'teams' || item.collection === 'users' ? null : item.data.version,
     items: item.collection === 'users' ? [] : item.headings,
+    visible: visibleCollections[item.collection],
     // @ts-ignore
     href: item.data.version ? `/docs/${item.collection}/${item.data.id}/${item.data.version}` : `/docs/${item.collection}/${item.data.id}`,
   };
@@ -61,6 +78,7 @@ const currentPath = Astro.url.pathname;
     {
       Object.keys(sideNav).map((key) => {
         const collection = sideNav[key];
+        if(collection[0] && collection[0].visible === false) return null;
         return (
           <ul class=" w-full space-y-2 pb-8">
             <li class="font-semibold capitalize ">{key}</li>

--- a/src/utils/config/catalog.ts
+++ b/src/utils/config/catalog.ts
@@ -1,2 +1,20 @@
 import * as config from '@config';
+
+type SideBarItemConfig = {
+  visible?: boolean;
+};
+
+export type CatalogConfig = {
+  docs: {
+    sidebar: {
+      showPageHeadings?: boolean;
+      domains: SideBarItemConfig;
+      services: SideBarItemConfig;
+      messages: SideBarItemConfig;
+      teams: SideBarItemConfig;
+      users: SideBarItemConfig;
+    };
+  };
+};
+
 export default config.default;


### PR DESCRIPTION
## Motivation

Some folks have large sidebars, and also want to hide things. This feature enables folks to hide any resource they like. By default all things are shown.

