### PR TITLE
fix: enforce the leading slash to the logo

### DIFF
--- a/.changeset/odd-pugs-know.md
+++ b/.changeset/odd-pugs-know.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix(core): enforce the leading slash to the logo

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -21,7 +21,7 @@ const navItems = [
 ];
 
 const logo = {
-  src: catalog?.logo?.src || '/logo.png',
+  src: ('/' + (catalog?.logo?.src || 'logo.png')).replace(/^\/+/, '/'), // replace the leading slashes with a single one
   alt: catalog?.logo?.alt || 'Event Catalog',
   text: catalog?.logo?.text || "EventCatalog"
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://github.com/event-catalog/eventcatalog/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

It always adds the leading slash to the logo, avoiding generating a wrong uri in buildUrl when using base.

Resolves #629

### Have you read the [Contributing Guidelines on pull requests](https://github.com/event-catalog/eventcatalog/blob/main/CONTRIBUTING.md#pull-requests)?

yes
