### PR TITLE
fix(core): fixed matching for ubiquitous lang

### DIFF
--- a/.changeset/eight-badgers-try.md
+++ b/.changeset/eight-badgers-try.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix(core): fixed matching for ubiquitous lang

--- a/eventcatalog/src/utils/collections/domains.ts
+++ b/eventcatalog/src/utils/collections/domains.ts
@@ -74,10 +74,9 @@ export const getDomains = async ({ getAllVersions = true }: Props = {}): Promise
 };
 
 export const getUbiquitousLanguage = async (domain: Domain): Promise<UbiquitousLanguage[]> => {
-  const { collection, data } = domain;
-
-  const ubiquitousLanguages = await getCollection('ubiquitousLanguages', (ubiquitousLanguage) => {
-    return ubiquitousLanguage.id.toLowerCase().includes(`${collection}/${data.name}`.toLowerCase());
+  const ubiquitousLanguages = await getCollection('ubiquitousLanguages', (ubiquitousLanguage: UbiquitousLanguage) => {
+    const folderPath = ubiquitousLanguage.id.replace('ubiquitous-language', '');
+    return domain.filePath?.toLowerCase().includes(folderPath.toLowerCase());
   });
 
   return ubiquitousLanguages;


### PR DESCRIPTION
Fixing matching for the ubiquitous language matching issues #1066

Should now read the filepaths rather than collection names and ids.