### PR TITLE
Fix/react peer conflicts

### DIFF
--- a/.changeset/chilled-bugs-pay.md
+++ b/.changeset/chilled-bugs-pay.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+chore(core): removing react conflicts with installs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@eventcatalog/core",
-  "version": "2.11.0",
+  "version": "2.11.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@eventcatalog/core",
-      "version": "2.11.0",
+      "version": "2.11.5",
       "dependencies": {
         "@astrojs/check": "^0.9.4",
         "@astrojs/markdown-remark": "^5.3.0",
@@ -71,6 +71,9 @@
         "tsup": "^8.1.0",
         "vite-tsconfig-paths": "^4.3.2",
         "vitest": "^2.0.5"
+      },
+      "peerDependencies": {
+        "react": "$react"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -96,5 +96,8 @@
     "tsup": "^8.1.0",
     "vite-tsconfig-paths": "^4.3.2",
     "vitest": "^2.0.5"
+  },
+  "peerDependencies": {
+    "react": "$react"
   }
 }


### PR DESCRIPTION
## Motivation

EC uses many dependent packages and we see lots of verbose warnings in CI 
We can override the react peers to use the project react installed version 
<img width="1205" alt="Screenshot 2024-10-09 at 13 49 34" src="https://github.com/user-attachments/assets/0dfbbbd4-3876-483f-97e5-df19a56d38c1">

## Caution
This need to be tested and we need to validate if all parts of project are working

