### PR TITLE
fix: look for slug instead of id

### DIFF
--- a/examples/default/events/Inventory/InventoryAdjusted/index.md
+++ b/examples/default/events/Inventory/InventoryAdjusted/index.md
@@ -1,5 +1,5 @@
 ---
-id: InventoryAdjusted
+id: inventuryadjusted
 name: Inventory adjusted
 version: 1.0.1
 summary: |

--- a/examples/default/events/Inventory/InventoryAdjusted/index.md
+++ b/examples/default/events/Inventory/InventoryAdjusted/index.md
@@ -1,5 +1,5 @@
 ---
-id: inventuryadjusted
+id: InventoryAdjusted
 name: Inventory adjusted
 version: 1.0.1
 summary: |

--- a/examples/default/events/Inventory/InventoryAdjusted/versioned/0.0.1/index.md
+++ b/examples/default/events/Inventory/InventoryAdjusted/versioned/0.0.1/index.md
@@ -1,5 +1,5 @@
 ---
-id: InventoryAdjusted
+id: inventuryadjusted
 name: Inventory adjusted
 version: 0.0.1
 summary: |

--- a/examples/default/events/Inventory/InventoryAdjusted/versioned/1.0.0/index.md
+++ b/examples/default/events/Inventory/InventoryAdjusted/versioned/1.0.0/index.md
@@ -1,5 +1,5 @@
 ---
-id: InventoryAdjusted
+id: inventuryadjusted
 name: Inventory adjusted
 version: 1.0.0
 summary: |

--- a/examples/default/events/Inventory/InventoryAdjusted/versioned/1.0.0/index.md
+++ b/examples/default/events/Inventory/InventoryAdjusted/versioned/1.0.0/index.md
@@ -1,5 +1,5 @@
 ---
-id: inventuryadjusted
+id: InventoryAdjusted
 name: Inventory adjusted
 version: 1.0.0
 summary: |

--- a/src/utils/changelogs/changelogs.ts
+++ b/src/utils/changelogs/changelogs.ts
@@ -4,11 +4,11 @@ import { getCollection, type CollectionEntry } from 'astro:content';
 export type ChangeLog = CollectionEntry<'changelogs'>;
 
 export const getChangeLogs = async (item: CollectionEntry<CollectionTypes>): Promise<ChangeLog[]> => {
-  const { collection, data } = item;
+  const { collection, data, slug } = item;
 
   // Get all logs for collection type and filter by given collection
   const logs = await getCollection('changelogs', (log) => {
-    return log.id.includes(`${collection}/`) && log.id.includes(`/${data.id}/`);
+    return log.id.includes(`${collection}/`) && log.slug.includes(slug);
   });
 
   const hydratedLogs = logs.map((log) => {


### PR DESCRIPTION
## Motivation

closes #668 

I tested it for "inventoryadjusted" (thats why I changed the ID there) however versioning in general seems to be a bit broken.
It works for domains but changelog page is empt and it does not work at all for services (also no changelogs). Not quite sure since when and at least this is what happens with the default example. Can you verify? (I always have issues running this)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/event-catalog/eventcatalog/blob/main/CONTRIBUTING.md#pull-requests)?

Yes
