### PR TITLE
refine and relook rapi-doc openapi renderer

### DIFF
--- a/.changeset/six-dolphins-protect.md
+++ b/.changeset/six-dolphins-protect.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+chore(core): fixed styled for openapi pages

--- a/examples/default/services/OrdersService/openapi.yml
+++ b/examples/default/services/OrdersService/openapi.yml
@@ -1,170 +1,96 @@
-openapi: "3.0.0"
+openapi: 3.1.0
 info:
-  title: Simple API overview
-  version: 2.0.0
+  title: Simple Task - API
+  version: 1.0.0
+  description: Simple Api
+  contact: {}
+  license:
+    name: apache 2.0
+    identifier: apache-2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+
+servers:
+  - url: https://example.com/
+    
 paths:
-  /:
-    get:
-      operationId: listVersionsv2
-      summary: List API versions
+  /v1/task/{id}:
+    put:
+      summary: Do Simple Task
+      operationId: DoSimpleTask
       responses:
         '200':
-          description: |-
-            200 response
+          description: do a task by id
           content:
             application/json:
-              examples: 
-                foo:
-                  value:
-                    {
-                      "versions": [
-                        {
-                            "status": "CURRENT",
-                            "updated": "2011-01-21T11:33:21Z",
-                            "id": "v2.0",
-                            "links": [
-                                {
-                                    "href": "http://127.0.0.1:8774/v2/",
-                                    "rel": "self"
-                                }
-                            ]
-                        },
-                        {
-                            "status": "EXPERIMENTAL",
-                            "updated": "2013-07-23T11:33:21Z",
-                            "id": "v3.0",
-                            "links": [
-                                {
-                                    "href": "http://127.0.0.1:8774/v3/",
-                                    "rel": "self"
-                                }
-                            ]
-                        }
-                      ]
-                    }
-        '300':
-          description: |-
-            300 response
+              schema:
+                $ref: '#/components/schemas/Task'
+        '204':
+          description: No content
+        '400':
+          description: Problem with data
           content:
-            application/json: 
-              examples: 
-                foo:
-                  value: |
-                   {
-                    "versions": [
-                          {
-                            "status": "CURRENT",
-                            "updated": "2011-01-21T11:33:21Z",
-                            "id": "v2.0",
-                            "links": [
-                                {
-                                    "href": "http://127.0.0.1:8774/v2/",
-                                    "rel": "self"
-                                }
-                            ]
-                        },
-                        {
-                            "status": "EXPERIMENTAL",
-                            "updated": "2013-07-23T11:33:21Z",
-                            "id": "v3.0",
-                            "links": [
-                                {
-                                    "href": "http://127.0.0.1:8774/v3/",
-                                    "rel": "self"
-                                }
-                            ]
-                        }
-                    ]
-                   }
-  /v2:
-    get:
-      operationId: getVersionDetailsv2
-      summary: Show API version details
-      responses:
-        '200':
-          description: |-
-            200 response
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Not Authorized
           content:
-            application/json: 
-              examples:
-                foo:
-                  value:
-                    {
-                      "version": {
-                        "status": "CURRENT",
-                        "updated": "2011-01-21T11:33:21Z",
-                        "media-types": [
-                          {
-                              "base": "application/xml",
-                              "type": "application/vnd.openstack.compute+xml;version=2"
-                          },
-                          {
-                              "base": "application/json",
-                              "type": "application/vnd.openstack.compute+json;version=2"
-                          }
-                        ],
-                        "id": "v2.0",
-                        "links": [
-                          {
-                              "href": "http://127.0.0.1:8774/v2/",
-                              "rel": "self"
-                          },
-                          {
-                              "href": "http://docs.openstack.org/api/openstack-compute/2/os-compute-devguide-2.pdf",
-                              "type": "application/pdf",
-                              "rel": "describedby"
-                          },
-                          {
-                              "href": "http://docs.openstack.org/api/openstack-compute/2/wadl/os-compute-2.wadl",
-                              "type": "application/vnd.sun.wadl+xml",
-                              "rel": "describedby"
-                          },
-                          {
-                            "href": "http://docs.openstack.org/api/openstack-compute/2/wadl/os-compute-2.wadl",
-                            "type": "application/vnd.sun.wadl+xml",
-                            "rel": "describedby"
-                          }
-                        ]
-                      }
-                    }
-        '203':
-          description: |-
-            203 response
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Unauthorized'
+        '404':
+          description: not found
           content:
