### PR TITLE
chore(core): fixing default for flows

### DIFF
--- a/.changeset/unlucky-stingrays-work.md
+++ b/.changeset/unlucky-stingrays-work.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": minor
+---
+
+chore(core): fixing default for flows

--- a/scripts/default-files-for-collections/flows.md
+++ b/scripts/default-files-for-collections/flows.md
@@ -1,5 +1,11 @@
 ---
 id: empty
+steps:
+    - id: "empty"
+      title: "empty"
+name: empty
+version: 0.0.1
+hidden: true
 ---
 
 <!-- Do not delete this file, required for EC, you an ignore this file -->

--- a/scripts/default-files-for-collections/pages.md
+++ b/scripts/default-files-for-collections/pages.md
@@ -1,6 +1,7 @@
 ---
 id: index
 slug: index
+hidden: true
 ---
 
 <!-- Do not delete this file, required for EC, you an ignore this file -->


### PR DESCRIPTION
Default for flows are broken in the newest release. This fixes that.