### PR TITLE
fix: pagefind not found

### DIFF
--- a/.changeset/few-seas-know.md
+++ b/.changeset/few-seas-know.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": minor
+---
+
+fix(core): fixing search not working after builds

--- a/bin/eventcatalog.ts
+++ b/bin/eventcatalog.ts
@@ -56,10 +56,15 @@ const copyCore = () => {
   });
 };
 
+const clearCore = () => {
+  if (fs.existsSync(core)) fs.rmSync(core, { recursive: true });
+};
+
 program
   .command('dev')
   .description('Run development server of EventCatalog')
   .option('-d, --debug', 'Output EventCatalog application information into your terminal')
+  .option('--force-recreate', 'Recreate the eventcatalog-core directory', false)
   .action((options) => {
     // // Copy EventCatalog core over
     console.log('Setting up EventCatalog....');
@@ -70,6 +75,7 @@ program
       console.log('CATALOG_DIR', core);
     }
 
+    if (options.forceRecreate) clearCore();
     copyCore();
 
     // // Copy the config and styles

--- a/bin/eventcatalog.ts
+++ b/bin/eventcatalog.ts
@@ -41,11 +41,6 @@ const ensureDir = (dir: string) => {
 };
 
 const copyCore = () => {
-  // First empty the core directory.
-  if (fs.existsSync(core)) {
-    fs.rmSync(core, { recursive: true });
-  }
-
   // make sure the core folder exists
   ensureDir(core);
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://github.com/event-catalog/eventcatalog/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Currently, running the `eventcatalog build` generates the `dist` folder with the `pagefind` index. After, running `eventcatalog dev`, the `.eventcatalog-core` is emptied by by the `copyCore` remnoving the `pagefind` index. 

This PR removes the empty core dir from `copyCore`, keeping the dist folder between commands if needed. 

Resolves #645.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/event-catalog/eventcatalog/blob/main/CONTRIBUTING.md#pull-requests)?

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/event-catalog/eventcatalog/blob/main/CONTRIBUTING.md#pull-requests)
