### PR TITLE
feat(core): added repo support for all resources

### DIFF
--- a/.changeset/mean-kings-jump.md
+++ b/.changeset/mean-kings-jump.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+feat(core): added repo support for all resources

--- a/examples/default/domains/Orders/services/InventoryService/index.md
+++ b/examples/default/domains/Orders/services/InventoryService/index.md
@@ -29,7 +29,7 @@ sends:
     version: 0.0.1
 repository:
   language: JavaScript
-  url: https://github.com/boyney123/pretend-shipping-service
+  url: https://github.com/event-catalog/pretend-shipping-service
 ---
 
 import Footer from '@catalog/components/footer.astro';

--- a/examples/default/domains/Orders/services/InventoryService/versioned/0.0.1/index.md
+++ b/examples/default/domains/Orders/services/InventoryService/versioned/0.0.1/index.md
@@ -24,7 +24,7 @@ sends:
     version: 0.0.3
 repository:
   language: JavaScript
-  url: https://github.com/boyney123/pretend-shipping-service
+  url: https://github.com/event-catalog/pretend-shipping-service
 ---
 
 ## Overview

--- a/examples/default/domains/Orders/services/NotificationService/index.md
+++ b/examples/default/domains/Orders/services/NotificationService/index.md
@@ -22,7 +22,7 @@ sends:
     version: 0.0.x
 repository:
   language: JavaScript
-  url: https://github.com/boyney123/pretend-shipping-service
+  url: https://github.com/event-catalog/pretend-shipping-service
 ---
 
 import Footer from '@catalog/components/footer.astro';

--- a/examples/default/domains/Orders/services/OrdersService/index.md
+++ b/examples/default/domains/Orders/services/OrdersService/index.md
@@ -16,7 +16,7 @@ sends:
     version: 0.0.3
 repository:
   language: JavaScript
-  url: https://github.com/boyney123/pretend-shipping-service
+  url: https://github.com/event-catalog/pretend-shipping-service
 schemaPath: "openapi.yml"
 specifications:
   asyncapiPath: order-service-asyncapi.yaml

--- a/examples/default/domains/Orders/services/OrdersService/versioned/0.0.2/index.md
+++ b/examples/default/domains/Orders/services/OrdersService/versioned/0.0.2/index.md
@@ -14,7 +14,7 @@ sends:
     version: 0.0.3
 repository:
   language: JavaScript
-  url: https://github.com/boyney123/pretend-shipping-service
+  url: https://github.com/event-catalog/pretend-shipping-service
 schemaPath: "openapi.yml"
 specifications:
   asyncapiPath: order-service-asyncapi.yaml

--- a/examples/default/domains/Payment/services/PaymentService/index.md
+++ b/examples/default/domains/Payment/services/PaymentService/index.md
@@ -16,7 +16,7 @@ sends:
   - id: GetOrder
 repository:
   language: JavaScript
-  url: https://github.com/boyney123/pretend-shipping-service
+  url: https://github.com/event-catalog/pretend-shipping-service
 ---
 
 The Payment Service is a crucial component of our system that handles all payment-related operations. It processes payments, manages transactions, and communicates with other services through events. Using an event-driven architecture, it ensures that all actions are asynchronous, decoupled, and scalable.

--- a/examples/default/domains/Subscriptions/services/SubscriptionService/index.md
+++ b/examples/default/domains/Subscriptions/services/SubscriptionService/index.md
@@ -19,7 +19,7 @@ sends:
     version: 0.0.1
 repository:
   language: JavaScript
-  url: https://github.com/boyney123/pretend-subscription-service
+  url: https://github.com/event-catalog/pretend-subscription-service
 ---
 
 import Footer from '@catalog/components/footer.astro';

--- a/scripts/__tests__/example-catalog/domains/Payment/services/ExternalPaymentService/index.md
+++ b/scripts/__tests__/example-catalog/domains/Payment/services/ExternalPaymentService/index.md
@@ -14,7 +14,7 @@ sends:
     version: 0.0.1
 repository:
   language: JavaScript
