### PR TITLE
chore: move types deps to dev deps

### DIFF
--- a/.changeset/light-meals-play.md
+++ b/.changeset/light-meals-play.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+chore(core): moved types deps to dev deps

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,13 @@
 {
   "name": "@eventcatalog/core",
-  "version": "2.12.0",
+  "version": "2.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@eventcatalog/core",
-      "version": "2.12.0",
+      "version": "2.13.1",
       "dependencies": {
-        "@astrojs/check": "^0.9.4",
         "@astrojs/markdown-remark": "^5.3.0",
         "@astrojs/mdx": "^3.1.8",
         "@astrojs/react": "^3.6.2",
@@ -21,12 +20,6 @@
         "@stoplight/mosaic": "^1.53.2",
         "@tailwindcss/typography": "^0.5.13",
         "@tanstack/react-table": "^8.17.3",
-        "@types/dagre": "^0.7.52",
-        "@types/diff": "^5.2.2",
-        "@types/lodash.debounce": "^4.0.9",
-        "@types/lodash.merge": "4.6.9",
-        "@types/node": "^20.14.2",
-        "@types/semver": "^7.5.8",
         "astro": "^4.16.5",
         "astro-expressive-code": "^0.36.1",
         "astro-pagefind": "^1.6.0",
@@ -62,10 +55,17 @@
         "eventcatalog": "bin/dist/eventcatalog.cjs"
       },
       "devDependencies": {
+        "@astrojs/check": "^0.9.4",
         "@changesets/cli": "^2.27.5",
         "@playwright/test": "^1.48.1",
+        "@types/dagre": "^0.7.52",
+        "@types/diff": "^5.2.2",
+        "@types/lodash.debounce": "^4.0.9",
+        "@types/lodash.merge": "4.6.9",
+        "@types/node": "^20.14.2",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
+        "@types/semver": "^7.5.8",
         "prettier": "^3.3.3",
         "prettier-plugin-astro": "^0.14.1",
         "tsup": "^8.1.0",
@@ -108,6 +108,7 @@
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/@astrojs/check/-/check-0.9.4.tgz",
       "integrity": "sha512-IOheHwCtpUfvogHHsvu0AbeRZEnjJg3MopdLddkJE70mULItS/Vh37BHcI00mcOJcH1vhD3odbpvWokpxam7xA==",
+      "dev": true,
       "dependencies": {
         "@astrojs/language-server": "^2.15.0",
         "chokidar": "^4.0.1",
@@ -125,6 +126,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.1.tgz",
       "integrity": "sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==",
+      "dev": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -139,6 +141,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.2.tgz",
       "integrity": "sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==",
+      "dev": true,
       "engines": {
         "node": ">= 14.16.0"
       },
@@ -6670,7 +6673,8 @@
     "node_modules/@types/dagre": {
       "version": "0.7.52",
       "resolved": "https://registry.npmjs.org/@types/dagre/-/dagre-0.7.52.tgz",
-      "integrity": "sha512-XKJdy+OClLk3hketHi9Qg6gTfe1F3y+UFnHxKA2rn9Dw+oXa4Gb378Ztz9HlMgZKSxpPmn4BNVh9wgkpvrK1uw=="
+      "integrity": "sha512-XKJdy+OClLk3hketHi9Qg6gTfe1F3y+UFnHxKA2rn9Dw+oXa4Gb378Ztz9HlMgZKSxpPmn4BNVh9wgkpvrK1uw==",
+      "dev": true
     },
     "node_modules/@types/debug": {
       "version": "4.1.12",
@@ -6683,7 +6687,8 @@
     "node_modules/@types/diff": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/@types/diff/-/diff-5.2.2.tgz",
-      "integrity": "sha512-qVqLpd49rmJA2nZzLVsmfS/aiiBpfVE95dHhPVwG0NmSBAt+riPxnj53wq2oBq5m4Q2RF1IWFEUpnZTgrQZfEQ=="
+      "integrity": "sha512-qVqLpd49rmJA2nZzLVsmfS/aiiBpfVE95dHhPVwG0NmSBAt+riPxnj53wq2oBq5m4Q2RF1IWFEUpnZTgrQZfEQ==",
+      "dev": true
     },
     "node_modules/@types/dompurify": {
       "version": "3.0.5",
@@ -6741,12 +6746,14 @@
       "version": "4.17.7",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.7.tgz",
       "integrity": "sha512-8wTvZawATi/lsmNu10/j2hk1KEP0IvjubqPE3cu1Xz7xfXXt5oCq3SNUz4fMIP4XGF9Ky+Ue2tBA3hcS7LSBlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/lodash.debounce": {
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/@types/lodash.debounce/-/lodash.debounce-4.0.9.tgz",
       "integrity": "sha512-Ma5JcgTREwpLRwMM+XwBR7DaWe96nC38uCBDFKZWbNKD+osjVzdpnUSwBcqCptrp16sSOLBAUb50Car5I0TCsQ==",
+      "dev": true,
       "dependencies": {
         "@types/lodash": "*"
       }
@@ -6755,6 +6762,7 @@
       "version": "4.6.9",
       "resolved": "https://registry.npmjs.org/@types/lodash.merge/-/lodash.merge-4.6.9.tgz",
       "integrity": "sha512-23sHDPmzd59kUgWyKGiOMO2Qb9YtqRO/x4IhkgNUiPQ1+5MUVqi6bCZeq9nBJ17msjIMbEIO5u+XW4Kz6aGUhQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/lodash": "*"
@@ -6864,7 +6872,8 @@
     "node_modules/@types/semver": {
       "version": "7.5.8",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
-      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ=="
+      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
+      "dev": true
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "format:diff": "prettier --config .prettierrc --list-different \"**/*.{js,jsx,ts,tsx,json,astro}\""
   },
   "dependencies": {
-    "@astrojs/check": "^0.9.4",
     "@astrojs/markdown-remark": "^5.3.0",
     "@astrojs/mdx": "^3.1.8",
     "@astrojs/react": "^3.6.2",
@@ -49,12 +48,6 @@
     "@stoplight/mosaic": "^1.53.2",
     "@tailwindcss/typography": "^0.5.13",
     "@tanstack/react-table": "^8.17.3",
-    "@types/dagre": "^0.7.52",
-    "@types/diff": "^5.2.2",
-    "@types/lodash.debounce": "^4.0.9",
-    "@types/lodash.merge": "4.6.9",
-    "@types/node": "^20.14.2",
-    "@types/semver": "^7.5.8",
     "astro": "^4.16.5",
     "astro-expressive-code": "^0.36.1",
     "astro-pagefind": "^1.6.0",
@@ -87,10 +80,17 @@
     "uuid": "^10.0.0"
   },
   "devDependencies": {
+    "@astrojs/check": "^0.9.4",
     "@changesets/cli": "^2.27.5",
     "@playwright/test": "^1.48.1",
+    "@types/dagre": "^0.7.52",
+    "@types/diff": "^5.2.2",
+    "@types/lodash.debounce": "^4.0.9",
+    "@types/lodash.merge": "4.6.9",
+    "@types/node": "^20.14.2",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
+    "@types/semver": "^7.5.8",
     "prettier": "^3.3.3",
     "prettier-plugin-astro": "^0.14.1",
     "tsup": "^8.1.0",


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://www.eventcatalog.dev/docs/contributing/overview

Happy contributing!

-->

## Motivation

It move `@astrojs/check` to devDeps. Astro check is used at build-ci script only.
It move `@types/*` to devDeps as in 95ca9aa the types check was removed.
