### PR TITLE
refactor: remove --root and --port flags from astro preview command

### DIFF
--- a/.changeset/friendly-radios-watch.md
+++ b/.changeset/friendly-radios-watch.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+chore(core): removed --root and --port flags from astro preview command

--- a/src/eventcatalog.ts
+++ b/src/eventcatalog.ts
@@ -123,16 +123,10 @@ program
   });
 
 const previewCatalog = ({ command }: { command: Command }) => {
-  /**
-   * TODO: get the port and outDir from the eventcatalog.config.js.
-   */
-  execSync(
-    `cross-env PROJECT_DIR='${dir}' CATALOG_DIR='${core}' npx astro preview --root ${dir} --port 3000 ${command.args.join(' ').trim()}`,
-    {
-      cwd: core,
-      stdio: 'inherit',
-    }
-  );
+  execSync(`cross-env PROJECT_DIR='${dir}' CATALOG_DIR='${core}' npx astro preview ${command.args.join(' ').trim()}`, {
+    cwd: core,
+    stdio: 'inherit',
+  });
 };
 
 program


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://www.eventcatalog.dev/docs/contributing/overview

Happy contributing!

-->

## Motivation

This change allows Astro to resolve the configuration using the astro.config.js with the eventcatalog.config.js and the cli options, ensuring proper handling of the options.

See https://github.com/event-catalog/eventcatalog/issues/1015#issuecomment-2542025240
