### PR TITLE
Rework how we sort versions

### DIFF
--- a/.changeset/grumpy-eels-play.md
+++ b/.changeset/grumpy-eels-play.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix(core): refactored how versions are sorted across the catalog

--- a/eventcatalog/src/utils/__tests__/collections/util.spec.ts
+++ b/eventcatalog/src/utils/__tests__/collections/util.spec.ts
@@ -1,4 +1,4 @@
-import { sortVersions, satisfies } from '@utils/collections/util';
+import { sortVersions, satisfies, sortStringVersions } from '@utils/collections/util';
 import { describe, it, expect } from 'vitest';
 
 describe('Collections - utils', () => {
@@ -26,13 +26,14 @@ describe('Collections - utils', () => {
     });
   });
 
-  describe('sortVersions', () => {
+  describe('sortStringVersions', () => {
     it.each([
       [{ versions: ['1', '3', '2'], result: ['3', '2', '1'], latest: '3' }],
       [{ versions: ['1.0.1', '1.1.0', '1.0.2'], result: ['1.1.0', '1.0.2', '1.0.1'], latest: '1.1.0' }],
       [{ versions: ['a', 'c', 'b'], result: ['c', 'b', 'a'], latest: 'c' }],
+      [{ versions: [], result: [], latest: undefined }],
     ])('should returns $latest as latest version of $versions', ({ versions, result, latest }) => {
-      expect(sortVersions(versions)).toEqual({ versions: result, latestVersion: latest });
+      expect(sortStringVersions(versions)).toEqual({ versions: result, latestVersion: latest });
     });
   });
 });

--- a/eventcatalog/src/utils/__tests__/collections/util.spec.ts
+++ b/eventcatalog/src/utils/__tests__/collections/util.spec.ts
@@ -1,4 +1,4 @@
-import { findLatestVersion, satisfies } from '@utils/collections/util';
+import { sortVersions, satisfies } from '@utils/collections/util';
 import { describe, it, expect } from 'vitest';
 
 describe('Collections - utils', () => {
@@ -26,13 +26,13 @@ describe('Collections - utils', () => {
     });
   });
 
-  describe('findLatestVersion', () => {
+  describe('sortVersions', () => {
     it.each([
-      [{ versions: ['1', '3', '2'], latest: '3' }],
-      [{ versions: ['1.0.1', '1.1.0', '1.0.2'], latest: '1.1.0' }],
-      [{ versions: ['a', 'c', 'b'], latest: 'c' }],
-    ])('should returns $latest as latest version of $versions', ({ versions, latest }) => {
-      expect(findLatestVersion(versions)).toBe(latest);
+      [{ versions: ['1', '3', '2'], result: ['3', '2', '1'], latest: '3' }],
+      [{ versions: ['1.0.1', '1.1.0', '1.0.2'], result: ['1.1.0', '1.0.2', '1.0.1'], latest: '1.1.0' }],
+      [{ versions: ['a', 'c', 'b'], result: ['c', 'b', 'a'], latest: 'c' }],
+    ])('should returns $latest as latest version of $versions', ({ versions, result, latest }) => {
+      expect(sortVersions(versions)).toEqual({ versions: result, latestVersion: latest });
     });
   });
 });

