### PR TITLE
Adding new resource type "queries" to EventCatalog

### DIFF
--- a/.changeset/tender-ladybugs-run.md
+++ b/.changeset/tender-ladybugs-run.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": minor
+---
+
+feat(core): added support for query message types/resources

--- a/examples/default/domains/Orders/services/InventoryService/index.md
+++ b/examples/default/domains/Orders/services/InventoryService/index.md
@@ -11,7 +11,9 @@ owners:
 receives:
   - id: OrderConfirmed
     version: 0.0.1
-  - id: OrderCancelled
+  - id: OrderConfirmed
+    version: 0.0.1
+  - id: GetInventoryList
     version: 0.0.1
   - id: OrderAmended
     version: 0.0.1
@@ -19,11 +21,14 @@ receives:
     version: 0.0.3
   - id: AddInventory
     version: x
+  - id: GetInventoryStatus
 sends:
   - id: InventoryAdjusted
     version: 0.0.4
   - id: OutOfStock
     version: 0.0.3
+  - id: GetOrder
+    version: 0.0.1
 repository:
   language: JavaScript
   url: https://github.com/boyney123/pretend-shipping-service

--- a/examples/default/domains/Orders/services/InventoryService/queries/GetInventoryList/index.md
+++ b/examples/default/domains/Orders/services/InventoryService/queries/GetInventoryList/index.md
@@ -1,0 +1,22 @@
+---
+id: GetInventoryList
+name: List inventory list
+version: 0.0.1
+summary: |
+  GET request that will return inventory list
+owners:
+    - dboyne
+badges:
+    - content: Recently updated!
+      backgroundColor: green
+      textColor: green
+schemaPath: schema.json
+---
+
+import Footer from '@catalog/components/footer.astro';
+
+## Overview
+
+The GetInventoryList message is a query used to retrieve a comprehensive list of all available inventory items within a system. It is designed to return detailed information about each item, such as product names, quantities, availability status, and potentially additional metadata like categories or locations. This query is typically utilized by systems or services that require a real-time view of current stock, ensuring that downstream applications or users have accurate and up-to-date information for decision-making or operational purposes. The GetInventoryList is ideal for use cases such as order processing, stock management, or reporting, providing visibility into the full range of inventory data.
+
+<NodeGraph />

--- a/examples/default/domains/Orders/services/InventoryService/queries/GetInventoryList/schema.json
+++ b/examples/default/domains/Orders/services/InventoryService/queries/GetInventoryList/schema.json
@@ -1,0 +1,53 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "GetInventoryList",
+    "description": "A query to retrieve a list of all available inventory items with their details.",
+    "type": "object",
+    "properties": {
+      "filters": {
+        "type": "object",
+        "description": "Optional filters to narrow down the inventory search.",
+        "properties": {
+          "category": {
+            "type": "string",
+            "description": "Filter items by category (e.g., electronics, clothing, etc.)."
+          },
+          "location": {
+            "type": "string",
+            "description": "Filter items by storage location or warehouse."
+          },
+          "minStockLevel": {
+            "type": "integer",
+            "description": "Filter items with a stock level greater than or equal to this value."
+          },
+          "inStock": {
+            "type": "boolean",
+            "description": "Filter items that are currently in stock (true) or out of stock (false)."
+          }
+        },
+        "additionalProperties": false
+      },
+      "pagination": {
+        "type": "object",
+        "description": "Pagination options for the query.",
+        "properties": {
+          "page": {
+            "type": "integer",
+            "description": "The current page of results.",
+            "minimum": 1,
+            "default": 1
+          },
+          "pageSize": {
+            "type": "integer",
+            "description": "The number of items per page.",
+            "minimum": 1,
+            "default": 10
+          }
+        },
+        "required": ["page", "pageSize"]
+      }
+    },
+    "required": [],
+    "additionalProperties": false
+  }
+  

--- a/examples/default/domains/Orders/services/InventoryService/queries/GetInventoryStatus/index.md
+++ b/examples/default/domains/Orders/services/InventoryService/queries/GetInventoryStatus/index.md
@@ -1,0 +1,41 @@
+---
+id: GetInventoryStatus
+name: Get inventory status
+version: 0.0.1
+summary: |
+  GET request that will return the current stock status for a specific product.
+owners:
+    - dboyne
+badges:
+    - content: GET Request
+      backgroundColor: green
+      textColor: green
+schemaPath: schema.json
+---
+
+import Footer from '@catalog/components/footer.astro';
+
+## Overview
+
+The GetInventoryStatus message is a query designed to retrieve the current stock status for a specific product. 
+
+This query provides detailed information about the available quantity, reserved quantity, and the warehouse location where the product is stored. It is typically used by systems or services that need to determine the real-time availability of a product, enabling efficient stock management, order fulfillment, and inventory tracking processes. 
+
+This query is essential for ensuring accurate stock levels are reported to downstream systems, including e-commerce platforms, warehouse management systems, and sales channels.
+
+<NodeGraph />
+
+<SchemaViewer file="schema.json" title="JSON Schema" maxHeight="500" />
+
+
+### Query using CURL
+
+Use this snippet to query the inventory status
+
+```sh title="Example CURL command"
+curl -X GET "https://api.yourdomain.com/inventory/status" \
+-H "Content-Type: application/json" \
+-d '{
+  "productId": "12345"
+}'
+```

--- a/examples/default/domains/Orders/services/InventoryService/queries/GetInventoryStatus/schema.json
+++ b/examples/default/domains/Orders/services/InventoryService/queries/GetInventoryStatus/schema.json
@@ -1,0 +1,28 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "GetInventoryStatusResponse",
+    "type": "object",
+    "properties": {
+      "productId": {
+        "type": "string",
+        "description": "The unique identifier for the product"
+      },
+      "availableQuantity": {
+        "type": "integer",
+        "description": "The quantity of the product currently available in stock",
+        "minimum": 0
+      },
+      "reservedQuantity": {
+        "type": "integer",
+        "description": "The quantity of the product that is reserved for pending orders",
+        "minimum": 0
+      },
+      "warehouseLocation": {
+        "type": "string",
+        "description": "The location of the warehouse where the product is stored"
+      }
+    },
+    "required": ["productId", "availableQuantity", "reservedQuantity", "warehouseLocation"],
+    "additionalProperties": false
+  }
+  

--- a/examples/default/domains/Orders/services/NotificationService/index.md
+++ b/examples/default/domains/Orders/services/NotificationService/index.md
@@ -11,8 +11,14 @@ receives:
     version: ">1.0.0"
   - id: PaymentProcessed
     version: ^1.0.0
+  - id: GetUserNotifications
+    version: x
+  - id: GetNotificationDetails
+    version: x
 sends:
   - id: OutOfStock
+    version: 0.0.x
+  - id: GetInventoryList
     version: 0.0.x
 repository:
   language: JavaScript

--- a/examples/default/domains/Orders/services/NotificationService/queries/GetNotificationDetails/index.md
+++ b/examples/default/domains/Orders/services/NotificationService/queries/GetNotificationDetails/index.md
@@ -1,0 +1,26 @@
+---
+id: GetNotificationDetails
+name: Get notification details
+version: 0.0.1
+summary: |
+  GET request that will return detailed information about a specific notification, identified by its notificationId.
+owners:
+    - dboyne
+badges:
+    - content: Recently updated!
+      backgroundColor: green
+      textColor: green
+schemaPath: schema.json
+---
+
+import Footer from '@catalog/components/footer.astro';
+
+## Overview
+
+The `GetNotificationDetails` message is a query used to retrieve detailed information about a specific notification identified by its `notificationId`. It provides a comprehensive overview of the notification, including the title, message content, status (read/unread), the date it was created, and any additional metadata related to the notification, such as associated orders or system events. This query is helpful in scenarios where users or systems need detailed insights into a particular notification, such as retrieving full messages or auditing notifications sent to users.
+
+Use cases include viewing detailed information about order updates, system notifications, or promotional messages, allowing users to view their full notification history and details.
+
+<NodeGraph />
+
+<SchemaViewer file="schema.json" title="JSON Schema" maxHeight="500" />

