### PR TITLE
fix: semver domains

### DIFF
--- a/.changeset/orange-goats-yell.md
+++ b/.changeset/orange-goats-yell.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": minor
+---
+
+fix(core): nodegraphs for domains now work with semver versions

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@eventcatalog/core",
-  "version": "2.3.3",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@eventcatalog/core",
-      "version": "2.3.3",
+      "version": "2.4.0",
       "dependencies": {
         "@astrojs/check": "^0.7.0",
         "@astrojs/markdown-remark": "^5.1.0",
@@ -29,6 +29,7 @@
         "dagre": "^0.8.5",
         "glob": "^10.4.1",
         "html-to-image": "^1.11.11",
+        "lodash.merge": "4.6.2",
         "mermaid": "^10.9.1",
         "rapidoc": "^9.3.4",
         "react": "^18.3.1",
@@ -46,6 +47,7 @@
       },
       "devDependencies": {
         "@parcel/watcher": "^2.4.1",
+        "@types/lodash.merge": "4.6.9",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
         "commander": "^12.1.0",
@@ -6358,6 +6360,23 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
     },
+    "node_modules/@types/lodash": {
+      "version": "4.17.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.7.tgz",
+      "integrity": "sha512-8wTvZawATi/lsmNu10/j2hk1KEP0IvjubqPE3cu1Xz7xfXXt5oCq3SNUz4fMIP4XGF9Ky+Ue2tBA3hcS7LSBlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash.merge": {
+      "version": "4.6.9",
+      "resolved": "https://registry.npmjs.org/@types/lodash.merge/-/lodash.merge-4.6.9.tgz",
+      "integrity": "sha512-23sHDPmzd59kUgWyKGiOMO2Qb9YtqRO/x4IhkgNUiPQ1+5MUVqi6bCZeq9nBJ17msjIMbEIO5u+XW4Kz6aGUhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash": "*"
+      }
+    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -11271,7 +11290,8 @@
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "license": "MIT"
     },
     "node_modules/lodash.sortby": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "dagre": "^0.8.5",
     "glob": "^10.4.1",
     "html-to-image": "^1.11.11",
+    "lodash.merge": "4.6.2",
     "mermaid": "^10.9.1",
     "rapidoc": "^9.3.4",
     "react": "^18.3.1",
