### PR TITLE
feat(config): add port config

### DIFF
--- a/.changeset/brown-wolves-judge.md
+++ b/.changeset/brown-wolves-judge.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/core': patch
+---
+
+feat(config): add port config

--- a/.changeset/brown-wolves-judge.md
+++ b/.changeset/brown-wolves-judge.md
@@ -2,4 +2,4 @@
 '@eventcatalog/core': patch
 ---
 
-feat(config): add port config
+feat(core): added ability to configure port on EventCatlog

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -16,7 +16,7 @@ import config from './eventcatalog.config';
 // https://astro.build/config
 export default defineConfig({
   base: config.base || '/',
-  server: { port: 3000 },
+  server: { port: config.port || 3000 },
 
   // https://docs.astro.build/en/reference/configuration-reference/#site
   site: config.homepageLink || 'https://eventcatalog.dev/',

--- a/bin/eventcatalog.config.ts
+++ b/bin/eventcatalog.config.ts
@@ -9,6 +9,7 @@ export interface Config {
   homepageLink: string;
   editUrl: string;
   base?: string;
+  port?: string;
   trailingSlash?: boolean;
   logo?: {
     alt: string;

--- a/examples/default/eventcatalog.config.js
+++ b/examples/default/eventcatalog.config.js
@@ -5,6 +5,7 @@ export default {
   organizationName: 'Your Company',
   homepageLink: 'https://eventcatalog.dev/',
   editUrl: 'https://github.com/event-catalog/eventcatalog/edit/main',
+  port: 3000,
   logo: {
     alt: 'EventCatalog',
     src: '/logo.png',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@eventcatalog/core",
-  "version": "2.0.12",
+  "version": "2.0.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@eventcatalog/core",
-      "version": "2.0.12",
+      "version": "2.0.17",
       "dependencies": {
         "@astrojs/check": "^0.7.0",
         "@astrojs/markdown-remark": "^5.1.0",


### PR DESCRIPTION
## Motivation

Our team already runs Docusaurus on port 3000 and we'd like to run the eventcatalog server simultaneously locally. Having a configurable port would be helpful in this case. 

## To do

- [ ] update the docs — (Question: where is the docs repository? I can't find it in the repo, and the "Edit this page" links are broken)
- [ ] consider raising a ticket for allowing complete configurability for Astro's config. ie spread an "astroConfig" onto a default base of settings.
