### PR TITLE
fix: cleanUrl must only replace double slash in URL pathname

### DIFF
--- a/src/utils/url-builder.ts
+++ b/src/utils/url-builder.ts
@@ -1,7 +1,9 @@
 import config from '@eventcatalog';
 
-const cleanUrl = (url: string) => {
-  return url.replace(/\/+/g, '/');
+const cleanUrl = (urlString: string) => {
+  const url = new URL(urlString);
+  url.pathname = url.pathname.replace(/\/+/g, '/');
+  return url.toString();
 };
 
 // Custom URL builder as Astro does not support this stuff out the box


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://github.com/event-catalog/eventcatalog/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

URLs in anchors in HTML are invalid as cleanUrl also replaces the double slash in the schema part instead of only in the pathname, which causes links to be broken.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/event-catalog/eventcatalog/blob/main/CONTRIBUTING.md#pull-requests)?

No, because that file does not exist.
