### PR TITLE
fix(core): new property renderParsedSchemas added

### DIFF
--- a/.changeset/fluffy-kids-invent.md
+++ b/.changeset/fluffy-kids-invent.md
@@ -2,4 +2,4 @@
 "@eventcatalog/core": patch
 ---
 
-fix(core): new property renderParsedSchemas added
+fix(core): new property for AsyncAPI rendering

--- a/.changeset/fluffy-kids-invent.md
+++ b/.changeset/fluffy-kids-invent.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix(core): new property renderParsedSchemas added

--- a/bin/eventcatalog.config.ts
+++ b/bin/eventcatalog.config.ts
@@ -17,6 +17,9 @@ export interface Config {
     src: string;
     text?: string;
   };
+  asyncAPI?: {
+    renderParsedSchemas?: boolean;
+  };
   mdxOptimize?: boolean;
   docs: {
     sidebar: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "@eventcatalog/core",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@eventcatalog/core",
-      "version": "2.11.0",
+      "version": "2.12.0",
       "dependencies": {
         "@astrojs/check": "^0.9.4",
         "@astrojs/markdown-remark": "^5.3.0",
         "@astrojs/mdx": "^3.1.8",
         "@astrojs/react": "^3.6.2",
         "@astrojs/tailwind": "^5.1.2",
-        "@asyncapi/react-component": "^2.2.2",
+        "@asyncapi/react-component": "^2.4.3",
         "@headlessui/react": "^2.0.3",
         "@heroicons/react": "^2.1.3",
         "@parcel/watcher": "^2.4.1",
@@ -844,11 +844,11 @@
       }
     },
     "node_modules/@asyncapi/parser": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.2.2.tgz",
-      "integrity": "sha512-ved4ja3ANs6BcRhWLbK/A7JIhJyMQBYdV1GZwo6Ptf+qBkGIdvV3dt8M4T6TZqtIbUI2NOvmO2YUqtaPWTudgA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.4.0.tgz",
+      "integrity": "sha512-Sxn74oHiZSU6+cVeZy62iPZMFMvKp4jupMFHelSICCMw1qELmUHPvuZSr+ZHDmNGgHcEpzJM5HN02kR7T4g+PQ==",
       "dependencies": {
-        "@asyncapi/specs": "^6.6.0",
+        "@asyncapi/specs": "^6.8.0",
         "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
         "@stoplight/json": "3.21.0",
         "@stoplight/json-ref-readers": "^1.2.2",
@@ -865,7 +865,7 @@
         "ajv-formats": "^2.1.1",
         "avsc": "^5.7.5",
         "js-yaml": "^4.1.0",
-        "jsonpath-plus": "^7.2.0",
+        "jsonpath-plus": "^10.0.0",
         "node-fetch": "2.6.7"
       }
     },
@@ -880,16 +880,16 @@
       }
     },
     "node_modules/@asyncapi/react-component": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@asyncapi/react-component/-/react-component-2.2.2.tgz",
