### PR TITLE
fix(core): fixed issue with using tmp directories

### DIFF
--- a/.changeset/kind-coins-check.md
+++ b/.changeset/kind-coins-check.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix(core): fixed issue with using tmp directories

--- a/scripts/eventcatalog-config-file-utils.js
+++ b/scripts/eventcatalog-config-file-utils.js
@@ -4,10 +4,9 @@ import { copyFile } from 'node:fs/promises';
 import path from 'node:path';
 import { v4 as uuidV4 } from 'uuid';
 import { pathToFileURL } from 'url';
-import { tmpdir } from 'node:os';
 
-export async function cleanup() {
-  const filePath = path.join(tmpdir(), 'eventcatalog.config.mjs');
+export async function cleanup(projectDirectory) {
+  const filePath = path.join(projectDirectory, 'eventcatalog.config.mjs');
   if (existsSync(filePath)) {
     await rm(filePath);
   }
@@ -21,8 +20,8 @@ export const getEventCatalogConfigFile = async (projectDirectory) => {
     const packageJson = JSON.parse(await readFile(filePath, 'utf-8'));
 
     if (packageJson?.type !== 'module') {
-      await copyFile(configFilePath, path.join(tmpdir(), 'eventcatalog.config.mjs'));
-      configFilePath = path.join(tmpdir(), 'eventcatalog.config.mjs');
+      await copyFile(configFilePath, path.join(projectDirectory, 'eventcatalog.config.mjs'));
+      configFilePath = path.join(projectDirectory, 'eventcatalog.config.mjs');
     }
 
     const configFileURL = pathToFileURL(configFilePath).href;
@@ -30,7 +29,7 @@ export const getEventCatalogConfigFile = async (projectDirectory) => {
 
     return config.default;
   } finally {
-    await cleanup();
+    await cleanup(projectDirectory);
   }
 };
 
@@ -65,7 +64,7 @@ export const writeEventCatalogConfigFile = async (projectDirectory, newConfig) =
     // Write the updated content back to the file
     await writeFile(configFilePath, content);
   } finally {
-    await cleanup();
+    await cleanup(projectDirectory);
   }
 };
 


### PR DESCRIPTION
We were using tmp directories on the OS for a temp `eventcatalog.config.mjs` file, which sounded great!

But when we use the generators, the users files might look like this

```js
import path from "path";
import url from "url";

const __dirname = path.dirname(url.fileURLToPath(import.meta.url));

/** @type {import('@eventcatalog/core/bin/eventcatalog.config').Config} */
export default {
  cId: "10b46030-5736-4600-8254-421c3ed56e47",
  title: "EventCatalog",
  tagline: "Discover, Explore and Document your Event Driven Architectures",
  organizationName: "Your Company",
  homepageLink: "https://eventcatalog.dev/",
  editUrl: "https://github.com/boyney123/eventcatalog-demo/edit/master",
  // By default set to false, add true to get urls ending in /
  trailingSlash: false,
  // Change to make the base url of the site different, by default https://{website}.com/docs,
  // changing to /company would be https://{website}.com/company/docs,
  base: "/",
  // Customize the logo, add your logo to public/ folder
  logo: {
    alt: "EventCatalog Logo",
    src: "/logo.png",
    text: "EventCatalog",
  },
  docs: {
    sidebar: {
      // Should the sub heading be rendered in the docs sidebar?
      showPageHeadings: true,
    },
  },
  generators: [
    [
      "@eventcatalog/generator-openapi",
      {
        services: [
          { path: path.join(__dirname, "openapi-files", "product-api.yml") },
        ],
        domain: { id: "products", name: "Products", version: "0.0.1" },
      },
    ],
    [
      "@eventcatalog/generator-openapi",
      {
        services: [
          { path: path.join(__dirname, "openapi-files", "order-api.yml"), id: 'order-service' },
          { path: path.join(__dirname, "openapi-files", "order-history.yml"), id: 'order-history' },
        ],
        domain: {
          id: "order-management",
          name: "Order management",
          version: "0.0.1",
        },
      },
    ],
    [
      "@eventcatalog/generator-openapi",
      {
        services: [
          { path: path.join(__dirname, "openapi-files", "payment-api.yml"), id: 'payment-service' },
        ],
        domain: { id: "payment", name: "Payment", version: "0.0.1" },
      },
    ],
  ],
};
```

When the generator script runs this, the `const __dirname = path.dirname(url.fileURLToPath(import.meta.url));` value is coming back as the tmp directory and we cannot find the requires files for generators.

I moved it back to use the catalog directory as the tmp directory and we still continue to clean up the mjs file here.