--- a/eventcatalog/src/utils/__tests__/collections/util.spec.ts
+++ b/eventcatalog/src/utils/__tests__/collections/util.spec.ts
@@ -29,6 +29,7 @@ describe('Collections - utils', () => {
   describe('sortStringVersions', () => {
     it.each([
       [{ versions: ['1', '3', '2'], result: ['3', '2', '1'], latest: '3' }],
+      [{ versions: ['10', '1', '2', '3'], result: ['10', '3', '2', '1'], latest: '10' }],
       [{ versions: ['1.0.1', '1.1.0', '1.0.2'], result: ['1.1.0', '1.0.2', '1.0.1'], latest: '1.1.0' }],
       [{ versions: ['a', 'c', 'b'], result: ['c', 'b', 'a'], latest: 'c' }],
       [{ versions: [], result: [], latest: undefined }],

--- a/eventcatalog/src/utils/__tests__/collections/util.spec.ts
+++ b/eventcatalog/src/utils/__tests__/collections/util.spec.ts
@@ -1,4 +1,4 @@
-import { sortVersions, satisfies, sortStringVersions } from '@utils/collections/util';
+import { satisfies, sortStringVersions } from '@utils/collections/util';
 import { describe, it, expect } from 'vitest';
 
 describe('Collections - utils', () => {

--- a/eventcatalog/src/utils/collections/util.ts
+++ b/eventcatalog/src/utils/collections/util.ts
@@ -22,7 +22,7 @@ export const getVersionForCollectionItem = (
   return getVersions(allVersionsForItem);
 };
 
-export function sortVersions<T extends { version: string }>(versioned: T[]): T[] {
+export function sortVersioned<T extends { version: string }>(versioned: T[]): T[] {
   // try to coerce semver versions from string input
   const semverVersions = versioned.map((v) => ({ original: v, semver: coerce(v.version) }));
 
@@ -38,7 +38,7 @@ export function sortVersions<T extends { version: string }>(versioned: T[]): T[]
 }
 
 export function sortStringVersions(versions: string[]) {
-  const sorted = sortVersions(versions.map((version) => ({ version })));
+  const sorted = sortVersioned(versions.map((version) => ({ version })));
 
   return { latestVersion: sorted[0]?.version, versions: sorted.map((v) => v.version) };
 }
@@ -66,7 +66,7 @@ export const getItemsFromCollectionByIdAndSemverOrLatest = <T extends { data: { 
   }
 
   // Order by version
-  const sorted = sortVersions(filteredCollection.map((x) => ({ version: x.data.version, original: x })));
+  const sorted = sortVersioned(filteredCollection.map((x) => ({ version: x.data.version, original: x })));
 
   // latest version
   return sorted[0] != null ? [sorted[0].original] : [];

--- a/eventcatalog/src/utils/collections/util.ts
+++ b/eventcatalog/src/utils/collections/util.ts
@@ -14,16 +14,19 @@ export const getVersions = (data: CollectionEntry<CollectionTypes>[]) => {
   return { versions, latestVersion };
 };
 
-export function findLatestVersion(versions: string[]) {
+export function sortVersions(versions: string[]) {
   // try to coerce semver versions from string input
   const semverVersions = versions.map((v) => ({ original: v, semver: coerce(v) }));
 
   // if all versions are semver'ish, use semver to order the versions
   if (semverVersions.every((v) => v.semver != null)) {
-    return semverVersions.sort((a, b) => compare(b.semver!, a.semver!))[0].original;
+    const sorted = semverVersions.sort((a, b) => compare(b.semver!, a.semver!));
+
+    return { versions: sorted.map((v) => v.original), latestVersion: sorted[0].original };
   } else {
     // fallback to default sort
-    return versions.sort().reverse()[0];
+    const sorted = versions.sort().reverse();
+    return { versions: sorted, latestVersion: sorted[0] };
   }
 }
 
@@ -36,9 +39,7 @@ export const getVersionForCollectionItem = (
   // unique versions
   const versions = [...new Set(allVersionsForItem)];
 
-  let latestVersion = findLatestVersion(versions);
-
-  return { versions, latestVersion };
+  return sortVersions(versions);
 };
 
 /**

--- a/eventcatalog/src/utils/collections/util.ts
+++ b/eventcatalog/src/utils/collections/util.ts
@@ -13,20 +13,11 @@ export const getVersions = (data: CollectionEntry<CollectionTypes>[]) => {
   return sortStringVersions(versions);
 };
 
-export const getVersionForCollectionItem = (
-  item: CollectionEntry<CollectionTypes>,
-  collection: CollectionEntry<CollectionTypes>[]
-) => {
-  const allVersionsForItem = collection.filter((i) => i.data.id === item.data.id);
-
-  return getVersions(allVersionsForItem);
-};
-
 /**
  * Sorts versioned items. Latest version first.
  */
 export function sortVersioned<T>(versioned: T[], versionExtractor: (e: T) => string): T[] {
-  // try to coerce semver versions from string input
+  // try to coerce semver versions from input version
   const semverVersions = versioned.map((v) => ({ original: v, semver: coerce(versionExtractor(v)) }));
 
   // if all versions are semver'ish, use semver to sort them
@@ -39,6 +30,15 @@ export function sortVersioned<T>(versioned: T[], versionExtractor: (e: T) => str
     return versioned.sort((a, b) => versionExtractor(b).localeCompare(versionExtractor(a)));
   }
 }
+
+export const getVersionForCollectionItem = (
+  item: CollectionEntry<CollectionTypes>,
+  collection: CollectionEntry<CollectionTypes>[]
+) => {
+  const allVersionsForItem = collection.filter((i) => i.data.id === item.data.id);
+
+  return getVersions(allVersionsForItem);
+};
 
 export function sortStringVersions(versions: string[]) {
   const sorted = sortVersioned(versions, (v) => v);


### PR DESCRIPTION
## Motivation

Just noticed that the sorted versions list was not returned by the new functionality which causes a wrong order here for example: https://demo.eventcatalog.dev/docs/domains/Orders/0.0.3
<img width="239" alt="Screenshot 2025-01-10 at 15 25 55" src="https://github.com/user-attachments/assets/5272c7f2-cfe8-4fbc-ac5d-c8596dfc5f4d" />