-      "integrity": "sha512-cv7Dncp5k0WG9Ap4lzzhg6oNzJi02ehtSAvOgjVl40HQckaYPs9R8rHcxWIFCffPVwEcycZI5hyvDN0gwMisjw==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@asyncapi/react-component/-/react-component-2.4.3.tgz",
+      "integrity": "sha512-8DZdadD2vGoq7rw18RehmytQLT2Y1RFQ+UgvhQA3UaTqIFL2qFOHIm1YMnl5VVPxtTmkvi20wZZk37nyNvzJug==",
       "dependencies": {
         "@asyncapi/avro-schema-parser": "^3.0.24",
         "@asyncapi/openapi-schema-parser": "^3.0.24",
-        "@asyncapi/parser": "^3.1.0",
+        "@asyncapi/parser": "^3.3.0",
         "@asyncapi/protobuf-schema-parser": "^3.2.14",
         "highlight.js": "^10.7.2",
-        "isomorphic-dompurify": "^2.12.0",
+        "isomorphic-dompurify": "^2.14.0",
         "marked": "^4.0.14",
         "openapi-sampler": "^1.2.1",
         "use-resize-observer": "^9.1.0"
@@ -2662,6 +2662,17 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@jsep-plugin/assignment": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.2.1.tgz",
+      "integrity": "sha512-gaHqbubTi29aZpVbBlECRpmdia+L5/lh2BwtIJTmtxdbecEyyX/ejAOg7eQDGNvGOUmPY7Z2Yxdy9ioyH/VJeA==",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
       }
     },
     "node_modules/@jsep-plugin/regex": {
@@ -5643,20 +5654,20 @@
       }
     },
     "node_modules/@stoplight/spectral-core": {
-      "version": "1.18.3",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-core/-/spectral-core-1.18.3.tgz",
-      "integrity": "sha512-YY8x7X2SWJIhGTLPol+eFiQpWPz0D0mJdkK2i4A0QJG68KkNhypP6+JBC7/Kz3XWjqr0L/RqAd+N5cQLPOKZGQ==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-core/-/spectral-core-1.19.1.tgz",
+      "integrity": "sha512-YiWhXdjyjn4vCl3102ywzwCEJzncxapFcj4dxcj1YP/bZ62DFeGJ8cEaMP164vSw2kI3rX7EMMzI/c8XOUnTfQ==",
       "dependencies": {
         "@stoplight/better-ajv-errors": "1.0.3",
         "@stoplight/json": "~3.21.0",
         "@stoplight/path": "1.3.2",
         "@stoplight/spectral-parsers": "^1.0.0",
-        "@stoplight/spectral-ref-resolver": "^1.0.0",
+        "@stoplight/spectral-ref-resolver": "^1.0.4",
         "@stoplight/spectral-runtime": "^1.0.0",
         "@stoplight/types": "~13.6.0",
         "@types/es-aggregate-error": "^1.0.2",
         "@types/json-schema": "^7.0.11",
-        "ajv": "^8.6.0",
+        "ajv": "^8.17.1",
         "ajv-errors": "~3.0.0",
         "ajv-formats": "~2.1.0",
         "es-aggregate-error": "^1.0.7",
@@ -5694,9 +5705,9 @@
       }
     },
     "node_modules/@stoplight/spectral-formats": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-formats/-/spectral-formats-1.6.0.tgz",
-      "integrity": "sha512-X27qhUfNluiduH0u/QwJqhOd8Wk5YKdxVmKM03Aijlx0AH1H5mYt3l9r7t2L4iyJrsBaFPnMGt7UYJDGxszbNA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-formats/-/spectral-formats-1.7.0.tgz",
+      "integrity": "sha512-vJ1vIkA2s96fdJp0d3AJBGuPAW3sj8yMamyzR+dquEFO6ZAoYBo/BVsKKQskYzZi/nwljlRqUmGVmcf2PncIaA==",
       "dependencies": {
         "@stoplight/json": "^3.17.0",
         "@stoplight/spectral-core": "^1.8.0",
@@ -5708,16 +5719,16 @@
       }
     },
     "node_modules/@stoplight/spectral-functions": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-functions/-/spectral-functions-1.8.0.tgz",
-      "integrity": "sha512-ZrAkYA/ZGbuQ6EyG1gisF4yQ5nWP/+glcqVoGmS6kH6ekaynz2Yp6FL0oIamWj3rWedFUN7ppwTRUdo+9f/uCw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-functions/-/spectral-functions-1.9.0.tgz",
+      "integrity": "sha512-T+xl93ji8bpus4wUsTq8Qr2DSu2X9PO727rbxW61tTCG0s17CbsXOLYI+Ezjg5P6aaQlgXszGX8khtc57xk8Yw==",
       "dependencies": {
         "@stoplight/better-ajv-errors": "1.0.3",
         "@stoplight/json": "^3.17.1",
         "@stoplight/spectral-core": "^1.7.0",
-        "@stoplight/spectral-formats": "^1.0.0",
+        "@stoplight/spectral-formats": "^1.7.0",
         "@stoplight/spectral-runtime": "^1.1.0",
-        "ajv": "^8.6.3",
+        "ajv": "^8.17.1",
         "ajv-draft-04": "~1.0.0",
         "ajv-errors": "~3.0.0",
         "ajv-formats": "~2.1.0",
@@ -8625,20 +8636,15 @@
       }
     },
     "node_modules/cssstyle": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.0.1.tgz",
