### PR TITLE
feat/discover-checkbox-latest-only

### DIFF
--- a/.changeset/lovely-bags-exercise.md
+++ b/.changeset/lovely-bags-exercise.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+feat(core): users can now filter by latest version of resources on the discover page

--- a/eventcatalog/src/components/Checkbox.astro
+++ b/eventcatalog/src/components/Checkbox.astro
@@ -1,0 +1,38 @@
+---
+import type { HTMLAttributes } from 'astro/types';
+
+export type Props = HTMLAttributes<'input'> & {
+  id: string;
+  name: string;
+  label: string;
+};
+
+const { id, name, label, class: className, ...attrs } = Astro.props;
+---
+
+<label for={id} class="relative block cursor-pointer select-none pl-5">
+  <input id={id} name={name} type="checkbox" class="h-0 w-0 cursor-pointer appearance-none group" {...attrs} />
+  <span class="text-md text-gray-700">{label}</span>
+</label>
+
+<style>
+  input::before {
+    @apply absolute left-0 top-1/2 block h-4 w-4 -translate-y-1/2 rounded-[4px] border border-gray-300;
+    content: '';
+  }
+
+  input:checked::before {
+    @apply bg-purple-600;
+  }
+
+  input:focus::before {
+    @apply outline outline-purple-300;
+  }
+
+  input:checked::after {
+    @apply absolute left-0 top-1/2 block h-4 w-4 -translate-y-1/2 bg-center bg-no-repeat;
+    content: '';
+    /** inline unicons checkmark SVG */
+    background-image: url("data:image/svg+xml;utf-8,<svg width='10' height='8' viewBox='0 0 10 8' fill='none' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' clip-rule='evenodd' d='M9.04731 1.01279C9.34958 1.296 9.36503 1.77062 9.08182 2.07289L4.19342 7.29032C3.77774 7.73398 3.07363 7.73398 2.65795 7.29032L1.01279 5.53443C0.729585 5.23216 0.745038 4.75754 1.04731 4.47433C1.34958 4.19112 1.8242 4.20658 2.1074 4.50884L3.42568 5.91586L7.98721 1.04731C8.27042 0.745037 8.74504 0.729585 9.04731 1.01279Z' fill='white'/></svg>");
+  }
+</style>

--- a/eventcatalog/src/layouts/DiscoverLayout.astro
+++ b/eventcatalog/src/layouts/DiscoverLayout.astro
@@ -11,6 +11,7 @@ import { buildUrl } from '@utils/url-builder';
 import { getQueries } from '@utils/queries';
 import { MagnifyingGlassIcon } from '@heroicons/react/20/solid';
 import VerticalSideBarLayout from './VerticalSideBarLayout.astro';
+import Checkbox from '@components/Checkbox.astro';
 
 const events = await getEvents();
 const queries = await getQueries();
@@ -21,6 +22,8 @@ const flows = await getFlows();
 
 const { title, subtitle, data, type } = Astro.props;
 const currentPath = Astro.url.pathname;
