### PR TITLE
fix(core): sidebar configuration for section visibility is now optional

### DIFF
--- a/.changeset/wicked-cars-hug.md
+++ b/.changeset/wicked-cars-hug.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix(core): sidebar configuration for section visibility is now optional

--- a/src/utils/config/catalog.ts
+++ b/src/utils/config/catalog.ts
@@ -8,11 +8,11 @@ export type CatalogConfig = {
   docs: {
     sidebar: {
       showPageHeadings?: boolean;
-      domains: SideBarItemConfig;
-      services: SideBarItemConfig;
-      messages: SideBarItemConfig;
-      teams: SideBarItemConfig;
-      users: SideBarItemConfig;
+      domains?: SideBarItemConfig;
+      services?: SideBarItemConfig;
+      messages?: SideBarItemConfig;
+      teams?: SideBarItemConfig;
+      users?: SideBarItemConfig;
     };
   };
 };


### PR DESCRIPTION
## Motivation

Trying to build eventcatalog without having values for `docs.sidebar.{domains,services,messages,teams,users}` set will result in an error:
```
src/components/DocsNavigation.astro:23:28 - error ts(2352): Conversion of type '{ title: string; trailingSlash: boolean; tagline: string; organizationName: string; homepageLink: string; editUrl: string; logo: { alt: string; src: string; text: string; }; docs: { sidebar: { showPageHeadings: boolean; }; }; }' to type 'CatalogConfig' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
  The types of 'docs.sidebar' are incompatible between these types.

23 const eventCatalogConfig = config as CatalogConfig;
                              ~~~~~~~~~~~~~~~~~~~~~~~

Result (95 files): 
- 1 error
```

Changing the values in the `eventcatalog.config.js` to something like:
```js
docs: {
  sidebar: {
    // Should the sub heading be rendered in the docs sidebar?
    showPageHeadings: true,
    domains: {},
    services: {},
    messages: {},
    teams: {},
    users: {},
  }
}
```
will make it build again.

However these config values should most likely be optional and not required since the template `eventcatalog.config.js` does not include them either.
