### PR TITLE
fix: remove forward slash before # to prevent double trailing slash

### DIFF
--- a/.changeset/tender-maps-walk.md
+++ b/.changeset/tender-maps-walk.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+core(fix): removed forward slash before # to prevent double trailing slash

--- a/src/components/DocsNavigation.astro
+++ b/src/components/DocsNavigation.astro
@@ -95,7 +95,7 @@ const currentPath = Astro.url.pathname;
                   {item.items.map((heading: any) => {
                     return (
                       <li class="text-xs">
-                        <a href={`${item.href}/#${heading.slug}`}>{heading.text}</a>
+                        <a href={`${item.href}#${heading.slug}`}>{heading.text}</a>
                       </li>
                     );
                   })}

--- a/src/pages/docs/[type]/[id]/[version]/index.astro
+++ b/src/pages/docs/[type]/[id]/[version]/index.astro
@@ -132,7 +132,7 @@ const badges = [
       <div>
         <!-- @ts-ignore -->
         <SchemaViewer id={props.data.id} catalog={props.catalog}  />
-        <NodeGraph id={props.data.id} collection={props.collection} version={props.data.version} mode="simple" href={{ label: 'Open in Visualiser', url: `/visualiser/${props.collection}/${props.data.id}/${props.data.version}`}} />
+        <NodeGraph id={props.data.id} collection={props.collection} version={props.data.version} mode="simple" href={{ label: 'Open in Visualiser', url: buildUrl(`/visualiser/${props.collection}/${props.data.id}/${props.data.version}`)}} />
       </div>
       <footer class="py-4 space-y-8 divide-y divide-gray-200/60">
         <a href="#" class="flex space-x-2 items-center text-gray-500 hover:text-purple-500 hover:underline"><PencilIcon className="w-4 h-4" /><span>Edit this page</span></a>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://github.com/event-catalog/eventcatalog/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

It removes the forward slash at the anchor element on `DocsNavigationSidebar` preventing double trailing slash when trailingSlash is enabled.

Resolves #638.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/event-catalog/eventcatalog/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.
