### PR TITLE
fix(script/watcher): support being in a subdirectory named events

### DIFF
--- a/scripts/catalog-to-astro-content-directory.js
+++ b/scripts/catalog-to-astro-content-directory.js
@@ -67,7 +67,7 @@ const copyFiles = async ({ source, target, catalogFilesDir, pathToMarkdownFiles,
     const relativePath = path.relative(source, file);
     const cleanedRelativePath = relativePath.split(type);
     if (!cleanedRelativePath[1]) continue;
-    const targetForEvents = path.join(type, cleanedRelativePath[cleanedRelativePath.length - 1]);
+    const targetForEvents = path.join(type, cleanedRelativePath[1]);
 
     // Catalog-files-directory
     const targetPath = path.join(catalogFilesDir, targetForEvents);

--- a/scripts/catalog-to-astro-content-directory.js
+++ b/scripts/catalog-to-astro-content-directory.js
@@ -67,7 +67,7 @@ const copyFiles = async ({ source, target, catalogFilesDir, pathToMarkdownFiles,
     const relativePath = path.relative(source, file);
     const cleanedRelativePath = relativePath.split(type);
     if (!cleanedRelativePath[1]) continue;
-    const targetForEvents = path.join(type, cleanedRelativePath[1]);
+    const targetForEvents = path.join(type, cleanedRelativePath[cleanedRelativePath.length - 1]);
 
     // Catalog-files-directory
     const targetPath = path.join(catalogFilesDir, targetForEvents);

--- a/scripts/watcher.js
+++ b/scripts/watcher.js
@@ -30,7 +30,7 @@ for (let item of [...verifiedWatchList]) {
     }
     for (let event of events) {
       const { path: eventPath, type } = event;
-      const pathParts = eventPath.split(item);
+      const pathParts = eventPath.split(`${path.sep}${item}${path.sep}`);
       const file = pathParts[pathParts.length - 1];
       let newPath = path.join(contentPath, item, extensionReplacer(item, file));
 

--- a/scripts/watcher.js
+++ b/scripts/watcher.js
@@ -30,7 +30,8 @@ for (let item of [...verifiedWatchList]) {
     }
     for (let event of events) {
       const { path: eventPath, type } = event;
-      const file = eventPath.split(item)[1];
+      const pathParts = eventPath.split(item);
+      const file = pathParts[pathParts.length - 1];
       let newPath = path.join(contentPath, item, extensionReplacer(item, file));
 
       // Check if changlogs, they need to go into their own content folder


### PR DESCRIPTION
## Motivation

When the path of a catalog project contains `events`, `services`, `commands`, etc., the watcher crashes on file change.