### PR TITLE
fix: Update Discover nav layout

### DIFF
--- a/.changeset/fuzzy-seas-report.md
+++ b/.changeset/fuzzy-seas-report.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix(core): fixed domain nav bar in discovery page

--- a/src/layouts/DiscoverLayout.astro
+++ b/src/layouts/DiscoverLayout.astro
@@ -49,7 +49,7 @@ const tabs = [
     isActive: currentPath === '/discover/domains',
     icon: RectangleGroupIcon,
     activeColor: 'yellow',
-    enabled: services.length > 0,
+    enabled: domains.length > 0,
   },
 ];
 ---


### PR DESCRIPTION
Use domains count, rather than service count when deciding to enable Domains link

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://github.com/event-catalog/eventcatalog/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fixes #595 