### PR TITLE
fix(core): fixed rapi-docs for large openapi files

### DIFF
--- a/src/pages/docs/[type]/[id]/[version]/spec/index.astro
+++ b/src/pages/docs/[type]/[id]/[version]/spec/index.astro
@@ -58,7 +58,8 @@ const fileExists = fs.existsSync(pathOnDisk);
         allow-authentication="true"
         allow-try="true"
         default-schema-tab="schema"
-        show-curl-before-try="true"
+        // this is causing the page to not load for large openAPI files, if you want this raise an issue we can look again.
+        // show-curl-before-try="true"
         use-path-in-nav-bar="true"
         show-method-in-nav-bar="as-colored-block"
         theme="light"


### PR DESCRIPTION
To help folks with large OpenAPI files, we have had reports of the page not loading. I can't share the OpenAPI file as its private to the user, but if anyone wants this feature back in the future we can explore it. For now this is the fix to the problem they were seeing.