### PR TITLE
fix(core): visualizer now defaults to correct messages

### DIFF
--- a/.changeset/ninety-bugs-brake.md
+++ b/.changeset/ninety-bugs-brake.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix(core): visualizer now defaults to correct messages

--- a/eventcatalog/src/layouts/VerticalSideBarLayout.astro
+++ b/eventcatalog/src/layouts/VerticalSideBarLayout.astro
@@ -46,7 +46,9 @@ const getDefaultUrl = (route: string, defaultValue: string) => {
   const collections = [
     { data: domains, key: 'domains' },
     { data: services, key: 'services' },
-    { data: messages, key: 'messages' },
+    { data: events, key: 'events' },
+    { data: commands, key: 'commands' },
+    { data: queries, key: 'queries' },
     { data: flows, key: 'flows' },
   ];
 


### PR DESCRIPTION
If an EventCatalog only has messages, then the visualizer does not work. This fixes the default URL that is loaded for the visualizer.