### PR TITLE
feat(core): added new content type "flows"

### DIFF
--- a/.changeset/chilled-jobs-suffer.md
+++ b/.changeset/chilled-jobs-suffer.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": minor
+---
+
+feat(core): added flows to eventcatalog

--- a/examples/default/commands/PlaceOrder/index.md
+++ b/examples/default/commands/PlaceOrder/index.md
@@ -1,0 +1,36 @@
+---
+id: PlaceOrder
+name: Place Order
+version: 0.0.1
+summary: |
+  Command that will place an order
+owners:
+    - dboyne
+    - msmith
+    - asmith
+    - full-stack
+    - mobile-devs
+badges:
+    - content: Recently updated!
+      backgroundColor: green
+      textColor: green
+schemaPath: 'schema.json'
+---
+
+import Footer from '@catalog/components/footer.astro';
+
+## Overview
+
+The Order Placement Command is a versatile and robust system designed to streamline the process of placing an order. This command takes care of all the essential details needed to complete a purchase, ensuring a smooth and efficient transaction from start to finish.
+
+## Architecture diagram
+
+<NodeGraph/>
+
+## Schema
+
+<SchemaViewer file="schema.json"/>
+
+<Footer />
+
+

--- a/examples/default/commands/PlaceOrder/schema.json
+++ b/examples/default/commands/PlaceOrder/schema.json
@@ -1,0 +1,124 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Order",
+  "description": "A schema representing an order placed by a customer",
+  "type": "object",
+  "properties": {
+    "orderId": {
+      "description": "Unique identifier for the order",
+      "type": "string"
+    },
+    "customer": {
+      "description": "Information about the customer placing the order",
+      "type": "object",
+      "properties": {
+        "customerId": {
+          "description": "Unique identifier for the customer",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the customer",
+          "type": "string"
+        },
+        "email": {
+          "description": "Email address of the customer",
+          "type": "string",
+          "format": "email"
+        },
+        "phone": {
+          "description": "Phone number of the customer",
+          "type": "string",
+          "pattern": "^[+]?[0-9]{10,15}$"
+        }
+      },
+      "required": ["customerId", "name", "email"]
+    },
+    "items": {
+      "description": "List of items in the order",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "itemId": {
+            "description": "Unique identifier for the item",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name of the item",
+            "type": "string"
+          },
+          "quantity": {
+            "description": "Quantity of the item ordered",
+            "type": "integer",
+            "minimum": 1
+          },
+          "price": {
+            "description": "Price per unit of the item",
+            "type": "number",
+            "minimum": 0
+          }
+        },
+        "required": ["itemId", "name", "quantity", "price"]
+      }
+    },
+    "shippingAddress": {
+      "description": "Address where the order will be shipped",
+      "type": "object",
+      "properties": {
+        "street": {
+          "description": "Street address",
+          "type": "string"
+        },
+        "city": {
+          "description": "City",
+          "type": "string"
+        },
+        "state": {
+          "description": "State or province",
+          "type": "string"
+        },
+        "zip": {
+          "description": "ZIP or postal code",
+          "type": "string"
+        },
+        "country": {
+          "description": "Country",
+          "type": "string"
+        }
+      },
+      "required": ["street", "city", "state", "zip", "country"]
+    },
+    "payment": {
+      "description": "Payment information for the order",
+      "type": "object",
+      "properties": {
+        "paymentMethod": {
+          "description": "Payment method used",
+          "type": "string",
+          "enum": ["Credit Card", "PayPal", "Bank Transfer"]
+        },
+        "transactionId": {
+          "description": "Transaction ID for the payment",
+          "type": "string"
+        },
+        "amount": {
+          "description": "Total amount paid",
+          "type": "number",
+          "minimum": 0
+        }
+      },
+      "required": ["paymentMethod", "transactionId", "amount"]
+    },
+    "orderDate": {
+      "description": "Date when the order was placed",
+      "type": "string",
+      "format": "date-time"
+    },
+    "status": {
+      "description": "Current status of the order",
+      "type": "string",
+      "enum": ["Pending", "Processing", "Shipped", "Delivered", "Cancelled"]
+    }
+  },
+  "required": ["orderId", "customer", "items", "shippingAddress", "payment", "orderDate", "status"]
+}

--- a/examples/default/flows/Payment/PaymentProcessed/index.md
+++ b/examples/default/flows/Payment/PaymentProcessed/index.md
@@ -1,0 +1,77 @@
+---
+id: PaymentFlow
+name: Payment Flow for E-commerce
+version: 1.0.0
+summary: Business flow for processing payments in an e-commerce platform
+steps:
+    - id: 1
+      title: Order Placed
+      message:
+        id: OrderCreated
+        version: 0.0.1
+      paths:
+        - step: 2
+          label: Proceed to payment
+    - id: 2
+      title: Payment Initiated
+      message:
+        id: PaymentInitiated
+        version: 0.0.1
+      paths:
+        - step: 3
+          label: Payment successful
+        - step: 4
+          label: Payment failed
+    - id: 3
+      title: Payment Processed
+      message:
+        id: PaymentProcessed
+        version: 0.0.1
+      paths:
+        - step: 5
+          label: Adjust inventory
+        - step: 6
+          label: Notify customer
+    - id: 4
+      title: Payment Failed
+      type: node
+      paths:
+        - step: 7
+          label: Notify customer of failure
+        - step: 8
+          label: Retry payment
+    - id: 5
+      title: Inventory Adjusted
+      message:
+        id: InventoryAdjusted
+        version: 0.0.3
+      paths:
+        - step: 9
+          label: Complete order
+    - id: 6
+      title: Customer Notified of Payment
+      type: node
+      paths:
+        - step: 9
+          label: Complete order
+    - id: 7
+      title: Customer Notified of Failure
+      type: node
+    - id: 8
+      title: Retry Payment
+      type: node
+      paths:
+        - step: 2
+          label: Retry payment process
+    - id: 9
+      title: Payment Complete
+      message:
+        id: PaymentComplete
+        version: 0.0.2
+      paths:
+        - step: 10
+          label: Order completed
+    - id: 10
+      title: Order Completed
+      type: node
+---

--- a/examples/default/flows/Payment/PaymentProcessed/index.md
+++ b/examples/default/flows/Payment/PaymentProcessed/index.md
@@ -4,80 +4,75 @@ name: Payment Flow for customers
 version: 1.0.0
 summary: Business flow for processing payments in an e-commerce platform
 steps:
-    - id: 1
+    - id: "customer_place_order"
       title: Customer places order
-      type: node
-      paths:
-        - step: 2
-          label: Proceed to payment
-    - id: 2
+      next_step: "place_order_request"
+    - id: "place_order_request"
       title: Place order
       message:
         id: PlaceOrder
         version: 0.0.1
-      paths:
-        - step: 3
-          label: Initiate payment
-    - id: 3
+      next_step:
+        id: "payment_initiated"
+        label: Initiate payment
+    - id: "payment_initiated"
       title: Payment Initiated
       message:
         id: PaymentInitiated
         version: 0.0.1
-      paths:
-        - step: 4
-          label: Payment successful
-        - step: 5
-          label: Payment failed
-    - id: 4
+      next_steps:
+        - "payment_processed"
+        - "payment_failed"
+    - id: "payment_processed"
       title: Payment Processed
       message:
         id: PaymentProcessed
         version: 0.0.1
-      paths:
-        - step: 6
+      next_steps:
+        - id: "adjust_inventory"
           label: Adjust inventory
-        - step: 7
+        - id: "send_custom_notification"
           label: Notify customer
-    - id: 5
+    - id: "payment_failed"
       title: Payment Failed
       type: node
-      paths:
-        - step: 8
+      next_steps:
+        - id: "failure_notification"
           label: Notify customer of failure
-        - step: 9
+        - id: "retry_payment"
           label: Retry payment
-    - id: 6
+    - id: "adjust_inventory"
       title: Inventory Adjusted
       message:
         id: InventoryAdjusted
         version: 1.0.1
-      paths:
-        - step: 10
-          label: Complete order
-    - id: 7
+      next_step:
+        id: "payment_complete"
+        label: Complete order
+    - id: "send_custom_notification"
       title: Customer Notified of Payment
       type: node
-      paths:
-        - step: 10
-          label: Complete order
-    - id: 8
+      next_step:
+        id: "payment_complete"
+        label: Complete order
+    - id: "failure_notification"
       title: Customer Notified of Failure
       type: node
-    - id: 9
+    - id: "retry_payment"
       title: Retry Payment
       type: node
-      paths:
-        - step: 3
-          label: Retry payment process
-    - id: 10
+      next_step:
+        id: "payment_initiated"
+        label: Retry payment process
+    - id: "payment_complete"
       title: Payment Complete
       message:
         id: PaymentComplete
         version: 0.0.2
-      paths:
-        - step: 11
-          label: Order completed
-    - id: 11
+      next_step:
+        id: "order-complete"
+        label: Order completed
+    - id: "order-complete"
       title: Order Completed
       type: node
 ---

--- a/examples/default/flows/Payment/PaymentProcessed/index.md
+++ b/examples/default/flows/Payment/PaymentProcessed/index.md
@@ -1,77 +1,86 @@
 ---
 id: PaymentFlow
-name: Payment Flow for E-commerce
+name: Payment Flow for customers
 version: 1.0.0
 summary: Business flow for processing payments in an e-commerce platform
 steps:
     - id: 1
-      title: Order Placed
-      message:
-        id: OrderCreated
-        version: 0.0.1
+      title: Customer places order
+      type: node
       paths:
         - step: 2
           label: Proceed to payment
     - id: 2
+      title: Place order
+      message:
+        id: PlaceOrder
+        version: 0.0.1
+      paths:
+        - step: 3
+          label: Initiate payment
+    - id: 3
       title: Payment Initiated
       message:
         id: PaymentInitiated
         version: 0.0.1
       paths:
-        - step: 3
-          label: Payment successful
         - step: 4
+          label: Payment successful
+        - step: 5
           label: Payment failed
-    - id: 3
+    - id: 4
       title: Payment Processed
       message:
         id: PaymentProcessed
         version: 0.0.1
       paths:
-        - step: 5
-          label: Adjust inventory
         - step: 6
+          label: Adjust inventory
+        - step: 7
           label: Notify customer
-    - id: 4
+    - id: 5
       title: Payment Failed
       type: node
       paths:
-        - step: 7
-          label: Notify customer of failure
         - step: 8
+          label: Notify customer of failure
+        - step: 9
           label: Retry payment
-    - id: 5
+    - id: 6
       title: Inventory Adjusted
       message:
         id: InventoryAdjusted
-        version: 0.0.3
+        version: 1.0.1
       paths:
-        - step: 9
+        - step: 10
           label: Complete order
-    - id: 6
+    - id: 7
       title: Customer Notified of Payment
       type: node
       paths:
-        - step: 9
+        - step: 10
           label: Complete order
-    - id: 7
+    - id: 8
       title: Customer Notified of Failure
       type: node
-    - id: 8
+    - id: 9
       title: Retry Payment
       type: node
       paths:
-        - step: 2
+        - step: 3
           label: Retry payment process
-    - id: 9
+    - id: 10
       title: Payment Complete
       message:
         id: PaymentComplete
         version: 0.0.2
       paths:
-        - step: 10
+        - step: 11
           label: Order completed
-    - id: 10
+    - id: 11
       title: Order Completed
       type: node
 ---
+
+### Flow of feature
+<NodeGraph/>

--- a/examples/default/flows/Subscriptions/CancelSubscription/index.md
+++ b/examples/default/flows/Subscriptions/CancelSubscription/index.md
@@ -1,59 +1,68 @@
 ---
-id: CancelSubscription
-name: User cancels subscription
-version: 0.0.1
-summary: Flow for when a user has cancelled a subscription
+id: "CancelSubscription"
+name: "User Cancels Subscription"
+version: "0.0.1"
+summary: "Flow for when a user has cancelled a subscription"
 steps:
