### PR TITLE
feat/changelog-collapse-lines

### DIFF
--- a/.changeset/strong-cherries-doubt.md
+++ b/.changeset/strong-cherries-doubt.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+feat(core): changelog collapsed lines simplified


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://www.eventcatalog.dev/docs/contributing/overview

Happy contributing!

-->

## Motivation

Close #1091

## Changes

It replaces the `diffLines` with `structurePatch` and `formatPatch` to render only the changed lines.

