### PR TITLE
fix: remove cache from `getMessages` function

### DIFF
--- a/eventcatalog/src/utils/__tests__/messages/messages.spec.ts
+++ b/eventcatalog/src/utils/__tests__/messages/messages.spec.ts
@@ -1,0 +1,142 @@
+import type { CollectionEntry, ContentCollectionKey } from 'astro:content';
+import { expect, describe, it, vi } from 'vitest';
+import { mockCommands, mockEvents, mockQueries, mockServices, mockChannels } from './mocks';
+import { getMessages } from '@utils/messages';
+
+vi.mock('astro:content', async (importOriginal) => {
+  return {
+    ...(await importOriginal<typeof import('astro:content')>()),
+    async getCollection<T extends ContentCollectionKey>(key: T, filterFn: (entry: CollectionEntry<T>) => boolean = () => true) {
+      switch (key) {
+        case 'services':
+          return mockServices.filter(filterFn);
+        case 'events':
+          return mockEvents.filter(filterFn as any);
+        case 'commands':
+          return mockCommands.filter(filterFn as any);
+        case 'channels':
+          return mockChannels.filter(filterFn);
+        case 'queries':
+          return mockQueries.filter(filterFn);
+      }
+    },
+  };
+});
+
+describe('getMessages', () => {
+  it('should return all versions of messages', async () => {
+    await expect(getMessages({ getAllVersions: true })).resolves.toEqual(
+      expect.objectContaining({
+        events: expect.arrayContaining([
+          expect.objectContaining({
+            collection: 'events',
+            data: expect.objectContaining({
+              id: 'PaymentProcessed',
+              version: '0.0.1',
+            }),
+          }),
+          expect.objectContaining({
+            collection: 'events',
+            data: expect.objectContaining({
+              id: 'PaymentProcessed',
+              version: '0.0.2',
+            }),
+          }),
+          expect.objectContaining({
+            collection: 'events',
+            data: expect.objectContaining({
+              id: 'PaymentProcessed',
+              version: '0.1.0',
+            }),
+          }),
+        ]),
+      })
+    );
+  });
+
+  it('should return current versions of messages', async () => {
+    await expect(getMessages({ getAllVersions: false })).resolves.toEqual({
+      queries: [],
+      commands: [
+        expect.objectContaining({
+          collection: 'commands',
+          data: expect.objectContaining({
+            id: 'ProcessPayment',
+            version: '0.1.0',
+          }),
+        }),
+      ],
+      events: [
+        expect.objectContaining({
+          collection: 'events',
+          data: expect.objectContaining({
+            id: 'PaymentProcessed',
+            version: '0.1.0',
+          }),
+        }),
+      ],
+    });
+  });
+
+  it('should return current versions even if the first call is to get all versions', async () => {
+    await getMessages({ getAllVersions: true });
+
+    const messages = await getMessages({ getAllVersions: false });
+
+    expect(messages).toEqual({
+      queries: [],
+      commands: [
+        expect.objectContaining({
+          collection: 'commands',
+          data: expect.objectContaining({
+            id: 'ProcessPayment',
+            version: '0.1.0',
+          }),
+        }),
+      ],
+      events: [
+        expect.objectContaining({
+          collection: 'events',
+          data: expect.objectContaining({
+            id: 'PaymentProcessed',
+            version: '0.1.0',
+          }),
+        }),
+      ],
+    });
+  });
+
+  it('should return all version even if the first call is to get current versions', async () => {
+    await getMessages({ getAllVersions: false });
+
+    const messages = await getMessages({ getAllVersions: true });
+
+    expect(messages).toEqual(
+      expect.objectContaining({
+        commands: expect.arrayContaining([
+          expect.objectContaining({
+            collection: 'commands',
+            data: expect.objectContaining({
+              id: 'ProcessPayment',
+              version: '0.0.1',
+            }),
+          }),
+          expect.objectContaining({
+            collection: 'commands',
+            data: expect.objectContaining({
+              id: 'ProcessPayment',
+              version: '0.0.2',
+            }),
+          }),
+          expect.objectContaining({
+            collection: 'commands',
+            data: expect.objectContaining({
+              id: 'ProcessPayment',
+              version: '0.1.0',
+            }),
+          }),
+        ]),
+      })
+    );
+  });
+});

