### PR TITLE
fix(core): generate script now works with npm packages

### DIFF
--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -1,53 +1,109 @@
-import { readFile, writeFile } from 'node:fs/promises';
-import { createRequire } from 'module';
+import { readFile, writeFile, rm } from 'node:fs/promises';
 import path from 'node:path';
 
-const generate = async () => {
-  // Fix for the file
-  const rawFile = await readFile(path.join(process.env.PROJECT_DIR, 'eventcatalog.config.js'), 'utf8');
-
-  const require = createRequire(process.env.PROJECT_DIR);
-
-  // Convert export default to module.exports (Needed for dynamic require)
-  if (rawFile.includes('export default')) {
-    const fixedFile = rawFile.replace('export default', 'module.exports =');
-    await writeFile(path.join(process.env.PROJECT_DIR, 'eventcatalog.config.js'), fixedFile);
-  }
-
-  const config = require(path.join(process.env.PROJECT_DIR, 'eventcatalog.config.js'));
-
-  const { generators = [] } = config;
-
-  if (!generators.length) {
-    console.log('No configured generators found, skipping generation');
-    return;
-  }
-
-  console.log('Running generators...');
-
-  // Tidy up
-  await writeFile(path.join(process.env.PROJECT_DIR, 'eventcatalog.config.js'), rawFile);
-
-  const plugins = generators.map((generator) => {
-    let plugin = generator[0];
-    const pluginConfig = generator[1];
-
-    if (plugin.startsWith('./')) {
-      plugin = path.join(process.env.PROJECT_DIR, plugin);
-    }
-
-    if (plugin.includes('<rootDir>')) {
-      plugin = plugin.replace('<rootDir>', process.env.PROJECT_DIR);
-    }
-
-    const importedGenerator = require(plugin);
-
-    console.log(`Generating EventCatalog docs using: ${plugin}`);
-
-    return importedGenerator({ eventCatalogConfig: config }, pluginConfig);
+/**
+ * Very strange behaviour when importing ESM files from catalogs into core.
+ * Core (node) does not know how to handle ESM files, so we have to try and convert them.
+ *
+ * This needs sorting out! Sorry if you are reading this, but it unblocked me for now!
+ * @param {*} content
+ * @returns
+ */
+function convertESMtoCJS(content) {
+  // Replace import statements with require
+  content = content.replace(/import\s+([a-zA-Z0-9{},\s*]+)\s+from\s+['"]([^'"]+)['"];/g, (match, imports, modulePath) => {
+    return `const ${imports.trim()} = require('${modulePath}');`;
   });
 
-  await Promise.all(plugins);
+  // Replace export default with module.exports
+  content = content.replace(/export\s+default\s+/g, 'module.exports = ');
+
+  // Replace named exports with module.exports
+  content = content.replace(/export\s+{([^}]+)}/g, (match, exports) => {
+    return `module.exports = {${exports.trim()}};`;
+  });
+
+  // Remove declarations of __filename and __dirname
+  content = content.replace(/^\s*(const|let|var)\s+__(filename|dirname)\s+=\s+.*;?\s*$/gm, '');
+
+  return content;
+}
+
+// TODO: Do we actually need this? Can we clean this up
+function getDefaultExport(importedModule) {
+  if (importedModule === null || typeof importedModule !== 'object') {
+    throw new Error('Invalid module');
+  }
+
+  if (typeof importedModule.default === 'object' && importedModule.default !== null) {
+    return importedModule.default.default || importedModule.default;
+  }
+
+  if (typeof importedModule.default !== 'undefined') {
+    return importedModule.default;
+  }
+
+  return importedModule;
+}
+
+async function cleanup() {
+  await rm(path.join(process.env.PROJECT_DIR, 'eventcatalog.config.cjs'));
+}
+
+const generate = async () => {
+  try {
+    // Fix for the file
+    const rawFile = await readFile(path.join(process.env.PROJECT_DIR, 'eventcatalog.config.js'), 'utf8');
+
+    // Have to conver the ESM to CJS...
+    const configAsCommonJS = convertESMtoCJS(rawFile);
+    await writeFile(path.join(process.env.PROJECT_DIR, 'eventcatalog.config.cjs'), configAsCommonJS);
+
+    const configAsCJS = await import(path.join(process.env.PROJECT_DIR, 'eventcatalog.config.cjs'));
+    const config = configAsCJS.default;
+
+    const { generators = [] } = config;
+
+    if (!generators.length) {
+      console.log('No configured generators found, skipping generation');
+      return;
+    }
+
+    // Tidy up
+    await writeFile(path.join(process.env.PROJECT_DIR, 'eventcatalog.config.js'), rawFile);
+
+    for (const generator of generators) {
+      let plugin = generator[0];
+      const pluginConfig = generator[1];
+
+      if (plugin.startsWith('./')) {
+        plugin = path.join(process.env.PROJECT_DIR, plugin);
+      }
+
+      if (plugin.includes('<rootDir>')) {
+        plugin = plugin.replace('<rootDir>', process.env.PROJECT_DIR);
+      }
+
+      try {
+        const importedGenerator = await import(plugin);
+
+        // TODO: Fix this...
+        const generator = getDefaultExport(importedGenerator);
+
+        await generator({ eventCatalogConfig: {} }, pluginConfig);
+
+        // Use importedGenerator here
+      } catch (error) {
+        console.error('Error loading plugin:', error);
+        await cleanup();
+        return;
+      }
+    }
+  } catch (error) {
+    // Failed to generate clean up...
+    console.error(error);
+    await cleanup();
+  }
 };
 
 generate();


### PR DESCRIPTION
The generator loads the plugins from the eventcatalog.config.js file. This file can be CJS or ESM. 

If its ESM the generator (node) can't work it out as it requires CJS code, but nothing fancy is happening here.

This code fixes that with a temp work around, and also tries to import plugins by checking ESM/CJS compatibility. 