@@ -65,6 +66,7 @@
   },
   "devDependencies": {
     "@parcel/watcher": "^2.4.1",
+    "@types/lodash.merge": "4.6.9",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "commander": "^12.1.0",

--- a/src/utils/__tests__/domains/domains.spec.ts
+++ b/src/utils/__tests__/domains/domains.spec.ts
@@ -1,0 +1,53 @@
+import type { ContentCollectionKey } from 'astro:content';
+import { expect, describe, it, vi } from 'vitest';
+import { mockDomains, mockServices, mockEvents, mockCommands } from './mocks';
+import { getDomains } from '../../domains/domains';
+
+vi.mock('astro:content', async (importOriginal) => {
+  return {
+    ...(await importOriginal<typeof import('astro:content')>()),
+    // this will only affect "foo" outside of the original module
+    getCollection: (key: ContentCollectionKey) => {
+      switch (key) {
+        case 'domains':
+          return Promise.resolve(mockDomains);
+        case 'services':
+          return Promise.resolve(mockServices);
+        case 'events':
+          return Promise.resolve(mockEvents);
+        case 'commands':
+          return Promise.resolve(mockCommands);
+        default:
+          return Promise.resolve([]);
+      }
+    },
+  };
+});
+
+describe('Domains', () => {
+  describe('getDomains', () => {
+    it('should returns an array of domains with services using semver or latest', async () => {
+      const domains = await getDomains();
+
+      const expectedDomains = [
+        // Shipping
+        {
+          ...mockDomains[0],
+          data: expect.objectContaining({ services: [mockServices[0]] }),
+        },
+        // Checkout
+        {
+          ...mockDomains[1],
+          data: expect.objectContaining({ services: [mockServices[2], mockServices[3]] }),
+        },
+        // Notification
+        {
+          ...mockDomains[2],
+          data: expect.objectContaining({ services: [] }),
+        },
+      ];
+
+      expect(domains).toEqual(expect.arrayContaining(expectedDomains.map((d) => expect.objectContaining(d))));
+    });
+  });
+});

--- a/src/utils/__tests__/domains/mocks.ts
+++ b/src/utils/__tests__/domains/mocks.ts
@@ -1,0 +1,181 @@
+export const mockDomains = [
+  {
+    id: 'domains/Shipping/index.mdx',
+    slug: 'domains/Shipping',
+    data: {
+      id: 'Shipping',
+      name: 'Shipping',
+      version: '0.0.1',
+      services: [{ id: 'LocationService', version: '0.0.1' }],
+    },
+  },
+  {
+    id: 'domains/Checkout/index.mdx',
+    slug: 'domains/Checkout',
+    data: {
+      id: 'Checkout',
+      name: 'Checkout',
+      version: '0.0.1',
+      services: [{ id: 'OrderService', version: '1.0.0' }, { id: 'PaymentService' }],
+    },
+  },
+];
+
+export const mockServices = [
+  {
+    id: 'services/LocationService/index.mdx',
+    slug: 'services/LocationService',
+    collection: 'services',
+    data: {
+      id: 'LocationService',
+      version: '0.0.1',
+      receives: [{ id: 'OrderPlaced', version: '0.0.1' }],
+    },
+  },
+  {
+    id: 'services/OrderService/versioned/001/index.mdx',
+    slug: 'services/OrderService/versioned/001',
+    collection: 'services',
+    data: {
+      id: 'OrderService',
+      version: '0.0.1',
+      receives: [{ id: 'PlaceOrder', version: '>1.5.0' }],
+      sends: [{ id: 'OrderPlaced', version: '0.0.1' }],
+    },
+  },
+  {
+    id: 'services/OrderService/index.mdx',
+    slug: 'services/OrderService',
+    collection: 'services',
+    data: {
+      id: 'OrderService',
+      version: '1.0.0',
+      receives: [{ id: 'PlaceOrder', version: '>1.5.0' }],
+      sends: [{ id: 'OrderPlaced', version: '0.0.1' }],
+    },
+  },
+  {
+    id: 'services/PaymentService/index.mdx',
+    slug: 'services/PaymentService',
+    collection: 'services',
+    data: {
+      id: 'PaymentService',
+      version: '0.0.1',
+      receives: [{ id: 'OrderPlaced' }],
+      sends: [{ id: 'PaymentPaid', version: 'x' }, { id: 'PaymentRefunded' }, { id: 'PaymentFailed', version: '^1.0.0' }],
+    },
+  },
+];
+
+export const mockCommands = [
+  // PlaceOrder
+  {
+    id: 'commands/PlaceOrder/versioned/100/index.mdx',
+    slug: 'commands/PlaceOrder/versoined/100',
+    collection: 'commands',
+    data: {
+      id: 'PlaceOrder',
+      version: '1.0.0',
+    },
+  },
+  {
+    id: 'commands/PlaceOrder/versioned/150/index.mdx',
+    slug: 'commands/PlaceOrder/versoined/150',
+    collection: 'commands',
+    data: {
+      id: 'PlaceOrder',
+      version: '1.5.0',
+    },
+  },
+  {
+    id: 'commands/PlaceOrder/versioned/177/index.mdx',
+    slug: 'commands/PlaceOrder/versoined/177',
+    collection: 'commands',
+    data: {
+      id: 'PlaceOrder',
+      version: '1.7.7',
+    },
+  },
+];
+
+export const mockEvents = [
+  // OrderPlaced
+  {
+    id: 'events/OrderPlaced/index.mdx',
+    slug: 'events/OrderPlaced',
+    collection: 'events',
+    data: {
+      id: 'OrderPlaced',
+      version: '0.0.1',
+    },
+  },
+
+  // PaymentPaid
+  {
+    id: 'events/PaymentPaid/versioned/001/index.mdx',
+    slug: 'events/PaymentPaid/versioned/001',
+    collection: 'events',
+    data: {
+      id: 'PaymentPaid',
+      version: '0.0.1',
+    },
+  },
+  {
+    id: 'events/PaymentPaid/index.mdx',
+    slug: 'events/PaymentPaid',
+    collection: 'events',
+    data: {
+      id: 'PaymentPaid',
+      version: '0.0.2',
+    },
+  },
+
+  // PaymentRefunded
+  {
+    id: 'events/PaymentRefunded/index.mdx',
+    slug: 'events/PaymentRefunded',
+    collection: 'events',
+    data: {
+      id: 'PaymentRefunded',
+      version: '0.0.1',
+    },
+  },
+  {
+    id: 'events/PaymentRefunded/index.mdx',
+    slug: 'events/PaymentRefunded',
+    collection: 'events',
+    data: {
+      id: 'PaymentRefunded',
+      version: '1.0.0',
+    },
+  },
+
+  // PaymentFailed
+  {
+    id: 'events/PaymentFailed/index.mdx',
+    slug: 'events/PaymentFailed',
+    collection: 'events',
+    data: {
+      id: 'PaymentFailed',
+      version: '0.0.1',
+    },
+  },
+  {
+    id: 'events/PaymentFailed/index.mdx',
+    slug: 'events/PaymentFailed',
+    collection: 'events',
+    data: {
+      id: 'PaymentFailed',
+      version: '1.0.0',
+    },
+  },
+  {
+    id: 'events/PaymentFailed/index.mdx',
+    slug: 'events/PaymentFailed',
+    collection: 'events',
+    data: {
+      id: 'PaymentFailed',
+      version: '2.0.0',
+    },
+  },
+];

--- a/src/utils/__tests__/domains/mocks.ts
+++ b/src/utils/__tests__/domains/mocks.ts
@@ -2,6 +2,7 @@ export const mockDomains = [
   {
     id: 'domains/Shipping/index.mdx',
     slug: 'domains/Shipping',
+    collection: 'domains',
     data: {
       id: 'Shipping',
       name: 'Shipping',
@@ -12,11 +13,23 @@ export const mockDomains = [
   {
     id: 'domains/Checkout/index.mdx',
     slug: 'domains/Checkout',
+    collection: 'domains',
     data: {
       id: 'Checkout',
       name: 'Checkout',
       version: '0.0.1',
-      services: [{ id: 'OrderService', version: '1.0.0' }, { id: 'PaymentService' }],
+      services: [{ id: 'OrderService' /* version: latest */ }, { id: 'PaymentService', version: '0.0.1' }],
+    },
+  },
+  {
+    id: 'domains/Notification/index.mdx',
+    slug: 'domains/Notification',
+    collection: 'domains',
+    data: {
+      id: 'Notification',
+      name: 'Notification',
+      version: '0.0.1',
+      services: [{ id: 'MailService' }],
     },
   },
 ];

--- a/src/utils/__tests__/domains/node-graph.spec.ts
+++ b/src/utils/__tests__/domains/node-graph.spec.ts
@@ -1,0 +1,234 @@
+import type { ContentCollectionKey } from 'astro:content';
+import { expect, describe, it, vi } from 'vitest';
+import { mockDomains, mockServices, mockEvents, mockCommands } from './mocks';
+import { getNodesAndEdges } from '../../domains/node-graph';
+
+vi.mock('astro:content', async (importOriginal) => {
+  return {
+    ...(await importOriginal<typeof import('astro:content')>()),
+    // this will only affect "foo" outside of the original module
+    getCollection: (key: ContentCollectionKey) => {
+      switch (key) {
+        case 'domains':
+          return Promise.resolve(mockDomains);
+        case 'services':
+          return Promise.resolve(mockServices);
+        case 'events':
+          return Promise.resolve(mockEvents);
+        case 'commands':
+          return Promise.resolve(mockCommands);
+        default:
+          return Promise.resolve([]);
+      }
+    },
+  };
+});
+
+describe('Domains NodeGraph', () => {
+  describe('getNodesAndEdges', () => {
+    it('returns an empty array if no domains are found', async () => {
+      const { nodes, edges } = await getNodesAndEdges({ id: 'UnknownDomain', version: '1.0.0' });
+
+      expect(nodes).toEqual([]);
+      expect(edges).toEqual([]);
+    });
+
+    it('should return nodes and edges for a given domain', async () => {
+      const { nodes, edges } = await getNodesAndEdges({ id: 'Shipping', version: '0.0.1' });
+
+      const expectedServiceNode = {
+        id: 'LocationService-0.0.1',
+        type: 'services',
+        sourcePosition: 'right',
+        targetPosition: 'left',
+        data: { mode: 'simple', service: mockServices[0], showSource: false, showTarget: true },
+        position: { x: expect.any(Number), y: expect.any(Number) },
+      };
+
+      const expectedEventNode = {
+        id: 'OrderPlaced-0.0.1',
+        sourcePosition: 'right',
+        targetPosition: 'left',
+        data: { mode: 'simple', message: mockEvents[0], showTarget: true },
+        position: { x: expect.any(Number), y: expect.any(Number) },
+        type: 'events',
+      };
+
+      const expectedEdges = [
+        {
+          id: 'OrderPlaced-0.0.1-LocationService-0.0.1',
+          source: 'OrderPlaced-0.0.1',
+          target: 'LocationService-0.0.1',
+          type: 'smoothstep',
+          label: 'receives event',
+          animated: false,
+          markerEnd: { type: 'arrow' },
+        },
+      ];
+
+      expect(nodes).toEqual(
+        expect.arrayContaining([
+          // Nodes on the left
+          expect.objectContaining(expectedEventNode),
+
+          // The command node itself
+          expect.objectContaining(expectedServiceNode),
+        ])
+      );
+
+      expect(edges).toEqual(expectedEdges);
+    });
+
+    it('should return nodes and edges for a given domain with services using semver range or latest version (version undefind)', async () => {
+      const { nodes, edges } = await getNodesAndEdges({ id: 'Checkout', version: '0.0.1' });
+
+      const expectedNodes = [
+        {
+          id: 'PlaceOrder-1.7.7',
+          sourcePosition: 'right',
+          targetPosition: 'left',
+          data: { mode: 'simple', message: mockCommands[2], showTarget: true },
+          position: { x: expect.any(Number), y: expect.any(Number) },
+          type: 'commands',
+        },
+        {
+          id: 'OrderService-1.0.0',
+          sourcePosition: 'right',
+          targetPosition: 'left',
+          data: {
+            mode: 'simple',
+            service: mockServices[2],
+            showSource: true,
+            showTarget: true,
+          },
+          position: { x: expect.any(Number), y: expect.any(Number) },
+          type: 'services',
+        },
+        {
+          id: 'OrderPlaced-0.0.1',
+          sourcePosition: 'right',
+          targetPosition: 'left',
+          data: { mode: 'simple', message: mockEvents[0], showSource: true, showTarget: true },
+          position: { x: expect.any(Number), y: expect.any(Number) },
+          type: 'events',
+        },
+        /** PAYMENT SERVICE */
+        {
+          id: 'PaymentService-0.0.1',
+          sourcePosition: 'right',
+          targetPosition: 'left',
+          data: {
+            mode: 'simple',
+            service: mockServices[3],
+            showSource: true,
+            showTarget: true,
+          },
+          position: { x: expect.any(Number), y: expect.any(Number) },
+          type: 'services',
+        },
+        {
+          id: 'PaymentPaid-0.0.1',
+          sourcePosition: 'right',
+          targetPosition: 'left',
+          data: { mode: 'simple', message: mockEvents[1], showSource: true },
+          position: { x: expect.any(Number), y: expect.any(Number) },
+          type: 'events',
+        },
+        {
+          id: 'PaymentPaid-0.0.2',
+          sourcePosition: 'right',
+          targetPosition: 'left',
+          data: { mode: 'simple', message: mockEvents[2], showSource: true },
+          position: { x: expect.any(Number), y: expect.any(Number) },
+          type: 'events',
+        },
+        {
+          id: 'PaymentRefunded-1.0.0',
+          sourcePosition: 'right',
+          targetPosition: 'left',
+          data: { mode: 'simple', message: mockEvents[4], showSource: true },
+          position: { x: expect.any(Number), y: expect.any(Number) },
+          type: 'events',
+        },
+        {
+          id: 'PaymentFailed-1.0.0',
+          sourcePosition: 'right',
+          targetPosition: 'left',
+          data: { mode: 'simple', message: mockEvents[6], showSource: true },
+          position: { x: expect.any(Number), y: expect.any(Number) },
+          type: 'events',
+        },
+      ];
+
+      const expectedEdges = [
+        {
+          id: 'PlaceOrder-1.7.7-OrderService-1.0.0',
+          source: 'PlaceOrder-1.7.7',
+          target: 'OrderService-1.0.0',
+          type: 'smoothstep',
+          label: 'accepts',
+          animated: false,
+          markerEnd: { type: 'arrow' },
+        },
+        {
+          id: 'OrderService-1.0.0-OrderPlaced-0.0.1',
+          source: 'OrderService-1.0.0',
+          target: 'OrderPlaced-0.0.1',
+          type: 'smoothstep',
+          label: 'publishes event',
+          animated: false,
+          markerEnd: { type: 'arrow' },
+        },
+        {
+          id: 'OrderPlaced-0.0.1-PaymentService-0.0.1',
+          source: 'OrderPlaced-0.0.1',
+          target: 'PaymentService-0.0.1',
+          type: 'smoothstep',
+          label: 'receives event',
+          animated: false,
+          markerEnd: { type: 'arrow' },
+        },
+        {
+          id: 'PaymentService-0.0.1-PaymentRefunded-1.0.0',
+          source: 'PaymentService-0.0.1',
+          target: 'PaymentRefunded-1.0.0',
+          type: 'smoothstep',
+          label: 'publishes event',
+          animated: false,
+          markerEnd: { type: 'arrow' },
+        },
+        {
+          id: 'PaymentService-0.0.1-PaymentFailed-1.0.0',
+          source: 'PaymentService-0.0.1',
+          target: 'PaymentFailed-1.0.0',
+          type: 'smoothstep',
+          label: 'publishes event',
+          animated: false,
+          markerEnd: { type: 'arrow' },
+        },
+        {
+          id: 'PaymentService-0.0.1-PaymentPaid-0.0.1',
+          source: 'PaymentService-0.0.1',
+          target: 'PaymentPaid-0.0.1',
+          type: 'smoothstep',
+          label: 'publishes event',
+          animated: false,
+          markerEnd: { type: 'arrow' },
+        },
+        {
+          id: 'PaymentService-0.0.1-PaymentPaid-0.0.2',
+          source: 'PaymentService-0.0.1',
+          target: 'PaymentPaid-0.0.2',
+          type: 'smoothstep',
+          label: 'publishes event',
+          animated: false,
+          markerEnd: { type: 'arrow' },
+        },
+      ];
+
+      expect(nodes).toStrictEqual(expect.arrayContaining(expectedNodes.map((n) => expect.objectContaining(n))));
+
+      expect(edges).toStrictEqual(expect.arrayContaining(expectedEdges));
+    });
+  });
+});

--- a/src/utils/collections/util.ts
+++ b/src/utils/collections/util.ts
@@ -1,5 +1,6 @@
 import type { CollectionTypes } from '@types';
 import type { CollectionEntry } from 'astro:content';
+import { satisfies, validRange } from 'semver';
 
 export const getVersions = (data: CollectionEntry<CollectionTypes>[]) => {
   const allVersions = data.map((item) => item.data.version).sort();
@@ -19,4 +20,25 @@ export const getVersionForCollectionItem = (
   const versions = [...new Set(allVersionsForItem)].reverse();
   const latestVersion = versions[0];
   return { versions, latestVersion };
+};
+
+export const getItemsFromCollectionByIdAndSemverOrLatest = <T extends { data: { id: string; version: string } }>(
+  collection: T[],
+  id: string,
+  version?: string
+): T[] => {
+  const semverRange = validRange(version);
+  const filteredCollection = collection.filter((c) => c.data.id == id);
+
+  if (semverRange) {
+    return filteredCollection.filter((c) => satisfies(c.data.version, semverRange));
+  }
+
+  // Order by version
+  const sorted = filteredCollection.sort((a, b) => {
+    return a.data.version.localeCompare(b.data.version);
+  });
+
+  // latest version
+  return sorted.length > 0 ? [sorted[sorted.length - 1]] : [];
 };

--- a/src/utils/domains/domains.ts
+++ b/src/utils/domains/domains.ts
@@ -1,8 +1,7 @@
-import { getVersionForCollectionItem } from '@utils/collections/util';
+import { getItemsFromCollectionByIdAndSemverOrLatest, getVersionForCollectionItem } from '@utils/collections/util';
 import { getCollection } from 'astro:content';
 import type { CollectionEntry } from 'astro:content';
 import path from 'path';
-import { validRange, satisfies } from 'semver';
 
 const PROJECT_DIR = process.env.PROJECT_DIR || process.cwd();
 
@@ -11,32 +10,6 @@ export type Domain = CollectionEntry<'domains'>;
 interface Props {
   getAllVersions?: boolean;
 }
-
-/**
- * Get the services from the collection with the same id that satisfies the
- * semver range (if version is defind) or the latest version (if version is not defined).
- */
-export const getVersion = (
-  collection: CollectionEntry<'services'>[],
-  id: string,
-  version?: string
-): CollectionEntry<'services'>[] => {
-  const semverRange = validRange(version);
-
-  const filteredCollection = collection.filter((c) => c.data.id == id);
-
-  if (semverRange) {
-    return filteredCollection.filter((c) => satisfies(c.data.version, semverRange));
-  }
-
-  // Order by version
-  const sorted = filteredCollection.sort((a, b) => {
-    return a.data.version.localeCompare(b.data.version);
-  });
-
-  // latest version
-  return sorted.length > 0 ? [sorted[sorted.length - 1]] : [];
-};
 
 export const getDomains = async ({ getAllVersions = true }: Props = {}): Promise<Domain[]> => {
   // Get all the domains that are not versioned
@@ -54,7 +27,9 @@ export const getDomains = async ({ getAllVersions = true }: Props = {}): Promise
     // const receives = service.data.receives || [];
     const servicesInDomain = domain.data.services || [];
 
-    const services = servicesInDomain.map((_service) => getVersion(servicesCollection, _service.id, _service.version)).flat();
+    const services = servicesInDomain
+      .map((_service) => getItemsFromCollectionByIdAndSemverOrLatest(servicesCollection, _service.id, _service.version))
+      .flat();
 
     return {
       ...domain,

--- a/src/utils/domains/domains.ts
+++ b/src/utils/domains/domains.ts
@@ -1,7 +1,8 @@
-import { getVersionForCollectionItem, getVersions } from '@utils/collections/util';
+import { getVersionForCollectionItem } from '@utils/collections/util';
 import { getCollection } from 'astro:content';
 import type { CollectionEntry } from 'astro:content';
 import path from 'path';
+import { validRange, satisfies } from 'semver';
 
 const PROJECT_DIR = process.env.PROJECT_DIR || process.cwd();
 
@@ -10,6 +11,32 @@ export type Domain = CollectionEntry<'domains'>;
 interface Props {
   getAllVersions?: boolean;
 }
+
+/**
+ * Get the services from the collection with the same id that satisfies the
+ * semver range (if version is defind) or the latest version (if version is not defined).
+ */
+export const getVersion = (
+  collection: CollectionEntry<'services'>[],
+  id: string,
+  version?: string
+): CollectionEntry<'services'>[] => {
+  const semverRange = validRange(version);
+
+  const filteredCollection = collection.filter((c) => c.data.id == id);
+
+  if (semverRange) {
+    return filteredCollection.filter((c) => satisfies(c.data.version, semverRange));
+  }
+
+  // Order by version
+  const sorted = filteredCollection.sort((a, b) => {
+    return a.data.version.localeCompare(b.data.version);
+  });
+
+  // latest version
+  return sorted.length > 0 ? [sorted[sorted.length - 1]] : [];
+};
 
 export const getDomains = async ({ getAllVersions = true }: Props = {}): Promise<Domain[]> => {
   // Get all the domains that are not versioned
@@ -27,11 +54,7 @@ export const getDomains = async ({ getAllVersions = true }: Props = {}): Promise
     // const receives = service.data.receives || [];
     const servicesInDomain = domain.data.services || [];
 
-    const services = servicesInDomain
-      .map((_service) => {
-        return servicesCollection.find((service) => _service.id === service.data.id);
-      })
-      .filter((e) => e !== undefined);
+    const services = servicesInDomain.map((_service) => getVersion(servicesCollection, _service.id, _service.version)).flat();
 
     return {
       ...domain,

--- a/src/utils/domains/node-graph.ts
+++ b/src/utils/domains/node-graph.ts
@@ -1,7 +1,9 @@
 // import { getColor } from '@utils/colors';
-import { getCollection } from 'astro:content';
+import { getCollection, type CollectionEntry } from 'astro:content';
 import dagre from 'dagre';
 import { getNodesAndEdges as getServicesNodeAndEdges } from '../services/node-graph';
+import { validRange, satisfies } from 'semver';
+import merge from 'lodash.merge';
 
 type DagreGraph = any;
 
@@ -20,10 +22,32 @@ interface Props {
   mode?: 'simple' | 'full';
 }
 
+/**
+ * Get the services from the collection with the same id that satisfies the
+ * semver range (if version is defind) or the latest version (if version is not defined).
+ */
+const getVersion = (collection: CollectionEntry<'services'>[], id: string, version?: string): CollectionEntry<'services'>[] => {
+  const semverRange = validRange(version);
+
+  const filteredCollection = collection.filter((c) => c.data.id == id);
+
+  if (semverRange) {
+    return filteredCollection.filter((c) => satisfies(c.data.version, semverRange));
+  }
+
+  // Order by version
+  const sorted = filteredCollection.sort((a, b) => {
+    return a.data.version.localeCompare(b.data.version);
+  });
+
+  // latest version
+  return sorted.length > 0 ? [sorted[sorted.length - 1]] : [];
+};
+
 export const getNodesAndEdges = async ({ id, version, defaultFlow, mode = 'simple' }: Props) => {
   const flow = defaultFlow || getDagreGraph();
-  let nodes = [] as any,
-    edges = [] as any;
+  let nodes = new Map(),
+    edges = new Map();
 
   const domains = await getCollection('domains');
 
@@ -39,9 +63,16 @@ export const getNodesAndEdges = async ({ id, version, defaultFlow, mode = 'simpl
 
   const rawServices = domain?.data.services || [];
 
+  const servicesCollection = await getCollection('services');
+
+  const domainServicesWithVersion = rawServices
+    .map((service) => getVersion(servicesCollection, service.id, service.version))
+    .flat()
+    .map((svc) => ({ id: svc.data.id, version: svc.data.version }));
+
   // Get all the nodes for everyhing
 
-  for (const service of rawServices) {
+  for (const service of domainServicesWithVersion) {
     const { nodes: serviceNodes, edges: serviceEdges } = await getServicesNodeAndEdges({
       id: service.id,
       version: service.version,
@@ -49,12 +80,23 @@ export const getNodesAndEdges = async ({ id, version, defaultFlow, mode = 'simpl
       mode,
       renderAllEdges: true,
     });
-    nodes = [...nodes, ...serviceNodes];
-    edges = [...edges, ...serviceEdges];
+    serviceNodes.forEach((n) => {
+      /**
+       * A message could be sent by one service and received by another service on the same domain.
+       * So, we need deep merge the message to keep the `showSource` and `showTarget` as true.
+       *
+       * Let's see an example:
+       *  Take an `OrderPlaced` event sent by the `OrderService` `{ showSource: true }` and
+       *  received by `PaymentService` `{ showTarget: true }`.
+       */
+      nodes.set(n.id, nodes.has(n.id) ? merge(nodes.get(n.id), n) : n);
+    });
+    // @ts-ignore
+    serviceEdges.forEach((e) => edges.set(e.id, e));
   }
 
   return {
-    nodes: nodes,
-    edges: edges,
+    nodes: [...nodes.values()],
+    edges: [...edges.values()],
   };
 };

--- a/src/utils/domains/node-graph.ts
+++ b/src/utils/domains/node-graph.ts
@@ -1,9 +1,8 @@
-// import { getColor } from '@utils/colors';
-import { getCollection, type CollectionEntry } from 'astro:content';
+import { getCollection } from 'astro:content';
 import dagre from 'dagre';
 import { getNodesAndEdges as getServicesNodeAndEdges } from '../services/node-graph';
-import { validRange, satisfies } from 'semver';
 import merge from 'lodash.merge';
+import { getVersion } from './domains';
 
 type DagreGraph = any;
 
@@ -21,28 +20,6 @@ interface Props {
   defaultFlow?: DagreGraph;
   mode?: 'simple' | 'full';
 }
-
-/**
- * Get the services from the collection with the same id that satisfies the
- * semver range (if version is defind) or the latest version (if version is not defined).
- */
-const getVersion = (collection: CollectionEntry<'services'>[], id: string, version?: string): CollectionEntry<'services'>[] => {
-  const semverRange = validRange(version);
-
-  const filteredCollection = collection.filter((c) => c.data.id == id);
-
-  if (semverRange) {
-    return filteredCollection.filter((c) => satisfies(c.data.version, semverRange));
-  }
-
-  // Order by version
-  const sorted = filteredCollection.sort((a, b) => {
-    return a.data.version.localeCompare(b.data.version);
-  });
-
-  // latest version
-  return sorted.length > 0 ? [sorted[sorted.length - 1]] : [];
-};
 
 export const getNodesAndEdges = async ({ id, version, defaultFlow, mode = 'simple' }: Props) => {
   const flow = defaultFlow || getDagreGraph();

--- a/src/utils/domains/node-graph.ts
+++ b/src/utils/domains/node-graph.ts
@@ -2,7 +2,7 @@ import { getCollection } from 'astro:content';
 import dagre from 'dagre';
 import { getNodesAndEdges as getServicesNodeAndEdges } from '../services/node-graph';
 import merge from 'lodash.merge';
-import { getVersion } from './domains';
+import { getItemsFromCollectionByIdAndSemverOrLatest } from '@utils/collections/util';
 
 type DagreGraph = any;
 
@@ -43,7 +43,7 @@ export const getNodesAndEdges = async ({ id, version, defaultFlow, mode = 'simpl
   const servicesCollection = await getCollection('services');
 
   const domainServicesWithVersion = rawServices
-    .map((service) => getVersion(servicesCollection, service.id, service.version))
+    .map((service) => getItemsFromCollectionByIdAndSemverOrLatest(servicesCollection, service.id, service.version))
     .flat()
     .map((svc) => ({ id: svc.data.id, version: svc.data.version }));
 


### PR DESCRIPTION
Includes:
- fix to `domains/getNodesAndEdges`: domain services matches semver or latest.
- fix to `domains/getDomains`: domain services matches semver or latest.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://github.com/event-catalog/eventcatalog/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Resolves #714.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/event-catalog/eventcatalog/blob/main/CONTRIBUTING.md#pull-requests)?

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/event-catalog/eventcatalog/blob/main/CONTRIBUTING.md#pull-requests)
