### PR TITLE
Change home redirect status code from permanent to temporary

### DIFF
--- a/.changeset/large-kangaroos-walk.md
+++ b/.changeset/large-kangaroos-walk.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix(core): homepage redirect status code from permanent to temporary

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -48,7 +48,10 @@ export default defineConfig({
     pagefind(),
   ],
   redirects: {
-    "/": join(base, config.landingPage || '/docs'),
+    "/": {
+      status: 302,
+      destination: join(base, config.landingPage || '/docs'),
+    },
   },
   vite: {
     build: {


### PR DESCRIPTION
This PR suggests making the home redirect temporary (status 302) rather than permanent (301, used by default).

#### Rationale
The default permanent redirect makes it hard to change the `landingPage` config setting since browsers tend to cache 301 redirects, well.. permanently. Any future changes may be ignored by the browser,  leading to unexpected behavior.