### PR TITLE
fix(core): fixed issue with importing users package json files

### DIFF
--- a/.changeset/wild-lamps-drop.md
+++ b/.changeset/wild-lamps-drop.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix(core): fixed issue with importing users package json files

--- a/scripts/eventcatalog-config-file-utils.js
+++ b/scripts/eventcatalog-config-file-utils.js
@@ -17,8 +17,10 @@ export const getEventCatalogConfigFile = async (projectDirectory) => {
   try {
     let configFilePath = path.join(projectDirectory, 'eventcatalog.config.js');
 
-    const packageJson = await import(/* @vite-ignore */ path.join(projectDirectory, 'package.json'));
-    if (packageJson.default?.type !== 'module') {
+    const filePath = path.join(projectDirectory, 'package.json');
+    const packageJson = JSON.parse(await readFile(filePath, 'utf-8'));
+
+    if (packageJson?.type !== 'module') {
       await copyFile(configFilePath, path.join(tmpdir(), 'eventcatalog.config.mjs'));
       configFilePath = path.join(tmpdir(), 'eventcatalog.config.mjs');
     }


### PR DESCRIPTION
The old way was giving these errors

```
ROJECT_DIR=/Users/dboyne/dev/eventcatalog/eventcatalog/examples/default node scripts/generate.js
TypeError [ERR_IMPORT_ASSERTION_TYPE_MISSING]: Module "file:///Users/dboyne/dev/eventcatalog/eventcatalog/examples/default/package.json" needs an import attribute of type "json"
```

Changed the way the file is now read.