### PR TITLE
fix(core): moving rimraf to dep of project

### DIFF
--- a/.changeset/mighty-lizards-listen.md
+++ b/.changeset/mighty-lizards-listen.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix(core): moving rimraf to dep of project

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@eventcatalog/core",
-  "version": "2.8.5",
+  "version": "2.8.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@eventcatalog/core",
-      "version": "2.8.5",
+      "version": "2.8.12",
       "dependencies": {
         "@astrojs/check": "^0.9.4",
         "@astrojs/markdown-remark": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,8 @@
     "tailwindcss": "^3.4.3",
     "typescript": "^5.4.5",
     "unist-util-visit": "^5.0.0",
-    "uuid": "^10.0.0"
+    "uuid": "^10.0.0",
+    "rimraf": "^5.0.7"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.5",
@@ -88,7 +89,6 @@
     "@types/react-dom": "^18.3.0",
     "prettier": "^3.3.3",
     "prettier-plugin-astro": "^0.14.1",
-    "rimraf": "^5.0.7",
     "tsup": "^8.1.0",
     "vite-tsconfig-paths": "^4.3.2",
     "vitest": "^2.0.5"


### PR DESCRIPTION
Fixing 2.9.0, moving rimraf to a dep of the project.