### PR TITLE
fix(core): splitting target path while coping content files

### DIFF
--- a/scripts/catalog-to-astro-content-directory.js
+++ b/scripts/catalog-to-astro-content-directory.js
@@ -7,10 +7,17 @@ import os from 'node:os';
 const __filename = fileURLToPath(import.meta.url);
 const scriptsDir = path.dirname(__filename);
 
+const cleanRelativePath = (relativePath, type) => {
+  const position = relativePath.indexOf(`${type}${path.sep}`);
+
+  return relativePath.slice(position + `${type}${path.sep}`.length);
+};
+
 const getTargetPath = (source, target, type, file) => {
   const relativePath = path.relative(source, file);
-  const cleanedRelativePath = relativePath.split(`${type}/`);
-  const targetForEvents = path.join(type, cleanedRelativePath[1]);
+  const cleanedRelativePath = cleanRelativePath(relativePath, type);
+  const targetForEvents = path.join(type, cleanedRelativePath);
+
   return path.join(target, targetForEvents);
 };
 
@@ -64,9 +71,9 @@ const copyFiles = async ({ source, target, catalogFilesDir, pathToMarkdownFiles,
     }
 
     const relativePath = path.relative(source, file);
-    const cleanedRelativePath = relativePath.split(`${type}/`);
-    if (!cleanedRelativePath[1]) continue;
-    const targetForEvents = path.join(type, cleanedRelativePath[1]);
+    const cleanedRelativePath = cleanRelativePath(relativePath, type);
+    if (!cleanedRelativePath) continue;
+    const targetForEvents = path.join(type, cleanedRelativePath);
 
     // Catalog-files-directory
     const targetPath = path.join(catalogFilesDir, targetForEvents);

--- a/scripts/catalog-to-astro-content-directory.js
+++ b/scripts/catalog-to-astro-content-directory.js
@@ -8,7 +8,7 @@ const __filename = fileURLToPath(import.meta.url);
 const scriptsDir = path.dirname(__filename);
 
 const cleanRelativePath = (relativePath, type) => {
-  const position = relativePath.indexOf(`${type}${path.sep}`);
+  const position = relativePath.indexOf(`${path.sep}${type}${path.sep}`);
 
   return relativePath.slice(position + `${type}${path.sep}`.length);
 };

--- a/scripts/catalog-to-astro-content-directory.js
+++ b/scripts/catalog-to-astro-content-directory.js
@@ -9,7 +9,7 @@ const scriptsDir = path.dirname(__filename);
 
 const getTargetPath = (source, target, type, file) => {
   const relativePath = path.relative(source, file);
-  const cleanedRelativePath = relativePath.split(type);
+  const cleanedRelativePath = relativePath.split(`${type}/`);
   const targetForEvents = path.join(type, cleanedRelativePath[1]);
   return path.join(target, targetForEvents);
 };
@@ -64,7 +64,7 @@ const copyFiles = async ({ source, target, catalogFilesDir, pathToMarkdownFiles,
     }
 
     const relativePath = path.relative(source, file);
-    const cleanedRelativePath = relativePath.split(type);
+    const cleanedRelativePath = relativePath.split(`${type}/`);
     if (!cleanedRelativePath[1]) continue;
     const targetForEvents = path.join(type, cleanedRelativePath[1]);
 


### PR DESCRIPTION
Hi,

I noticed a bug when executing the command: `npm run build` aka (`eventcatalog build`). When I try to build the production version of the catalog, one of my application/microservice disappears. The application that disappears in the production environment _(everything works on localhost)_ is the one named **external-services-builder**

During analysis, I found that the method `getTargetPath` is losing my name. The directory where Event Catalog places applications is **services** and my application / microservice also contains the word "services" _(external-services-builder)_. So after calling the method "getTargetPath," an incorrect path is generated, which causes the application not to appear in the menu at all.

I analyzed the change history in the file `scripts/catalog-to-astro-content-directory.js` and noticed that it used to work previously. I restored that one code fragment.