### PR TITLE
fix: invalid hook call warning

### DIFF
--- a/.changeset/smooth-drinks-give.md
+++ b/.changeset/smooth-drinks-give.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix(core): moved node graphs to only load on client fixing the invalid hook call warning

--- a/src/components/MDX/Flow/Flow.astro
+++ b/src/components/MDX/Flow/Flow.astro
@@ -52,7 +52,7 @@ const { nodes, edges } = await getNodesAndEdges({
     linkTo={'visualiser'}
     includeKey={includeKey}
     footerLabel=`Flow diagram - ${flow.data.name} - v(${flow.data.version})`
-    client:load
+    client:only="react"
   />
 </div>
 

--- a/src/components/MDX/NodeGraph/NodeGraph.astro
+++ b/src/components/MDX/NodeGraph/NodeGraph.astro
@@ -88,7 +88,7 @@ if (collection === 'flows') {
     hrefLabel={href.label}
     href={href.url}
     linkTo={linkTo}
-    client:load
+    client:only="react"
   />
 </div>
 

--- a/src/components/MDX/SchemaViewer/SchemaViewer.astro
+++ b/src/components/MDX/SchemaViewer/SchemaViewer.astro
@@ -72,7 +72,7 @@ try {
     schemas.length > 0 &&
       schemas.map((schema) => (
         <div>
-          {schema.exists && <SchemaViewerClient {...schema} client:load />}
+          {schema.exists && <SchemaViewerClient {...schema} client:only="react" />}
 
           {/* User has tried to load the schema, but it was not found on file system */}
           {!schema.exists && (


### PR DESCRIPTION
It replaces the client:load by client:only directive of NodeGraph and SchemaViewer to prevent these from render at build time on the server.

Fix #726 