### PR TITLE
add path an verb in openapi viewer nav bar

### DIFF
--- a/.changeset/early-steaks-sparkle.md
+++ b/.changeset/early-steaks-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+feat(core): added api path and http verb in openapi viewer

--- a/examples/default/services/OrdersService/openapi.yml
+++ b/examples/default/services/OrdersService/openapi.yml
@@ -59,7 +59,45 @@ paths:
           required: true
           schema:
             type: string
-  
+    delete: 
+      summary: Delete Task
+      operationId: DeleteTask
+      responses:
+        '204':
+          description: Task deleted
+        '400':
+          description: Problem with data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Not Authorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Unauthorized'
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      description: Delete a task
+      security:
+        - authorization: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
   /v1/tasks:
     get:
       summary: Get List of Tasks

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@eventcatalog/core",
-  "version": "2.7.14",
+  "version": "2.7.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@eventcatalog/core",
-      "version": "2.7.14",
+      "version": "2.7.16",
       "dependencies": {
         "@astrojs/check": "^0.9.3",
         "@astrojs/markdown-remark": "^5.2.0",

--- a/src/pages/docs/[type]/[id]/[version]/spec/index.astro
+++ b/src/pages/docs/[type]/[id]/[version]/spec/index.astro
@@ -53,24 +53,26 @@ const fileExists = fs.existsSync(pathOnDisk);
     ) : (
       <rapi-doc
         spec-url={buildUrl(pathToSpec, true)}
+        render-style="read"
         show-header="false"
         allow-authentication="true"
         allow-try="true"
+        default-schema-tab="schema"
+        show-curl-before-try="true"
+        use-path-in-nav-bar="true"
+        show-method-in-nav-bar="as-colored-block"
+        theme="light"
+        schema-style="table"
         class="relative top-0"
         style={{ height: '100vh', width: '100%', zIndex: 100 }}
         regular-font="ui-sans-serif, system-ui, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol, Noto Color Emoji"
-        schema-style="table"
-        default-schema-tab="schema"
         bg-color="#ffffff"
-        text-color=""
+        primary-color="#6b21a8"
         nav-bg-color="#fff"
         nav-text-color=""
         nav-hover-bg-color="#fff"
         nav-hover-text-color="#6b21a8"
         nav-accent-color=""
-        primary-color="#6b21a8"
-        theme="light"
-        render-style="read"
       />
     )
   }


### PR DESCRIPTION
## Motivation
In openApi viewer, the summary was shown in nav bar, and as this became verbose  and hard to read , the option of showing the http verb + endpoint path in navbar seems a better and readable option