-    - id: 1
-      title: Cancels subscription
-      summary: User cancels their subscription
-      actor:
-        name: User
-      paths:
-        - step: 2
-          label: http request
-    - id: 2
-      title: Cancel Subscription
-      message:
-        id: CancelSubscription
-        version: 0.0.1
-      paths:
-        - step: 4
-    - id: 3
-      title: Stripe
-      externalSystem:
-        name: Stripe
-        summary: 3rd party payment system
-        url: https://stripe.com/
-      paths:
-        - step: 4
-    - id: 4
-      title: Subscription Service
-      service:
-        id: SubscriptionService
-        version: 0.0.1
-      paths:
-        - step: 3
-          label: 'Cancel subscription'
-        - step: 5
-          label: 'successful'
-        - step: 6  
-          label: 'failed'
-    - id: 5
-      title: Subscription has been cancelled
-      message:
-        id: UserSubscriptionCancelled
-        version: 0.0.1
-      paths:
-        - step: 7
-          label: 'email customer'
-    - id: 6
-      title: Subscription has been rejected
-    - id: 7
-      title: Notifications Service
-      service:
-        id: NotificationService
-        version: 0.0.2
+  - id: "cancel_subscription_initiated"
+    title: "Cancels Subscription"
+    summary: "User cancels their subscription"
+    actor:
+      name: "User"
+    next_step: 
+      id: "cancel_subscription_request"
+      label: "Initiate subscription cancellation"
+
+  - id: "cancel_subscription_request"
+    title: "Cancel Subscription"
+    message:
+      id: "CancelSubscription"
+      version: "0.0.1"
+    next_step: 
+      id: "subscription_service"
+      label: "Proceed to subscription service"
+
+  - id: "stripe_integration"
+    title: "Stripe"
+    externalSystem:
+      name: "Stripe"
+      summary: "3rd party payment system"
+      url: "https://stripe.com/"
+    next_step: 
+      id: "subscription_service"
+      label: "Return to subscription service"
+
+  - id: "subscription_service"
+    title: "Subscription Service"
+    service:
+      id: "SubscriptionService"
+      version: "0.0.1"
+    next_steps:
+      - id: "stripe_integration"
+        label: "Cancel subscription via Stripe"
+      - id: "subscription_cancelled"
+        label: "Successful cancellation"
+      - id: "subscription_rejected"
+        label: "Failed cancellation"
+
+  - id: "subscription_cancelled"
+    title: "Subscription has been Cancelled"
+    message:
+      id: "UserSubscriptionCancelled"
+      version: "0.0.1"
+    next_step:
+      id: "notification_service"
+      label: "Email customer"
+
+  - id: "subscription_rejected"
+    title: "Subscription cancellation has been rejected"
+
+  - id: "notification_service"
+    title: "Notifications Service"
+    service:
+      id: "NotificationService"
+      version: "0.0.2"
+
 ---
 
 <NodeGraph />

--- a/examples/default/flows/Subscriptions/CancelSubscription/index.md
+++ b/examples/default/flows/Subscriptions/CancelSubscription/index.md
@@ -1,0 +1,59 @@
+---
+id: CancelSubscription
+name: User cancels subscription
+version: 0.0.1
+summary: Flow for when a user has cancelled a subscription
+steps:
+    - id: 1
+      title: Cancels subscription
+      summary: User cancels their subscription
+      actor:
+        name: User
+      paths:
+        - step: 2
+          label: http request
+    - id: 2
+      title: Cancel Subscription
+      message:
+        id: CancelSubscription
+        version: 0.0.1
+      paths:
+        - step: 4
+    - id: 3
+      title: Stripe
+      externalSystem:
+        name: Stripe
+        summary: 3rd party payment system
+        url: https://stripe.com/
+      paths:
+        - step: 4
+    - id: 4
+      title: Subscription Service
+      service:
+        id: SubscriptionService
+        version: 0.0.1
+      paths:
+        - step: 3
+          label: 'Cancel subscription'
+        - step: 5
+          label: 'successful'
+        - step: 6  
+          label: 'failed'
+    - id: 5
+      title: Subscription has been cancelled
+      message:
+        id: UserSubscriptionCancelled
+        version: 0.0.1
+      paths:
+        - step: 7
+          label: 'email customer'
+    - id: 6
+      title: Subscription has been rejected
+    - id: 7
+      title: Notifications Service
+      service:
+        id: NotificationService
+        version: 0.0.2
+---
+
+<NodeGraph />

--- a/examples/default/services/InventoryService/versioned/0.0.1/index.md
+++ b/examples/default/services/InventoryService/versioned/0.0.1/index.md
@@ -1,6 +1,6 @@
 ---
 id: InventoryService
-version: 0.0.2
+version: 0.0.1
 name: Inventory Service
 summary: |
   Service that handles the inventory

--- a/examples/default/services/SubscriptionService/commands/CancelSubscription/index.md
+++ b/examples/default/services/SubscriptionService/commands/CancelSubscription/index.md
@@ -1,0 +1,25 @@
+---
+id: CancelSubscription
+name: Cancel subscription
+version: 0.0.1
+summary: |
+  Command that will try and cancel a users subscription
+owners:
+    - dboyne
+badges:
+    - content: New!
+      backgroundColor: green
+      textColor: green
+---
+
+import Footer from '@catalog/components/footer.astro';
+
+## Overview
+
+The `CancelSubscription` command will try and cancel a subscription for the user.
+
+## Architecture diagram
+
+<NodeGraph />
+
+<Footer />

--- a/examples/default/services/SubscriptionService/commands/SubscribeUser/index.md
+++ b/examples/default/services/SubscriptionService/commands/SubscribeUser/index.md
@@ -1,0 +1,25 @@
+---
+id: SubscribeUser
+name: Subscribe user
+version: 0.0.1
+summary: |
+  Command that will try and subscribe a given user
+owners:
+    - dboyne
+badges:
+    - content: New!
+      backgroundColor: green
+      textColor: green
+---
+
+import Footer from '@catalog/components/footer.astro';
+
+## Overview
+
+The `SubscribeUser` command represents when a new user wants to subscribe to our service.
+
+## Architecture diagram
+
+<NodeGraph />
+
+<Footer />

--- a/examples/default/services/SubscriptionService/events/UserSubscriptionCancelled/index.md
+++ b/examples/default/services/SubscriptionService/events/UserSubscriptionCancelled/index.md
@@ -1,0 +1,25 @@
+---
+id: UserSubscriptionCancelled
+name: User subscription cancelled
+version: 0.0.1
+summary: |
+  An event that is triggered when a users subscription has been cancelled
+owners:
+    - dboyne
+badges:
+    - content: New!
+      backgroundColor: green
+      textColor: green
+---
+
+import Footer from '@catalog/components/footer.astro';
+
+## Overview
+
+The `UserSubscriptionCancelled` event is triggered when a users subscription has been cancelled.
+
+## Architecture diagram
+
+<NodeGraph />
+
+<Footer />

--- a/examples/default/services/SubscriptionService/events/UserSubscriptionStarted/index.md
+++ b/examples/default/services/SubscriptionService/events/UserSubscriptionStarted/index.md
@@ -1,0 +1,25 @@
+---
+id: UserSubscriptionStarted
+name: User subscription started
+version: 0.0.1
+summary: |
+  An event that is triggered when a new user subscription has started
+owners:
+    - dboyne
+badges:
+    - content: New!
+      backgroundColor: green
+      textColor: green
+---
+
+import Footer from '@catalog/components/footer.astro';
+
+## Overview
+
+The `UserSubscriptionStarted` event is triggered when a user starts a new subscription with our service.
+
+## Architecture diagram
+
+<NodeGraph />
+
+<Footer />

--- a/examples/default/services/SubscriptionService/index.md
+++ b/examples/default/services/SubscriptionService/index.md
@@ -1,0 +1,30 @@
+---
+id: SubscriptionService
+version: 0.0.1
+name: Subscription Service
+summary: |
+  Service that handles subscriptions
+owners:
+    - dboyne
+receives:
+  - id: SubscribeUser
+    version: 0.0.1
+sends:
+  - id: UserSubscriptionStarted  
+    version: 0.0.1
+repository:
+  language: JavaScript
+  url: https://github.com/boyney123/pretend-subscription-service
+---
+
+import Footer from '@catalog/components/footer.astro';
+
+## Overview
+
+The subscription Service is responsible for handling customer subscriptions in our system. It handles new subscriptions, cancelling subscriptions and updating htem.
+
+## Architecture diagram 
+
+<NodeGraph />
+
+<Footer />

--- a/scripts/__tests__/catalog-to-astro-content-directory.spec.ts
+++ b/scripts/__tests__/catalog-to-astro-content-directory.spec.ts
@@ -146,6 +146,39 @@ describe('catalog-to-astro-content-directory', () => {
     });
   });
 
