### PR TITLE
chore(core): fixing z-index issue with the header nav and removing the max-width

### DIFF
--- a/.changeset/lovely-hairs-film.md
+++ b/.changeset/lovely-hairs-film.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+chore(core): fixing z-index issue with the header nav and removing the max-width

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@eventcatalog/core",
-  "version": "2.12.2",
+  "version": "2.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@eventcatalog/core",
-      "version": "2.12.2",
+      "version": "2.12.0",
       "dependencies": {
         "@astrojs/check": "^0.9.4",
         "@astrojs/markdown-remark": "^5.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@eventcatalog/core",
-  "version": "2.12.0",
+  "version": "2.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@eventcatalog/core",
-      "version": "2.12.0",
+      "version": "2.12.2",
       "dependencies": {
         "@astrojs/check": "^0.9.4",
         "@astrojs/markdown-remark": "^5.3.0",

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -12,9 +12,9 @@ const logo = {
 
 <nav
   id="eventcatalog-header"
-  class="fixed top-0 left-0 right-0 bg-white border-b border-gray-100 py-3 font-bold text-xl bg-opacity-20 backdrop-blur-sm"
+  class="fixed top-0 left-0 right-0 bg-white border-b border-gray-100 py-3 font-bold text-xl bg-opacity-20 backdrop-blur-sm z-10"
 >
-  <div class="max-w-[120em] mx-auto px-4 sm:px-4 lg:px-4 xxl:max-w-[96em]">
+  <div class="px-4 sm:px-4 lg:px-4">
     <div class="flex justify-between items-center">
       <div class="flex-shrink-0 flex items-center w-1/3">
         <a href={buildUrl(catalog.landingPage || '/')} class="flex space-x-2 items-center">


### PR DESCRIPTION
Was taking a look at EC and running on my 27inch 4k Monitor - the catalog header starts to look at bit off as there is a max width set. This PR is now suggesting that we let this flow right to the edges (as the rest of the application does) so everything is in line. See screenshots below:

Before (https://demo.eventcatalog.dev):
<img width="2753" alt="image" src="https://github.com/user-attachments/assets/590036c4-0f9d-43f3-9f3b-d5cdc648c8a1">

After:
<img width="2748" alt="image" src="https://github.com/user-attachments/assets/4b095fcf-2546-42bb-b8b0-83ebdb08b28a">

Also....

While I was here I noticed that there is a weird z-index issue where the payload content block goes above the header.

Before (https://demo.eventcatalog.dev/docs/events/OrderCancelled/0.0.1): 
<img width="851" alt="image" src="https://github.com/user-attachments/assets/c1d3787a-155f-4fd1-8b17-71b2a3977fb1">

After:
<img width="862" alt="image" src="https://github.com/user-attachments/assets/5a8cc5e4-1be8-4418-af3b-11c2fe6898e3">

What you recon @boyney123 ?
