### PR TITLE
fix(core): changelog buttons now render the correct changelog

### DIFF
--- a/.changeset/thin-pens-chew.md
+++ b/.changeset/thin-pens-chew.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix(core): changelog buttons now render the correct changelog

--- a/src/components/SideBars/DomainSideBar.astro
+++ b/src/components/SideBars/DomainSideBar.astro
@@ -66,7 +66,7 @@ const ownersList = owners.map((o) => ({
         <span class="block">View in visualiser</span>
       </a>
       <a
-        href={buildUrl(`/docs/${domain.collection}/${domain.data.id}/${domain.data.version}/changelog`)}
+        href={buildUrl(`/docs/${domain.collection}/${domain.data.id}/${domain.data.latestVersion}/changelog`)}
         class="flex items-center space-x-2 justify-center text-center rounded-md w-full bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-100/60 hover:text-primary"
       >
         <ScrollText strokeWidth={2} size={16} />

--- a/src/components/SideBars/MessageSideBar.astro
+++ b/src/components/SideBars/MessageSideBar.astro
@@ -151,7 +151,7 @@ const schemaURL = path.join(publicPath, schemaFilePath || '');
       </a>
 
       <a
-        href={buildUrl(`/docs/${message.collection}/${message.data.id}/${message.data.version}/changelog`)}
+        href={buildUrl(`/docs/${message.collection}/${message.data.id}/${message.data.latestVersion}/changelog`)}
         class="flex items-center space-x-2 justify-center text-center rounded-md w-full bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-100/60 hover:text-primary"
       >
         <ScrollText strokeWidth={2} size={16} />

--- a/src/components/SideBars/ServiceSideBar.astro
+++ b/src/components/SideBars/ServiceSideBar.astro
@@ -107,7 +107,7 @@ const schemaURL = join(publicPath, schemaFilePath || '');
         <span class="block">View in visualiser</span>
       </a>
       <a
-        href={buildUrl(`/docs/${service.collection}/${service.data.id}/${service.data.version}/changelog`)}
+        href={buildUrl(`/docs/${service.collection}/${service.data.id}/${service.data.latestVersion}/changelog`)}
         class="flex items-center space-x-2 justify-center text-center rounded-md w-full bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-100/60 hover:text-primary"
       >
         <ScrollText strokeWidth={2} size={16} />


### PR DESCRIPTION
Clicking a button in a previous version of the changelog would show that changelog, but there is more value just showing the whole changelog of the resource.