-  url: https://github.com/boyney123/pretend-shipping-service
+  url: https://github.com/event-catalog/pretend-shipping-service
 ---
 
 The Payment Service is a crucial component of our system that handles all payment-related operations. It processes payments, manages transactions, and communicates with other services through events. Using an event-driven architecture, it ensures that all actions are asynchronous, decoupled, and scalable.

--- a/scripts/__tests__/example-catalog/domains/Payment/services/ExternalPaymentService/versioned/0.0.1/index.md
+++ b/scripts/__tests__/example-catalog/domains/Payment/services/ExternalPaymentService/versioned/0.0.1/index.md
@@ -14,7 +14,7 @@ sends:
     version: 0.0.1
 repository:
   language: JavaScript
-  url: https://github.com/boyney123/pretend-shipping-service
+  url: https://github.com/event-catalog/pretend-shipping-service
 ---
 
 The Payment Service is a crucial component of our system that handles all payment-related operations. It processes payments, manages transactions, and communicates with other services through events. Using an event-driven architecture, it ensures that all actions are asynchronous, decoupled, and scalable.

--- a/scripts/__tests__/example-catalog/services/PaymentService/index.md
+++ b/scripts/__tests__/example-catalog/services/PaymentService/index.md
@@ -14,7 +14,7 @@ sends:
     version: 0.0.1
 repository:
   language: JavaScript
-  url: https://github.com/boyney123/pretend-shipping-service
+  url: https://github.com/event-catalog/pretend-shipping-service
 ---
 
 The Payment Service is a crucial component of our system that handles all payment-related operations. It processes payments, manages transactions, and communicates with other services through events. Using an event-driven architecture, it ensures that all actions are asynchronous, decoupled, and scalable.

--- a/scripts/__tests__/example-catalog/services/PaymentService/versioned/0.0.1/index.md
+++ b/scripts/__tests__/example-catalog/services/PaymentService/versioned/0.0.1/index.md
@@ -14,7 +14,7 @@ sends:
     version: 0.0.1
 repository:
   language: JavaScript
-  url: https://github.com/boyney123/pretend-shipping-service
+  url: https://github.com/event-catalog/pretend-shipping-service
 ---
 
 import Footer from '@catalog/components/footer.astro';

--- a/src/components/Lists/RepositoryList.astro
+++ b/src/components/Lists/RepositoryList.astro
@@ -1,0 +1,36 @@
+---
+import { ScrollText, Workflow, FileDownIcon, Code, Link } from 'lucide-react';
+
+interface Props {
+  repository?: string;
+  language?: string;
+}
+
+const { repository, language } = Astro.props;
+---
+
+<div class="mx-auto pb-8 w-full max-w-lg divide-y divide-white/5 rounded-xl bg-white/5">
+  <span class="text-sm text-black group-data-[hover]:text-black/80 capitalize">Repository </span>
+  <ul role="list" class="space-y-2 mt-2">
+    {
+      repository && (
+        <li class="has-tooltip rounded-md text-gray-600 group px-1 w-full hover:bg-gradient-to-l hover:from-purple-500 hover:to-purple-700 hover:text-white hover:font-normal  ">
+          <a class={`flex items-center space-x-2`} target="_blank" href={repository}>
+            <Link className="h-4 w-4 text-gray-800 group-hover:text-white" strokeWidth={1} />
+            <span class="font-light text-sm truncate">{repository}</span>
+          </a>
+        </li>
+      )
+    }
+    {
+      language && (
+        <li class=" rounded-md text-gray-600 group px-1 w-full  ">
+          <div class={`flex items-center space-x-2`}>
+            <Code className="h-3 w-3 text-gray-800 " strokeWidth={1} />
+            <span class="font-light text-sm truncate">{language}</span>
+          </div>
+        </li>
+      )
+    }
+  </ul>
+</div>

