### PR TITLE
chore/eventcatalog-config-import

### DIFF
--- a/.changeset/good-rockets-study.md
+++ b/.changeset/good-rockets-study.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+chore(core): changed the way eventcatalog file is now imported into the project

--- a/scripts/__tests__/eventcatalog-config-file-utils.spec.ts
+++ b/scripts/__tests__/eventcatalog-config-file-utils.spec.ts
@@ -10,6 +10,7 @@ import {
   verifyRequiredFieldsAreInCatalogConfigFile,
   writeEventCatalogConfigFile,
 } from 'scripts/eventcatalog-config-file-utils';
+import { tmpdir } from 'os';
 
 describe('catalog-to-astro-content-directory', () => {
   afterEach(async () => {
@@ -101,11 +102,11 @@ describe('catalog-to-astro-content-directory', () => {
         })
       );
     });
-    it('eventcatalog.config.cjs (temp commonjs file) is removed when fetching the catalog file', async () => {
+    it('removes eventcatalog config from the tmpdir', async () => {
       await getEventCatalogConfigFile(CATALOG_DIR);
 
-      const commonJsFile = path.join(CATALOG_DIR, 'eventcatalog.config.cjs');
-      expect(existsSync(commonJsFile)).toBe(false);
+      const configFile = path.join(tmpdir(), 'eventcatalog.config.mjs');
+      expect(existsSync(configFile)).toBe(false);
     });
   });
 

--- a/scripts/__tests__/example-catalog/package.json
+++ b/scripts/__tests__/example-catalog/package.json
@@ -1,0 +1,3 @@
+{
+  "description": "Only for testing purposes"
+}

--- a/scripts/eventcatalog-config-file-utils.js
+++ b/scripts/eventcatalog-config-file-utils.js
@@ -1,38 +1,13 @@
 import { readFile, writeFile, rm } from 'node:fs/promises';
-import { existsSync } from 'fs';
+import { existsSync } from 'node:fs';
+import { copyFile } from 'node:fs/promises';
 import path from 'node:path';
 import { v4 as uuidV4 } from 'uuid';
 import { pathToFileURL } from 'url';
+import { tmpdir } from 'node:os';
 
-// * Very strange behavior when importing ESM files from catalogs into core.
-//  * Core (node) does not know how to handle ESM files, so we have to try and convert them.
-//  *
-//  * This needs sorting out! Sorry if you are reading this, but it unblocked me for now!
-//  * @param {*} content
-//  * @returns
-//  */
-function convertESMtoCJS(content) {
-  // Replace import statements with require
-  content = content.replace(/import\s+([a-zA-Z0-9{},\s*]+)\s+from\s+['"]([^'"]+)['"];/g, (match, imports, modulePath) => {
-    return `const ${imports.trim()} = require('${modulePath}');`;
-  });
-
-  // Replace export default with module.exports
-  content = content.replace(/export\s+default\s+/g, 'module.exports = ');
-
-  // Replace named exports with module.exports
-  content = content.replace(/export\s+{([^}]+)}/g, (match, exports) => {
-    return `module.exports = {${exports.trim()}};`;
-  });
-
-  // Remove declarations of __filename and __dirname
-  content = content.replace(/^\s*(const|let|var)\s+__(filename|dirname)\s+=\s+.*;?\s*$/gm, '');
-
-  return content;
-}
-
-export async function cleanup(projectDirectory) {
-  const filePath = path.join(projectDirectory, 'eventcatalog.config.cjs');
+export async function cleanup() {
+  const filePath = path.join(tmpdir(), 'eventcatalog.config.mjs');
   if (existsSync(filePath)) {
     await rm(filePath);
   }
@@ -40,25 +15,20 @@ export async function cleanup(projectDirectory) {
 
 export const getEventCatalogConfigFile = async (projectDirectory) => {
   try {
-    const rawFile = await readFile(path.join(projectDirectory, 'eventcatalog.config.js'), 'utf8');
+    let configFilePath = path.join(projectDirectory, 'eventcatalog.config.js');
 
-    // Have to conver the ESM to CJS...
-    const configAsCommonJS = convertESMtoCJS(rawFile);
+    const packageJson = await import(/* @vite-ignore */ path.join(projectDirectory, 'package.json'));
+    if (packageJson.default?.type !== 'module') {
+      await copyFile(configFilePath, path.join(tmpdir(), 'eventcatalog.config.mjs'));
+      configFilePath = path.join(tmpdir(), 'eventcatalog.config.mjs');
+    }
 
-    await writeFile(path.join(projectDirectory, 'eventcatalog.config.cjs'), configAsCommonJS);
-
-    const configFilePath = path.join(projectDirectory, 'eventcatalog.config.cjs');
     const configFileURL = pathToFileURL(configFilePath).href;
-    const configAsCJS = await import(/* @vite-ignore */ configFileURL);
+    const config = await import(/* @vite-ignore */ configFileURL);
 
-    //  Clean up?
-    await writeFile(path.join(projectDirectory, 'eventcatalog.config.js'), rawFile);
-
-    await cleanup(projectDirectory);
-
-    return configAsCJS.default;
-  } catch (error) {
-    await cleanup(projectDirectory);
+    return config.default;
+  } finally {
+    await cleanup();
   }
 };
 
@@ -92,10 +62,8 @@ export const writeEventCatalogConfigFile = async (projectDirectory, newConfig) =
 
     // Write the updated content back to the file
     await writeFile(configFilePath, content);
-
-    await cleanup(projectDirectory);
-  } catch (error) {
-    await cleanup(projectDirectory);
+  } finally {
+    await cleanup();
   }
 };
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://www.eventcatalog.dev/docs/contributing/overview

Happy contributing!

-->

## Motivation

Close #830.

## Solution

It imports the `package.json` from projectDirectory to check the module system, ECMAScript Modules or CommonJS. If the  module system is ESM then just import the `eventcatalog.config.js`. Otherwise, make a copy of eventcatalog.config.js to the os tmpdir/eventcatalog.config.mjs and import it. 

It removes the convertEsmToCjs used before.

This solution was chosen because it touches less code.