### PR TITLE
fix(core): fixed favicon url

### DIFF
--- a/.changeset/five-terms-try.md
+++ b/.changeset/five-terms-try.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix(core): favicon having invalid url with default base url configuration

--- a/src/components/Seo.astro
+++ b/src/components/Seo.astro
@@ -2,6 +2,7 @@
 import { SEO } from 'astro-seo';
 import config from '@config';
 import defaultImageFile from '../../public/opengraph.png';
+import { buildUrl } from '@utils/url-builder';
 
 const {
 	title = config.title,
@@ -30,7 +31,7 @@ if (typeof _image === 'string') {
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <meta name="viewport" content="width=device-width" />
-<link rel="icon" type="image/svg+xml" href={`${import.meta.env.BASE_URL}/favicon.ico`} />
+<link rel="icon" type="image/svg+xml" href={buildUrl('/favicon.ico')} />
 
 <SEO
 	title={title}

--- a/src/layouts/CustomDocsPageLayout.astro
+++ b/src/layouts/CustomDocsPageLayout.astro
@@ -8,6 +8,7 @@ const { title } = Astro.props;
 import Header from '@components/Header.astro';
 import SideBar from '@components/DocsNavigation.astro';
 import catalog from '@eventcatalog';
+import { buildUrl } from '@utils/url-builder';
 ---
 
 <!doctype html>
@@ -16,7 +17,7 @@ import catalog from '@eventcatalog';
     <meta charset="UTF-8" />
     <meta name="description" content="Astro description" />
     <meta name="viewport" content="width=device-width" />
-    <link rel="icon" type="image/svg+xml" href={`${import.meta.env.BASE_URL}/favicon.ico`} />
+    <link rel="icon" type="image/svg+xml" href={buildUrl('/favicon.ico')} />
     <meta name="generator" content={Astro.generator} />
     <title>EventCatalog</title>
   </head>


### PR DESCRIPTION
## Motivation

When using the default base url configuration it defaults to `/`.
The favicon url is currently evaluated from 
```astro
href={`${import.meta.env.BASE_URL}/favicon.ico`}
```
which results in a url of `//favicon.ico`.

```html
<link rel="icon" type="image/svg+xml" href="//favicon.ico">
```

The browser interprets that as a host and tries to load a favicon from `https://favicon.ico/` (if the catalog url uses https as protocol).

This PR makes the favicon url use the utils method that other places use as well to calculate its url.