--- a/examples/default/domains/Orders/services/NotificationService/queries/GetNotificationDetails/schema.json
+++ b/examples/default/domains/Orders/services/NotificationService/queries/GetNotificationDetails/schema.json
@@ -1,0 +1,56 @@
+
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "GetNotificationDetailsResponse",
+  "type": "object",
+  "properties": {
+    "notificationId": {
+      "type": "string",
+      "description": "The unique identifier for the notification."
+    },
+    "title": {
+      "type": "string",
+      "description": "The title or subject of the notification."
+    },
+    "message": {
+      "type": "string",
+      "description": "The content or message body of the notification."
+    },
+    "status": {
+      "type": "string",
+      "enum": ["unread", "read"],
+      "description": "The read status of the notification."
+    },
+    "userId": {
+      "type": "string",
+      "description": "The unique identifier for the user who received the notification."
+    },
+    "createdAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "The date and time when the notification was created."
+    },
+    "type": {
+      "type": "string",
+      "description": "The type of the notification, such as order or system."
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Additional metadata related to the notification, such as order details.",
+      "properties": {
+        "orderId": {
+          "type": "string",
+          "description": "The associated order ID, if applicable."
+        },
+        "shippingProvider": {
+          "type": "string",
+          "description": "The shipping provider for the associated order, if applicable."
+        }
+      },
+      "required": ["orderId"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["notificationId", "title", "message", "status", "userId", "createdAt", "type"],
+  "additionalProperties": false
+}

--- a/examples/default/domains/Orders/services/NotificationService/queries/GetUserNotifications/index.md
+++ b/examples/default/domains/Orders/services/NotificationService/queries/GetUserNotifications/index.md
@@ -1,0 +1,27 @@
+---
+id: GetUserNotifications
+name: Get user notifications
+version: 0.0.1
+summary: |
+  GET request that will return a list of notifications for a specific user, with options to filter by status (unread or all).
+owners:
+    - dboyne
+badges:
+    - content: Recently updated!
+      backgroundColor: green
+      textColor: green
+schemaPath: schema.json
+---
+
+import Footer from '@catalog/components/footer.astro';
+
+## Overview
+
+The `GetUserNotifications` message is a query used to retrieve a list of notifications for a specific user. It allows filtering by notification status, such as unread or all notifications. This query is typically utilized by notification services to display user-specific messages, such as order updates, promotional offers, or system notifications. It supports pagination through `limit` and `offset` parameters, ensuring that only a manageable number of notifications are retrieved at once. This query helps users stay informed about important events or updates related to their account, orders, or the platform.
+
+Use cases include delivering notifications for order updates, promotional campaigns, or general system messages to keep the user informed.
+
+<NodeGraph />
+
+<SchemaViewer file="schema.json" title="JSON Schema" maxHeight="500" />
+

--- a/examples/default/domains/Orders/services/NotificationService/queries/GetUserNotifications/schema.json
+++ b/examples/default/domains/Orders/services/NotificationService/queries/GetUserNotifications/schema.json
@@ -1,0 +1,47 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "GetUserNotificationsResponse",
+    "type": "object",
+    "properties": {
+      "userId": {
+        "type": "string",
+        "description": "The unique identifier for the user."
+      },
+      "notifications": {
+        "type": "array",
+        "description": "A list of notifications for the user.",
+        "items": {
+          "type": "object",
+          "properties": {
+            "notificationId": {
+              "type": "string",
+              "description": "The unique identifier for the notification."
+            },
+            "title": {
+              "type": "string",
+              "description": "The title or subject of the notification."
+            },
+            "message": {
+              "type": "string",
+              "description": "The message body of the notification."
+            },
+            "status": {
+              "type": "string",
+              "enum": ["unread", "read"],
+              "description": "The read status of the notification."
+            },
+            "createdAt": {
+              "type": "string",
+              "format": "date-time",
+              "description": "The date and time when the notification was created."
+            }
+          },
+          "required": ["notificationId", "title", "message", "status", "createdAt"],
+          "additionalProperties": false
+        }
+      }
+    },
+    "required": ["userId", "notifications"],
+    "additionalProperties": false
+  }
+  

--- a/examples/default/domains/Orders/services/OrdersService/index.md
+++ b/examples/default/domains/Orders/services/OrdersService/index.md
@@ -9,6 +9,8 @@ owners:
 receives:
   - id: InventoryAdjusted
     version: 0.0.3
+  - id: GetOrder
+    version: 0.0.1
 sends:
   - id: AddInventory  
     version: 0.0.3

--- a/examples/default/domains/Orders/services/OrdersService/queries/GetOrder/index.md
+++ b/examples/default/domains/Orders/services/OrdersService/queries/GetOrder/index.md
@@ -1,0 +1,26 @@
+---
+id: GetOrder
+name: Get order details
+version: 0.0.1
+summary: |
+  GET request that will return detailed information about a specific order, identified by its orderId.
+owners:
+    - dboyne
+badges:
+    - content: Recently updated!
+      backgroundColor: green
+      textColor: green
+schemaPath: schema.json
+---
+
+import Footer from '@catalog/components/footer.astro';
+
+## Overview
+
+The `GetOrder` message is a query used to retrieve detailed information about a specific order, identified by its `orderId`. It provides information such as the order status (e.g., pending, completed, shipped), the items within the order, billing and shipping details, payment information, and the order's total amount. This query is commonly used by systems managing order processing, customer service, or order tracking functionalities.
+
+This query can be applied in e-commerce systems, marketplaces, or any platform where users and systems need real-time order data for tracking, auditing, or managing customer purchases.
+
+<NodeGraph />
+
+<SchemaViewer file="schema.json" title="JSON Schema" maxHeight="500" />

--- a/examples/default/domains/Payment/services/PaymentService/index.md
+++ b/examples/default/domains/Payment/services/PaymentService/index.md
@@ -9,9 +9,11 @@ owners:
 receives:
   - id: PaymentInitiated
     version: 0.0.1
+  - id: GetPaymentStatus
 sends:
   - id: PaymentProcessed
     version: 0.0.1
+  - id: GetOrder
 repository:
   language: JavaScript
   url: https://github.com/boyney123/pretend-shipping-service

--- a/examples/default/domains/Payment/services/PaymentService/queries/GetPaymentStatus/index.md
+++ b/examples/default/domains/Payment/services/PaymentService/queries/GetPaymentStatus/index.md
@@ -1,0 +1,26 @@
+---
+id: GetPaymentStatus
+name: Get payment status
+version: 0.0.1
+summary: |
+  GET request that will return the payment status for a specific order, identified by its orderId.
+owners:
+    - dboyne
+badges:
+    - content: Recently updated!
+      backgroundColor: green
+      textColor: green
+schemaPath: schema.json
+---
+
+import Footer from '@catalog/components/footer.astro';
+
+## Overview
+
+The `GetPaymentStatus` message is a query used to retrieve the payment status for a specific order, identified by its `orderId`. This query returns the current status of the payment, such as whether it is pending, completed, failed, or refunded. It is used by systems that need to track the lifecycle of payments associated with orders, ensuring that the payment has been successfully processed or identifying if any issues occurred during the transaction.
+
+This query is useful in scenarios such as order management, refund processing, or payment auditing, ensuring that users or systems have real-time visibility into the payment status for a given order.
+
+<NodeGraph />
+
+<SchemaViewer file="schema.json" title="JSON Schema" maxHeight="500" />

--- a/examples/default/domains/Payment/services/PaymentService/queries/GetPaymentStatus/schema.json
+++ b/examples/default/domains/Payment/services/PaymentService/queries/GetPaymentStatus/schema.json
@@ -1,0 +1,40 @@
+
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "GetPaymentStatusResponse",
+  "type": "object",
+  "properties": {
+    "orderId": {
+      "type": "string",
+      "description": "The unique identifier for the order."
+    },
+    "paymentStatus": {
+      "type": "string",
+      "enum": ["pending", "completed", "failed", "refunded"],
+      "description": "The current payment status of the order."
+    },
+    "amount": {
+      "type": "number",
+      "description": "The amount paid for the order."
+    },
+    "currency": {
+      "type": "string",
+      "description": "The currency in which the payment was made (e.g., USD, EUR)."
+    },
+    "paymentMethod": {
+      "type": "string",
+      "description": "The payment method used for the transaction (e.g., Credit Card, PayPal)."
+    },
+    "transactionId": {
+      "type": "string",
+      "description": "The unique identifier for the payment transaction."
+    },
+    "paymentDate": {
+      "type": "string",
+      "format": "date-time",
+      "description": "The date and time when the payment was processed."
+    }
+  },
+  "required": ["orderId", "paymentStatus", "amount", "currency", "paymentMethod", "transactionId", "paymentDate"],
+  "additionalProperties": false
+}

--- a/examples/default/domains/Subscriptions/services/SubscriptionService/index.md
+++ b/examples/default/domains/Subscriptions/services/SubscriptionService/index.md
@@ -11,6 +11,7 @@ receives:
     version: 0.0.1
   - id: CancelSubscription
     version: 0.0.1
+  - id: GetSubscriptionStatus  
 sends:
   - id: UserSubscriptionStarted
     version: 0.0.1

--- a/examples/default/domains/Subscriptions/services/SubscriptionService/queries/GetSubscriptionStatus/index.md
+++ b/examples/default/domains/Subscriptions/services/SubscriptionService/queries/GetSubscriptionStatus/index.md
@@ -1,0 +1,26 @@
+---
+id: GetSubscriptionStatus
+name: Get subscription status
+version: 0.0.2
+summary: |
+  GET request that will return the current subscription status for a specific user, identified by their userId.
+owners:
+    - dboyne
+badges:
+    - content: Recently updated!
+      backgroundColor: green
+      textColor: green
+schemaPath: schema.json
+---
+
+import Footer from '@catalog/components/footer.astro';
+
+## Overview
+
+The `GetSubscriptionStatus` message is a query used to retrieve the current subscription status for a specific user, identified by their `userId`. This query returns detailed information about the user's subscription, such as its current status (active, canceled, expired), the subscription tier or plan, and the next billing date. It is typically used by systems that manage user subscriptions, billing, and renewal processes to ensure that users are aware of their subscription details and any upcoming renewals.
+
+This query is particularly useful in managing subscriptions for SaaS products, media services, or any recurring payment-based services where users need to manage and view their subscription information.
+
+<NodeGraph />
+
+<SchemaViewer file="schema.json" title="JSON Schema" maxHeight="500" />

--- a/examples/default/domains/Subscriptions/services/SubscriptionService/queries/GetSubscriptionStatus/schema.json
+++ b/examples/default/domains/Subscriptions/services/SubscriptionService/queries/GetSubscriptionStatus/schema.json
@@ -1,0 +1,46 @@
+
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "GetSubscriptionStatusResponse",
+  "type": "object",
+  "properties": {
+    "userId": {
+      "type": "string",
+      "description": "The unique identifier for the user."
+    },
+    "subscriptionStatus": {
+      "type": "string",
+      "enum": ["active", "canceled", "expired", "pending"],
+      "description": "The current status of the user's subscription."
+    },
+    "subscriptionPlan": {
+      "type": "string",
+      "description": "The name or tier of the subscription plan."
+    },
+    "nextBillingDate": {
+      "type": "string",
+      "format": "date-time",
+      "description": "The date and time of the next billing or renewal."
+    },
+    "billingFrequency": {
+      "type": "string",
+      "enum": ["monthly", "yearly"],
+      "description": "The frequency of the billing cycle."
+    },
+    "amount": {
+      "type": "number",
+      "description": "The amount to be billed for the subscription."
+    },
+    "currency": {
+      "type": "string",
+      "description": "The currency in which the subscription is billed (e.g., USD, EUR)."
+    },
+    "lastPaymentDate": {
+      "type": "string",
+      "format": "date-time",
+      "description": "The date and time when the last payment was processed."
+    }
+  },
+  "required": ["userId", "subscriptionStatus", "subscriptionPlan", "nextBillingDate", "billingFrequency", "amount", "currency", "lastPaymentDate"],
+  "additionalProperties": false
+}