+  describe('flows', () => {
+    describe('/flows directory', () => {
+      it('takes flows from the users catalog and puts it into the expected directory structure', async () => {
+        expect(existsSync(path.join(ASTRO_OUTPUT, 'flows', 'Payment', 'PaymentProcessed', 'index.mdx'))).toBe(true);
+      });
+
+      it('when a flow is versioned it copies this version into the correct location', async () => {
+        expect(
+          existsSync(path.join(ASTRO_OUTPUT, 'flows', 'Payment', 'PaymentProcessed', 'versioned', '0.0.1', 'index.mdx'))
+        ).toBe(true);
+      });
+    });
+    describe('flows within the /services directory', () => {
+      it('takes flows from the users catalog (which are in a services folder) and puts it into the expected directory structure', async () => {
+        expect(existsSync(path.join(ASTRO_OUTPUT, 'flows', 'PaymentAccepted', 'index.mdx'))).toBe(true);
+      });
+
+      it('when a flow is versioned (within a services folder) it copies this version into the correct location', async () => {
+        expect(existsSync(path.join(ASTRO_OUTPUT, 'flows', 'PaymentAccepted', 'versioned', '0.0.1', 'index.mdx'))).toBe(true);
+      });
+    });
+
+    describe('flows within the /domains directory', () => {
+      it('takes flows from the users catalog (which are in a domains folder) and puts it into the expected directory structure', async () => {
+        expect(existsSync(path.join(ASTRO_OUTPUT, 'flows', 'ProcessingOfAnOrder', 'index.mdx'))).toBe(true);
+      });
+
+      it('when a flow is versioned (within a domains folder) it copies this version into the correct location', async () => {
+        expect(existsSync(path.join(ASTRO_OUTPUT, 'flows', 'ProcessingOfAnOrder', 'versioned', '0.0.1', 'index.mdx'))).toBe(true);
+      });
+    });
+  });
+
   describe('users', () => {
     it('takes users from the catalog and puts it into the expected directory structure', async () => {
       expect(existsSync(path.join(ASTRO_OUTPUT, 'users', 'dboyne.md'))).toBe(true);

--- a/scripts/__tests__/example-catalog/domains/Payment/flows/ProcessingOfAnOrder/index.md
+++ b/scripts/__tests__/example-catalog/domains/Payment/flows/ProcessingOfAnOrder/index.md
@@ -1,0 +1,20 @@
+---
+id: ProcessingOfAnOrder
+name: Processing of an order
+version: 1.0.0
+steps:
+    - id: "customer_place_order"
+      title: Customer places order
+      next_step: "place_order_request"
+    - id: "place_order_request"
+      title: Place order
+      message:
+        id: PlaceOrder
+        version: 0.0.1
+      next_step:
+        id: "payment_initiated"
+        label: Initiate payment
+---
+
+### Flow of feature
+<NodeGraph/>

--- a/scripts/__tests__/example-catalog/domains/Payment/flows/ProcessingOfAnOrder/versioned/0.0.1/index.md
+++ b/scripts/__tests__/example-catalog/domains/Payment/flows/ProcessingOfAnOrder/versioned/0.0.1/index.md
@@ -1,0 +1,20 @@
+---
+id: ProcessingOfAnOrder
+name: Processing of an order
+version: 0.0.1
+steps:
+    - id: "customer_place_order"
+      title: Customer places order
+      next_step: "place_order_request"
+    - id: "place_order_request"
+      title: Place order
+      message:
+        id: PlaceOrder
+        version: 0.0.1
+      next_step:
+        id: "payment_initiated"
+        label: Initiate payment
+---
+
+### Flow of feature
+<NodeGraph/>

--- a/scripts/__tests__/example-catalog/flows/Payment/PaymentProcessed/index.md
+++ b/scripts/__tests__/example-catalog/flows/Payment/PaymentProcessed/index.md
@@ -1,0 +1,81 @@
+---
+id: PaymentFlow
+name: Payment Flow for customers
+version: 1.0.0
+summary: Business flow for processing payments in an e-commerce platform
+steps:
+    - id: "customer_place_order"
+      title: Customer places order
+      next_step: "place_order_request"
+    - id: "place_order_request"
+      title: Place order
+      message:
+        id: PlaceOrder
+        version: 0.0.1
+      next_step:
+        id: "payment_initiated"
+        label: Initiate payment
+    - id: "payment_initiated"
+      title: Payment Initiated
+      message:
+        id: PaymentInitiated
+        version: 0.0.1
+      next_steps:
+        - "payment_processed"
+        - "payment_failed"
+    - id: "payment_processed"
+      title: Payment Processed
+      message:
+        id: PaymentProcessed
+        version: 0.0.1
+      next_steps:
+        - id: "adjust_inventory"
+          label: Adjust inventory
+        - id: "send_custom_notification"
+          label: Notify customer
+    - id: "payment_failed"
+      title: Payment Failed
+      type: node
+      next_steps:
+        - id: "failure_notification"
+          label: Notify customer of failure
+        - id: "retry_payment"
+          label: Retry payment
+    - id: "adjust_inventory"
+      title: Inventory Adjusted
+      message:
+        id: InventoryAdjusted
+        version: 1.0.1
+      next_step:
+        id: "payment_complete"
+        label: Complete order
+    - id: "send_custom_notification"
+      title: Customer Notified of Payment
+      type: node
+      next_step:
+        id: "payment_complete"
+        label: Complete order
+    - id: "failure_notification"
+      title: Customer Notified of Failure
+      type: node
+    - id: "retry_payment"
+      title: Retry Payment
+      type: node
+      next_step:
+        id: "payment_initiated"
+        label: Retry payment process
+    - id: "payment_complete"
+      title: Payment Complete
+      message:
+        id: PaymentComplete
+        version: 0.0.2
+      next_step:
+        id: "order-complete"
+        label: Order completed
+    - id: "order-complete"
+      title: Order Completed
+      type: node
+---
+
+### Flow of feature
+<NodeGraph/>

--- a/scripts/__tests__/example-catalog/flows/Payment/PaymentProcessed/versioned/0.0.1/index.md
+++ b/scripts/__tests__/example-catalog/flows/Payment/PaymentProcessed/versioned/0.0.1/index.md
@@ -1,0 +1,81 @@
+---
+id: PaymentFlow
+name: Payment Flow for customers
+version: 0.0.1
+summary: Business flow for processing payments in an e-commerce platform
+steps:
+    - id: "customer_place_order"
+      title: Customer places order
+      next_step: "place_order_request"
+    - id: "place_order_request"
+      title: Place order
+      message:
+        id: PlaceOrder
+        version: 0.0.1
+      next_step:
+        id: "payment_initiated"
+        label: Initiate payment
+    - id: "payment_initiated"
+      title: Payment Initiated
+      message:
+        id: PaymentInitiated
+        version: 0.0.1
+      next_steps:
+        - "payment_processed"
+        - "payment_failed"
+    - id: "payment_processed"
+      title: Payment Processed
+      message:
+        id: PaymentProcessed
+        version: 0.0.1
+      next_steps:
+        - id: "adjust_inventory"
+          label: Adjust inventory
+        - id: "send_custom_notification"
+          label: Notify customer
+    - id: "payment_failed"
+      title: Payment Failed
+      type: node
+      next_steps:
+        - id: "failure_notification"
+          label: Notify customer of failure
+        - id: "retry_payment"
+          label: Retry payment
+    - id: "adjust_inventory"
+      title: Inventory Adjusted
+      message:
+        id: InventoryAdjusted
+        version: 1.0.1
+      next_step:
+        id: "payment_complete"
+        label: Complete order
+    - id: "send_custom_notification"
+      title: Customer Notified of Payment
+      type: node
+      next_step:
+        id: "payment_complete"
+        label: Complete order
+    - id: "failure_notification"
+      title: Customer Notified of Failure
+      type: node
+    - id: "retry_payment"
+      title: Retry Payment
+      type: node
+      next_step:
+        id: "payment_initiated"
+        label: Retry payment process
+    - id: "payment_complete"
+      title: Payment Complete
+      message:
+        id: PaymentComplete
+        version: 0.0.2
+      next_step:
+        id: "order-complete"
+        label: Order completed
+    - id: "order-complete"
+      title: Order Completed
+      type: node
+---
+
+### Flow of feature
+<NodeGraph/>

--- a/scripts/__tests__/example-catalog/flows/Subscriptions/CancelSubscription/index.md
+++ b/scripts/__tests__/example-catalog/flows/Subscriptions/CancelSubscription/index.md
@@ -1,0 +1,68 @@
+---
+id: "CancelSubscription"
+name: "User Cancels Subscription"
+version: "0.0.1"
+summary: "Flow for when a user has cancelled a subscription"
+steps:
+  - id: "cancel_subscription_initiated"
+    title: "Cancels Subscription"
+    summary: "User cancels their subscription"
+    actor:
+      name: "User"
+    next_step: 
+      id: "cancel_subscription_request"
+      label: "Initiate subscription cancellation"
+
+  - id: "cancel_subscription_request"
+    title: "Cancel Subscription"
+    message:
+      id: "CancelSubscription"
+      version: "0.0.1"
+    next_step: 
+      id: "subscription_service"
+      label: "Proceed to subscription service"
+
+  - id: "stripe_integration"
+    title: "Stripe"
+    externalSystem:
+      name: "Stripe"
+      summary: "3rd party payment system"
+      url: "https://stripe.com/"
+    next_step: 
+      id: "subscription_service"
+      label: "Return to subscription service"
+
+  - id: "subscription_service"
+    title: "Subscription Service"
+    service:
+      id: "SubscriptionService"
+      version: "0.0.1"
+    next_steps:
+      - id: "stripe_integration"
+        label: "Cancel subscription via Stripe"
+      - id: "subscription_cancelled"
+        label: "Successful cancellation"
+      - id: "subscription_rejected"
+        label: "Failed cancellation"
+
+  - id: "subscription_cancelled"
+    title: "Subscription has been Cancelled"
+    message:
+      id: "UserSubscriptionCancelled"
+      version: "0.0.1"
+    next_step:
+      id: "notification_service"
+      label: "Email customer"
+
+  - id: "subscription_rejected"
+    title: "Subscription cancellation has been rejected"
+
+  - id: "notification_service"
+    title: "Notifications Service"
+    service:
+      id: "NotificationService"
+      version: "0.0.2"
+
+---
+
+<NodeGraph />

--- a/scripts/__tests__/example-catalog/services/PaymentService/flows/PaymentAccepted/index.md
+++ b/scripts/__tests__/example-catalog/services/PaymentService/flows/PaymentAccepted/index.md
@@ -1,0 +1,20 @@
+---
+id: PaymentAccepted
+name: Payment Flow for customers
+version: 1.0.0
+steps:
+    - id: "customer_place_order"
+      title: Customer places order
+      next_step: "place_order_request"
+    - id: "place_order_request"
+      title: Place order
+      message:
+        id: PlaceOrder
+        version: 0.0.1
+      next_step:
+        id: "payment_initiated"
+        label: Initiate payment
+---
+
+### Flow of feature
+<NodeGraph/>

--- a/scripts/__tests__/example-catalog/services/PaymentService/flows/PaymentAccepted/versioned/0.0.1/index.md
+++ b/scripts/__tests__/example-catalog/services/PaymentService/flows/PaymentAccepted/versioned/0.0.1/index.md
@@ -1,0 +1,20 @@
+---
+id: PaymentAccepted
+name: Payment Flow for customers
+version: 0.0.1
+steps:
+    - id: "customer_place_order"
+      title: Customer places order
+      next_step: "place_order_request"
+    - id: "place_order_request"
+      title: Place order
+      message:
+        id: PlaceOrder
+        version: 0.0.1
+      next_step:
+        id: "payment_initiated"
+        label: Initiate payment
+---
+
+### Flow of feature
+<NodeGraph/>

--- a/scripts/catalog-to-astro-content-directory.js
+++ b/scripts/catalog-to-astro-content-directory.js
@@ -198,7 +198,11 @@ export const catalogToAstro = async (source, astroContentDir, catalogFilesDir) =
     catalogFilesDir,
     pathToMarkdownFiles: [path.join(source, 'domains/**/**/index.md'), path.join(source, 'domains/**/**/changelog.md')],
     pathToAllFiles: [path.join(source, 'domains/**')],
-    ignore: [path.join(source, 'domains/**/services/**'), path.join(source, 'domains/**/commands/**'), path.join(source, 'domains/**/events/**')],
+    ignore: [
+      path.join(source, 'domains/**/services/**'),
+      path.join(source, 'domains/**/commands/**'),
+      path.join(source, 'domains/**/events/**'),
+    ],
     type: 'domains',
   });
 

--- a/scripts/catalog-to-astro-content-directory.js
+++ b/scripts/catalog-to-astro-content-directory.js
@@ -187,7 +187,11 @@ export const catalogToAstro = async (source, astroContentDir, catalogFilesDir) =
       path.join(source, 'services/**/**/changelog.md'),
     ],
     pathToAllFiles: [path.join(source, 'services/**'), path.join(source, 'domains/**/services/**')],
-    ignore: [path.join(source, 'services/**/events/**'), path.join(source, 'services/**/commands/**')],
+    ignore: [
+      path.join(source, 'services/**/events/**'),
+      path.join(source, 'services/**/commands/**'),
+      path.join(source, 'services/**/flows/**'),
+    ],
     type: 'services',
   });
 
@@ -202,6 +206,7 @@ export const catalogToAstro = async (source, astroContentDir, catalogFilesDir) =
       path.join(source, 'domains/**/services/**'),
       path.join(source, 'domains/**/commands/**'),
       path.join(source, 'domains/**/events/**'),
+      path.join(source, 'domains/**/flows/**'),
     ],
     type: 'domains',
   });
@@ -211,8 +216,17 @@ export const catalogToAstro = async (source, astroContentDir, catalogFilesDir) =
     source,
     target: astroContentDir,
     catalogFilesDir,
-    pathToMarkdownFiles: [path.join(source, 'flows/**/**/index.md'), path.join(source, 'flows/**/**/changelog.md')],
-    pathToAllFiles: [path.join(source, 'flows/**')],
+    pathToMarkdownFiles: [
+      path.join(source, 'flows/**/**/index.md'),
+      path.join(source, 'flows/**/**/changelog.md'),
+      path.join(source, 'services/**/flows/**/index.md'),
+      path.join(source, 'domains/**/flows/**/index.md'),
+    ],
+    pathToAllFiles: [
+      path.join(source, 'flows/**'),
+      path.join(source, 'services/**/flows/**'),
+      path.join(source, 'domains/**/flows/**'),
+    ],
     type: 'flows',
   });
 

--- a/scripts/catalog-to-astro-content-directory.js
+++ b/scripts/catalog-to-astro-content-directory.js
@@ -22,11 +22,12 @@ const ensureDirSync = async (filePath) => {
   }
 };
 
-const copyFiles = async ({ source, target, catalogFilesDir, pathToMarkdownFiles, pathToAllFiles, type }) => {
+const copyFiles = async ({ source, target, catalogFilesDir, pathToMarkdownFiles, pathToAllFiles, type, ignore = null }) => {
   // Find all the event files
   const markdownFiles = await glob(pathToMarkdownFiles, {
     nodir: true,
     windowsPathsNoEscape: os.platform() == 'win32',
+    ignore: ignore,
   });
   const files = await glob(pathToAllFiles, {
     ignore: {
@@ -186,6 +187,7 @@ export const catalogToAstro = async (source, astroContentDir, catalogFilesDir) =
       path.join(source, 'services/**/**/changelog.md'),
     ],
     pathToAllFiles: [path.join(source, 'services/**'), path.join(source, 'domains/**/services/**')],
+    ignore: [path.join(source, 'services/**/events/**'), path.join(source, 'services/**/commands/**')],
     type: 'services',
   });
 
@@ -196,6 +198,7 @@ export const catalogToAstro = async (source, astroContentDir, catalogFilesDir) =
     catalogFilesDir,
     pathToMarkdownFiles: [path.join(source, 'domains/**/**/index.md'), path.join(source, 'domains/**/**/changelog.md')],
     pathToAllFiles: [path.join(source, 'domains/**')],
+    ignore: [path.join(source, 'domains/**/services/**'), path.join(source, 'domains/**/commands/**'), path.join(source, 'domains/**/events/**')],
     type: 'domains',
   });
 

--- a/scripts/catalog-to-astro-content-directory.js
+++ b/scripts/catalog-to-astro-content-directory.js
@@ -199,6 +199,16 @@ export const catalogToAstro = async (source, astroContentDir, catalogFilesDir) =
     type: 'domains',
   });
 
