### PR TITLE
fix(core): watcher segmentation fault

### DIFF
--- a/src/watcher.js
+++ b/src/watcher.js
@@ -1,5 +1,6 @@
 import watcher from '@parcel/watcher';
 import fs from 'node:fs';
+import path from 'node:path';
 import { mapCatalogToAstro } from './map-catalog-to-astro.js';
 import { rimrafSync } from 'rimraf';
 import { addPropertyToFrontMatter } from './eventcatalog-config-file-utils.js';

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -70,7 +70,7 @@ export async function watch(projectDirectory, catalogDirectory, callback = undef
       callback
     ),
     {
-      ignore: [`**/${catalogDirectory}/!(${projectDirectory})**`],
+      ignore: [catalogDirectory],
     }
   );
 

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -1,6 +1,5 @@
 import watcher from '@parcel/watcher';
 import fs from 'node:fs';
-import path from 'node:path';
 import { mapCatalogToAstro } from './map-catalog-to-astro.js';
 import { rimrafSync } from 'rimraf';
 import { addPropertyToFrontMatter } from './eventcatalog-config-file-utils.js';


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://www.eventcatalog.dev/docs/contributing/overview

Happy contributing!

-->

## Motivation

When you run `npm run start:catalog` it gaves the `Segmentation fault` error. This is related with the ignore path on watcher. Changing the ignore path to only `catalogDirectory` works. 

As the `catalogDirectory` is usually within the `projectDirectory` (`.eventcatalog-core/`) we won't have a problem with that change. 

_The ignore path was changed to `**/${catalogDirectory}/!(${projectDirectory})**` before because, the CATALOG_DIR was the root of the package and the PROJECT_DIR was `examples/default/` within the CATALOG_DIR. With the restructure of the package, CATALOG_DIR now refers to the `<root>/eventcatalog/` and PROJECT_DIR to `<root>/examples/default/`._
