### PR TITLE
fix/missing-base-url-at-assets

### DIFF
--- a/.changeset/sixty-ants-jog.md
+++ b/.changeset/sixty-ants-jog.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix(core): fixed url paths for EC assets 

--- a/src/components/Seo.astro
+++ b/src/components/Seo.astro
@@ -31,7 +31,7 @@ if (typeof _image === 'string') {
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <meta name="viewport" content="width=device-width" />
-<link rel="icon" type="image/svg+xml" href={buildUrl('/favicon.ico')} />
+<link rel="icon" type="image/svg+xml" href={buildUrl('/favicon.ico', true)} />
 
 <SEO
 	title={title}

--- a/src/components/SideBars/MessageSideBar.astro
+++ b/src/components/SideBars/MessageSideBar.astro
@@ -59,7 +59,7 @@ const schemaURL = path.join(publicPath, schemaFilePath || '')
       {
         message?.data?.schemaPath && (
           <a
-            href={schemaURL}
+            href={buildUrl(schemaURL, true)}
             download={`${message.data.name}(${message.data.version})-${schemaFilePath}`}
             class="hidden w-full md:inline-flex h-10 justify-center px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-200 bg-gray-800 hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-900"
           >

--- a/src/components/SideBars/ServiceSideBar.astro
+++ b/src/components/SideBars/ServiceSideBar.astro
@@ -60,7 +60,7 @@ const schemaURL = join(publicPath, schemaFilePath || '')
       {
         service?.data?.schemaPath && (
           <a
-            href={schemaURL}
+            href={buildUrl(schemaURL, true)}
             download={`${service.data.name}(${service.data.version})-${schemaFilePath}`}
             class="hidden w-full md:inline-flex h-10 justify-center px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-200 bg-gray-800 hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-900"
           >

--- a/src/layouts/CustomDocsPageLayout.astro
+++ b/src/layouts/CustomDocsPageLayout.astro
@@ -15,7 +15,7 @@ import { buildUrl } from '@utils/url-builder';
     <meta charset="UTF-8" />
     <meta name="description" content="Astro description" />
     <meta name="viewport" content="width=device-width" />
-    <link rel="icon" type="image/svg+xml" href={buildUrl('/favicon.ico')} />
+    <link rel="icon" type="image/svg+xml" href={buildUrl('/favicon.ico', true)} />
     <meta name="generator" content={Astro.generator} />
     <title>EventCatalog</title>
   </head>

--- a/src/layouts/Footer.astro
+++ b/src/layouts/Footer.astro
@@ -1,11 +1,13 @@
 ---
+import { buildUrl } from "@utils/url-builder"
+
 ---
 
 <footer class="py-4 space-y-8 border-t border-gray-300">
   <div class="flex justify-between items-center py-8 text-gray-500 text-sm font-light">
     <div class="flex space-x-5">
-      <a href="https://github.com/event-catalog/eventcatalog" target="_blank"><svg class="w-5 h-5 bg-gray-400  hover:bg-purple-500 dark:hover:bg-gray-400" style="mask-image: url(&quot;/icons/github.svg&quot;); mask-repeat: no-repeat; mask-position: center center;"></svg></a>
-      <a href="https://x.com/event_catalog" target="_blank"><span class="sr-only">x</span><svg class="w-5 h-5 bg-gray-400  hover:bg-purple-500 dark:hover:bg-gray-400" style="mask-image: url(&quot;/icons/x-twitter.svg&quot;); mask-repeat: no-repeat; mask-position: center center;"></svg></a>
+      <a href="https://github.com/event-catalog/eventcatalog" target="_blank"><svg class="w-5 h-5 bg-gray-400  hover:bg-purple-500 dark:hover:bg-gray-400" style={`mask-image: url("${buildUrl('/icons/github.svg', true)}"); mask-repeat: no-repeat; mask-position: center center;`}></svg></a>
+      <a href="https://x.com/event_catalog" target="_blank"><span class="sr-only">x</span><svg class="w-5 h-5 bg-gray-400  hover:bg-purple-500 dark:hover:bg-gray-400" style={`mask-image: url("${buildUrl('/icons/x-twitter.svg', true)}"); mask-repeat: no-repeat; mask-position: center center;`}></svg></a>
     </div>
     <a target="_blank" class="hover:text-purple-500 hover:underline text-gray-400 font-light not-prose" href="https://eventcatalog.dev">Powered by EventCatalog</a>
   </div>

--- a/src/pages/docs/[type]/[id]/[version]/spec/index.astro
+++ b/src/pages/docs/[type]/[id]/[version]/spec/index.astro
@@ -10,6 +10,7 @@ import { getDomains } from '@utils/domains/domains';
 import type { CollectionTypes } from '@types';
 import PlainPage from '@layouts/PlainPage.astro';
 import { DocumentMinusIcon } from '@heroicons/react/24/outline';
+import { buildUrl } from '@utils/url-builder';
 
 export async function getStaticPaths() {
   const events = await getEvents();
@@ -42,22 +43,18 @@ const fileExists = fs.existsSync(pathOnDisk);
 ---
 
 <PlainPage title="OpenAPI Spec">
-  <!-- {fileExists && <div>Here</div>} -->
   {
-    !fileExists && (
+    !fileExists ? (
       <div class="text-center h-screen  flex flex-col justify-center ">
-       <DocumentMinusIcon className="mx-auto h-12 w-12 text-gray-400" />
+        <DocumentMinusIcon className="mx-auto h-12 w-12 text-gray-400" />
         <h3 class="mt-2 text-sm font-semibold text-gray-900">No OpenAPI spec file found</h3>
-        <p class="mt-1 text-xs text-gray-400">Could not find OpenAPI file for {data.name} in {`/${catalog.path}`}</p>
-        
+        <p class="mt-1 text-xs text-gray-400">
+          Could not find OpenAPI file for {data.name} in {`/${catalog.path}`}
+        </p>
       </div>
-    )
-  }
-
-  {
-    fileExists && (
+    ) : (
       <rapi-doc
-        spec-url={pathToSpec}
+        spec-url={buildUrl(pathToSpec, true)}
         render-style="table"
         show-header="false"
         allow-authentication="false"


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://github.com/event-catalog/eventcatalog/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

It resolves #637 using `buildUrl` utility to generate the uri for public assets (openapi.yml, icons, favicon.ico).

<!-- It adds the footer component and replaces where applicable. -->

### Have you read the [Contributing Guidelines on pull requests](https://github.com/event-catalog/eventcatalog/blob/main/CONTRIBUTING.md#pull-requests)?
yes.
