### PR TITLE
feat(core): use `gray-matter` to `stringify` dependencies frontmatter

### DIFF
--- a/.changeset/quote-dependencies-frontmatter.md
+++ b/.changeset/quote-dependencies-frontmatter.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix(core): fixed dependencies frontmatter quoting when values would be interpreted as non-scalar

--- a/src/__tests__/example-catalog-dependencies/eventcatalog.config.js
+++ b/src/__tests__/example-catalog-dependencies/eventcatalog.config.js
@@ -35,6 +35,10 @@ export default {
     services: [
       { id: 'TestingServiceOrder', version: '5.0.0' }
     ],
+    channels: [
+      { id: 'TestingChannelOrder', version: '5.0.0'},
+      { id: '{env}.testing.channel.order', version: '5.0.0'}
+    ],
     domains: [
       { id: 'TestingDomainOrder', version: '5.0.0' }
     ],

--- a/src/__tests__/resolve-catalog-dependencies.spec.ts
+++ b/src/__tests__/resolve-catalog-dependencies.spec.ts
@@ -90,5 +90,27 @@ describe('resolve-catalog-dependencies', () => {
         expect(content).toContain('version: 5.0.0');
       });
     });
+
+    describe('channels', () => {
+      it('creates a dependency file for each channel', async () => {
+        const content = await fs.readFile(
+          path.join(CATALOG_DIR, 'dependencies', 'channels', 'TestingChannelOrder', 'index.md'),
+          'utf8'
+        );
+        expect(content).toContain('id: TestingChannelOrder');
+        expect(content).toContain('name: TestingChannelOrder');
+        expect(content).toContain('version: 5.0.0');
+      });
+
+      it('creates a dependency file for parameterized channels', async () => {
+        const content = await fs.readFile(
+          path.join(CATALOG_DIR, 'dependencies', 'channels', '{env}.testing.channel.order', 'index.md'),
+          'utf8'
+        );
+        expect(content).toContain(`id: '{env}.testing.channel.order'`);
+        expect(content).toContain(`name: '{env}.testing.channel.order'`);
+        expect(content).toContain('version: 5.0.0');
+      });
+    });
   });
 });

--- a/src/resolve-catalog-dependencies.js
+++ b/src/resolve-catalog-dependencies.js
@@ -1,6 +1,7 @@
 import { getEventCatalogConfigFile } from './eventcatalog-config-file-utils';
 import path from 'node:path';
 import fs from 'node:fs';
+import matter from 'gray-matter';
 
 // Create a fake file for this dependency in the project directory ()
 
@@ -27,27 +28,25 @@ export default async (catalogDir, core) => {
   const resourceTypes = Object.keys(dependencies);
   for (const resourceType of resourceTypes) {
     for (const dependency of dependencies[resourceType]) {
-      const resource = {
+      const frontmatter = {
         id: dependency.id,
+        name: dependency.id,
         version: dependency.version || '1.0.0',
       };
 
-      const markdown = `---
-id: ${resource.id}
-name: ${resource.id}
-version: ${resource.version}
----
+      const markdown = matter.stringify(
+        {
+          content: [
+            ':::warning',
+            'You are running EventCatalog with dependencies enabled.',
+            'This resource is mocked and is a dependency. This means that the resource is managed and owned by another catalog.',
+            ':::',
+          ].join('\n\n'),
+        },
+        frontmatter
+      );
 
-:::warning
-
-You are running EventCatalog with dependencies enabled.
-
-This resource is mocked and is a dependency. This means that the resource is managed and owned by another catalog.
-:::
-
-`;
-
-      const resourceFile = path.join(dependenciesDir, resourceType, resource.id, `index.md`);
+      const resourceFile = path.join(dependenciesDir, resourceType, dependency.id, `index.md`);
       // ensure the directory exists
       fs.mkdirSync(path.dirname(resourceFile), { recursive: true });
       fs.writeFileSync(resourceFile, markdown);


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://www.eventcatalog.dev/docs/contributing/overview

Happy contributing!

-->

## Motivation

Use `gray-matter` to generate dependencies frontmatter, as per discussion in #1081 

Fixes #1081 

* [ ] Not sure how you feel about the `[].join()` for the markdown 🥲 (Never know how to format multi-lines where indentation affects output)
* [ ] Not sure how you feel about the changeset wording
