### PR TITLE
fix: cross-compatibility between operational systems

### DIFF
--- a/.changeset/curvy-goats-approve.md
+++ b/.changeset/curvy-goats-approve.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix(core): running eventcatalog on windows (cross-compatibility between operational systems)

--- a/bin/eventcatalog.ts
+++ b/bin/eventcatalog.ts
@@ -84,7 +84,7 @@ program
 
     console.log('EventCatalog is starting at http://localhost:3000/docs');
 
-    execSync(`PROJECT_DIR='${dir}' CATALOG_DIR='${core}' npm run dev`, {
+    execSync(`cross-env PROJECT_DIR='${dir}' CATALOG_DIR='${core}' npm run dev`, {
       cwd: core,
       // @ts-ignore
       stdio: 'inherit',
@@ -104,7 +104,7 @@ program
     copyFile(join(dir, 'eventcatalog.config.js'), join(core, 'eventcatalog.config.js'));
     copyFile(join(dir, 'eventcatalog.styles.css'), join(core, 'eventcatalog.styles.css'));
 
-    execSync(`PROJECT_DIR='${dir}' CATALOG_DIR='${core}' npm run build`, {
+    execSync(`cross-env PROJECT_DIR='${dir}' CATALOG_DIR='${core}' npm run build`, {
       cwd: core,
       stdio: 'inherit',
     });
@@ -121,7 +121,7 @@ const previewCatalog = () => {
   copyFile(join(dir, 'eventcatalog.config.js'), join(core, 'eventcatalog.config.js'));
   copyFile(join(dir, 'eventcatalog.styles.css'), join(core, 'eventcatalog.styles.css'));
 
-  execSync(`PROJECT_DIR='${dir}' CATALOG_DIR='${core}' npm run preview -- --root ${dir} --port 3000`, {
+  execSync(`cross-env PROJECT_DIR='${dir}' CATALOG_DIR='${core}' npm run preview -- --root ${dir} --port 3000`, {
     cwd: core,
     stdio: 'inherit',
   });
@@ -156,7 +156,7 @@ program
     copyFile(join(dir, 'eventcatalog.config.js'), join(core, 'eventcatalog.config.js'));
     copyFile(join(dir, 'eventcatalog.styles.css'), join(core, 'eventcatalog.styles.css'));
 
-    execSync(`PROJECT_DIR='${dir}' npm run generate`, {
+    execSync(`cross-env PROJECT_DIR='${dir}' npm run generate`, {
       cwd: core,
       stdio: 'inherit',
     });

--- a/scripts/build-ci.js
+++ b/scripts/build-ci.js
@@ -16,7 +16,7 @@ fs.copyFileSync(join(projectDIR, 'eventcatalog.config.js'), join(catalogDir, 'ev
 
 fs.copyFileSync(join(projectDIR, 'eventcatalog.styles.css'), join(catalogDir, 'eventcatalog.styles.css'));
 
-execSync(`NODE_ENV=CI PROJECT_DIR=${projectDIR} CATALOG_DIR=${catalogDir} npm run scripts:hydrate-content`, {
+execSync(`cross-env NODE_ENV=CI PROJECT_DIR=${projectDIR} CATALOG_DIR=${catalogDir} npm run scripts:hydrate-content`, {
   cwd: catalogDir,
   stdio: 'inherit',
 });

--- a/scripts/catalog-to-astro-content-directory.js
+++ b/scripts/catalog-to-astro-content-directory.js
@@ -2,13 +2,14 @@ import { glob } from 'glob';
 import * as path from 'node:path';
 import fs from 'fs';
 import { fileURLToPath } from 'url';
+import os from 'node:os';
 
 const __filename = fileURLToPath(import.meta.url);
 const scriptsDir = path.dirname(__filename);
 
 const getTargetPath = (source, target, type, file) => {
   const relativePath = path.relative(source, file);
-  const cleanedRelativePath = relativePath.split(`${type}/`);
+  const cleanedRelativePath = relativePath.split(type);
   const targetForEvents = path.join(type, cleanedRelativePath[1]);
   return path.join(target, targetForEvents);
 };
@@ -25,12 +26,14 @@ const copyFiles = async ({ source, target, catalogFilesDir, pathToMarkdownFiles,
   // Find all the event files
   const markdownFiles = await glob(pathToMarkdownFiles, {
     nodir: true,
+    windowsPathsNoEscape: os.platform() == 'win32',
   });
   const files = await glob(pathToAllFiles, {
     ignore: {
       ignored: (p) => /\.md$/.test(p.name),
     },
     nodir: true,
+    windowsPathsNoEscape: os.platform() == 'win32',
   });
 
   const publicDir = path.join(target, '../../public/generated');
@@ -52,7 +55,7 @@ const copyFiles = async ({ source, target, catalogFilesDir, pathToMarkdownFiles,
     }
 
     const relativePath = path.relative(source, file);
-    const cleanedRelativePath = relativePath.split(`${type}/`);
+    const cleanedRelativePath = relativePath.split(type);
     if (!cleanedRelativePath[1]) continue;
     const targetForEvents = path.join(type, cleanedRelativePath[1]);
 

--- a/scripts/start-catalog-locally.js
+++ b/scripts/start-catalog-locally.js
@@ -14,7 +14,7 @@ fs.copyFileSync(join(projectDIR, 'eventcatalog.config.js'), join(catalogDir, 'ev
 fs.copyFileSync(join(projectDIR, 'eventcatalog.styles.css'), join(catalogDir, 'eventcatalog.styles.css'));
 
 execSync(
-  `NODE_ENV=development PROJECT_DIR=${projectDIR} CATALOG_DIR=${catalogDir} npm run scripts:hydrate-content && PROJECT_DIR=${projectDIR} CATALOG_DIR=${catalogDir} npm run dev:local`,
+  `cross-env NODE_ENV=development PROJECT_DIR=${projectDIR} CATALOG_DIR=${catalogDir} npm run scripts:hydrate-content && cross-env PROJECT_DIR=${projectDIR} CATALOG_DIR=${catalogDir} npm run dev:local`,
   {
     cwd: catalogDir,
     stdio: 'inherit',

--- a/scripts/verify-build.js
+++ b/scripts/verify-build.js
@@ -14,7 +14,7 @@ fs.copyFileSync(join(projectDIR, 'eventcatalog.config.js'), join(catalogDir, 'ev
 
 fs.copyFileSync(join(projectDIR, 'eventcatalog.styles.css'), join(catalogDir, 'eventcatalog.styles.css'));
 
-execSync(`PROJECT_DIR=${projectDIR} CATALOG_DIR=${catalogDir} npm run scripts:hydrate-content && npm run build`, {
+execSync(`cross-env PROJECT_DIR=${projectDIR} CATALOG_DIR=${catalogDir} npm run scripts:hydrate-content && npm run build`, {
   cwd: catalogDir,
   stdio: 'inherit',
 });


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://github.com/event-catalog/eventcatalog/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation
This PR applies some fixes for cross-compatibility between Operational Systems.

1. Return the use of `cross-env` (used at v1);
2. Change the `glob pattern matcher` behavior for `win32` platform at `scripts/catalog-to-astro-content-directory.js`. Only on `win32`, all `\\` will be replaced with `/`.


Related with [issue#547](https://github.com/event-catalog/eventcatalog/issues/547).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/event-catalog/eventcatalog/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.