-            application/json: 
-              examples:
-                foo:
-                  value:
-                    {
-                      "version": {
-                        "status": "CURRENT",
-                        "updated": "2011-01-21T11:33:21Z",
-                        "media-types": [
-                          {
-                              "base": "application/xml",
-                              "type": "application/vnd.openstack.compute+xml;version=2"
-                          },
-                          {
-                              "base": "application/json",
-                              "type": "application/vnd.openstack.compute+json;version=2"
-                          }
-                        ],
-                        "id": "v2.0",
-                        "links": [
-                          {
-                              "href": "http://23.253.228.211:8774/v2/",
-                              "rel": "self"
-                          },
-                          {
-                              "href": "http://docs.openstack.org/api/openstack-compute/2/os-compute-devguide-2.pdf",
-                              "type": "application/pdf",
-                              "rel": "describedby"
-                          },
-                          {
-                              "href": "http://docs.openstack.org/api/openstack-compute/2/wadl/os-compute-2.wadl",
-                              "type": "application/vnd.sun.wadl+xml",
-                              "rel": "describedby"
-                          }
-                        ]
-                      }
-                    }
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      description: Allows to do a simple task
+      security:
+        - authorization: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+
+components:
+  schemas:
+    Task:
+      properties:
+        comments:
+          type: string
+        creationDate:
+          type: string
+        taskId:
+          type: string
+        description:
+          type: string
+        lastUpdate:
+          type: string
+      type: object
+      additionalProperties: false
+    Error:
+      properties:
+        error:
+          type: string
+      required:
+        - error
+      type: object
+    Unauthorized:
+      properties:
+        message:
+          type: string
+      required:
+        - message
+      type: object
+  securitySchemes:
+    authorization:
+      type: http
+      scheme: bearer

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@eventcatalog/core",
-  "version": "2.6.0",
+  "version": "2.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@eventcatalog/core",
-      "version": "2.6.0",
+      "version": "2.6.2",
       "dependencies": {
         "@astrojs/check": "^0.9.2",
         "@astrojs/markdown-remark": "^5.2.0",

--- a/src/pages/docs/[type]/[id]/[version]/spec/index.astro
+++ b/src/pages/docs/[type]/[id]/[version]/spec/index.astro
@@ -63,19 +63,19 @@ const fileExists = fs.existsSync(pathOnDisk);
         show-header="false"
         allow-authentication="true"
         allow-try="true"
-        style={{ height: '100vh', width: '100%' }}
-        class="py-4"
+        class="relative top-0"
+        style={{ height: '100vh', width: '100%', zIndex: 100 }}
         regular-font="ui-sans-serif, system-ui, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol, Noto Color Emoji"
         schema-style="table"
         default-schema-tab="schema"
         bg-color="#ffffff"
         text-color=""
-        nav-bg-color="#fafafa"
+        nav-bg-color="#fff"
         nav-text-color=""
-        nav-hover-bg-color="#ffebea"
-        nav-hover-text-color="#9b0700"
+        nav-hover-bg-color="#fff"
+        nav-hover-text-color="#6b21a8"
         nav-accent-color=""
-        primary-color="#F63C41"
+        primary-color="#6b21a8"
         theme="light"
         render-style="read"
       />
@@ -91,13 +91,44 @@ const fileExists = fs.existsSync(pathOnDisk);
 <style>
   rapi-doc::part(section-servers) {
     /* <<< targets the server div */
-    background: #6b5b95;
-    color: #d1c2e4;
+    /* background: #6b5b95; */
+    border: 2px solid #f1edff;
+    color: black;
     margin: 0 24px 0 24px;
     border-radius: 5px;
   }
   rapi-doc::part(label-selected-server) {
     /* <<< targets selected server label */
-    color: #fff;
+    color: black;
+  }
+
+  rapi-doc::part(section-navbar-search) {
+    margin: 0;
+    padding: 0;
+    margin-bottom: 1em;
+  }
+  rapi-doc::part(section-overview) {
+    margin: 0 2em 0 2em;
+    padding: 1em 0 1em;
+  }
+  rapi-doc::part(section-auth) {
+    margin: 2em 2em;
+    padding: 0;
+  }
+  rapi-doc::part(section-tag) {
+    margin: 2em 2em;
+    padding: 0;
+  }
+  rapi-doc::part(section-tag-title) {
+    margin: 0.5em 0 0;
+    padding: 0;
+  }
+  rapi-doc::part(section-operations-in-tag) {
+    margin: 1em 2em;
+    padding: 0;
+  }
+  rapi-doc::part(section-navbar) {
+    border-right: 1px solid #f1edff;
+    padding: 1em 1em 0 0;
   }
 </style>

--- a/src/pages/docs/[type]/[id]/[version]/spec/index.astro
+++ b/src/pages/docs/[type]/[id]/[version]/spec/index.astro
@@ -60,16 +60,24 @@ const fileExists = fs.existsSync(pathOnDisk);
     ) : (
       <rapi-doc
         spec-url={buildUrl(pathToSpec, true)}
-        render-style="table"
         show-header="false"
-        allow-authentication="false"
-        allow-try="false"
+        allow-authentication="true"
+        allow-try="true"
         style={{ height: '100vh', width: '100%' }}
         class="py-4"
-        nav-bg-color="#fff"
+        regular-font="ui-sans-serif, system-ui, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol, Noto Color Emoji"
         schema-style="table"
-        primary-color="#e0baff"
-        bg-color="#fff"
+        default-schema-tab="schema"
+        bg-color="#ffffff"
+        text-color=""
+        nav-bg-color="#fafafa"
+        nav-text-color=""
+        nav-hover-bg-color="#ffebea"
+        nav-hover-text-color="#9b0700"
+        nav-accent-color=""
+        primary-color="#F63C41"
+        theme="light"
+        render-style="read"
       />
     )
   }


### PR DESCRIPTION
## Motivation
having OpenApi spec viewer with a higher level of look and feel to make it readable but operational.

- [x] Enable Try button
- [x] Enable Auth configuration
- [x] Refine them and styling
- [x] Expand the schema tab by default instead of example
- [x] Set schema representation as tabular     