### PR TITLE
chore: truncate item label text

### DIFF
--- a/.changeset/spotty-years-fold.md
+++ b/.changeset/spotty-years-fold.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+chore(core): fixed long labels on the documentation sidebar 

--- a/src/components/DocsNavigation.astro
+++ b/src/components/DocsNavigation.astro
@@ -97,7 +97,7 @@ const currentPath = Astro.url.pathname;
                   class={`flex justify-between items-center w-full px-2 rounded-md font-normal ${currentPath.includes(item.href) ? 'bg-purple-200 text-purple-800 ' : 'font-thin'}`}
                   href={`${item.href}`}
                 >
-                  <span class="block">{item.label}</span>
+                  <span class="block truncate !whitespace-normal">{item.label}</span>
                   {item.version && (
                     <span class="block text-sm bg-purple-100 p-0.5 px-1 text-gray-600  rounded-md font-light">
                       v{item.version}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://github.com/event-catalog/eventcatalog/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

This PR resolves #550. It adds `truncate` to the label. The result looks like below:
![image](https://github.com/user-attachments/assets/da8e8a12-4523-47c2-8570-0aba4ef3e806) 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/event-catalog/eventcatalog/blob/main/CONTRIBUTING.md#pull-requests)?

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/event-catalog/eventcatalog/blob/main/CONTRIBUTING.md#pull-requests)