-      "integrity": "sha512-8ZYiJ3A/3OkDd093CBT/0UKDWry7ak4BdPTFP2+QEP7cmhouyq/Up709ASSj2cK02BbZiMgk7kYjZNS4QP5qrQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.1.0.tgz",
+      "integrity": "sha512-h66W1URKpBS5YMI/V8PyXvTMFT8SupJ1IzoIV8IeBC/ji8WVmrO8dGlTi+2dh6whmdk6BiKJLD/ZBkhWbcg6nA==",
       "dependencies": {
-        "rrweb-cssom": "^0.6.0"
+        "rrweb-cssom": "^0.7.1"
       },
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/cssstyle/node_modules/rrweb-cssom": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
-      "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw=="
     },
     "node_modules/csstype": {
       "version": "3.1.3",
@@ -9552,9 +9558,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.6.tgz",
-      "integrity": "sha512-cTOAhc36AalkjtBpfG6O8JimdTMWNXjiePT2xQH/ppBGi/4uIpmj8eKyIkMJErXWARyINV/sB38yf8JCLF5pbQ=="
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.7.tgz",
+      "integrity": "sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ=="
     },
     "node_modules/dset": {
       "version": "3.1.4",
@@ -11703,13 +11709,13 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "node_modules/isomorphic-dompurify": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-2.15.0.tgz",
-      "integrity": "sha512-RDHlyeVmwEDAPZuX1VaaBzSn9RrsfvswxH7faEQK9cTHC1dXeNuK6ElUeSr7locFyeLguut8ASfhQWxHB4Ttug==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-2.16.0.tgz",
+      "integrity": "sha512-cXhX2owp8rPxafCr0ywqy2CGI/4ceLNgWkWBEvUz64KTbtg3oRL2ZRqq/zW0pzt4YtDjkHLbwcp/lozpKzAQjg==",
       "dependencies": {
         "@types/dompurify": "^3.0.5",
-        "dompurify": "^3.1.6",
-        "jsdom": "^25.0.0"
+        "dompurify": "^3.1.7",
+        "jsdom": "^25.0.1"
       },
       "engines": {
         "node": ">=18"
@@ -11828,11 +11834,11 @@
       }
     },
     "node_modules/jsdom": {
-      "version": "25.0.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.0.tgz",
-      "integrity": "sha512-OhoFVT59T7aEq75TVw9xxEfkXgacpqAhQaYgP9y/fDqWQCMB/b1H66RfmPm/MaeaAIU9nDwMOVTlPN51+ao6CQ==",
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
       "dependencies": {
-        "cssstyle": "^4.0.1",
+        "cssstyle": "^4.1.0",
         "data-urls": "^5.0.0",
         "decimal.js": "^10.4.3",
         "form-data": "^4.0.0",
@@ -11845,7 +11851,7 @@
         "rrweb-cssom": "^0.7.1",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^4.1.4",
+        "tough-cookie": "^5.0.0",
         "w3c-xmlserializer": "^5.0.0",
         "webidl-conversions": "^7.0.0",
         "whatwg-encoding": "^3.1.1",
@@ -11969,11 +11975,20 @@
       }
     },
     "node_modules/jsonpath-plus": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-7.2.0.tgz",
-      "integrity": "sha512-zBfiUPM5nD0YZSBT/o/fbCUlCcepMIdP0CJZxM1+KgA4f2T206f6VAg9e7mX35+KlMaIc5qXW34f3BnwJ3w+RA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.1.0.tgz",
+      "integrity": "sha512-gHfV1IYqH8uJHYVTs8BJX1XKy2/rR93+f8QQi0xhx95aCiXn1ettYAd5T+7FU6wfqyDoX/wy0pm/fL3jOKJ9Lg==",
+      "dependencies": {
+        "@jsep-plugin/assignment": "^1.2.1",
+        "@jsep-plugin/regex": "^1.0.3",
+        "jsep": "^1.3.9"
+      },
+      "bin": {
+        "jsonpath": "bin/jsonpath-cli.js",
+        "jsonpath-plus": "bin/jsonpath-cli.js"
+      },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/jsonpointer": {
@@ -17921,11 +17936,6 @@
       "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
       "dev": true
     },