+
+const checkboxLatestId = 'latest-only';
 
 const tabs = [
   {
@@ -102,17 +105,19 @@ const tabs = [
     <!-- Table -->
     <div class="pb-20 ml-6 md:pr-10">
       <div>
-        <div class="sm:flex sm:items-center py-4 pb-4" id="discover-title">
+        <div class="sm:flex sm:items-end py-4 pb-4" id="discover-title">
           <div class="sm:flex-auto space-y-2">
             <h1 class="text-4xl font-semibold text-gray-900 capitalize">{title}</h1>
             <p class="text-md text-gray-700">{subtitle}</p>
+          </div>
+          <div class="p-4 border border-gray-200 rounded-md">
+            <Checkbox id={checkboxLatestId} name={checkboxLatestId} label="Show latest only" checked />
           </div>
         </div>
         <div class="mt-4 flow-root">
           <div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
             <div class="inline-block min-w-full align-middle sm:px-6 lg:px-8">
-              <!-- @ts-ignore -->
-              <Table data={data} collection={type} client:load />
+              <Table checkboxLatestId={checkboxLatestId} data={data} collection={type} client:load />
             </div>
           </div>
         </div>

--- a/eventcatalog/src/layouts/DiscoverLayout.astro
+++ b/eventcatalog/src/layouts/DiscoverLayout.astro
@@ -111,7 +111,7 @@ const tabs = [
             <p class="text-md text-gray-700">{subtitle}</p>
           </div>
           <div class="p-4 border border-gray-200 rounded-md">
-            <Checkbox id={checkboxLatestId} name={checkboxLatestId} label="Show latest only" checked />
+            <Checkbox id={checkboxLatestId} name={checkboxLatestId} label="Show latest version only" checked />
           </div>
         </div>
         <div class="mt-4 flow-root">

--- a/eventcatalog/src/utils/__tests__/collections/util.spec.ts
+++ b/eventcatalog/src/utils/__tests__/collections/util.spec.ts
@@ -1,4 +1,4 @@
-import { satisfies, sortStringVersions } from '@utils/collections/util';
+import { isSameVersion, satisfies, sortStringVersions } from '@utils/collections/util';
 import { describe, it, expect } from 'vitest';
 
 describe('Collections - utils', () => {
@@ -35,6 +35,20 @@ describe('Collections - utils', () => {
       [{ versions: [], result: [], latest: undefined }],
     ])('should returns $latest as latest version of $versions', ({ versions, result, latest }) => {
       expect(sortStringVersions(versions)).toEqual({ versions: result, latestVersion: latest });
+    });
+  });
+
+  describe('isSameVersion', () => {
+    it.each([
+      [{ versions: ['1', '2'], result: false }],
+      [{ versions: ['1', '1'], result: true }],
+      [{ versions: ['2.0.0', '1.1.0'], result: false }],
+      [{ versions: ['2.0.0', '2.0.0'], result: true }],
+      [{ versions: ['a', 'b'], result: false }],
+      [{ versions: ['a', 'a'], result: true }],
+      [{ versions: ['1.0.0', undefined], result: false }],
+    ])('should returns $result when versions is $versions', ({ versions, result }) => {
+      expect(isSameVersion(versions[0], versions[1])).toBe(result);
     });
   });
 });

--- a/eventcatalog/src/utils/collections/util.ts
+++ b/eventcatalog/src/utils/collections/util.ts
@@ -1,6 +1,6 @@
 import type { CollectionTypes } from '@types';
 import type { CollectionEntry } from 'astro:content';
-import { coerce, compare, satisfies as satisfiesRange } from 'semver';
+import { coerce, compare, eq, satisfies as satisfiesRange } from 'semver';
 
 export const getPreviousVersion = (version: string, versions: string[]) => {
   const index = versions.indexOf(version);
@@ -12,6 +12,17 @@ export const getVersions = (data: CollectionEntry<CollectionTypes>[]) => {
   const versions = [...new Set(allVersions)];
   return sortStringVersions(versions);
 };
+
+export function isSameVersion(v1: string | undefined, v2: string | undefined) {
+  const semverV1 = coerce(v1);
+  const semverV2 = coerce(v2);
+
+  if (semverV1 != null && semverV2 != null) {
+    return eq(semverV1, semverV2);
+  }
+
+  return v1 === v2;
+}
 
 /**
  * Sorts versioned items. Latest version first.


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://www.eventcatalog.dev/docs/contributing/overview

Happy contributing!

-->

## Motivation

This PR introduces a new checkbox on the discover pages, allowing users to choose whether to display only the latest versions or all versions.
- The checkbox is **checked by default**, meaning users will initially see only the latest versions and can opt out to display all versions if desired. This behavior aligns with the discussion [here](https://github.com/event-catalog/eventcatalog/issues/1100#issuecomment-2595167186).

By enabling this feature:
- When the checkbox is **checked**, the autocomplete/search functionality for names will only show the latest versions, addressing the issue #1100.
- When the checkbox is **unchecked**, the behavior remains unchanged, displaying all versions.

## Related issues
Close #702
Fix #1100