--- a/src/components/SideBars/DomainSideBar.astro
+++ b/src/components/SideBars/DomainSideBar.astro
@@ -1,6 +1,7 @@
 ---
 import OwnersList from '@components/Lists/OwnersList';
 import PillListFlat from '@components/Lists/PillListFlat';
+import RepositoryList from '@components/Lists/RepositoryList.astro';
 import VersionList from '@components/Lists/VersionList.astro';
 import { buildUrl } from '@utils/url-builder';
 import { getEntry, type CollectionEntry } from 'astro:content';
@@ -45,6 +46,11 @@ const ownersList = owners.map((o) => ({
       client:load
     />
     {domain.data.versions && <VersionList versions={domain.data.versions} collectionItem={domain} />}
+    {
+      domain.data.repository && (
+        <RepositoryList repository={domain.data.repository?.url} language={domain.data.repository?.language} />
+      )
+    }
     <OwnersList
       title={`Domain owners (${ownersList.length})`}
       owners={ownersList}

--- a/src/components/SideBars/MessageSideBar.astro
+++ b/src/components/SideBars/MessageSideBar.astro
@@ -7,6 +7,7 @@ import * as path from 'path';
 import VersionList from '@components/Lists/VersionList.astro';
 import { buildUrl } from '@utils/url-builder';
 import { FileDownIcon, ScrollText, Workflow } from 'lucide-react';
+import RepositoryList from '@components/Lists/RepositoryList.astro';
 interface Props {
   message: CollectionEntry<CollectionMessageTypes>;
 }
@@ -121,6 +122,12 @@ const schemaURL = path.join(publicPath, schemaFilePath || '');
       emptyMessage={`This ${type} does not have any documented owners.`}
       client:load
     />
+
+    {
+      message.data.repository && (
+        <RepositoryList repository={message.data.repository?.url} language={message.data.repository?.language} />
+      )
+    }
 
     <div class="space-y-2">
       {

--- a/src/components/SideBars/ServiceSideBar.astro
+++ b/src/components/SideBars/ServiceSideBar.astro
@@ -1,11 +1,12 @@
 ---
 import OwnersList from '@components/Lists/OwnersList';
 import PillListFlat from '@components/Lists/PillListFlat';
+import RepositoryList from '@components/Lists/RepositoryList.astro';
 import SpecificationsList from '@components/Lists/SpecificationsList.astro';
 import VersionList from '@components/Lists/VersionList.astro';
 import { buildUrl } from '@utils/url-builder';
 import { getEntry, type CollectionEntry } from 'astro:content';
-import { ScrollText, Workflow, FileDownIcon } from 'lucide-react';
+import { ScrollText, Workflow, FileDownIcon, Code, Link } from 'lucide-react';
 import { join } from 'node:path';
 interface Props {
   service: CollectionEntry<'services'>;
@@ -78,6 +79,12 @@ const schemaURL = join(publicPath, schemaFilePath || '');
       emptyMessage={`This service does not have any documented owners.`}
       client:load
     />
+
+    {
+      service.data.repository && (
+        <RepositoryList repository={service.data.repository?.url} language={service.data.repository?.language} />
+      )
+    }
 
     <div class="space-y-2">
       {

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -51,6 +51,12 @@ const baseSchema = z.object({
   badges: z.array(badge).optional(),
   owners: z.array(ownerReference).optional(),
   schemaPath: z.string().optional(),
+  repository: z
+    .object({
+      language: z.string().optional(),
+      url: z.string().optional(),
+    })
+    .optional(),
   specifications: z
     .object({
       openapiPath: z.string().optional(),


### PR DESCRIPTION
Added ability to add repo and lang to all resources in EventCatalog.

```
repository:
  language: JavaScript
  url: https://github.com/event-catalog/pretend-shipping-service
```

Add this to your frontmatter will show in the sidebar
<img width="327" alt="image" src="https://github.com/user-attachments/assets/5f3c5b54-2d19-4833-a3ee-835b19c9a08d">

Fix for #897 