-    "node_modules/psl": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
-    },
     "node_modules/pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -17957,11 +17967,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/querystringify": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -18622,11 +18627,6 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
-    },
-    "node_modules/requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "node_modules/resize-observer-polyfill": {
       "version": "1.5.1",
@@ -20115,6 +20115,22 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.58",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.58.tgz",
+      "integrity": "sha512-MQJrJhjHOYGYb8DobR6Y4AdDbd4TYkyQ+KBDVc5ODzs1cbrvPpfN1IemYi9jfipJ/vR1YWvrDli0hg1y19VRoA==",
+      "dependencies": {
+        "tldts-core": "^6.1.58"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.58",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.58.tgz",
+      "integrity": "sha512-dR936xmhBm7AeqHIhCWwK765gZ7dFyL+IqLSFAjJbFlUXGMLCb8i2PzlzaOuWBuplBTaBYseSb565nk/ZEM0Bg=="
+    },
     "node_modules/tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -20160,25 +20176,14 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
-      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.0.0.tgz",
+      "integrity": "sha512-FRKsF7cz96xIIeMZ82ehjC3xW2E+O2+v11udrDYewUbszngYhsGa8z6YUMMzO9QJZzzyd0nGGXnML/TReX6W8Q==",
       "dependencies": {
-        "psl": "^1.1.33",
-        "punycode": "^2.1.1",
-        "universalify": "^0.2.0",
-        "url-parse": "^1.5.3"
+        "tldts": "^6.1.32"
       },
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tough-cookie/node_modules/universalify": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-      "engines": {
-        "node": ">= 4.0.0"
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -21001,15 +21006,6 @@
       "version": "1.19.11",
       "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.11.tgz",
       "integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ=="
-    },
-    "node_modules/url-parse": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "dependencies": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
-      }
     },
     "node_modules/use-resize-observer": {
       "version": "9.1.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@astrojs/mdx": "^3.1.8",
     "@astrojs/react": "^3.6.2",
     "@astrojs/tailwind": "^5.1.2",
-    "@asyncapi/react-component": "^2.2.2",
+    "@asyncapi/react-component": "^2.4.3",
     "@headlessui/react": "^2.0.3",
     "@heroicons/react": "^2.1.3",
     "@parcel/watcher": "^2.4.1",

--- a/src/pages/docs/[type]/[id]/[version]/asyncapi/index.astro
+++ b/src/pages/docs/[type]/[id]/[version]/asyncapi/index.astro
@@ -7,14 +7,13 @@ import { Parser } from '@asyncapi/parser';
 
 import type { CollectionTypes, PageTypes } from '@types';
 
-import PlainPage from '@layouts/PlainPage.astro';
-
 import '@asyncapi/react-component/styles/default.min.css';
 import js from '@asyncapi/react-component/browser/standalone/without-parser.js?url';
 import { AsyncApiComponentWP, type ConfigInterface } from '@asyncapi/react-component';
 import { pageDataLoader } from '@utils/pages/pages';
 import type { CollectionEntry } from 'astro:content';
 import VerticalSideBarLayout from '@layouts/VerticalSideBarLayout.astro';
+import Config from '@eventcatalog';
 
 export async function getStaticPaths() {
   const itemTypes: PageTypes[] = ['events', 'commands', 'queries', 'services', 'domains'];
@@ -45,7 +44,9 @@ const pathToSpec = path.join(catalog.publicPath, fileName);
 const pathOnDisk = path.join(process.cwd(), 'public', pathToSpec);
 const fileContent = readFileSync(pathOnDisk, 'utf-8');
 
-const parsed = await new Parser().parse(fileContent);
+// AsyncAPI parser will parser schemas for users, they can turn this off.
+const parseSchemas = Config?.asyncAPI?.renderParsedSchemas ?? true;
+const parsed = await new Parser().parse(fileContent, { parseSchemas });
 const stringified = parsed.document?.json();
 const config: ConfigInterface = { show: { sidebar: true, errors: true } };
 


### PR DESCRIPTION
The AsyncAPI renderer in Eventcatalog will render AsyncAPI files, the parser used will parse the schemas for users too.

Normally this is OK, but we are seeing issues when users have avro schemas, and want to keep the schemas as they are.

This optional field let's users render AsyncAPI files without parsing the schemas.