--- a/examples/default/domains/Subscriptions/services/SubscriptionService/queries/GetSubscriptionStatus/versioned/0.0.1/index.md
+++ b/examples/default/domains/Subscriptions/services/SubscriptionService/queries/GetSubscriptionStatus/versioned/0.0.1/index.md
@@ -1,0 +1,26 @@
+---
+id: GetSubscriptionStatus
+name: Get subscription status
+version: 0.0.1
+summary: |
+  GET request that will return the current subscription status for a specific user, identified by their userId.
+owners:
+    - dboyne
+badges:
+    - content: Recently updated!
+      backgroundColor: green
+      textColor: green
+schemaPath: schema.json
+---
+
+import Footer from '@catalog/components/footer.astro';
+
+## Overview
+
+The `GetSubscriptionStatus` message is a query used to retrieve the current subscription status for a specific user, identified by their `userId`. This query returns detailed information about the user's subscription, such as its current status (active, canceled, expired), the subscription tier or plan, and the next billing date. It is typically used by systems that manage user subscriptions, billing, and renewal processes to ensure that users are aware of their subscription details and any upcoming renewals.
+
+This query is particularly useful in managing subscriptions for SaaS products, media services, or any recurring payment-based services where users need to manage and view their subscription information.
+
+<NodeGraph />
+
+<SchemaViewer file="schema.json" title="JSON Schema" maxHeight="500" />

--- a/examples/default/domains/Subscriptions/services/SubscriptionService/queries/GetSubscriptionStatus/versioned/0.0.1/schema.json
+++ b/examples/default/domains/Subscriptions/services/SubscriptionService/queries/GetSubscriptionStatus/versioned/0.0.1/schema.json
@@ -1,0 +1,46 @@
+
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "GetSubscriptionStatusResponse",
+  "type": "object",
+  "properties": {
+    "userId": {
+      "type": "string",
+      "description": "The unique identifier for the user."
+    },
+    "subscriptionStatus": {
+      "type": "string",
+      "enum": ["active", "canceled", "expired", "pending"],
+      "description": "The current status of the user's subscription."
+    },
+    "subscriptionPlan": {
+      "type": "string",
+      "description": "The name or tier of the subscription plan."
+    },
+    "nextBillingDate": {
+      "type": "string",
+      "format": "date-time",
+      "description": "The date and time of the next billing or renewal."
+    },
+    "billingFrequency": {
+      "type": "string",
+      "enum": ["monthly", "yearly"],
+      "description": "The frequency of the billing cycle."
+    },
+    "amount": {
+      "type": "number",
+      "description": "The amount to be billed for the subscription."
+    },
+    "currency": {
+      "type": "string",
+      "description": "The currency in which the subscription is billed (e.g., USD, EUR)."
+    },
+    "lastPaymentDate": {
+      "type": "string",
+      "format": "date-time",
+      "description": "The date and time when the last payment was processed."
+    }
+  },
+  "required": ["userId", "subscriptionStatus", "subscriptionPlan", "nextBillingDate", "billingFrequency", "amount", "currency", "lastPaymentDate"],
+  "additionalProperties": false
+}

