### PR TITLE
fix json schema viewer

### DIFF
--- a/.changeset/nervous-pets-develop.md
+++ b/.changeset/nervous-pets-develop.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix(core): fixed the json schema viewer require issues

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -44,5 +44,12 @@ export default defineConfig({
   ],
   redirects: {
     "/": config.landingPage || '/docs',
+  },
+  vite: {
+    build: {
+      commonjsOptions: {
+        transformMixedEsModules: true,
+      }
+    },
   }
 });

--- a/src/components/MDX/SchemaViewer/SchemaViewer.tsx
+++ b/src/components/MDX/SchemaViewer/SchemaViewer.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useState } from 'react';
 
+import 'prismjs';
 // @ts-ignore
 import { JsonSchemaViewer } from '@stoplight/json-schema-viewer';
-
+import '@stoplight/mosaic/themes/default.css';
 import '@stoplight/mosaic/styles.css';
+
 import { createPortal } from 'react-dom';
 
 type Props = {


### PR DESCRIPTION
closes #590
fixes #583

[transformMixedEsModules: true](
https://github.com/event-catalog/eventcatalog/pull/636/files#diff-e0f0c5adbe0b9ca5d0b57caf5cea33a8d88899fd02a43df1e9862b185f8a1e5fR51) fixes the error described in the issue (require not defined). 

Afterwards I encountered "Prism not defined" which can be fixed by importing [prismjs](https://github.com/event-catalog/eventcatalog/pull/636/files#diff-237ec20cf679c8019d1ddb5bd0ea6558e9e361264f6493625762b7a36f338255R3) and is somehow a known problem with astro.

And while the missing CSS was fixed, it still misses some CSS vars to show correct color, border width, background colors and such things and this was fixed by importing the default [theme files](https://github.com/event-catalog/eventcatalog/pull/636/files#diff-237ec20cf679c8019d1ddb5bd0ea6558e9e361264f6493625762b7a36f338255R6) of mosaic.
 
<img width="367" alt="Screenshot 2024-07-19 at 22 44 43" src="https://github.com/user-attachments/assets/0ddda7c8-7588-4795-9ba4-d23e3f2acf87">


