### PR TITLE
fix(core): fixed start and preview commands

### DIFF
--- a/.changeset/slow-bags-know.md
+++ b/.changeset/slow-bags-know.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix(core): fixed start and preview commands

--- a/bin/eventcatalog.ts
+++ b/bin/eventcatalog.ts
@@ -121,7 +121,7 @@ const previewCatalog = () => {
   copyFile(join(dir, 'eventcatalog.config.js'), join(core, 'eventcatalog.config.js'));
   copyFile(join(dir, 'eventcatalog.styles.css'), join(core, 'eventcatalog.styles.css'));
 
-  execSync(`PROJECT_DIR='${dir}' CATALOG_DIR='${core}' npm run preview`, {
+  execSync(`PROJECT_DIR='${dir}' CATALOG_DIR='${core}' npm run preview -- --root ${dir} --port 3000`, {
     cwd: core,
     stdio: 'inherit',
   });


### PR DESCRIPTION
Fixed an issue with the start and preview commands, now runs from users catalog.