--- a/scripts/catalog-to-astro-content-directory.js
+++ b/scripts/catalog-to-astro-content-directory.js
@@ -41,7 +41,7 @@ const copyFiles = async (source, target) => {
 
 const ensureAstroCollectionNotEmpty = async (astroDir) => {
   // TODO: maybe import collections from `src/content/config.ts`...
-  const COLLECTIONS = ['events', 'commands', 'services', 'users', 'teams', 'domains', 'flows', 'pages', 'changelogs'];
+  const COLLECTIONS = ['events', 'commands', 'services', 'users', 'teams', 'domains', 'flows', 'pages', 'changelogs', 'queries'];
 
   // Check empty collections
   const emptyCollections = [];
@@ -68,8 +68,6 @@ const ensureAstroCollectionNotEmpty = async (astroDir) => {
 
 export const catalogToAstro = async (source, astroDir) => {
   const astroContentDir = path.join(astroDir, 'src/content/');
-
-  console.log(path.join(astroContentDir, 'config.ts'));
 
   // Config file
   const astroConfigFile = fs.readFileSync(path.join(astroContentDir, 'config.ts'));

--- a/scripts/default-files-for-collections/queries.md
+++ b/scripts/default-files-for-collections/queries.md
@@ -1,0 +1,8 @@
+---
+id: empty
+name: empty
+version: 0.0.1
+hidden: true
+---
+
+<!-- Do not delete this file, required for EC, you an ignore this file -->

--- a/scripts/map-catalog-to-astro.js
+++ b/scripts/map-catalog-to-astro.js
@@ -1,6 +1,17 @@
 import path from 'node:path';
 
-const COLLECTION_KEYS = ['events', 'commands', 'services', 'users', 'teams', 'domains', 'flows', 'pages', 'changelogs'];
+const COLLECTION_KEYS = [
+  'events',
+  'commands',
+  'services',
+  'users',
+  'teams',
+  'domains',
+  'flows',
+  'pages',
+  'changelogs',
+  'queries',
+];
 
 /**
  * @typedef {Object} MapCatalogToAstroParams

--- a/src/components/DiscoverInsight.astro
+++ b/src/components/DiscoverInsight.astro
@@ -6,7 +6,7 @@ interface Props {
   color: string;
   dataTarget: number;
   icon: React.ElementType;
-  label: 'domains' | 'services' | 'commands' | 'events' | 'flows';
+  label: 'domains' | 'services' | 'commands' | 'queries' | 'events' | 'flows';
 }
 
 const { color, dataTarget, icon: Icon, label } = Astro.props;

--- a/src/components/DocsNavigation.astro
+++ b/src/components/DocsNavigation.astro
@@ -8,16 +8,18 @@ import { getTeams } from '@utils/teams';
 import { getUsers } from '@utils/users';
 import config, { type CatalogConfig } from '@eventcatalog';
 import { buildUrl } from '@utils/url-builder';
+import { getQueries } from '@utils/queries';
 
 const events = await getEvents({ getAllVersions: false });
 const commands = await getCommands({ getAllVersions: false });
+const queries = await getQueries({ getAllVersions: false });
 const services = await getServices({ getAllVersions: false });
 const domains = await getDomains({ getAllVersions: false });
 const flows = await getFlows({ getAllVersions: false });
 const teams = await getTeams();
 const users = await getUsers();
 
-const messages = [...events, ...commands];
+const messages = [...events, ...commands, ...queries];
 
 // @ts-ignore for large catalogs https://github.com/event-catalog/eventcatalog/issues/552
 const allData = [...domains, ...services, ...messages, ...flows, ...teams, ...users];

--- a/src/components/MDX/NodeGraph/NodeGraph.astro
+++ b/src/components/MDX/NodeGraph/NodeGraph.astro
@@ -3,6 +3,7 @@ import NodeGraphNew from './NodeGraph';
 import { getNodesAndEdges as getNodesAndEdgesForService } from '@utils/services/node-graph';
 import { getNodesAndEdges as getNodesAndEdgesForEvent } from '@utils/events/node-graph';
 import { getNodesAndEdges as getNodesAndEdgesForCommand } from '@utils/commands/node-graph';
+import { getNodesAndEdges as getNodesAndEdgesForQueries } from '@utils/queries/node-graph';
 import { getNodesAndEdges as getNodesAndEdgesForDomain } from '@utils/domains/node-graph';
 import { getNodesAndEdges as getNodesAndEdgesForFlows } from '@utils/flows/node-graph';
 
@@ -48,6 +49,17 @@ if (collection === 'events') {
 
 if (collection === 'commands') {
   const { nodes: eventNodes, edges: eventEdges } = await getNodesAndEdgesForCommand({
+    id: id,
+    version,
+    mode,
+  });
+
+  nodes = eventNodes;
+  edges = eventEdges;
+}
+
+if (collection === 'queries') {
+  const { nodes: eventNodes, edges: eventEdges } = await getNodesAndEdgesForQueries({
     id: id,
     version,
     mode,

--- a/src/components/MDX/NodeGraph/NodeGraph.tsx
+++ b/src/components/MDX/NodeGraph/NodeGraph.tsx
@@ -15,6 +15,7 @@ import ReactFlow, {
 import 'reactflow/dist/style.css';
 import ServiceNode from './Nodes/Service';
 import EventNode from './Nodes/Event';
+import QueryNode from './Nodes/Query';
 import UserNode from './Nodes/User';
 import StepNode from './Nodes/Step';
 import CommandNode from './Nodes/Command';
@@ -57,6 +58,7 @@ const NodeGraphBuilder = ({
     () => ({
       services: ServiceNode,
       events: EventNode,
+      queries: QueryNode,
       commands: CommandNode,
       step: StepNode,
       user: UserNode,
@@ -160,20 +162,24 @@ const NodeGraphBuilder = ({
       {includeBackground && <Controls />}
       {includeKey && (
         <Panel position="bottom-right">
-          <div className=" bg-white font-light px-4 text-[14px] shadow-md py-1 rounded-md">
-            <span className="font-bold">Key</span>
-            <ul>
-              <li className="flex space-x-2 items-center text-[12px]">
+          <div className=" bg-white font-light px-4 text-[12px] shadow-md py-1 rounded-md">
+            {/* <span className="font-bold">Key</span> */}
+            <ul className="m-0 p-0">
+              <li className="flex space-x-2 items-center text-[10px]">
                 <span className="w-2 h-2 bg-orange-500 block" />
                 <span className="block">Event</span>
               </li>
-              <li className="flex space-x-2 items-center text-[12px]">
+              <li className="flex space-x-2 items-center text-[10px]">
                 <span className="w-2 h-2 bg-pink-500 block" />
                 <span className="block">Service</span>
               </li>
-              <li className="flex space-x-2 items-center text-[12px]">
+              <li className="flex space-x-2 items-center text-[10px]">
                 <span className="w-2 h-2 bg-blue-500 block" />
                 <span className="block">Command</span>
+              </li>
+              <li className="flex space-x-2 items-center text-[10px]">
+                <span className="w-2 h-2 bg-green-500 block" />
+                <span className="block">Query</span>
               </li>
             </ul>
           </div>

--- a/src/components/MDX/NodeGraph/Nodes/Query.tsx
+++ b/src/components/MDX/NodeGraph/Nodes/Query.tsx
@@ -1,0 +1,74 @@
+import { MagnifyingGlassIcon } from '@heroicons/react/16/solid';
+import type { CollectionEntry } from 'astro:content';
+import { Handle } from 'reactflow';
+
+interface Data {
+  title: string;
+  label: string;
+  bgColor: string;
+  color: string;
+  mode: 'simple' | 'full';
+  message: CollectionEntry<'queries'>;
+  showTarget?: boolean;
+  showSource?: boolean;
+}
+
+function classNames(...classes: any) {
+  return classes.filter(Boolean).join(' ');
+}
+
+export default function QueryNode({ data, sourcePosition, targetPosition }: any) {
+  const { mode, message, showTarget = true, showSource = true } = data as Data;
+
+  const { name, version, summary, owners = [], producers = [], consumers = [] } = message.data;
+
+  const renderTarget = showTarget || (targetPosition && producers.length > 0);
+  const renderSource = showSource || (sourcePosition && consumers.length > 0);
+
+  return (
+    <div className={classNames('w-full rounded-md border flex justify-start  bg-white text-black border-green-400')}>
+      <div
+        className={classNames(
+          'bg-gradient-to-b from-green-500 to-green-700 relative flex items-center w-5 justify-center rounded-l-sm text-green-100-500',
+          `border-r-[1px] border-green-500`
+        )}
+      >
+        <MagnifyingGlassIcon className="w-4 h-4 opacity-90 text-white absolute top-1 " />
+        {mode === 'full' && (
+          <span className="rotate -rotate-90 w-1/2 text-center absolute bottom-1 text-[9px] text-white font-bold uppercase tracking-[3px] ">
+            Query
+          </span>
+        )}
+      </div>
+      <div className="p-1 min-w-60 max-w-[min-content]">
+        {renderTarget && <Handle type="target" position={targetPosition} />}
+        {renderSource && <Handle type="source" position={sourcePosition} />}
+        <div className={classNames(mode === 'full' ? `border-b border-gray-200` : '')}>
+          <span className="text-xs font-bold block pb-0.5">{name}</span>
+          <div className="flex justify-between">
+            <span className="text-[10px] font-light block pt-0.5 pb-0.5 ">v{version}</span>
+            {mode === 'simple' && <span className="text-[10px] text-gray-500 font-light block pt-0.5 pb-0.5 ">Query</span>}
+          </div>
+        </div>
+        {mode === 'full' && (
+          <div className="divide-y divide-gray-200 ">
+            <div className="leading-3 py-1">
+              <span className="text-[8px] font-light">{summary}</span>
+            </div>
+            <div className="grid grid-cols-2 gap-x-4 py-1">
+              <span className="text-xs" style={{ fontSize: '0.2em' }}>
+                Producers: {producers.length}
+              </span>
+              <span className="text-xs" style={{ fontSize: '0.2em' }}>
+                Consumers: {consumers.length}
+              </span>
+              <span className="text-xs" style={{ fontSize: '0.2em' }}>
+                Owners: {owners.length}
+              </span>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/SideBars/MessageSideBar.astro
+++ b/src/components/SideBars/MessageSideBar.astro
@@ -38,7 +38,38 @@ const ownersList = owners.map((o) => ({
   href: buildUrl(`/docs/${o.collection}/${o.data.id}`),
 }));
 
-const type = message.collection.slice(0, -1);
+const getType = (type: string) => {
+  switch (type) {
+    case 'queries':
+      return 'Query';
+    default:
+      return message.collection.slice(0, -1);
+  }
+};
+
+const getProducerEmptyMessage = (type: string) => {
+  const value = type.toLowerCase();
+  switch (value) {
+    case 'query':
+    case 'command':
+      return `This ${value} does not get invoked by any services.`;
+    default:
+      return `This ${value} does not get produced by any services.`;
+  }
+};
+
+const getConsumerEmptyMessage = (type: string) => {
+  const value = type.toLowerCase();
+  switch (value) {
+    case 'query':
+    case 'command':
+      return `This ${value} does not invoke any service.`;
+    default:
+      return `This ${value} does not get consumed by any services.`;
+  }
+};
+
+const type = getType(message.collection);
 
 // @ts-ignore
 const publicPath = message?.catalog?.publicPath;
@@ -52,14 +83,14 @@ const schemaURL = path.join(publicPath, schemaFilePath || '');
       color="pink"
       title={`${type} Producers (${producerList.length})`}
       pills={producerList}
-      emptyMessage={`This ${type} does not get produced by any services.`}
+      emptyMessage={getProducerEmptyMessage(type)}
       client:load
     />
     <PillList
       color="pink"
       title={`${type} Consumers (${consumerList.length})`}
       pills={consumerList}
-      emptyMessage={`This ${type} does not get consumed by any services.`}
+      emptyMessage={getConsumerEmptyMessage(type)}
       client:load
     />
     <OwnersList

--- a/src/components/Tables/columns/MessageTableColumns.tsx
+++ b/src/components/Tables/columns/MessageTableColumns.tsx
@@ -1,4 +1,4 @@
-import { ServerIcon, BoltIcon, ChatBubbleLeftIcon } from '@heroicons/react/24/solid';
+import { ServerIcon, BoltIcon, ChatBubbleLeftIcon, MagnifyingGlassIcon } from '@heroicons/react/24/solid';
 import { createColumnHelper } from '@tanstack/react-table';
 import type { CollectionMessageTypes } from '@types';
 import type { CollectionEntry } from 'astro:content';
@@ -8,6 +8,20 @@ import { buildUrl } from '@utils/url-builder';
 
 const columnHelper = createColumnHelper<CollectionEntry<CollectionMessageTypes>>();
 
+export const getColorAndIconForMessageType = (type: string) => {
+  switch (type) {
+    case 'event':
+      return { color: 'orange', Icon: BoltIcon };
+    case 'command':
+      return { color: 'blue', Icon: ChatBubbleLeftIcon };
+    case 'querie':
+    case 'query':
+      return { color: 'green', Icon: MagnifyingGlassIcon };
+    default:
+      return { color: 'gray', Icon: ChatBubbleLeftIcon };
+  }
+};
+
 export const columns = () => [
   columnHelper.accessor('data.name', {
     id: 'name',
@@ -15,8 +29,7 @@ export const columns = () => [
     cell: (info) => {
       const messageRaw = info.row.original;
       const type = useMemo(() => messageRaw.collection.slice(0, -1), [messageRaw.collection]);
-      const color = type === 'event' ? 'orange' : 'blue';
-      const Icon = type === 'event' ? BoltIcon : ChatBubbleLeftIcon;
+      const { color, Icon } = getColorAndIconForMessageType(type);
       return (
         <div className=" group ">
           <a

--- a/src/components/Tables/columns/ServiceTableColumns.tsx
+++ b/src/components/Tables/columns/ServiceTableColumns.tsx
@@ -4,6 +4,7 @@ import type { CollectionEntry } from 'astro:content';
 import { useMemo } from 'react';
 import { filterByName, filterCollectionByName } from '../filters/custom-filters';
 import { buildUrl } from '@utils/url-builder';
+import { getColorAndIconForMessageType } from './MessageTableColumns';
 
 const columnHelper = createColumnHelper<CollectionEntry<'services'>>();
 
@@ -13,7 +14,6 @@ export const columns = () => [
     header: () => <span>Service</span>,
     cell: (info) => {
       const messageRaw = info.row.original;
-      const type = useMemo(() => messageRaw.collection.slice(0, -1), [messageRaw.collection]);
       const color = 'pink';
       return (
         <div className="group font-light">
@@ -73,8 +73,7 @@ export const columns = () => [
         <ul>
           {receives.map((consumer: any) => {
             const type = consumer.collection.slice(0, -1);
-            const color = type === 'event' ? 'orange' : 'blue';
-            const Icon = type === 'event' ? BoltIcon : ChatBubbleLeftIcon;
+            const { color, Icon } = useMemo(() => getColorAndIconForMessageType(type), [type]);
             return (
               <li key={consumer.data.id} className="py-1 group font-light ">
                 <a

--- a/src/components/Tables/columns/index.tsx
+++ b/src/components/Tables/columns/index.tsx
@@ -7,6 +7,7 @@ export const getColumnsByCollection = (collection: string): any => {
   switch (collection) {
     case 'events':
     case 'commands':
+    case 'queries':
       return MessageTableColumns();
     case 'services':
       return ServiceTableColumns();

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -150,6 +150,16 @@ const commands = defineCollection({
     .merge(baseSchema),
 });
 
+const queries = defineCollection({
+  type: 'content',
+  schema: z
+    .object({
+      producers: z.array(reference('services')).optional(),
+      consumers: z.array(reference('services')).optional(),
+    })
+    .merge(baseSchema),
+});
+
 const services = defineCollection({
   type: 'content',
   schema: z
@@ -207,6 +217,7 @@ const teams = defineCollection({
 export const collections = {
   events,
   commands,
+  queries,
   services,
   users,
   teams,

--- a/src/layouts/DiscoverLayout.astro
+++ b/src/layouts/DiscoverLayout.astro
@@ -9,8 +9,11 @@ import { getFlows } from '@utils/flows/flows';
 import { getEvents } from '@utils/events';
 import { getServices } from '@utils/services/services';
 import { buildUrl } from '@utils/url-builder';
+import { getQueries } from '@utils/queries';
+import { MagnifyingGlassIcon } from '@heroicons/react/20/solid';
 
 const events = await getEvents();
+const queries = await getQueries();
 const commands = await getCommands();
 const services = await getServices();
 const domains = await getDomains();
@@ -35,6 +38,14 @@ const tabs = [
     icon: ChatBubbleLeftIcon,
     activeColor: 'blue',
     enabled: commands.length > 0,
+  },
+  {
+    label: `Queries (${queries.length})`,
+    href: buildUrl('/discover/queries'),
+    isActive: currentPath === '/discover/queries',
+    icon: MagnifyingGlassIcon,
+    activeColor: 'green',
+    enabled: queries.length > 0,
   },
   {
     label: `Services (${services.length})`,

--- a/src/layouts/VisualiserLayout.astro
+++ b/src/layouts/VisualiserLayout.astro
@@ -5,20 +5,22 @@ import { getCommands } from '@utils/commands';
 import { getDomains } from '@utils/domains/domains';
 import { getEvents } from '@utils/events';
 import { getFlows } from '@utils/flows/flows';
+import { getQueries } from '@utils/queries';
 import { getServices } from '@utils/services/services';
 import { buildUrl } from '@utils/url-builder';
 import { ViewTransitions } from 'astro:transitions';
 
-const [services, events, commands, domains, flows] = await Promise.all([
+const [services, events, commands, queries, domains, flows] = await Promise.all([
   getServices(),
   getEvents(),
   getCommands(),
+  getQueries(),
   getDomains(),
   getFlows(),
 ]);
 
 // @ts-ignore for large catalogs https://github.com/event-catalog/eventcatalog/issues/552
-const navItems = [...domains, ...services, ...events, ...commands, ...flows];
+const navItems = [...domains, ...services, ...events, ...commands, ...queries, ...flows];
 
 const navigation = navItems
   .filter((item) => item.data.version === item.data.latestVersion)
@@ -41,6 +43,8 @@ const getColor = (collection: string) => {
       return 'green';
     case 'events':
       return 'red';
+    case 'queries':
+      return 'green';
     case 'commands':
       return 'yellow';
     case 'domains':
@@ -52,45 +56,47 @@ const getColor = (collection: string) => {
 ---
 
 <PlainPage title={title} description={description}>
-  <div class="flex min-h-full flex-row md:flex-col">
-    <div class="mx-auto flex flex-col-reverse md:flex-row w-full items-start">
-      <div>
-        <aside
-          class="md:sticky mt-8 md:mt-0 top-0 w-full md:w-60 xl:w-[19em] shrink-0 lg:block font-light pr-10"
-          id="visualiser-navigation"
-        >
-          {
-            Object.keys(navigation).map((key: any) => {
-              const items = navigation[key]
-                .map((item: any) => {
-                  const isCurrent = currentPath.includes(`${item.collection}/${item.data.id}/${item.data.version}`);
-                  const isLatest = item.data.version === item.data.latestVersion;
-                  if (!isLatest) return null;
-                  return {
-                    label: item.data.name,
-                    version: item.data.version,
-                    color: getColor(item.collection),
-                    href: buildUrl(`/visualiser/${item.collection}/${item.data.id}/${item.data.version}`),
-                    active: isCurrent,
-                  };
-                })
-                .filter((n: any) => n !== null);
-              return (
-                <BasicList
-                  title={`${key} (${navigation[key].length})`}
-                  items={items}
-                  emptyMessage="Nothing to show"
-                  color="gray"
-                  client:load
-                />
-              );
-            })
-          }
+  <div class="">
+    <div class="">
+      <div class="hidden md:block">
+        <aside class="sm:fixed grow w-56 xl:w-[19em] overflow-y-auto h-full z-10 pb-20" id="visualiser-navigation">
+          <div class="w-full">
+            <div class="sticky top-0 z-10 h-8 pointer-events-none -mt-7">
+              <div class="h-full bg-gradient-to-b from-white to-transparent"></div>
+            </div>
+            {
+              Object.keys(navigation).map((key: any) => {
+                const items = navigation[key]
+                  .map((item: any) => {
+                    const isCurrent = currentPath.includes(`${item.collection}/${item.data.id}/${item.data.version}`);
+                    const isLatest = item.data.version === item.data.latestVersion;
+                    if (!isLatest) return null;
+                    return {
+                      label: item.data.name,
+                      version: item.data.version,
+                      color: getColor(item.collection),
+                      href: buildUrl(`/visualiser/${item.collection}/${item.data.id}/${item.data.version}`),
+                      active: isCurrent,
+                    };
+                  })
+                  .filter((n: any) => n !== null);
+                return (
+                  <BasicList
+                    title={`${key} (${navigation[key].length})`}
+                    items={items}
+                    emptyMessage="Nothing to show"
+                    color="gray"
+                    client:load
+                  />
+                );
+              })
+            }
+          </div>
         </aside>
       </div>
 
-      <main class="flex-1 h-full w-full relative">
-        <button
+      <main class="flex-1 h-full w-full relative sm:pl-60 xl:pl-80">
+        <!-- <button
           id="fullscreen-toggle"
           class="absolute top-[1em] z-40 left-5 bg-white hover:bg-gray-100/50 border border-gray-200 hover:text-primary text-gray-800 font-semibold py-2 px-4 rounded-lg transition duration-300 ease-in-out flex items-center space-x-2 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-opacity-75"
         >
@@ -102,7 +108,7 @@ const getColor = (collection: string) => {
               d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4"></path>
           </svg>
           <span>Toggle Fullscreen</span>
-        </button>
+        </button> -->
         <slot />
       </main>
     </div>

--- a/src/pages/discover/[type]/index.astro
+++ b/src/pages/discover/[type]/index.astro
@@ -12,7 +12,7 @@ export async function getStaticPaths() {
     flows: getFlows,
   };
 
-  const itemTypes: PageTypesWithFlows[] = ['events', 'commands', 'services', 'domains', 'flows'];
+  const itemTypes: PageTypesWithFlows[] = ['events', 'commands', 'queries', 'services', 'domains', 'flows'];
   const allItems = await Promise.all(itemTypes.map((type) => loaders[type]()));
 
   return allItems.flatMap((items, index) => ({

--- a/src/pages/docs/[type]/[id]/[version]/asyncapi/index.astro
+++ b/src/pages/docs/[type]/[id]/[version]/asyncapi/index.astro
@@ -16,7 +16,7 @@ import { pageDataLoader } from '@utils/pages/pages';
 import type { CollectionEntry } from 'astro:content';
 
 export async function getStaticPaths() {
-  const itemTypes: PageTypes[] = ['events', 'commands', 'services', 'domains'];
+  const itemTypes: PageTypes[] = ['events', 'commands', 'queries', 'services', 'domains'];
   const allItems = await Promise.all(itemTypes.map((type) => pageDataLoader[type]()));
 
   const hasAsyncAPISpec = (item: CollectionEntry<CollectionTypes>) => item.data.specifications?.asyncapiPath !== undefined;

--- a/src/pages/docs/[type]/[id]/[version]/changelog/index.astro
+++ b/src/pages/docs/[type]/[id]/[version]/changelog/index.astro
@@ -4,7 +4,7 @@ import Footer from '@layouts/Footer.astro';
 
 import type { PageTypes } from '@types';
 import { getChangeLogs } from '@utils/changelogs/changelogs';
-import { RectangleGroupIcon, ServerIcon, BoltIcon, ChatBubbleLeftIcon } from '@heroicons/react/24/outline';
+import { RectangleGroupIcon, ServerIcon, BoltIcon, ChatBubbleLeftIcon, MagnifyingGlassIcon } from '@heroicons/react/24/outline';
 import { pageDataLoader } from '@utils/pages/pages';
 import 'diff2html/bundles/css/diff2html.min.css';
 
@@ -13,7 +13,7 @@ import { getVersions, getPreviousVersion } from '@utils/collections/util';
 import { getDiffsForCurrentAndPreviousVersion } from '@utils/collections/file-diffs';
 
 export async function getStaticPaths() {
-  const itemTypes: PageTypes[] = ['events', 'commands', 'services', 'domains'];
+  const itemTypes: PageTypes[] = ['events', 'commands', 'queries', 'services', 'domains'];
   const allItems = await Promise.all(itemTypes.map((type) => pageDataLoader[type]()));
 
   return allItems.flatMap((items, index) =>
@@ -84,6 +84,9 @@ const getBadge = () => {
   }
   if (props.collection === 'commands') {
     return { backgroundColor: 'blue', textColor: 'blue', content: 'Command', icon: ChatBubbleLeftIcon, class: 'text-blue-400' };
+  }
+  if (props.collection === 'queries') {
+    return { backgroundColor: 'green', textColor: 'green', content: 'Query', icon: MagnifyingGlassIcon, class: 'text-blue-400' };
   }
   if (props.collection === 'domains') {
     return {

--- a/src/pages/docs/[type]/[id]/[version]/index.astro
+++ b/src/pages/docs/[type]/[id]/[version]/index.astro
@@ -26,7 +26,7 @@ export async function getStaticPaths() {
     flows: getFlows,
   };
 
-  const itemTypes: PageTypesWithFlows[] = ['events', 'commands', 'services', 'domains', 'flows'];
+  const itemTypes: PageTypesWithFlows[] = ['events', 'commands', 'queries', 'services', 'domains', 'flows'];
   const allItems = await Promise.all(itemTypes.map((type) => loaders[type]()));
 
   return allItems.flatMap((items, index) =>
@@ -206,7 +206,11 @@ const badges = [getBadge(), ...contentBadges, ...getSpecificationBadges()];
     </main>
     <aside class="hidden lg:block sticky top-20 h-[calc(100vh-theme(spacing.16))] w-56 overflow-y-auto">
       <!-- @ts-ignore -->
-      {(props?.collection === 'events' || props.collection === 'commands') && <MessageSideBar message={props} />}
+      {
+        (props?.collection === 'events' || props.collection === 'commands' || props.collection === 'queries') && (
+          <MessageSideBar message={props} />
+        )
+      }
       {props?.collection === 'services' && <ServiceSideBar service={props} />}
       {props?.collection === 'domains' && <DomainSideBar domain={props} />}
     </aside>

--- a/src/pages/docs/[type]/[id]/[version]/spec/index.astro
+++ b/src/pages/docs/[type]/[id]/[version]/spec/index.astro
@@ -10,7 +10,7 @@ import { buildUrl } from '@utils/url-builder';
 import { pageDataLoader } from '@utils/pages/pages';
 
 export async function getStaticPaths() {
-  const itemTypes: PageTypes[] = ['events', 'commands', 'services', 'domains'];
+  const itemTypes: PageTypes[] = ['events', 'commands', 'queries', 'services', 'domains'];
 
   const allItems = await Promise.all(itemTypes.map((type) => pageDataLoader[type]()));
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,7 +2,14 @@
 import Footer from '@layouts/Footer.astro';
 import PlainPage from '@layouts/PlainPage.astro';
 import { buildUrl } from '@utils/url-builder';
-import { BoltIcon, ChatBubbleLeftIcon, QueueListIcon, RectangleGroupIcon, ServerIcon } from '@heroicons/react/24/outline';
+import {
+  BoltIcon,
+  ChatBubbleLeftIcon,
+  QueueListIcon,
+  RectangleGroupIcon,
+  ServerIcon,
+  MagnifyingGlassIcon,
+} from '@heroicons/react/24/outline';
 
 import { getMessages } from '@utils/messages';
 import { getDomains } from '@utils/domains/domains';
@@ -10,7 +17,7 @@ import { getServices } from '@utils/services/services';
 import { getFlows } from '@utils/flows/flows';
 import DiscoverInsight from '@components/DiscoverInsight.astro';
 
-const { commands = [], events = [] } = await getMessages();
+const { commands = [], events = [], queries = [] } = await getMessages();
 const domains = await getDomains();
 const services = await getServices();
 const flows = await getFlows();
@@ -30,12 +37,14 @@ const flows = await getFlows();
       <div class="hidden md:block">
         <h2 class="text-center text-xl font-bold">Architecture insights</h2>
         <section class="mb-16 bg-white rounded-xl shadow-lg p-6">
-          <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
+          <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">
             <DiscoverInsight color="text-yellow-600" dataTarget={domains.length} icon={RectangleGroupIcon} label="domains" />
 
             <DiscoverInsight color="text-pink-500" dataTarget={services.length} icon={ServerIcon} label="services" />
 
             <DiscoverInsight color="text-blue-500" dataTarget={commands.length} icon={ChatBubbleLeftIcon} label="commands" />
+
+            <DiscoverInsight color="text-green-500" dataTarget={queries.length} icon={MagnifyingGlassIcon} label="queries" />
 
             <DiscoverInsight color="text-orange-400" dataTarget={events.length} icon={BoltIcon} label="events" />
 

--- a/src/pages/visualiser/[type]/[id]/[version]/index.astro
+++ b/src/pages/visualiser/[type]/[id]/[version]/index.astro
@@ -14,7 +14,7 @@ export async function getStaticPaths() {
     flows: getFlows,
   };
 
-  const itemTypes: PageTypesWithFlows[] = ['events', 'commands', 'services', 'domains', 'flows'];
+  const itemTypes: PageTypesWithFlows[] = ['events', 'commands', 'queries', 'services', 'domains', 'flows'];
   const allItems = await Promise.all(itemTypes.map((type) => loaders[type]()));
 
   return allItems.flatMap((items, index) =>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-export type CollectionTypes = 'commands' | 'events' | 'domains' | 'services' | 'flows';
-export type CollectionMessageTypes = 'commands' | 'events';
+export type CollectionTypes = 'commands' | 'events' | 'queries' | 'domains' | 'services' | 'flows';
+export type CollectionMessageTypes = 'commands' | 'events' | 'queries';
 
-export type PageTypes = 'events' | 'commands' | 'services' | 'domains';
+export type PageTypes = 'events' | 'commands' | 'queries' | 'services' | 'domains';

--- a/src/utils/__tests__/queries/mocks.ts
+++ b/src/utils/__tests__/queries/mocks.ts
@@ -1,0 +1,120 @@
+export const mockServices = [
+  {
+    id: 'OrderService',
+    slug: 'OrderService',
+    collection: 'services',
+    data: {
+      id: 'OrderService',
+      version: '0.0.1',
+      sends: [
+        {
+          id: 'GetLatestOrder',
+          version: '0.0.1',
+        },
+      ],
+    },
+  },
+  {
+    id: 'PaymentService',
+    slug: 'PaymentService',
+    collection: 'services',
+    data: {
+      id: 'PaymentService',
+      version: '0.0.1',
+      receives: [
+        {
+          id: 'GetLatestOrder',
+          version: '0.0.1',
+        },
+      ],
+    },
+  },
+  {
+    id: 'InventoryService',
+    slug: 'InventoryService',
+    collection: 'services',
+    data: {
+      id: 'InventoryService',
+      version: '0.0.1',
+      sends: [
+        {
+          id: 'GetInventoryItem',
+          version: '>1.2.0',
+        },
+        {
+          id: 'GetProductStatus',
+        },
+        {
+          id: 'GetStockStatus',
+          version: 'latest',
+        },
+      ],
+    },
+  },
+  {
+    id: 'CatalogService',
+    slug: 'CatalogService',
+    collection: 'services',
+    data: {
+      id: 'CatalogService',
+      version: '0.0.1',
+      receives: [
+        {
+          id: 'GetInventoryItem',
+        },
+        {
+          id: 'GetStockStatus',
+          version: '*',
+        },
+      ],
+    },
+  },
+];
+
+export const mockQueries = [
+  {
+    id: 'GetLatestOrder',
+    slug: 'GetLatestOrder',
+    collection: 'queries',
+    data: {
+      id: 'GetLatestOrder',
+      version: '0.0.1',
+    },
+  },
+  {
+    id: 'GetInventoryItem',
+    slug: 'GetInventoryItem',
+    collection: 'queries',
+    data: {
+      id: 'GetInventoryItem',
+      version: '1.5.1',
+    },
+  },
+  {
+    id: 'GetStockStatus',
+    slug: 'GetStockStatus',
+    collection: 'queries',
+    data: {
+      id: 'GetStockStatus',
+      version: '0.0.1',
+    },
+  },
+  {
+    id: 'GetStockStatus',
+    slug: 'GetStockStatus',
+    collection: 'queries',
+    data: {
+      id: 'GetStockStatus',
+      version: '1.0.0',
+    },
+  },
+  {
+    id: 'GetProductStatus',
+    slug: 'GetProductStatus',
+    collection: 'queries',
+    data: {
+      id: 'GetProductStatus',
+      version: '0.0.1',
+    },
+  },
+];

--- a/src/utils/__tests__/queries/node-graph.spec.ts
+++ b/src/utils/__tests__/queries/node-graph.spec.ts
@@ -1,0 +1,205 @@
+import { MarkerType } from 'reactflow';
+import { getNodesAndEdges } from '../../queries/node-graph';
+import { expect, describe, it, vi, beforeEach } from 'vitest';
+import { mockQueries, mockServices } from './mocks';
+
+vi.mock('astro:content', async (importOriginal) => {
+  return {
+    ...(await importOriginal<typeof import('astro:content')>()),
+    // this will only affect "foo" outside of the original module
+    getCollection: (key: string) => {
+      if (key === 'services') {
+        return Promise.resolve(mockServices);
+      }
+      if (key === 'queries') {
+        return Promise.resolve(mockQueries);
+      }
+      return Promise.resolve([]);
+    },
+  };
+});
+
+describe('Queries NodeGraph', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('getNodesAndEdges', () => {
+    it('should return nodes and edges for a given query', async () => {
+      const { nodes, edges } = await getNodesAndEdges({ id: 'GetLatestOrder', version: '0.0.1' });
+
+      // The middle node itself, the service
+      const expectedQueryNode = {
+        id: 'GetLatestOrder-0.0.1',
+        sourcePosition: 'right',
+        targetPosition: 'left',
+        // data: { mode: 'simple', message: expect.anything(), showTarget: false, showSource: false },
+        data: expect.anything(),
+        position: { x: expect.any(Number), y: expect.any(Number) },
+        type: 'queries',
+      };
+
+      const expectedProducerNode = {
+        id: 'OrderService-0.0.1',
+        type: 'services',
+        sourcePosition: 'right',
+        targetPosition: 'left',
+        data: { mode: 'simple', service: mockServices[0], showTarget: false },
+        position: { x: expect.any(Number), y: expect.any(Number) },
+      };
+
+      const expectedConsumerNode = {
+        id: 'PaymentService-0.0.1',
+        sourcePosition: 'right',
+        targetPosition: 'left',
+        data: {
+          title: 'PaymentService',
+          mode: 'simple',
+          service: mockServices[1],
+          showSource: false,
+        },
+        position: { x: expect.any(Number), y: expect.any(Number) },
+        type: 'services',
+      };
+
+      const expectedEdges = [
+        {
+          id: 'OrderService-0.0.1-GetLatestOrder-0.0.1',
+          source: 'OrderService-0.0.1',
+          target: 'GetLatestOrder-0.0.1',
+          type: 'smoothstep',
+          label: 'requests',
+          animated: false,
+          markerEnd: {
+            type: MarkerType.ArrowClosed,
+            width: 40,
+            height: 40,
+          },
+          style: {
+            strokeWidth: 1,
+          },
+        },
+        {
+          id: 'GetLatestOrder-0.0.1-PaymentService-0.0.1',
+          source: 'GetLatestOrder-0.0.1',
+          target: 'PaymentService-0.0.1',
+          type: 'smoothstep',
+          label: 'accepts',
+          animated: false,
+          markerEnd: {
+            type: MarkerType.ArrowClosed,
+            width: 40,
+            height: 40,
+          },
+          style: {
+            strokeWidth: 1,
+          },
+        },
+      ];
+
+      expect(nodes).toEqual(
+        expect.arrayContaining([
+          // Nodes on the left
+          expect.objectContaining(expectedConsumerNode),
+
+          // The event node itself
+          expect.objectContaining(expectedQueryNode),
+
+          // Nodes on the right
+          expect.objectContaining(expectedProducerNode),
+        ])
+      );
+
+      expect(edges).toEqual(expectedEdges);
+    });
+
+    it('returns empty nodes and edges if no query is found', async () => {
+      const { nodes, edges } = await getNodesAndEdges({ id: 'UnknownQuery', version: '1.0.0' });
+
+      expect(nodes).toEqual([]);
+      expect(edges).toEqual([]);
+    });
+
+    it('should return nodes and edges for a given query using semver range', async () => {
+      const { nodes, edges } = await getNodesAndEdges({ id: 'GetInventoryItem', version: '1.5.1' });
+
+      // The middle node itself, the service
+      const expectedQueryNode = {
+        id: 'GetInventoryItem-1.5.1',
+        sourcePosition: 'right',
+        targetPosition: 'left',
+        data: expect.anything(),
+        position: { x: expect.any(Number), y: expect.any(Number) },
+        type: 'queries',
+      };
+
+      const expectedProducerNode = {
+        id: 'InventoryService-0.0.1',
+        type: 'services',
+        sourcePosition: 'right',
+        targetPosition: 'left',
+        data: { mode: 'simple', service: mockServices[2], showTarget: false },
+        position: { x: expect.any(Number), y: expect.any(Number) },
+      };
+
+      const expectedConsumerNode = {
+        id: 'CatalogService-0.0.1',
+        sourcePosition: 'right',
+        targetPosition: 'left',
+        data: { title: 'CatalogService', mode: 'simple', service: mockServices[3], showSource: false },
+        position: { x: expect.any(Number), y: expect.any(Number) },
+        type: 'services',
+      };
+
+      const expectedEdges = [
+        {
+          id: 'InventoryService-0.0.1-GetInventoryItem-1.5.1',
+          source: 'InventoryService-0.0.1',
+          target: 'GetInventoryItem-1.5.1',
+          type: 'smoothstep',
+          label: 'requests',
+          animated: false,
+          markerEnd: {
+            type: MarkerType.ArrowClosed,
+            width: 40,
+            height: 40,
+          },
+          style: {
+            strokeWidth: 1,
+          },
+        },
+        {
+          id: 'GetInventoryItem-1.5.1-CatalogService-0.0.1',
+          source: 'GetInventoryItem-1.5.1',
+          target: 'CatalogService-0.0.1',
+          type: 'smoothstep',
+          label: 'accepts',
+          animated: false,
+          markerEnd: {
+            type: MarkerType.ArrowClosed,
+            width: 40,
+            height: 40,
+          },
+          style: {
+            strokeWidth: 1,
+          },
+        },
+      ];
+
+      expect(nodes).toEqual(
+        expect.arrayContaining([
+          // Nodes on the left
+          expect.objectContaining(expectedProducerNode),
+
+          // The event node itself
+          expect.objectContaining(expectedQueryNode),
+
+          // Nodes on the right
+          expect.objectContaining(expectedConsumerNode),
+        ])
+      );
+
+      expect(edges).toEqual(expectedEdges);
+    });
+  });
+});

--- a/src/utils/__tests__/queries/queries.spec.ts
+++ b/src/utils/__tests__/queries/queries.spec.ts
@@ -1,0 +1,86 @@
+import type { ContentCollectionKey } from 'astro:content';
+import { expect, describe, it, vi } from 'vitest';
+import { mockServices, mockQueries } from './mocks';
+import { getQueries } from '@utils/queries';
+
+vi.mock('astro:content', async (importOriginal) => {
+  return {
+    ...(await importOriginal<typeof import('astro:content')>()),
+    // this will only affect "foo" outside of the original module
+    getCollection: (key: ContentCollectionKey) => {
+      switch (key) {
+        case 'services':
+          return Promise.resolve(mockServices);
+        case 'queries':
+          return Promise.resolve(mockQueries);
+        default:
+          return Promise.resolve([]);
+      }
+    },
+  };
+});
+
+describe('Queries', () => {
+  describe('getQueries', () => {
+    it('should returns an array of queries', async () => {
+      const queries = await getQueries();
+
+      const expectedQueries = [
+        {
+          id: 'GetLatestOrder',
+          slug: 'GetLatestOrder',
+          collection: 'queries',
+          data: expect.objectContaining({
+            id: 'GetLatestOrder',
+            version: '0.0.1',
+            producers: [mockServices[0]],
+            consumers: [mockServices[1]],
+          }),
+        },
+        {
+          id: 'GetInventoryItem',
+          slug: 'GetInventoryItem',
+          collection: 'queries',
+          data: expect.objectContaining({
+            id: 'GetInventoryItem',
+            version: '1.5.1',
+            producers: [mockServices[2]],
+            consumers: [mockServices[3]],
+          }),
+        },
+        {
+          id: 'GetStockStatus',
+          slug: 'GetStockStatus',
+          collection: 'queries',
+          data: expect.objectContaining({
+            id: 'GetStockStatus',
+            version: '1.0.0',
+            producers: [mockServices[2]],
+          }),
+        },
+      ];
+
+      expect(queries).toEqual(expect.arrayContaining(expectedQueries.map((e) => expect.objectContaining(e))));
+    });
+
+    it('should returns an array of queries with producers/consumers using semver or latest', async () => {
+      const queries = await getQueries();
+
+      expect(queries).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: 'GetStockStatus',
+            slug: 'GetStockStatus',
+            collection: 'queries',
+            data: expect.objectContaining({
+              id: 'GetStockStatus',
+              version: '1.0.0',
+              producers: [mockServices[2]],
+              consumers: [mockServices[3]],
+            }),
+          }),
+        ])
+      );
+    });
+  });
+});

--- a/src/utils/__tests__/services/mocks.ts
+++ b/src/utils/__tests__/services/mocks.ts
@@ -171,3 +171,13 @@ export const mockCommands = [
     },
   },
 ];
+export const mockQueries = [
+  {
+    slug: 'GetOrder',
+    collection: 'queries',
+    data: {
+      id: 'GetOrder',
+      version: '0.0.1',
+    },
+  },
+];

--- a/src/utils/__tests__/services/node-graph.spec.ts
+++ b/src/utils/__tests__/services/node-graph.spec.ts
@@ -1,7 +1,7 @@
 import { MarkerType } from 'reactflow';
 import { getNodesAndEdges } from '../../services/node-graph';
 import { expect, describe, it, vi, beforeEach } from 'vitest';
-import { mockCommands, mockEvents, mockServices } from './mocks';
+import { mockCommands, mockEvents, mockQueries, mockServices } from './mocks';
 import type { ContentCollectionKey } from 'astro:content';
 
 vi.mock('astro:content', async (importOriginal) => {
@@ -16,6 +16,8 @@ vi.mock('astro:content', async (importOriginal) => {
           return Promise.resolve(mockEvents);
         case 'commands':
           return Promise.resolve(mockCommands);
+        case 'queries':
+          return Promise.resolve(mockQueries);
       }
     },
   };

--- a/src/utils/__tests__/services/services.spec.ts
+++ b/src/utils/__tests__/services/services.spec.ts
@@ -1,6 +1,6 @@
 import type { ContentCollectionKey } from 'astro:content';
 import { expect, describe, it, vi } from 'vitest';
-import { mockCommands, mockEvents, mockServices } from './mocks';
+import { mockCommands, mockEvents, mockQueries, mockServices } from './mocks';
 import { getServices } from '@utils/services/services';
 
 vi.mock('astro:content', async (importOriginal) => {
@@ -15,6 +15,8 @@ vi.mock('astro:content', async (importOriginal) => {
           return Promise.resolve(mockEvents);
         case 'commands':
           return Promise.resolve(mockCommands);
+        case 'queries':
+          return Promise.resolve(mockQueries);
       }
     },
   };

--- a/src/utils/flows/node-graph.ts
+++ b/src/utils/flows/node-graph.ts
@@ -25,7 +25,7 @@ const getServiceNode = (step: any, services: CollectionEntry<'services'>[]) => {
   };
 };
 
-const getMessageNode = (step: any, messages: CollectionEntry<'events' | 'commands'>[]) => {
+const getMessageNode = (step: any, messages: CollectionEntry<'events' | 'commands' | 'queries'>[]) => {
   const messagesForVersion = getItemsFromCollectionByIdAndSemverOrLatest(messages, step.message.id, step.message.version);
   const message = messagesForVersion[0];
   return {
@@ -53,9 +53,10 @@ export const getNodesAndEdges = async ({ id, defaultFlow, version, mode = 'simpl
 
   const events = await getCollection('events');
   const commands = await getCollection('commands');
+  const queries = await getCollection('queries');
   const services = await getCollection('services');
 
-  const messages = [...events, ...commands];
+  const messages = [...events, ...commands, ...queries];
 
   const steps = flow?.data.steps || [];
 
@@ -69,7 +70,7 @@ export const getNodesAndEdges = async ({ id, defaultFlow, version, mode = 'simpl
   });
 
   // Create nodes
-  hydratedSteps.forEach((step, index: number) => {
+  hydratedSteps.forEach((step: any, index: number) => {
     const node = {
       id: `step-${step.id}`,
       sourcePosition: 'right',
@@ -93,7 +94,7 @@ export const getNodesAndEdges = async ({ id, defaultFlow, version, mode = 'simpl
   });
 
   // Create Edges
-  hydratedSteps.forEach((step, index: number) => {
+  hydratedSteps.forEach((step: any, index: number) => {
     let paths = step.next_steps || [];
 
     if (step.next_step) {

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -1,6 +1,7 @@
 // Exporting getCommands and getEvents directly
 import { getCommands } from '@utils/commands';
 import { getEvents } from '@utils/events';
+import { getQueries } from './queries';
 export { getCommands } from '@utils/commands';
 export { getEvents } from '@utils/events';
 
@@ -8,6 +9,7 @@ export { getEvents } from '@utils/events';
 export const getMessages = async () => {
   const commands = await getCommands();
   const events = await getEvents();
+  const queries = await getQueries();
 
-  return { commands, events };
+  return { commands, events, queries };
 };

--- a/src/utils/node-graph-utils/utils.ts
+++ b/src/utils/node-graph-utils/utils.ts
@@ -2,13 +2,13 @@ import type { CollectionEntry } from 'astro:content';
 import type { Node } from 'reactflow';
 import dagre from 'dagre';
 
-export const generateIdForNode = (node: CollectionEntry<'events' | 'services' | 'commands'>) => {
+export const generateIdForNode = (node: CollectionEntry<'events' | 'services' | 'commands' | 'queries'>) => {
   return `${node.data.id}-${node.data.version}`;
 };
 
 export const generatedIdForEdge = (
-  source: CollectionEntry<'events' | 'services' | 'commands'>,
-  target: CollectionEntry<'events' | 'services' | 'commands'>
+  source: CollectionEntry<'events' | 'services' | 'commands' | 'queries'>,
+  target: CollectionEntry<'events' | 'services' | 'commands' | 'queries'>
 ) => {
   return `${source.data.id}-${source.data.version}-${target.data.id}-${target.data.version}`;
 };

--- a/src/utils/pages/pages.ts
+++ b/src/utils/pages/pages.ts
@@ -1,12 +1,14 @@
 import type { CollectionTypes, PageTypes } from '@types';
 import { getDomains } from '@utils/domains/domains';
 import { getCommands, getEvents } from '@utils/messages';
+import { getQueries } from '@utils/queries';
 import { getServices } from '@utils/services/services';
 import type { CollectionEntry } from 'astro:content';
 
 export const pageDataLoader: Record<PageTypes, () => Promise<CollectionEntry<CollectionTypes>[]>> = {
   events: getEvents,
   commands: getCommands,
+  queries: getQueries,
   services: getServices,
   domains: getDomains,
 };

--- a/src/utils/queries.ts
+++ b/src/utils/queries.ts
@@ -1,0 +1,65 @@
+import { getCollection } from 'astro:content';
+import type { CollectionEntry } from 'astro:content';
+import path from 'path';
+import { getVersionForCollectionItem, satisfies } from './collections/util';
+
+const PROJECT_DIR = process.env.PROJECT_DIR || process.cwd();
+
+type Query = CollectionEntry<'queries'> & {
+  catalog: {
+    path: string;
+    filePath: string;
+    type: string;
+  };
+};
+
+interface Props {
+  getAllVersions?: boolean;
+}
+
+export const getQueries = async ({ getAllVersions = true }: Props = {}): Promise<Query[]> => {
+  const queries = await getCollection('queries', (query) => {
+    return (getAllVersions || !query.slug.includes('versioned')) && query.data.hidden !== true;
+  });
+
+  const services = await getCollection('services');
+
+  return queries.map((query) => {
+    const { latestVersion, versions } = getVersionForCollectionItem(query, queries);
+
+    const producers = services.filter((service) =>
+      service.data.sends?.some((item) => {
+        if (item.id != query.data.id) return false;
+        if (item.version == 'latest' || item.version == undefined) return query.data.version == latestVersion;
+        return satisfies(query.data.version, item.version);
+      })
+    );
+
+    const consumers = services.filter((service) =>
+      service.data.receives?.some((item) => {
+        if (item.id != query.data.id) return false;
+        if (item.version == 'latest' || item.version == undefined) return query.data.version == latestVersion;
+        return satisfies(query.data.version, item.version);
+      })
+    );
+
+    return {
+      ...query,
+      data: {
+        ...query.data,
+        producers,
+        consumers,
+        versions,
+        latestVersion,
+      },
+      catalog: {
+        path: path.join(query.collection, query.id.replace('/index.mdx', '')),
+        absoluteFilePath: path.join(PROJECT_DIR, query.collection, query.id.replace('/index.mdx', '/index.md')),
+        astroContentFilePath: path.join(process.cwd(), 'src', 'content', query.collection, query.id),
+        filePath: path.join(process.cwd(), 'src', 'catalog-files', query.collection, query.id.replace('/index.mdx', '')),
+        publicPath: path.join('/generated', query.collection, query.id.replace('/index.mdx', '')),
+        type: 'event',
+      },
+    };
+  });
+};

--- a/src/utils/queries/node-graph.ts
+++ b/src/utils/queries/node-graph.ts
@@ -1,0 +1,118 @@
+import { getQueries } from '@utils/queries';
+import type { CollectionEntry } from 'astro:content';
+import dagre from 'dagre';
+import { calculatedNodes, createDagreGraph, generatedIdForEdge, generateIdForNode } from '../node-graph-utils/utils';
+import { MarkerType } from 'reactflow';
+
+type DagreGraph = any;
+
+interface Props {
+  id: string;
+  version: string;
+  defaultFlow?: DagreGraph;
+  mode?: 'simple' | 'full';
+}
+
+export const getNodesAndEdges = async ({ id, version, defaultFlow, mode = 'simple' }: Props) => {
+  const flow = defaultFlow || createDagreGraph({ ranksep: 300, nodesep: 50 });
+  const nodes = [] as any,
+    edges = [] as any;
+
+  const queries = await getQueries();
+
+  const query = queries.find((query) => query.data.id === id && query.data.version === version);
+
+  // Nothing found...
+  if (!query) {
+    return {
+      nodes: [],
+      edges: [],
+    };
+  }
+
+  const producers = (query.data.producers as CollectionEntry<'services'>[]) || [];
+  const consumers = (query.data.consumers as CollectionEntry<'services'>[]) || [];
+
+  if (producers && producers.length > 0) {
+    producers.forEach((producer) => {
+      nodes.push({
+        id: generateIdForNode(producer),
+        type: producer?.collection,
+        sourcePosition: 'right',
+        targetPosition: 'left',
+        data: { mode, service: producer, showTarget: false },
+        position: { x: 250, y: 0 },
+      });
+      edges.push({
+        id: generatedIdForEdge(producer, query),
+        source: generateIdForNode(producer),
+        target: generateIdForNode(query),
+        type: 'smoothstep',
+        label: 'requests',
+        animated: false,
+        markerEnd: {
+          type: MarkerType.ArrowClosed,
+          width: 40,
+          height: 40,
+        },
+        style: {
+          strokeWidth: 1,
+        },
+      });
+    });
+  }
+
+  // The query itself
+  nodes.push({
+    id: generateIdForNode(query),
+    sourcePosition: 'right',
+    targetPosition: 'left',
+    data: { mode, message: query, showTarget: producers.length > 0, showSource: consumers.length > 0 },
+    position: { x: 0, y: 0 },
+    type: query.collection,
+  });
+
+  // The messages the service sends
+  consumers.forEach((consumer) => {
+    nodes.push({
+      id: generateIdForNode(consumer),
+      sourcePosition: 'right',
+      targetPosition: 'left',
+      data: { title: consumer?.data.id, mode, service: consumer, showSource: false },
+      position: { x: 0, y: 0 },
+      type: consumer?.collection,
+    });
+    edges.push({
+      id: generatedIdForEdge(query, consumer),
+      source: generateIdForNode(query),
+      target: generateIdForNode(consumer),
+      type: 'smoothstep',
+      label: 'accepts',
+      animated: false,
+      markerEnd: {
+        type: MarkerType.ArrowClosed,
+        width: 40,
+        height: 40,
+      },
+      style: {
+        strokeWidth: 1,
+      },
+    });
+  });
+
+  nodes.forEach((node: any) => {
+    flow.setNode(node.id, { width: 150, height: 100 });
+  });
+
+  edges.forEach((edge: any) => {
+    flow.setEdge(edge.source, edge.target);
+  });
+
+  // Render the diagram in memory getting hte X and Y
+  dagre.layout(flow);
+
+  return {
+    nodes: calculatedNodes(flow, nodes),
+    edges: edges,
+  };
+};

--- a/src/utils/services/services.ts
+++ b/src/utils/services/services.ts
@@ -18,8 +18,9 @@ export const getServices = async ({ getAllVersions = true }: Props = {}): Promis
   });
   const events = await getCollection('events');
   const commands = await getCollection('commands');
+  const queries = await getCollection('queries');
 
-  const allMessages = [...events, ...commands];
+  const allMessages = [...events, ...commands, ...queries];
 
   // @ts-ignore // TODO: Fix this type
   return services.map((service) => {
@@ -29,14 +30,14 @@ export const getServices = async ({ getAllVersions = true }: Props = {}): Promis
     const receivesMessages = service.data.receives || [];
 
     const sends = sendsMessages
-      .map((message) => getItemsFromCollectionByIdAndSemverOrLatest(allMessages, message.id, message.version))
+      .map((message: any) => getItemsFromCollectionByIdAndSemverOrLatest(allMessages, message.id, message.version))
       .flat()
-      .filter((e) => e !== undefined);
+      .filter((e: any) => e !== undefined);
 
     const receives = receivesMessages
-      .map((message) => getItemsFromCollectionByIdAndSemverOrLatest(allMessages, message.id, message.version))
+      .map((message: any) => getItemsFromCollectionByIdAndSemverOrLatest(allMessages, message.id, message.version))
       .flat()
-      .filter((e) => e !== undefined);
+      .filter((e: any) => e !== undefined);
 
     return {
       ...service,


### PR DESCRIPTION
EventCatalog currently supports events and commands, and now it supports queries. 

These are new resource types users can create, and attach to services.

This last message type completes the command/event/query group of messages.