+  // // Copy all the flow files over
+  await copyFiles({
+    source,
+    target: astroContentDir,
+    catalogFilesDir,
+    pathToMarkdownFiles: [path.join(source, 'flows/**/**/index.md'), path.join(source, 'flows/**/**/changelog.md')],
+    pathToAllFiles: [path.join(source, 'flows/**')],
+    type: 'flows',
+  });
+
   // // Copy all the users
   await copyFiles({
     source,

--- a/scripts/default-files-for-collections/flows.md
+++ b/scripts/default-files-for-collections/flows.md
@@ -1,0 +1,5 @@
+---
+id: empty
+---
+
+<!-- Do not delete this file, required for EC, you an ignore this file -->

--- a/scripts/watcher.js
+++ b/scripts/watcher.js
@@ -11,7 +11,7 @@ const catalogDirectory = process.env.CATALOG_DIR;
 
 const contentPath = path.join(catalogDirectory, 'src', 'content');
 
-const watchList = ['domains', 'commands', 'events', 'services', 'teams', 'users', 'pages', 'components'];
+const watchList = ['domains', 'commands', 'events', 'services', 'teams', 'users', 'pages', 'components', 'flows'];
 // const absoluteWatchList = watchList.map((item) => path.join(projectDirectory, item));
 
 // confirm folders exist before watching them

--- a/scripts/watcher.js
+++ b/scripts/watcher.js
@@ -62,7 +62,6 @@ for (let item of [...verifiedWatchList]) {
 
       // IF directory remove it
       if (type === 'delete') {
-        console.log('eventPath', eventPath);
         fs.rmSync(newPath);
       }
     }

--- a/src/components/DocsNavigation.astro
+++ b/src/components/DocsNavigation.astro
@@ -3,6 +3,7 @@ import { getCommands } from '@utils/commands';
 import { getDomains } from '@utils/domains/domains';
 import { getEvents } from '@utils/events';
 import { getServices } from '@utils/services/services';
+import { getFlows } from '@utils/flows/flows';
 import { getTeams } from '@utils/teams';
 import { getUsers } from '@utils/users';
 import config, { type CatalogConfig } from '@eventcatalog';
@@ -12,19 +13,21 @@ const events = await getEvents({ getAllVersions: false });
 const commands = await getCommands({ getAllVersions: false });
 const services = await getServices({ getAllVersions: false });
 const domains = await getDomains({ getAllVersions: false });
+const flows = await getFlows({ getAllVersions: false });
 const teams = await getTeams();
 const users = await getUsers();
 
 const messages = [...events, ...commands];
 
 // @ts-ignore for large catalogs https://github.com/event-catalog/eventcatalog/issues/552
-const allData = [...domains, ...services, ...messages, ...teams, ...users];
+const allData = [...domains, ...services, ...messages, ...flows, ...teams, ...users];
 
 const eventCatalogConfig = config as CatalogConfig;
 const {
   services: servicesConfig,
   domains: domainsConfig,
   messages: messagesConfig,
+  flows: flowsConfig,
   teams: teamsConfig,
   users: usersConfig,
   showPageHeadings = true,
@@ -38,6 +41,7 @@ const visibleCollections: { [key: string]: boolean } = {
   events: getConfigValue(messagesConfig, 'visible', true),
   commands: getConfigValue(messagesConfig, 'visible', true),
   domains: getConfigValue(domainsConfig, 'visible', true),
+  flows: getConfigValue(flowsConfig, 'visible', true),
   services: getConfigValue(servicesConfig, 'visible', true),
   teams: getConfigValue(teamsConfig, 'visible', true),
   users: getConfigValue(usersConfig, 'visible', true),

--- a/src/components/Lists/BasicList.tsx
+++ b/src/components/Lists/BasicList.tsx
@@ -33,7 +33,7 @@ const BasicList = ({ title, items, emptyMessage, color = 'gray' }: Props) => {
                       className={`flex justify-between items-center w-full px-2 rounded-md font-normal   ${item.active ? 'bg-purple-200 text-purple-800 ' : 'font-thin'}`}
                       href={item.href}
                     >
-                      <span className="block">{item.label}</span>
+                      <span className="block truncate !whitespace-normal">{item.label}</span>
                       {item.version && (
                         <span className="block text-sm bg-purple-100 p-0.5 px-1 text-gray-600  rounded-md font-light">
                           v{item.version}

--- a/src/components/MDX/NodeGraph/NodeGraph.astro
+++ b/src/components/MDX/NodeGraph/NodeGraph.astro
@@ -4,6 +4,7 @@ import { getNodesAndEdges as getNodesAndEdgesForService } from '@utils/services/
 import { getNodesAndEdges as getNodesAndEdgesForEvent } from '@utils/events/node-graph';
 import { getNodesAndEdges as getNodesAndEdgesForCommand } from '@utils/commands/node-graph';
 import { getNodesAndEdges as getNodesAndEdgesForDomain } from '@utils/domains/node-graph';
+import { getNodesAndEdges as getNodesAndEdgesForFlows } from '@utils/flows/node-graph';
 
 interface Props {
   id: string;
@@ -57,6 +58,17 @@ if (collection === 'commands') {
 
 if (collection === 'domains') {
   const { nodes: eventNodes, edges: eventEdges } = await getNodesAndEdgesForDomain({
+    id: id,
+    version,
+    mode,
+  });
+
+  nodes = eventNodes;
+  edges = eventEdges;
+}
+
+if (collection === 'flows') {
+  const { nodes: eventNodes, edges: eventEdges } = await getNodesAndEdgesForFlows({
     id: id,
     version,
     mode,

--- a/src/components/MDX/NodeGraph/NodeGraph.tsx
+++ b/src/components/MDX/NodeGraph/NodeGraph.tsx
@@ -1,19 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
-<<<<<<< HEAD
 import ReactFlow, { Background, ConnectionLineType, Controls, Panel, ReactFlowProvider, useNodesState, type Edge, type Node } from 'reactflow';
-=======
-import ReactFlow, {
-  Background,
-  ConnectionLineType,
-  Controls,
-  Panel,
-  ReactFlowProvider,
-  useNodesState,
-  type Edge,
-  type Node,
-} from 'reactflow';
->>>>>>> main
 import 'reactflow/dist/style.css';
 import ServiceNode from './Nodes/Service';
 import EventNode from './Nodes/Event';
@@ -45,19 +32,9 @@ const getVisualiserUrlForCollection = (collectionItem: CollectionEntry<Collectio
 };
 
 // const NodeGraphBuilder = ({ title, subtitle, includeBackground = true, includeControls = true }: Props) => {
-<<<<<<< HEAD
 const NodeGraphBuilder = ({ nodes:initialNodes, edges, title, includeBackground = true, linkTo = 'docs' }: Props) => {
-  // const { fitView, viewportInitialized } = useReactFlow();
-
-  // const nodeTypes = useMemo(() => ({ service: ServiceNode, event: EventNode, command: CommandNode }), []);
   const nodeTypes = useMemo(() => ({ services: ServiceNode, events: EventNode, commands: CommandNode, step: StepNode, user: UserNode, actor: UserNode, externalSystem: ExternalSystemNode }), []);
   const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
-=======
-const NodeGraphBuilder = ({ nodes: initialNodes, edges, title, includeBackground = true, linkTo = 'docs' }: Props) => {
-  const [nodes, _, onNodesChange] = useNodesState(initialNodes);
-
-  const nodeTypes = useMemo(() => ({ services: ServiceNode, events: EventNode, commands: CommandNode }), []);
->>>>>>> main
   const nodeOrigin = [0.5, 0.5];
 
   const handleNodeClick = (_: any, node: Node) => {
@@ -76,10 +53,6 @@ const NodeGraphBuilder = ({ nodes: initialNodes, edges, title, includeBackground
       nodes={nodes}
       edges={edges}
       fitView
-<<<<<<< HEAD
-=======
-      nodesDraggable
->>>>>>> main
       onNodesChange={onNodesChange}
       connectionLineType={ConnectionLineType.SmoothStep}
       // @ts-ignore

--- a/src/components/MDX/NodeGraph/NodeGraph.tsx
+++ b/src/components/MDX/NodeGraph/NodeGraph.tsx
@@ -1,6 +1,15 @@
 import { useEffect, useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
-import ReactFlow, { Background, ConnectionLineType, Controls, Panel, ReactFlowProvider, useNodesState, type Edge, type Node } from 'reactflow';
+import ReactFlow, {
+  Background,
+  ConnectionLineType,
+  Controls,
+  Panel,
+  ReactFlowProvider,
+  useNodesState,
+  type Edge,
+  type Node,
+} from 'reactflow';
 import 'reactflow/dist/style.css';
 import ServiceNode from './Nodes/Service';
 import EventNode from './Nodes/Event';
@@ -32,8 +41,19 @@ const getVisualiserUrlForCollection = (collectionItem: CollectionEntry<Collectio
 };
 
 // const NodeGraphBuilder = ({ title, subtitle, includeBackground = true, includeControls = true }: Props) => {
-const NodeGraphBuilder = ({ nodes:initialNodes, edges, title, includeBackground = true, linkTo = 'docs' }: Props) => {
-  const nodeTypes = useMemo(() => ({ services: ServiceNode, events: EventNode, commands: CommandNode, step: StepNode, user: UserNode, actor: UserNode, externalSystem: ExternalSystemNode }), []);
+const NodeGraphBuilder = ({ nodes: initialNodes, edges, title, includeBackground = true, linkTo = 'docs' }: Props) => {
+  const nodeTypes = useMemo(
+    () => ({
+      services: ServiceNode,
+      events: EventNode,
+      commands: CommandNode,
+      step: StepNode,
+      user: UserNode,
+      actor: UserNode,
+      externalSystem: ExternalSystemNode,
+    }),
+    []
+  );
   const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
   const nodeOrigin = [0.5, 0.5];
 

--- a/src/components/MDX/NodeGraph/NodeGraph.tsx
+++ b/src/components/MDX/NodeGraph/NodeGraph.tsx
@@ -1,10 +1,13 @@
 import { useEffect, useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
-import ReactFlow, { Background, ConnectionLineType, Controls, Panel, ReactFlowProvider, type Edge, type Node } from 'reactflow';
+import ReactFlow, { Background, ConnectionLineType, Controls, Panel, ReactFlowProvider, useNodesState, type Edge, type Node } from 'reactflow';
 import 'reactflow/dist/style.css';
 import ServiceNode from './Nodes/Service';
 import EventNode from './Nodes/Event';
+import UserNode from './Nodes/User';
+import StepNode from './Nodes/Step';
 import CommandNode from './Nodes/Command';
+import ExternalSystemNode from './Nodes/ExternalSystem';
 import type { CollectionEntry } from 'astro:content';
 import { navigate } from 'astro:transitions/client';
 import type { CollectionTypes } from '@types';
@@ -29,11 +32,12 @@ const getVisualiserUrlForCollection = (collectionItem: CollectionEntry<Collectio
 };
 
 // const NodeGraphBuilder = ({ title, subtitle, includeBackground = true, includeControls = true }: Props) => {
-const NodeGraphBuilder = ({ nodes, edges, title, includeBackground = true, linkTo = 'docs' }: Props) => {
+const NodeGraphBuilder = ({ nodes:initialNodes, edges, title, includeBackground = true, linkTo = 'docs' }: Props) => {
   // const { fitView, viewportInitialized } = useReactFlow();
 
   // const nodeTypes = useMemo(() => ({ service: ServiceNode, event: EventNode, command: CommandNode }), []);
-  const nodeTypes = useMemo(() => ({ services: ServiceNode, events: EventNode, commands: CommandNode }), []);
+  const nodeTypes = useMemo(() => ({ services: ServiceNode, events: EventNode, commands: CommandNode, step: StepNode, user: UserNode, actor: UserNode, externalSystem: ExternalSystemNode }), []);
+  const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
   const nodeOrigin = [0.5, 0.5];
 
   const handleNodeClick = (_: any, node: Node) => {
@@ -54,7 +58,7 @@ const NodeGraphBuilder = ({ nodes, edges, title, includeBackground = true, linkT
       nodes={nodes}
       edges={edges}
       fitView
-      nodesDraggable
+      onNodesChange={onNodesChange}
       connectionLineType={ConnectionLineType.SmoothStep}
       // @ts-ignore
       nodeOrigin={nodeOrigin}

--- a/src/components/MDX/NodeGraph/Nodes/ExternalSystem.tsx
+++ b/src/components/MDX/NodeGraph/Nodes/ExternalSystem.tsx
@@ -22,14 +22,11 @@ export default function ExternalSystemNode({ data, sourcePosition, targetPositio
   const { externalSystem } = step;
   const { name, summary, url } = externalSystem;
 
-  const minHeight = mode === 'full' ? '7em' : '2em';
-
-  // const { version, owners = [], sends = [], receives = [], name } = service.data;
-
   return (
     <div
       className={classNames(
-        `w-full rounded-md border flex justify-start  bg-white text-black border-pink-500 min-h-[${minHeight}]`
+        `w-full rounded-md border flex justify-start  bg-white text-black border-pink-500`,
+        mode === 'full' ? 'min-h-[7em]' : 'min-h-[2em]'
       )}
     >
       <div

--- a/src/components/MDX/NodeGraph/Nodes/ExternalSystem.tsx
+++ b/src/components/MDX/NodeGraph/Nodes/ExternalSystem.tsx
@@ -1,0 +1,96 @@
+import { ServerIcon } from '@heroicons/react/16/solid';
+import { GlobeAmericasIcon } from '@heroicons/react/20/solid';
+import type { CollectionEntry } from 'astro:content';
+import { Handle } from 'reactflow';
+
+interface Data {
+  label: string;
+  bgColor: string;
+  color: string;
+  mode: 'simple' | 'full';
+  step: { id: string; title: string; summary: string; externalSystem: { name: string; summary?: string; url?: string } };
+  showTarget?: boolean;
+  showSource?: boolean;
+}
+
+function classNames(...classes: any) {
+  return classes.filter(Boolean).join(' ');
+}
+
+export default function ExternalSystemNode({ data, sourcePosition, targetPosition }: any) {
+  const { mode, step, showTarget = true, showSource = true } = data as Data;
+  const { externalSystem } = step;
+  const { name, summary, url } = externalSystem;
+
+  const minHeight = mode === 'full' ? '7em' : '2em';
+
+  // const { version, owners = [], sends = [], receives = [], name } = service.data;
+
+  return (
+    <div
+      className={classNames(
+        `w-full rounded-md border flex justify-start  bg-white text-black border-pink-500 min-h-[${minHeight}]`
+      )}
+    >
+      <div
+        className={classNames(
+          'bg-gradient-to-b from-pink-500 to-pink-700 relative flex items-center w-5 justify-center rounded-l-sm text-red-100-500',
+          `border-r-[1px] border-pink-500`
+        )}
+      >
+        <GlobeAmericasIcon className="w-4 h-4 opacity-90 text-white absolute top-1 " />
+        {mode === 'full' && (
+          <span className="rotate -rotate-90 w-1/2 text-center absolute bottom-1 text-[9px] text-white font-bold uppercase tracking-[3px] ">
+            External
+          </span>
+        )}
+      </div>
+      <div className="p-1 min-w-60 max-w-[min-content]">
+        {showTarget && <Handle type="target" position={targetPosition} />}
+        {showSource && <Handle type="source" position={sourcePosition} />}
+        {/* {mode === 'full' && (
+        <div className="flex justify-end font-thin space-x-1 border-b border-orange-200  pb-0.5 " style={{ fontSize: '0.2em' }}>
+          <span>Service</span>
+          <ServerIcon className="w-2 h-2 opacity-90" />
+        </div>
+      )} */}
+        <div className={classNames(mode === 'full' ? `border-b border-gray-200` : '')}>
+          <div className="h-full ">
+            <span className="text-sm font-bold pb-0.5 block w-full">{name}</span>
+            {mode === 'simple' && (
+              <div className="w-full text-right">
+                <span className=" w-full text-[10px] text-gray-500 font-light block pt-0.5 pb-0.5 ">External System</span>
+              </div>
+            )}
+          </div>
+
+          {/* <div className="flex justify-between">
+            <span className="text-[10px] font-light block pt-0.5 pb-0.5 ">v{version}</span>
+            {mode === 'simple' && <span className="text-[10px] text-gray-500 font-light block pt-0.5 pb-0.5 ">Service</span>}
+          </div> */}
+          {/* <div className="flex justify-end">
+            <span className="text-[8px] text-gray-500 font-light block pt-0.5 pb-0.5 ">View service</span>
+          </div> */}
+        </div>
+        {mode === 'full' && (
+          <div className="divide-y divide-gray-200 ">
+            <div className="leading-3 py-1">
+              <span className="text-[8px] font-light">{summary}</span>
+            </div>
+
+            {url && (
+              <div className="grid grid-cols-2 gap-x-4 py-1">
+                <span className="text-xs" style={{ fontSize: '0.2em' }}>
+                  URL:{' '}
+                  <a href={url} target="_blank" className="text-purple-500 underline">
+                    {url}
+                  </a>
+                </span>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/MDX/NodeGraph/Nodes/ExternalSystem.tsx
+++ b/src/components/MDX/NodeGraph/Nodes/ExternalSystem.tsx
@@ -45,12 +45,6 @@ export default function ExternalSystemNode({ data, sourcePosition, targetPositio
       <div className="p-1 min-w-60 max-w-[min-content]">
         {showTarget && <Handle type="target" position={targetPosition} />}
         {showSource && <Handle type="source" position={sourcePosition} />}
-        {/* {mode === 'full' && (
-        <div className="flex justify-end font-thin space-x-1 border-b border-orange-200  pb-0.5 " style={{ fontSize: '0.2em' }}>
-          <span>Service</span>
-          <ServerIcon className="w-2 h-2 opacity-90" />
-        </div>
-      )} */}
         <div className={classNames(mode === 'full' ? `border-b border-gray-200` : '')}>
           <div className="h-full ">
             <span className="text-sm font-bold pb-0.5 block w-full">{name}</span>
@@ -60,14 +54,6 @@ export default function ExternalSystemNode({ data, sourcePosition, targetPositio
               </div>
             )}
           </div>
-
-          {/* <div className="flex justify-between">
-            <span className="text-[10px] font-light block pt-0.5 pb-0.5 ">v{version}</span>
-            {mode === 'simple' && <span className="text-[10px] text-gray-500 font-light block pt-0.5 pb-0.5 ">Service</span>}
-          </div> */}
-          {/* <div className="flex justify-end">
-            <span className="text-[8px] text-gray-500 font-light block pt-0.5 pb-0.5 ">View service</span>
-          </div> */}
         </div>
         {mode === 'full' && (
           <div className="divide-y divide-gray-200 ">

--- a/src/components/MDX/NodeGraph/Nodes/Service.tsx
+++ b/src/components/MDX/NodeGraph/Nodes/Service.tsx
@@ -21,9 +21,6 @@ export default function ServiceNode({ data, sourcePosition, targetPosition }: an
 
   const { version, owners = [], sends = [], receives = [], name } = service.data;
 
-  const renderTarget = showTarget;
-  const renderSource = showSource;
-
   return (
     <div className={classNames('w-full rounded-md border flex justify-start  bg-white text-black border-pink-500')}>
       <div
@@ -42,21 +39,12 @@ export default function ServiceNode({ data, sourcePosition, targetPosition }: an
       <div className="p-1 min-w-60 max-w-[min-content]">
         {showTarget && <Handle type="target" position={targetPosition} />}
         {showSource && <Handle type="source" position={sourcePosition} />}
-        {/* {mode === 'full' && (
-        <div className="flex justify-end font-thin space-x-1 border-b border-orange-200  pb-0.5 " style={{ fontSize: '0.2em' }}>
-          <span>Service</span>
-          <ServerIcon className="w-2 h-2 opacity-90" />
-        </div>
-      )} */}
         <div className={classNames(mode === 'full' ? `border-b border-gray-200` : '')}>
           <span className="text-xs font-bold block pt-0.5 pb-0.5">{name}</span>
           <div className="flex justify-between">
             <span className="text-[10px] font-light block pt-0.5 pb-0.5 ">v{version}</span>
             {mode === 'simple' && <span className="text-[10px] text-gray-500 font-light block pt-0.5 pb-0.5 ">Service</span>}
           </div>
-          {/* <div className="flex justify-end">
-            <span className="text-[8px] text-gray-500 font-light block pt-0.5 pb-0.5 ">View service</span>
-          </div> */}
         </div>
         {mode === 'full' && (
           <div className="divide-y divide-gray-200 ">

--- a/src/components/MDX/NodeGraph/Nodes/Step.tsx
+++ b/src/components/MDX/NodeGraph/Nodes/Step.tsx
@@ -44,7 +44,7 @@ export default function StepNode({ data, sourcePosition, targetPosition }: any) 
         {renderSource && <Handle type="source" position={sourcePosition} />}
 
         {!summary && (
-          <div className='h-full flex items-center'>
+          <div className="h-full flex items-center">
             <span className="text-sm font-bold block pb-0.5">{title}</span>
           </div>
         )}

--- a/src/components/MDX/NodeGraph/Nodes/Step.tsx
+++ b/src/components/MDX/NodeGraph/Nodes/Step.tsx
@@ -1,0 +1,69 @@
+import { EnvelopeIcon } from '@heroicons/react/16/solid';
+import type { CollectionEntry } from 'astro:content';
+import { Handle } from 'reactflow';
+
+interface Data {
+  title: string;
+  label: string;
+  bgColor: string;
+  color: string;
+  mode: 'simple' | 'full';
+  step: { id: string; title: string; summary: string };
+  showTarget?: boolean;
+  showSource?: boolean;
+}
+
+function classNames(...classes: any) {
+  return classes.filter(Boolean).join(' ');
+}
+
+export default function StepNode({ data, sourcePosition, targetPosition }: any) {
+  const { mode, step, showTarget = true, showSource = true } = data as Data;
+
+  const { title, summary } = step;
+
+  const renderTarget = showTarget || true;
+  const renderSource = showSource || true;
+
+  return (
+    <div className={classNames('w-full rounded-md border flex justify-start  bg-white text-black border-blue-400 min-h-[3em]')}>
+      <div
+        className={classNames(
+          'bg-gradient-to-b from-gray-700 to-gray-700 relative flex items-center w-5 justify-center rounded-l-sm text-orange-100-500',
+          `border-r-[1px] border-gray-500`
+        )}
+      >
+        {mode === 'full' && (
+          <span className="rotate -rotate-90 w-1/2 text-center absolute bottom-1 text-[9px] text-white font-bold uppercase tracking-[3px] ">
+            Step
+          </span>
+        )}
+      </div>
+      <div className="p-1 min-w-60 max-w-[min-content]">
+        {renderTarget && <Handle type="target" position={targetPosition} />}
+        {renderSource && <Handle type="source" position={sourcePosition} />}
+
+        {!summary && (
+          <div className='h-full flex items-center'>
+            <span className="text-sm font-bold block pb-0.5">{title}</span>
+          </div>
+        )}
+
+        {summary && (
+          <>
+            <div className={classNames(mode === 'full' ? `border-b border-gray-200` : '')}>
+              <span className="text-xs font-bold block pb-0.5">{title}</span>
+            </div>
+            {mode === 'full' && (
+              <div className="divide-y divide-gray-200 ">
+                <div className="leading-3 py-1">
+                  <span className="text-[8px] font-light">{summary}</span>
+                </div>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/MDX/NodeGraph/Nodes/User.tsx
+++ b/src/components/MDX/NodeGraph/Nodes/User.tsx
@@ -24,12 +24,11 @@ export default function UserNode({ data, sourcePosition, targetPosition }: any) 
   const renderTarget = showTarget || true;
   const renderSource = showSource || true;
 
-  const minHeight = mode === 'full' ? '5em' : '2em';
-
   return (
     <div
       className={classNames(
-        `w-full rounded-md border flex justify-start  bg-white text-black border-yellow-400 min-h-[${minHeight}]`
+        `w-full rounded-md border flex justify-start  bg-white text-black border-yellow-400`,
+        mode === 'full' ? 'min-h-[5em]' : 'min-h-[2em]'
       )}
     >
       <div

--- a/src/components/MDX/NodeGraph/Nodes/User.tsx
+++ b/src/components/MDX/NodeGraph/Nodes/User.tsx
@@ -1,0 +1,80 @@
+import { UserIcon } from '@heroicons/react/20/solid';
+import { Handle } from 'reactflow';
+
+interface Data {
+  title: string;
+  label: string;
+  bgColor: string;
+  color: string;
+  mode: 'simple' | 'full';
+  step: { id: string; title: string; summary: string; name: string; actor: { name: string } };
+  showTarget?: boolean;
+  showSource?: boolean;
+}
+
+function classNames(...classes: any) {
+  return classes.filter(Boolean).join(' ');
+}
+
+export default function UserNode({ data, sourcePosition, targetPosition }: any) {
+  const { mode, step, showTarget = true, showSource = true } = data as Data;
+
+  const { summary, actor: { name } = {} } = step;
+
+  const renderTarget = showTarget || true;
+  const renderSource = showSource || true;
+
+  const minHeight = mode === 'full' ? '5em' : '2em';
+
+  return (
+    <div
+      className={classNames(
+        `w-full rounded-md border flex justify-start  bg-white text-black border-yellow-400 min-h-[${minHeight}]`
+      )}
+    >
+      <div
+        className={classNames(
+          'bg-gradient-to-b from-yellow-400 to-yellow-600 relative flex items-center w-5 justify-center rounded-l-sm text-orange-100-500',
+          `border-r-[1px] border-yellow-500`
+        )}
+      >
+        <UserIcon className="w-4 h-4 opacity-90 text-white absolute top-1 " />
+        {mode === 'full' && (
+          <span className="rotate -rotate-90 w-1/2 text-center absolute bottom-1 text-[9px] text-white font-bold uppercase tracking-[3px] ">
+            ACTOR
+          </span>
+        )}
+      </div>
+      <div className="p-1 min-w-60 max-w-[min-content]">
+        {renderTarget && <Handle type="target" position={targetPosition} />}
+        {renderSource && <Handle type="source" position={sourcePosition} />}
+
+        {(!summary || mode !== 'full') && (
+          <div className="h-full ">
+            <span className="text-sm font-bold block pb-0.5 block w-full">{name}</span>
+            {mode === 'simple' && (
+              <div className="w-full text-right">
+                <span className=" w-full text-[10px] text-gray-500 font-light block pt-0.5 pb-0.5 ">Event</span>
+              </div>
+            )}
+          </div>
+        )}
+
+        {summary && mode === 'full' && (
+          <>
+            <div className={classNames(mode === 'full' ? `border-b border-gray-200` : '')}>
+              <span className="text-xs font-bold block pb-0.5">{name}</span>
+            </div>
+            {mode === 'full' && (
+              <div className="divide-y divide-gray-200 ">
+                <div className="leading-3 py-1">
+                  <span className="text-[8px] font-light">{summary}</span>
+                </div>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Tables/columns/FlowTableColumns.tsx
+++ b/src/components/Tables/columns/FlowTableColumns.tsx
@@ -45,7 +45,9 @@ export const columns = () => [
     header: () => <span>Version</span>,
     cell: (info) => {
       const service = info.row.original;
-      return <div className="text-left font-light">{`v${info.getValue()} ${service.data.latestVersion === service.data.version ? '(latest)': ''}`}</div>
+      return (
+        <div className="text-left font-light">{`v${info.getValue()} ${service.data.latestVersion === service.data.version ? '(latest)' : ''}`}</div>
+      );
     },
     footer: (info) => info.column.id,
   }),

--- a/src/components/Tables/columns/FlowTableColumns.tsx
+++ b/src/components/Tables/columns/FlowTableColumns.tsx
@@ -1,0 +1,80 @@
+import { ServerIcon } from '@heroicons/react/20/solid';
+import { RectangleGroupIcon } from '@heroicons/react/20/solid';
+import { createColumnHelper } from '@tanstack/react-table';
+import type { CollectionEntry } from 'astro:content';
+import { filterByName, filterCollectionByName } from '../filters/custom-filters';
+import { buildUrl } from '@utils/url-builder';
+import { QueueListIcon } from '@heroicons/react/24/solid';
+
+const columnHelper = createColumnHelper<CollectionEntry<'flows'>>();
+
+export const columns = () => [
+  columnHelper.accessor('data.name', {
+    id: 'name',
+    header: () => <span>Flow</span>,
+    cell: (info) => {
+      const flowRaw = info.row.original;
+      const color = 'teal';
+      return (
+        <div className=" group ">
+          <a
+            href={buildUrl(`/docs/${flowRaw.collection}/${flowRaw.data.id}/${flowRaw.data.version}`)}
+            className={`group-hover:text-${color}-500 flex space-x-1 items-center`}
+          >
+            <div className={`flex items-center border border-gray-300 shadow-sm rounded-md group-hover:border-${color}-400`}>
+              <span className="flex items-center">
+                <span className={`bg-${color}-500 group-hover:bg-${color}-600 h-full rounded-tl rounded-bl p-1`}>
+                  <QueueListIcon className="h-4 w-4 text-white" />
+                </span>
+                <span className="leading-none px-2 group-hover:underline group-hover:text-purple-500 font-light">
+                  {flowRaw.data.name} (v{flowRaw.data.version})
+                </span>
+              </span>
+            </div>
+          </a>
+        </div>
+      );
+    },
+    footer: (info) => info.column.id,
+    meta: {
+      filterVariant: 'name',
+    },
+    filterFn: filterByName,
+  }),
+  columnHelper.accessor('data.version', {
+    header: () => <span>Version</span>,
+    cell: (info) => {
+      const service = info.row.original;
+      return <div className="text-left font-light">{`v${info.getValue()} ${service.data.latestVersion === service.data.version ? '(latest)': ''}`}</div>
+    },
+    footer: (info) => info.column.id,
+  }),
+  columnHelper.accessor('data.summary', {
+    id: 'summary',
+    header: () => 'Summary',
+    cell: (info) => <span className="font-light ">{info.renderValue()}</span>,
+    footer: (info) => info.column.id,
+    meta: {
+      showFilter: false,
+      className: 'max-w-md',
+    },
+  }),
+  columnHelper.accessor('data.name', {
+    header: () => <span />,
+    cell: (info) => {
+      const domain = info.row.original;
+      return (
+        <a
+          className="hover:text-purple-500 hover:underline px-4 font-light"
+          href={buildUrl(`/visualiser/${domain.collection}/${domain.data.id}/${domain.data.version}`)}
+        >
+          Visualiser &rarr;
+        </a>
+      );
+    },
+    id: 'actions',
+    meta: {
+      showFilter: false,
+    },
+  }),
+];

--- a/src/components/Tables/columns/index.tsx
+++ b/src/components/Tables/columns/index.tsx
@@ -1,6 +1,7 @@
 import { columns as MessageTableColumns } from './MessageTableColumns';
 import { columns as ServiceTableColumns } from './ServiceTableColumns';
 import { columns as DomainTableColumns } from './DomainTableColumns';
+import { columns as FlowTableColumns } from './FlowTableColumns';
 
 export const getColumnsByCollection = (collection: string): any => {
   switch (collection) {
@@ -11,6 +12,8 @@ export const getColumnsByCollection = (collection: string): any => {
       return ServiceTableColumns();
     case 'domains':
       return DomainTableColumns();
+    case 'flows':
+      return FlowTableColumns();
     default:
       return [];
   }

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -68,11 +68,36 @@ const flows = defineCollection({
   schema: z
     .object({
       steps: z.array(
-        z.object({
-          title: z.string(),
-          summary: z.string().optional(),
-          message: pointer.optional(),
-        })
+        z
+          .object({
+            id: z.union([z.string(), z.number()]),
+            type: z.enum(['node', 'message', 'user', 'actor']).optional(),
+            title: z.string(),
+            summary: z.string().optional(),
+            message: pointer.optional(),
+            service: pointer.optional(),
+            actor: z.object({
+              name: z.string(),
+            }).optional(),
+            externalSystem: z.object({
+              name: z.string(),
+              summary: z.string().optional(),
+              url: z.string().optional(),
+            }).optional(),
+            paths: z
+              .array(
+                z.object({
+                  step: z.number(),
+                  label: z.string().optional(),
+                })
+              )
+              .optional(),
+          })
+          .refine((data) => {
+            if(!data.message && !data.service && !data.actor) return true;
+            // Either message or service or actor must be present, but not all
+            return (data.message && !data.service && !data.actor) || (!data.message && data.service) || (data.actor && !data.message && !data.service);
+          })
       ),
     })
     .merge(baseSchema),

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -58,6 +58,26 @@ const baseSchema = z.object({
     .optional(),
 });
 
+const pointer = z.object({
+  id: z.string(),
+  version: z.string(),
+});
+
+const flows = defineCollection({
+  type: 'content',
+  schema: z
+    .object({
+      steps: z.array(
+        z.object({
+          title: z.string(),
+          summary: z.string().optional(),
+          message: pointer.optional(),
+        })
+      ),
+    })
+    .merge(baseSchema),
+});
+
 const events = defineCollection({
   type: 'content',
   schema: z
@@ -76,11 +96,6 @@ const commands = defineCollection({
       consumers: z.array(reference('services')).optional(),
     })
     .merge(baseSchema),
-});
-
-const pointer = z.object({
-  id: z.string(),
-  version: z.string(),
 });
 
 const services = defineCollection({
@@ -142,6 +157,7 @@ export const collections = {
   users,
   teams,
   domains,
+  flows,
   pages,
   changelogs,
 };

--- a/src/layouts/DiscoverLayout.astro
+++ b/src/layouts/DiscoverLayout.astro
@@ -1,11 +1,12 @@
 ---
 import { Table } from '@components/Tables/Table';
-import { RectangleGroupIcon } from '@heroicons/react/24/outline';
+import { QueueListIcon, RectangleGroupIcon } from '@heroicons/react/24/outline';
 import EnvelopeIcon from '@heroicons/react/24/outline/EnvelopeIcon';
 import ServerIcon from '@heroicons/react/24/outline/ServerIcon';
 import PlainPage from '@layouts/PlainPage.astro';
 import { getCommands } from '@utils/commands';
 import { getDomains } from '@utils/domains/domains';
+import { getFlows } from '@utils/flows/flows';
 import { getEvents } from '@utils/events';
 import { getServices } from '@utils/services/services';
 import { buildUrl } from '@utils/url-builder';
@@ -14,6 +15,7 @@ const events = await getEvents();
 const commands = await getCommands();
 const services = await getServices();
 const domains = await getDomains();
+const flows = await getFlows();
 
 const { title, subtitle, data, type } = Astro.props;
 const currentPath = Astro.url.pathname;
@@ -50,6 +52,14 @@ const tabs = [
     icon: RectangleGroupIcon,
     activeColor: 'yellow',
     enabled: domains.length > 0,
+  },
+  {
+    label: `Flows (${flows.length})`,
+    href: buildUrl('/discover/flows'),
+    isActive: currentPath === '/discover/flows',
+    icon: QueueListIcon,
+    activeColor: 'teal',
+    enabled: flows.length > 0,
   },
 ];
 ---

--- a/src/layouts/VisualiserLayout.astro
+++ b/src/layouts/VisualiserLayout.astro
@@ -1,19 +1,18 @@
 ---
 import BasicList from '@components/Lists/BasicList';
 import PlainPage from '@layouts/PlainPage.astro';
-import type { CollectionTypes } from '@types';
 import { getCommands } from '@utils/commands';
 import { getDomains } from '@utils/domains/domains';
 import { getEvents } from '@utils/events';
+import { getFlows } from '@utils/flows/flows';
 import { getServices } from '@utils/services/services';
 import { buildUrl } from '@utils/url-builder';
-import type { CollectionEntry } from 'astro:content';
 import { ViewTransitions } from 'astro:transitions';
 
-const [services, events, commands, domains] = await Promise.all([getServices(), getEvents(), getCommands(), getDomains()]);
+const [services, events, commands, domains, flows] = await Promise.all([getServices(), getEvents(), getCommands(), getDomains(), getFlows()]);
 
 // @ts-ignore for large catalogs https://github.com/event-catalog/eventcatalog/issues/552
-const navItems = [...domains, ...services, ...events, ...commands];
+const navItems = [...domains, ...services, ...events, ...commands, ...flows];
 
 const navigation = navItems.reduce((acc, item) => {
   //  @ts-ignore
@@ -24,6 +23,7 @@ const navigation = navItems.reduce((acc, item) => {
     [item.collection]: [...group, item],
   };
 }, {}) as any;
+
 
 const currentPath = Astro.url.pathname;
 const { title, description } = Astro.props;
@@ -55,6 +55,8 @@ const getColor = (collection: string) => {
           Object.keys(navigation).map((key: any) => {
             const items = navigation[key].map((item: any) => {
               const isCurrent = currentPath.includes(`${item.collection}/${item.data.id}/${item.data.version}`);
+              const isLatest = item.data.version === item.data.latestVersion;
+              if(!isLatest) return null;
               return {
                 label: item.data.name,
                 version: item.data.version,
@@ -62,7 +64,7 @@ const getColor = (collection: string) => {
                 href: buildUrl(`/visualiser/${item.collection}/${item.data.id}/${item.data.version}`),
                 active: isCurrent,
               };
-            });
+            }).filter((n: any) => n !== null);
             return (
               <BasicList
                 title={`${key} (${navigation[key].length})`}

--- a/src/layouts/VisualiserLayout.astro
+++ b/src/layouts/VisualiserLayout.astro
@@ -9,7 +9,13 @@ import { getServices } from '@utils/services/services';
 import { buildUrl } from '@utils/url-builder';
 import { ViewTransitions } from 'astro:transitions';
 
-const [services, events, commands, domains, flows] = await Promise.all([getServices(), getEvents(), getCommands(), getDomains(), getFlows()]);
+const [services, events, commands, domains, flows] = await Promise.all([
+  getServices(),
+  getEvents(),
+  getCommands(),
+  getDomains(),
+  getFlows(),
+]);
 
 // @ts-ignore for large catalogs https://github.com/event-catalog/eventcatalog/issues/552
 const navItems = [...domains, ...services, ...events, ...commands, ...flows];
@@ -23,7 +29,6 @@ const navigation = navItems.reduce((acc, item) => {
     [item.collection]: [...group, item],
   };
 }, {}) as any;
-
 
 const currentPath = Astro.url.pathname;
 const { title, description } = Astro.props;
@@ -53,18 +58,20 @@ const getColor = (collection: string) => {
       >
         {
           Object.keys(navigation).map((key: any) => {
-            const items = navigation[key].map((item: any) => {
-              const isCurrent = currentPath.includes(`${item.collection}/${item.data.id}/${item.data.version}`);
-              const isLatest = item.data.version === item.data.latestVersion;
-              if(!isLatest) return null;
-              return {
-                label: item.data.name,
-                version: item.data.version,
-                color: getColor(item.collection),
-                href: buildUrl(`/visualiser/${item.collection}/${item.data.id}/${item.data.version}`),
-                active: isCurrent,
-              };
-            }).filter((n: any) => n !== null);
+            const items = navigation[key]
+              .map((item: any) => {
+                const isCurrent = currentPath.includes(`${item.collection}/${item.data.id}/${item.data.version}`);
+                const isLatest = item.data.version === item.data.latestVersion;
+                if (!isLatest) return null;
+                return {
+                  label: item.data.name,
+                  version: item.data.version,
+                  color: getColor(item.collection),
+                  href: buildUrl(`/visualiser/${item.collection}/${item.data.id}/${item.data.version}`),
+                  active: isCurrent,
+                };
+              })
+              .filter((n: any) => n !== null);
             return (
               <BasicList
                 title={`${key} (${navigation[key].length})`}

--- a/src/pages/discover/[type]/index.astro
+++ b/src/pages/discover/[type]/index.astro
@@ -6,12 +6,14 @@ import type { CollectionTypes } from '@types';
 import { getCommands } from '@utils/commands';
 import { getServices } from '@utils/services/services';
 import { getDomains } from '@utils/domains/domains';
+import { getFlows } from '@utils/flows/flows';
 
 export async function getStaticPaths() {
   const events = await getEvents();
   const commands = await getCommands();
   const services = await getServices();
   const domains = await getDomains();
+  const flows = await getFlows();
 
   const buildPage = (type: string, collection: CollectionEntry<CollectionTypes>[]) => {
     return {
@@ -30,6 +32,7 @@ export async function getStaticPaths() {
     buildPage('commands', commands),
     buildPage('services', services),
     buildPage('domains', domains),
+    buildPage('flows', flows),
   ];
 }
 

--- a/src/pages/docs/[type]/[id]/[version]/index.astro
+++ b/src/pages/docs/[type]/[id]/[version]/index.astro
@@ -13,7 +13,7 @@ import MessageSideBar from '@components/SideBars/MessageSideBar.astro';
 import { getEvents } from '@utils/events';
 import { getServices } from '@utils/services/services';
 import { getCommands } from '@utils/commands';
-import { EnvelopeIcon, PencilIcon, RectangleGroupIcon, ServerIcon } from '@heroicons/react/24/outline';
+import { EnvelopeIcon, PencilIcon, QueueListIcon, RectangleGroupIcon, ServerIcon } from '@heroicons/react/24/outline';
 import { getDomains } from '@utils/domains/domains';
 import DomainSideBar from '@components/SideBars/DomainSideBar.astro';
 import type { CollectionTypes } from '@types';
@@ -73,7 +73,11 @@ const getBadge = () => {
     };
   }
 
-  return { backgroundColor: 'gray', textColor: 'gray', content: props.collection, icon: PencilIcon, class: 'text-gray'}
+  if (props.collection === 'flows') {
+    return { backgroundColor: 'teal', textColor: 'teal', content: 'Flow', icon: QueueListIcon, class: 'text-gray' };
+  }
+
+  return { backgroundColor: 'teal', textColor: 'teal', content: '', icon: QueueListIcon, class: 'text-gray'}
 };
 
 const badges = [getBadge(), ...contentBadges];

--- a/src/pages/docs/[type]/[id]/[version]/index.astro
+++ b/src/pages/docs/[type]/[id]/[version]/index.astro
@@ -19,12 +19,14 @@ import DomainSideBar from '@components/SideBars/DomainSideBar.astro';
 import type { CollectionTypes } from '@types';
 import SchemaViewer from '@components/MDX/SchemaViewer/SchemaViewer.astro';
 import { buildUrl } from '@utils/url-builder';
+import { getFlows } from '@utils/flows/flows';
 
 export async function getStaticPaths() {
   const events = await getEvents();
   const commands = await getCommands();
   const services = await getServices();
   const domains = await getDomains();
+  const flows = await getFlows();
 
   const buildPages = (collection: CollectionEntry<CollectionTypes>[]) => {
     return collection.map((item) => ({
@@ -40,7 +42,7 @@ export async function getStaticPaths() {
     }));
   };
 
-  return [...buildPages(domains), ...buildPages(events), ...buildPages(services), ...buildPages(commands)];
+  return [...buildPages(domains), ...buildPages(events), ...buildPages(services), ...buildPages(commands), ...buildPages(flows)];
 }
 
 const props = Astro.props;
@@ -70,6 +72,8 @@ const getBadge = () => {
       class: 'text-yellow-400',
     };
   }
+
+  return { backgroundColor: 'gray', textColor: 'gray', content: props.collection, icon: PencilIcon, class: 'text-gray'}
 };
 
 const badges = [getBadge(), ...contentBadges];

--- a/src/pages/docs/[type]/[id]/[version]/index.astro
+++ b/src/pages/docs/[type]/[id]/[version]/index.astro
@@ -77,7 +77,7 @@ const getBadge = () => {
     return { backgroundColor: 'teal', textColor: 'teal', content: 'Flow', icon: QueueListIcon, class: 'text-gray' };
   }
 
-  return { backgroundColor: 'teal', textColor: 'teal', content: '', icon: QueueListIcon, class: 'text-gray'}
+  return { backgroundColor: 'teal', textColor: 'teal', content: '', icon: QueueListIcon, class: 'text-gray' };
 };
 
 const badges = [getBadge(), ...contentBadges];

--- a/src/pages/visualiser/[type]/[id]/[version]/index.astro
+++ b/src/pages/visualiser/[type]/[id]/[version]/index.astro
@@ -5,12 +5,13 @@ import type { CollectionTypes } from '@types';
 import { getCommands } from '@utils/commands';
 import { getDomains } from '@utils/domains/domains';
 import { getEvents } from '@utils/events';
+import { getFlows } from '@utils/flows/flows';
 import { getServices } from '@utils/services/services';
 import { buildUrl } from '@utils/url-builder';
 import type { CollectionEntry } from 'astro:content';
 
 export async function getStaticPaths() {
-  const [services, events, commands, domains] = await Promise.all([getServices(), getEvents(), getCommands(), getDomains()]);
+  const [services, events, commands, domains, flows] = await Promise.all([getServices(), getEvents(), getCommands(), getDomains(), getFlows()]);
 
   const buildPages = (collection: CollectionEntry<CollectionTypes>[]) => {
     return collection.map((item) => ({
@@ -26,7 +27,7 @@ export async function getStaticPaths() {
     }));
   };
 
-  return [...buildPages(services), ...buildPages(events), ...buildPages(commands), ...buildPages(domains)];
+  return [...buildPages(services), ...buildPages(events), ...buildPages(commands), ...buildPages(domains), ...buildPages(flows)];
 }
 
 const props = Astro.props;

--- a/src/pages/visualiser/[type]/[id]/[version]/index.astro
+++ b/src/pages/visualiser/[type]/[id]/[version]/index.astro
@@ -11,7 +11,13 @@ import { buildUrl } from '@utils/url-builder';
 import type { CollectionEntry } from 'astro:content';
 
 export async function getStaticPaths() {
-  const [services, events, commands, domains, flows] = await Promise.all([getServices(), getEvents(), getCommands(), getDomains(), getFlows()]);
+  const [services, events, commands, domains, flows] = await Promise.all([
+    getServices(),
+    getEvents(),
+    getCommands(),
+    getDomains(),
+    getFlows(),
+  ]);
 
   const buildPages = (collection: CollectionEntry<CollectionTypes>[]) => {
     return collection.map((item) => ({

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,2 +1,2 @@
-export type CollectionTypes = 'commands' | 'events' | 'domains' | 'services';
+export type CollectionTypes = 'commands' | 'events' | 'domains' | 'services' | 'flows';
 export type CollectionMessageTypes = 'commands' | 'events';

--- a/src/utils/__tests__/flows/mocks.ts
+++ b/src/utils/__tests__/flows/mocks.ts
@@ -1,0 +1,122 @@
+export const mockEvents = [
+  {
+    slug: 'PaymentInitiated',
+    collection: 'events',
+    data: {
+      id: 'PaymentInitiated',
+      version: '0.0.1',
+    },
+  },
+  {
+    slug: 'PaymentProcessed',
+    collection: 'events',
+    data: {
+      id: 'PaymentProcessed',
+      version: '0.0.1',
+    },
+  },
+];
+
+export const mockFlow = [
+  {
+    id: 'Payment/PaymentProcessed/index.mdx',
+    slug: 'payment/paymentprocessed',
+    body: '',
+    collection: 'flows',
+    data: {
+      steps: [
+        {
+          id: 1,
+          type: 'node',
+          title: 'Order Placed',
+          next_step: {
+            id: 2,
+            label: 'Proceed to payment',
+          },
+        },
+        {
+          id: 2,
+          title: 'Payment Initiated',
+          message: {
+            id: 'PaymentInitiated',
+            version: '0.0.1',
+          },
+          next_steps: [
+            {
+              id: 3,
+              label: 'Payment successful',
+            },
+            {
+              id: 4,
+              label: 'Payment failed',
+            },
+          ],
+        },
+        {
+          id: 3,
+          title: 'Payment Processed',
+          message: {
+            id: 'PaymentProcessed',
+            version: '0.0.1',
+          },
+        },
+        {
+          id: 4,
+          type: 'node',
+          title: 'Payment Failed',
+        },
+      ],
+      id: 'PaymentFlow',
+      name: 'Payment Flow for E-commerce',
+      summary: 'Business flow for processing payments in an e-commerce platform',
+      version: '1.0.0',
+      type: 'node',
+    },
+  },
+];
+
+export const mockFlowByIds = [
+  {
+    id: 'Payment/PaymentProcessed/index.mdx',
+    slug: 'payment/paymentprocessed',
+    body: '',
+    collection: 'flows',
+    data: {
+      steps: [
+        {
+          id: 1,
+          type: 'node',
+          title: 'Order Placed',
+          next_step: 2,
+        },
+        {
+          id: 2,
+          title: 'Payment Initiated',
+          message: {
+            id: 'PaymentInitiated',
+            version: '0.0.1',
+          },
+          next_steps: [3, 4],
+        },
+        {
+          id: 3,
+          title: 'Payment Processed',
+          message: {
+            id: 'PaymentProcessed',
+            version: '0.0.1',
+          },
+        },
+        {
+          id: 4,
+          type: 'node',
+          title: 'Payment Failed',
+        },
+      ],
+      id: 'PaymentFlow',
+      name: 'Payment Flow for E-commerce',
+      summary: 'Business flow for processing payments in an e-commerce platform',
+      version: '1.0.0',
+      type: 'node',
+    },
+  },
+];

--- a/src/utils/__tests__/flows/node-graph.spec.ts
+++ b/src/utils/__tests__/flows/node-graph.spec.ts
@@ -1,0 +1,153 @@
+import { getNodesAndEdges } from '../../flows/node-graph';
+import { expect, describe, it, vi, beforeEach } from 'vitest';
+
+const mockEvents = [
+  {
+    slug: 'PaymentInitiated',
+    collection: 'events',
+    data: {
+      id: 'PaymentInitiated',
+      version: '0.0.1',
+    },
+  },
+  {
+    slug: 'PaymentProcessed',
+    collection: 'events',
+    data: {
+      id: 'PaymentProcessed',
+      version: '0.0.1',
+    },
+  },
+];
+
+const mockFlow = [
+  {
+    id: 'Payment/PaymentProcessed/index.mdx',
+    slug: 'payment/paymentprocessed',
+    body: '',
+    collection: 'flows',
+    data: {
+      steps: [
+        {
+          id: 1,
+          type: 'node',
+          title: 'Order Placed',
+          paths: [
+            {
+              step: 2,
+              label: 'Proceed to payment',
+            },
+          ],
+        },
+        {
+          id: 2,
+          title: 'Payment Initiated',
+          message: {
+            id: 'PaymentInitiated',
+            version: '0.0.1',
+          },
+          paths: [
+            {
+              step: 3,
+              label: 'Payment successful',
+            },
+            {
+              step: 4,
+              label: 'Payment failed',
+            },
+          ],
+        },
+        {
+          id: 3,
+          title: 'Payment Processed',
+          message: {
+            id: 'PaymentProcessed',
+            version: '0.0.1',
+          },
+        },
+        {
+          id: 4,
+          type: 'node',
+          title: 'Payment Failed',
+        },
+      ],
+      id: 'PaymentFlow',
+      name: 'Payment Flow for E-commerce',
+      summary: 'Business flow for processing payments in an e-commerce platform',
+      version: '1.0.0',
+      type: 'node',
+    },
+  },
+];
+
+vi.mock('astro:content', async (importOriginal) => {
+  return {
+    ...(await importOriginal<typeof import('astro:content')>()),
+    // this will only affect "foo" outside of the original module
+    getCollection: (key: string) => {
+      if (key === 'flows') {
+        return Promise.resolve(mockFlow);
+      }
+      if (key === 'events') {
+        return Promise.resolve(mockEvents);
+      }
+      return Promise.resolve([]);
+    },
+  };
+});
+
+describe('Flows NodeGraph', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('getNodesAndEdges', () => {
+    it.only('should return nodes and edges for a given flow', async () => {
+      const { nodes, edges } = await getNodesAndEdges({ id: 'PaymentFlow', version: '1.0.0' });
+
+      const expectedNodes = [
+        {
+          id: 'step-1',
+          sourcePosition: 'right',
+          targetPosition: 'left',
+          data: expect.anything(),
+          position: { x: expect.any(Number), y: expect.any(Number) },
+          type: 'node',
+        },
+        {
+          id: 'step-2',
+          sourcePosition: 'right',
+          targetPosition: 'left',
+          data: expect.anything(),
+          position: { x: expect.any(Number), y: expect.any(Number) },
+          type: 'message',
+        },
+      ];
+
+      const expectedEdges = [
+        {
+          id: 'step-1-step-2',
+          source: 'step-1',
+          target: 'step-2',
+          type: 'smoothstep',
+          label: 'Proceed to payment',
+          animated: false,
+          markerEnd: { type: 'arrow' },
+        },
+      ];
+
+      expect(nodes).toEqual(
+        expect.arrayContaining([expect.objectContaining(expectedNodes[0]), expect.objectContaining(expectedNodes[1])])
+      );
+
+      expect(edges[0]).toEqual(expectedEdges[0]);
+    });
+
+    it('returns empty nodes and edges if no flow is found', async () => {
+      const { nodes, edges } = await getNodesAndEdges({ id: 'UnknownFlow', version: '1.0.0' });
+
+      expect(nodes).toEqual([]);
+      expect(edges).toEqual([]);
+    });
+  });
+});

--- a/src/utils/config/catalog.ts
+++ b/src/utils/config/catalog.ts
@@ -9,6 +9,7 @@ export type CatalogConfig = {
     sidebar: {
       showPageHeadings?: boolean;
       domains?: SideBarItemConfig;
+      flows?: SideBarItemConfig;
       services?: SideBarItemConfig;
       messages?: SideBarItemConfig;
       teams?: SideBarItemConfig;

--- a/src/utils/flows/flows.ts
+++ b/src/utils/flows/flows.ts
@@ -1,0 +1,84 @@
+import { getVersionForCollectionItem, getVersions } from '@utils/collections/util';
+import { getCollection } from 'astro:content';
+import type { CollectionEntry } from 'astro:content';
+import path from 'path';
+
+const PROJECT_DIR = process.env.PROJECT_DIR || process.cwd();
+
+export type Flow = CollectionEntry<'flows'>;
+
+// export const getVersion = (collection: CollectionEntry<'events' | 'commands'>[], id: string, version?: string) => {
+//   const data = collection;
+//   if (version) {
+//     return data.find((event) => event.data.version === version && event.data.id === id);
+//   }
+
+//   const filteredEvents = data.filter((event) => event.data.id === id);
+
+//   // Order by version
+//   const sorted = filteredEvents.sort((a, b) => {
+//     return a.data.version.localeCompare(b.data.version);
+//   });
+
+//   // latest version
+//   return sorted[sorted.length - 1];
+// };
+
+interface Props {
+  getAllVersions?: boolean;
+}
+
+export const getFlows = async ({ getAllVersions = true }: Props = {}): Promise<Flow[]> => {
+  // Get flows that are not versioned
+  const flows = await getCollection('flows', (flow) => {
+    return (getAllVersions || !flow.slug.includes('versioned')) && flow.data.hidden !== true;
+  });
+
+
+  // const events = await getCollection('events');
+  // const commands = await getCollection('commands');
+
+  // const allMessages = [...events, ...commands];
+
+  // @ts-ignore // TODO: Fix this type
+  return flows.map((flow) => {
+    // @ts-ignore
+    const { latestVersion, versions } = getVersionForCollectionItem(flow, flows);
+
+    // // const receives = service.data.receives || [];
+    // const sendsMessages = service.data.sends || [];
+    // const receivesMessages = service.data.receives || [];
+
+    // const sends = sendsMessages
+    //   .map((message) => {
+    //     const event = getVersion(allMessages, message.id, message.version);
+    //     // const event = allMessages.find((_message) => _message.data.id === message.id && _message.data.version === message.version);
+    //     return event;
+    //   })
+    //   .filter((e) => e !== undefined);
+
+    // const receives = receivesMessages
+    //   .map((message) => {
+    //     const event = getVersion(allMessages, message.id, message.version);
+    //     // const event = allMessages.find((_message) => _message.data.id === message.id && _message.data.version === message.version);
+    //     return event;
+    //   })
+    //   .filter((e) => e !== undefined);
+
+    return {
+      ...flow,
+      data: {
+        ...flow.data,
+        versions,
+        latestVersion,
+      },
+      catalog: {
+        path: path.join(flow.collection, flow.id.replace('/index.mdx', '')),
+        absoluteFilePath: path.join(PROJECT_DIR, flow.collection, flow.id.replace('/index.mdx', '/index.md')),
+        filePath: path.join(process.cwd(), 'src', 'catalog-files', flow.collection, flow.id.replace('/index.mdx', '')),
+        publicPath: path.join('/generated', flow.collection, flow.id.replace('/index.mdx', '')),
+        type: 'flow',
+      },
+    };
+  });
+};

--- a/src/utils/flows/flows.ts
+++ b/src/utils/flows/flows.ts
@@ -35,7 +35,6 @@ export const getFlows = async ({ getAllVersions = true }: Props = {}): Promise<F
     return (getAllVersions || !flow.slug.includes('versioned')) && flow.data.hidden !== true;
   });
 
-
   const events = await getCollection('events');
   const commands = await getCollection('commands');
 
@@ -48,14 +47,14 @@ export const getFlows = async ({ getAllVersions = true }: Props = {}): Promise<F
     const steps = flow.data.steps || [];
 
     const hydrateSteps = steps.map((step) => {
-      if(!step.message) return { ...flow, data: { ...flow.data, type: 'node' } };
+      if (!step.message) return { ...flow, data: { ...flow.data, type: 'node' } };
       const message = getVersion(allMessages, step.message.id, step.message.version);
       return {
         ...step,
         type: 'message',
         message: message,
       };
-    })
+    });
 
     return {
       ...flow,

--- a/src/utils/flows/flows.ts
+++ b/src/utils/flows/flows.ts
@@ -8,23 +8,6 @@ const PROJECT_DIR = process.env.PROJECT_DIR || process.cwd();
 
 export type Flow = CollectionEntry<'flows'>;
 
-// export const getVersion = (collection: CollectionEntry<'events' | 'commands'>[], id: string, version?: string) => {
-//   const data = collection;
-//   if (version) {
-//     return data.find((event) => event.data.version === version && event.data.id === id);
-//   }
-
-//   const filteredEvents = data.filter((event) => event.data.id === id);
-
-//   // Order by version
-//   const sorted = filteredEvents.sort((a, b) => {
-//     return a.data.version.localeCompare(b.data.version);
-//   });
-
-//   // latest version
-//   return sorted[sorted.length - 1];
-// };
-
 interface Props {
   getAllVersions?: boolean;
 }

--- a/src/utils/flows/flows.ts
+++ b/src/utils/flows/flows.ts
@@ -1,4 +1,5 @@
 import { getVersionForCollectionItem, getVersions } from '@utils/collections/util';
+import { getVersion } from '@utils/services/services';
 import { getCollection } from 'astro:content';
 import type { CollectionEntry } from 'astro:content';
 import path from 'path';
@@ -35,40 +36,32 @@ export const getFlows = async ({ getAllVersions = true }: Props = {}): Promise<F
   });
 
 
-  // const events = await getCollection('events');
-  // const commands = await getCollection('commands');
+  const events = await getCollection('events');
+  const commands = await getCollection('commands');
 
-  // const allMessages = [...events, ...commands];
+  const allMessages = [...events, ...commands];
 
   // @ts-ignore // TODO: Fix this type
   return flows.map((flow) => {
     // @ts-ignore
     const { latestVersion, versions } = getVersionForCollectionItem(flow, flows);
+    const steps = flow.data.steps || [];
 
-    // // const receives = service.data.receives || [];
-    // const sendsMessages = service.data.sends || [];
-    // const receivesMessages = service.data.receives || [];
-
-    // const sends = sendsMessages
-    //   .map((message) => {
-    //     const event = getVersion(allMessages, message.id, message.version);
-    //     // const event = allMessages.find((_message) => _message.data.id === message.id && _message.data.version === message.version);
-    //     return event;
-    //   })
-    //   .filter((e) => e !== undefined);
-
-    // const receives = receivesMessages
-    //   .map((message) => {
-    //     const event = getVersion(allMessages, message.id, message.version);
-    //     // const event = allMessages.find((_message) => _message.data.id === message.id && _message.data.version === message.version);
-    //     return event;
-    //   })
-    //   .filter((e) => e !== undefined);
+    const hydrateSteps = steps.map((step) => {
+      if(!step.message) return { ...flow, data: { ...flow.data, type: 'node' } };
+      const message = getVersion(allMessages, step.message.id, step.message.version);
+      return {
+        ...step,
+        type: 'message',
+        message: message,
+      };
+    })
 
     return {
       ...flow,
       data: {
         ...flow.data,
+        steps: hydrateSteps,
         versions,
         latestVersion,
       },

--- a/src/utils/flows/node-graph.ts
+++ b/src/utils/flows/node-graph.ts
@@ -1,4 +1,3 @@
-// import { getColor } from '@utils/colors';
 import { getCollection, type CollectionEntry } from 'astro:content';
 import dagre from 'dagre';
 import { getVersion } from '../services/services';

--- a/src/utils/flows/node-graph.ts
+++ b/src/utils/flows/node-graph.ts
@@ -3,7 +3,8 @@ import { getCollection, type CollectionEntry } from 'astro:content';
 import dagre from 'dagre';
 import { getVersion } from '../services/services';
 import { createDagreGraph, calculatedNodes } from '@utils/node-graph-utils/utils';
-import { MarkerType, Node } from 'reactflow';
+import { MarkerType } from 'reactflow';
+import type { Node as NodeType } from 'reactflow';
 
 type DagreGraph = any;
 
@@ -83,7 +84,7 @@ export const getNodesAndEdges = async ({ id, defaultFlow, version, mode = 'simpl
       },
       position: { x: 250, y: index * 150 },
       type: step.type,
-    } as Node;
+    } as NodeType;
 
     if (step.service) node.data.service = step.service;
     if (step.message) node.data.message = step.message;
@@ -98,8 +99,8 @@ export const getNodesAndEdges = async ({ id, defaultFlow, version, mode = 'simpl
     let paths = step.next_steps || [];
 
     if (step.next_step) {
-      // If its a string
-      if (typeof step.next_step === 'string') {
+      // If its a string or number
+      if (!step.next_step?.id) {
         paths = [{ id: step.next_step }];
       } else {
         paths = [step.next_step];

--- a/src/utils/flows/node-graph.ts
+++ b/src/utils/flows/node-graph.ts
@@ -1,0 +1,147 @@
+// import { getColor } from '@utils/colors';
+import { getCollection } from 'astro:content';
+import dagre from 'dagre';
+import { getVersion } from '../services/services';
+import { createDagreGraph, calculatedNodes } from '@utils/node-graph-utils/utils';
+import { MarkerType } from 'reactflow';
+
+type DagreGraph = any;
+
+interface Props {
+  id: string;
+  version: string;
+  defaultFlow?: DagreGraph;
+  mode?: 'simple' | 'full';
+  renderAllEdges?: boolean;
+}
+
+export const getNodesAndEdges = async ({ id, defaultFlow, version, mode = 'simple', renderAllEdges = false }: Props) => {
+  const graph = defaultFlow || createDagreGraph({ ranksep: 300, nodesep: 200 });
+  const nodes = [] as any,
+    edges = [] as any;
+
+  const flows = await getCollection('flows');
+  const flow = flows.find((flow) => flow.data.id === id && flow.data.version === version);
+
+  // Nothing found...
+  if (!flow) {
+    return {
+      nodes: [],
+      edges: [],
+    };
+  }
+
+  const events = await getCollection('events');
+  const commands = await getCollection('commands');
+  const services = await getCollection('services');
+
+  const messages = [...events, ...commands];
+
+  const steps = flow?.data.steps || [];
+  const hydratedSteps = steps.map((step: any) => {
+    const type = step.type || 'step';
+
+    
+
+    if (step.service) {
+      const service = services.find(
+        (service) => service.data.id === step.service.id && service.data.version === step.service.version
+      );
+      return {
+        ...step,
+        type: service ? service.collection : type,
+        service,
+      };
+    }
+
+    if (step.message) {
+      const message = getVersion(messages, step.message.id, step.message.version);
+      return {
+        ...step,
+        type: message ? message.collection : type,
+        message,
+      };
+    }
+
+    if (step.actor) {
+      return {
+        ...step,
+        type: 'actor',
+        actor: step.actor,
+      };
+    }
+
+    if (step.externalSystem) {
+      return {
+        ...step,
+        type: 'externalSystem',
+        externalSystem: step.externalSystem,
+      };
+    }
+
+    return { ...step, type: 'step' };
+  });
+
+  // Create nodes
+  hydratedSteps.forEach((step, index: number) => {
+    nodes.push({
+      id: `step-${step.id}`,
+      sourcePosition: 'right',
+      targetPosition: 'left',
+      data: {
+        mode,
+        step: step,
+        message: step.message,
+        service: step.service,
+        actor: step.actor,
+        externalSystem: step.externalSystem,
+        showTarget: true,
+        showSource: true,
+      },
+      position: { x: 250, y: index * 150 },
+      type: step.type,
+    });
+  });
+
+
+  // Create Edges
+  hydratedSteps.forEach((step, index: number) => {
+    const paths = step.paths || [];
+    paths.forEach((path: any) => {
+      edges.push({
+        id: `step-${step.id}-step-${path.step}`,
+        source: `step-${step.id}`,
+        target: `step-${path.step}`,
+        type: 'smoothstep',
+        label: path.label,
+        animated: true,
+        markerEnd: {
+          type: MarkerType.ArrowClosed,
+          width: 20,
+          height: 20,
+          color: '#742fca75',
+        },
+        style: {
+          strokeWidth: 2,
+          stroke: '#742fca75',
+        },
+      });
+    });
+  });
+
+  nodes.forEach((node: any) => {
+    graph.setNode(node.id, { width: 150, height: 100 });
+  });
+
+  edges.forEach((edge: any) => {
+    graph.setEdge(edge.source, edge.target);
+  });
+
+  // Render the diagram in memory getting hte X and Y
+  dagre.layout(graph);
+
+  return {
+    nodes: calculatedNodes(graph, nodes),
+    edges: edges,
+  };
+};

--- a/src/utils/services/node-graph.ts
+++ b/src/utils/services/node-graph.ts
@@ -15,7 +15,7 @@ interface Props {
 }
 
 export const getNodesAndEdges = async ({ id, defaultFlow, version, mode = 'simple', renderAllEdges = false }: Props) => {
-  const flow = defaultFlow || createDagreGraph({ ranksep: 200, nodesep: 50 });
+  const flow = defaultFlow || createDagreGraph({ ranksep: 300, nodesep: 50 });
   const nodes = [] as any,
     edges = [] as any;
 

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -7,6 +7,7 @@ export default {
   safelist: [
     {pattern: /border-.*-(200|400|500)/},
     {pattern: /bg-.*-(100|200|400|500)/},
+    {pattern: /from-.*-(100|200|400|500|700)/},
     {pattern: /text-.*-(400|500|800)/},
     'border-blue-200',
     'border-green-300',


### PR DESCRIPTION
New feature for EventCatalog that allows users to document "flows".

Flows are way to document processes or EDA choreography across your domains, services and messages.

Flows API allows you to define "steps" for a particular feature. An example of this would be capturing a payment from a user.


## Example

An example of a "flow" would be capturing a payment from a user.

When a payment is captured from a user commands are sent, and events are raised. Services are also involved as well as external systems. From end-to-end many commands, events and services will be interacted with. Flows allows you to document this, version it and visualize it.