### PR TITLE
Fix 697 : Truncate labels on visualiser page

### DIFF
--- a/.changeset/stale-jars-provide.md
+++ b/.changeset/stale-jars-provide.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix(core): visualiser now truncates labels on sidebar

--- a/src/components/Lists/BasicList.tsx
+++ b/src/components/Lists/BasicList.tsx
@@ -33,7 +33,7 @@ const BasicList = ({ title, items, emptyMessage, color = 'gray' }: Props) => {
                       className={`flex justify-between items-center w-full px-2 rounded-md font-normal   ${item.active ? 'bg-purple-200 text-purple-800 ' : 'font-thin'}`}
                       href={item.href}
                     >
-                      <span className="block">{item.label}</span>
+                      <span className="block truncate !whitespace-normal">{item.label}</span>
                       {item.version && (
                         <span className="block text-sm bg-purple-100 p-0.5 px-1 text-gray-600  rounded-md font-light">
                           v{item.version}


### PR DESCRIPTION
Added truncate as class to BasicList to also visualise long service/event/domain names correctly on visualiser page.