--- a/eventcatalog/src/utils/__tests__/messages/mocks.ts
+++ b/eventcatalog/src/utils/__tests__/messages/mocks.ts
@@ -1,0 +1,65 @@
+export const mockCommands = [
+  {
+    id: 'ProcessPayment',
+    collection: 'commands',
+    data: {
+      id: 'ProcessPayment',
+      version: '0.0.1',
+      pathToFile: 'commands/ProcessPayment/versioned/0.0.1/index.md',
+    },
+  },
+  {
+    id: 'ProcessPayment',
+    collection: 'commands',
+    data: {
+      id: 'ProcessPayment',
+      version: '0.0.2',
+      pathToFile: 'commands/ProcessPayment/versioned/0.0.2/index.md',
+    },
+  },
+  {
+    id: 'ProcessPayment',
+    collection: 'commands',
+    data: {
+      id: 'ProcessPayment',
+      version: '0.1.0',
+      pathToFile: 'commands/ProcessPayment/index.md',
+    },
+  },
+];
+
+export const mockEvents = [
+  {
+    id: 'PaymentProcessed',
+    collection: 'events',
+    data: {
+      id: 'PaymentProcessed',
+      version: '0.0.1',
+      pathToFile: 'events/PaymentProcessed/versioned/0.0.1/index.md',
+    },
+  },
+  {
+    id: 'PaymentProcessed',
+    collection: 'events',
+    data: {
+      id: 'PaymentProcessed',
+      version: '0.0.2',
+      pathToFile: 'events/PaymentProcessed/versioned/0.0.2/index.md',
+    },
+  },
+  {
+    id: 'PaymentProcessed',
+    collection: 'events',
+    data: {
+      id: 'PaymentProcessed',
+      version: '0.1.0',
+      pathToFile: 'events/PaymentProcessed/index.md',
+    },
+  },
+];
+
+export const mockQueries = [];
+
+export const mockServices = [];
+
+export const mockChannels = [];

--- a/eventcatalog/src/utils/messages.ts
+++ b/eventcatalog/src/utils/messages.ts
@@ -16,28 +16,17 @@ type Messages = {
   queries: CollectionEntry<'queries'>[];
 };
 
-// Cache for build time
-let cachedMessages: Messages = {
-  commands: [],
-  events: [],
-  queries: [],
-};
-
 // Main function that uses the imported functions
 export const getMessages = async ({ getAllVersions = true }: Props = {}): Promise<Messages> => {
-  if (cachedMessages.commands.length > 0) {
-    return cachedMessages;
-  }
+  const [commands, events, queries] = await Promise.all([
+    getCommands({ getAllVersions }),
+    getEvents({ getAllVersions }),
+    getQueries({ getAllVersions }),
+  ]);
 
-  const commands = await getCommands({ getAllVersions });
-  const events = await getEvents({ getAllVersions });
-  const queries = await getQueries({ getAllVersions });
-
-  cachedMessages = {
-    commands: commands as CollectionEntry<'commands'>[],
-    events: events as CollectionEntry<'events'>[],
-    queries: queries as CollectionEntry<'queries'>[],
+  return {
+    commands,
+    events,
+    queries,
   };
-
-  return cachedMessages;
 };


### PR DESCRIPTION
### Summary
This pull request refactors the `getMessages` function by removing its cache handling. The downstream functions `getEvents`, `getCommands`, and `getQueries` already handle caching appropriately, and `getMessages` does not differentiate the cache between `currentVersions` and `allVersions` as the others do.

### Changes
- Removed cache handling from the `getMessages` function.

### Reasoning
The cache handling in `getMessages` was redundant and inconsistent with the downstream functions. This change simplifies the code and ensures that caching is managed uniformly across all related functions.

### Related issues
- [Observed by @otbe](https://discord.com/channels/918092420338569216/929038631564353639/1328432263460819015)