### PR TITLE
Support Avro schemaFormat in AsyncApi rendering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "@eventcatalog/core",
-  "version": "2.13.1",
+  "version": "2.14.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@eventcatalog/core",
-      "version": "2.13.1",
+      "version": "2.14.2",
       "dependencies": {
         "@astrojs/markdown-remark": "^5.3.0",
         "@astrojs/mdx": "^3.1.8",
         "@astrojs/react": "^3.6.2",
         "@astrojs/tailwind": "^5.1.2",
+        "@asyncapi/avro-schema-parser": "^3.0.24",
         "@asyncapi/react-component": "^2.4.3",
         "@headlessui/react": "^2.0.3",
         "@heroicons/react": "^2.1.3",
@@ -828,6 +829,7 @@
       "version": "3.0.24",
       "resolved": "https://registry.npmjs.org/@asyncapi/avro-schema-parser/-/avro-schema-parser-3.0.24.tgz",
       "integrity": "sha512-YMyr2S2heMrWHRyECknjHeejlZl5exUSv9nD1gTejAT13fSf0PqIRydZ9ZuoglCLBg55AeehypR2zLIBu/9kHQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@asyncapi/parser": "^3.1.0",
         "@types/json-schema": "^7.0.11",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@astrojs/mdx": "^3.1.8",
     "@astrojs/react": "^3.6.2",
     "@astrojs/tailwind": "^5.1.2",
+    "@asyncapi/avro-schema-parser": "^3.0.24",
     "@asyncapi/react-component": "^2.4.3",
     "@headlessui/react": "^2.0.3",
     "@heroicons/react": "^2.1.3",

--- a/src/pages/docs/[type]/[id]/[version]/asyncapi/index.astro
+++ b/src/pages/docs/[type]/[id]/[version]/asyncapi/index.astro
@@ -4,6 +4,7 @@ import { readFileSync } from 'fs';
 import { createElement } from 'react';
 import { renderToString } from 'react-dom/server';
 import { Parser } from '@asyncapi/parser';
+import { AvroSchemaParser } from '@asyncapi/avro-schema-parser';
 
 import type { CollectionTypes, PageTypes } from '@types';
 
@@ -46,7 +47,7 @@ const fileContent = readFileSync(pathOnDisk, 'utf-8');
 
 // AsyncAPI parser will parser schemas for users, they can turn this off.
 const parseSchemas = Config?.asyncAPI?.renderParsedSchemas ?? true;
-const parsed = await new Parser().parse(fileContent, { parseSchemas });
+const parsed = await new Parser({ schemaParsers: [AvroSchemaParser()] }).parse(fileContent, { parseSchemas });
 const stringified = parsed.document?.json();
 const config: ConfigInterface = { show: { sidebar: true, errors: true } };
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://www.eventcatalog.dev/docs/contributing/overview

Happy contributing!

-->

## Motivation

It adds `@asyncapi/avro-schema-parser` to support schemaFormat in AsyncApi rendering.

Closes #976
