### PR TITLE
fix(core): now word wrapping code blocks by default in markdown files so not to break the layout

### DIFF
--- a/.changeset/hungry-ads-wash.md
+++ b/.changeset/hungry-ads-wash.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix(core): now word wrapping code blocks by default in markdown files so not to break the layout of the page

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -33,6 +33,10 @@ export default defineConfig({
     tailwind(),
     expressiveCode({
       themes: ['github-light'],
+      defaultProps: {
+        // Enable word wrap by default
+        wrap: true,
+      },
     }),
     
     mdx({


### PR DESCRIPTION
## Motivation

Fixing https://github.com/event-catalog/eventcatalog/issues/634

Enabling word wrapping by default in the `expressiveCode` being used to render code blocks in md files.

**Before:**
Note the sidebar missing on the right
![image](https://github.com/user-attachments/assets/cb945920-580f-4f39-963b-73ba05f79c77)

**After:**
Code block now wraps automatically and sidebar is back.
![image](https://github.com/user-attachments/assets/9eb703e0-dc98-401c-a93d-a4298db78e7f)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/event-catalog/eventcatalog/blob/main/CONTRIBUTING.md#pull-requests)?

Yep
