### PR TITLE
chore(core): added backstage license checks to embed eventcatalog

### DIFF
--- a/eventcatalog/src/layouts/VerticalSideBarLayout.astro
+++ b/eventcatalog/src/layouts/VerticalSideBarLayout.astro
@@ -142,6 +142,8 @@ const currentNavigationItem = navigationItems.find((item) => item.current);
 const { title, description, sidebar: showSideBarOverride } = Astro.props;
 
 const showSideBarOnLoad = currentNavigationItem?.sidebar;
+
+const canPageBeEmbedded = process.env.ENABLE_EMBED === 'true';
 ---
 
 <!doctype html>
@@ -209,10 +211,26 @@ const showSideBarOnLoad = currentNavigationItem?.sidebar;
       >
         <slot />
       </main>
+
+      <!-- Creae a overlay that tells people to purchase backstage plugin if they want to embed the page -->
+      <div class="absolute inset-0 bg-black items-center justify-center z-50 hidden" id="embed-overlay">
+        <div class="text-white text-center space-y-4">
+          <div>
+            <h1 class="text-2xl font-bold">EventCatalog Backstage Integration</h1>
+            <p class="text-md text-red-500">Missing license key for backstage integration.</p>
+          </div>
+          <div>
+            <p class="text-sm text-gray-500">Please configure the backstage plugin to embed this page into Backstage.</p>
+            <a href="https://www.eventcatalog.dev/integrations/backstage" class="text-blue-500 text-xs"
+              >Configure backstage plugin &rarr;</a
+            >
+          </div>
+        </div>
+      </div>
     </div>
   </body>
 </html>
-<script define:vars={{ navigationItems, currentNavigationItem, showSideBarOnLoad }}>
+<script define:vars={{ navigationItems, currentNavigationItem, showSideBarOnLoad, canPageBeEmbedded }}>
   // Listen for Astro transititions
   document.addEventListener('astro:page-load', () => {
     document.dispatchEvent(new CustomEvent('contentLoaded'));
@@ -229,6 +247,12 @@ const showSideBarOnLoad = currentNavigationItem?.sidebar;
     const params = Object.fromEntries(urlSearchParams.entries());
     const embeded = params.embed === 'true' ? true : false;
     const content = document.getElementById('content');
+
+    if (embeded && !canPageBeEmbedded) {
+      const overlay = document.getElementById('embed-overlay');
+      overlay.style.display = 'flex';
+      return;
+    }
 
     if (embeded) {
       const elementsToHide = [

--- a/src/eventcatalog.ts
+++ b/src/eventcatalog.ts
@@ -13,6 +13,7 @@ import { catalogToAstro } from './catalog-to-astro-content-directory';
 import resolveCatalogDependencies from './resolve-catalog-dependencies';
 import semver from 'semver';
 import boxen from 'boxen';
+import { isBackstagePluginEnabled } from './features';
 const boxenOptions = {
   padding: 1,
   margin: 1,
@@ -128,6 +129,9 @@ program
     await resolveCatalogDependencies(dir, core);
     await catalogToAstro(dir, core);
 
+    // Check if backstage is enabled
+    const canEmbedPages = await isBackstagePluginEnabled();
+
     let watchUnsub;
     try {
       watchUnsub = await watch(dir, core);
@@ -140,6 +144,7 @@ program
           env: {
             PROJECT_DIR: dir,
             CATALOG_DIR: core,
+            ENABLE_EMBED: canEmbedPages,
           },
         },
       ]);
@@ -167,17 +172,29 @@ program
     await resolveCatalogDependencies(dir, core);
     await catalogToAstro(dir, core);
 
-    execSync(`cross-env PROJECT_DIR='${dir}' CATALOG_DIR='${core}' npx astro build ${command.args.join(' ').trim()}`, {
-      cwd: core,
-      stdio: 'inherit',
-    });
+    // Check if backstage is enabled
+    const canEmbedPages = await isBackstagePluginEnabled();
+
+    execSync(
+      `cross-env PROJECT_DIR='${dir}' CATALOG_DIR='${core}' ENABLE_EMBED=${canEmbedPages} npx astro build ${command.args.join(' ').trim()}`,
+      {
+        cwd: core,
+        stdio: 'inherit',
+      }
+    );
   });
 
-const previewCatalog = ({ command }: { command: Command }) => {
-  execSync(`cross-env PROJECT_DIR='${dir}' CATALOG_DIR='${core}' npx astro preview ${command.args.join(' ').trim()}`, {
-    cwd: core,
-    stdio: 'inherit',
-  });
+const previewCatalog = async ({ command }: { command: Command }) => {
+  // Check if backstage is enabled
+  const canEmbedPages = await isBackstagePluginEnabled();
+
+  execSync(
+    `cross-env PROJECT_DIR='${dir}' CATALOG_DIR='${core}' ENABLE_EMBED=${canEmbedPages} npx astro preview ${command.args.join(' ').trim()}`,
+    {
+      cwd: core,
+      stdio: 'inherit',
+    }
+  );
 };
 
 program

--- a/src/features.ts
+++ b/src/features.ts
@@ -1,0 +1,62 @@
+import boxen from 'boxen';
+
+type LicenseResponse = {
+  is_trial: boolean;
+  plugin: string;
+  state: string;
+};
+
+// Checks to see if the backstage feature is enabled (or not)
+export const isBackstagePluginEnabled = async (licenseKey?: string) => {
+  const LICENSE_KEY = process.env.EVENTCATALOG_LICENSE_KEY_BACKSTAGE || null;
+
+  // no license key, so it's not enabled
+  if (!LICENSE_KEY) {
+    return false;
+  }
+
+  // Verify the license key
+  const response = await fetch('https://api.eventcatalog.cloud/functions/v1/license', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${LICENSE_KEY}`,
+      'Content-Type': 'application/json',
+    },
+  });
+
+  if (response.status !== 200) {
+    console.log(
+      '\nTried to verify your backstage license but it is not valid. Please check your license key or purchase a license at https://eventcatalog.cloud/\n'
+    );
+    return false;
+  }
+
+  if (response.status === 200) {
+    const data = (await response.json()) as LicenseResponse;
+
+    if ('@eventcatalog/backstage-plugin-eventcatalog' !== data.plugin) {
+      console.log(
+        '\nInvalid license key for backstage integration, please check your license key or purchase a license at https://eventcatalog.cloud/\n'
+      );
+      return false;
+    }
+
+    let message = 'Backstage integration is enabled for EventCatalog';
+
+    if (data.is_trial) {
+      message += '\nYou are using a trial license for backstage integration.';
+    }
+
+    console.log(
+      boxen(message, {
+        padding: 1,
+        margin: 1,
+        borderColor: 'green',
+        title: '@eventcatalog/backstage-plugin-eventcatalog',
+        titleAlignment: 'center',
+      })
+    );
+  }
+
+  return true;
+};


### PR DESCRIPTION
The generators for EventCatalog now require a license key from eventcatlaog.cloud.

The backstage works slightly different, as it's a feature of EventCatalog. This now checks to make sure the backstage key is present and valid before enabling on EventCatalog.