### PR TITLE
feat(core): added support for llms.txt

### DIFF
--- a/.changeset/four-trees-mix.md
+++ b/.changeset/four-trees-mix.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": minor
+---
+
+feat(core): added support for llms.txt

--- a/eventcatalog/src/content/config.ts
+++ b/eventcatalog/src/content/config.ts
@@ -269,6 +269,7 @@ const users = defineCollection({
     ownedCommands: z.array(reference('commands')).optional(),
     ownedQueries: z.array(reference('queries')).optional(),
     associatedTeams: z.array(reference('teams')).optional(),
+    pathToFile: z.string().optional(),
   }),
 });
 
@@ -288,6 +289,7 @@ const teams = defineCollection({
     ownedDomains: z.array(reference('domains')).optional(),
     ownedServices: z.array(reference('services')).optional(),
     ownedEvents: z.array(reference('events')).optional(),
+    pathToFile: z.string().optional(),
   }),
 });
 

--- a/eventcatalog/src/pages/docs/[type]/[id]/[version].md.ts
+++ b/eventcatalog/src/pages/docs/[type]/[id]/[version].md.ts
@@ -1,0 +1,55 @@
+// This file exposes the markdown for EventCatalog in the Url
+// For example http://localhost:3000/docs/events/OrderAmended/0.0.1 loads the Page and http://localhost:3000/docs/events/OrderAmended/0.0.1.md loads the markdown
+// This is used for the LLMs to load the markdown for the given item (llms.txt);
+
+import type { APIRoute } from 'astro';
+import { getCollection } from 'astro:content';
+import config from '@config';
+import fs from 'fs';
+
+const events = await getCollection('events');
+const commands = await getCollection('commands');
+const queries = await getCollection('queries');
+const services = await getCollection('services');
+const domains = await getCollection('domains');
+const flows = await getCollection('flows');
+const channels = await getCollection('channels');
+
+export async function getStaticPaths() {
+  // Just return empty array if LLMs are not enabled
+  if (!config.llmsTxt?.enabled) {
+    return [];
+  }
+
+  const collections = {
+    events,
+    commands,
+    queries,
+    services,
+    domains,
+    flows,
+    channels,
+  };
+  const paths = Object.keys(collections).map((type) => {
+    return collections[type as keyof typeof collections].map((item: { data: { id: string; version: string } }) => ({
+      params: { type, id: item.data.id, version: item.data.version },
+      props: { content: item },
+    }));
+  });
+
+  return paths.flat();
+}
+
+export const GET: APIRoute = async ({ params, props }) => {
+  // Just return empty array if LLMs are not enabled
+  if (!config.llmsTxt?.enabled) {
+    return new Response('llms.txt is not enabled for this Catalog.', { status: 404 });
+  }
+
+  if (props?.content?.data?.pathToFile) {
+    const file = fs.readFileSync(props.content.data.pathToFile, 'utf8');
+    return new Response(file, { status: 200 });
+  }
+
+  return new Response('Not found', { status: 404 });
+};

--- a/eventcatalog/src/pages/docs/llm/llms-full.txt.ts
+++ b/eventcatalog/src/pages/docs/llm/llms-full.txt.ts
@@ -1,0 +1,31 @@
+import { getCollection } from 'astro:content';
+import config from '@config';
+import type { APIRoute } from 'astro';
+import fs from 'fs';
+
+const events = await getCollection('events');
+const commands = await getCollection('commands');
+const queries = await getCollection('queries');
+const services = await getCollection('services');
+const domains = await getCollection('domains');
+const teams = await getCollection('teams');
+const users = await getCollection('users');
+
+export const GET: APIRoute = async ({ params, request }) => {
+  if (!config.llmsTxt?.enabled) {
+    return new Response('llms.txt is not enabled for this Catalog.', { status: 404 });
+  }
+
+  const resources = [...events, ...commands, ...queries, ...services, ...domains, ...teams, ...users];
+
+  const content = resources
+    .map((item) => {
+      if (!item.data.pathToFile) return '';
+      return fs.readFileSync(item.data.pathToFile, 'utf8');
+    })
+    .join('\n');
+
+  return new Response(content, {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+  });
+};

--- a/eventcatalog/src/pages/docs/llm/llms.txt.ts
+++ b/eventcatalog/src/pages/docs/llm/llms.txt.ts
@@ -1,0 +1,47 @@
+import { getCollection } from 'astro:content';
+import config from '@config';
+import type { APIRoute } from 'astro';
+
+const events = await getCollection('events');
+const commands = await getCollection('commands');
+const queries = await getCollection('queries');
+
+const services = await getCollection('services');
+const domains = await getCollection('domains');
+
+const teams = await getCollection('teams');
+const users = await getCollection('users');
+
+export const GET: APIRoute = async ({ params, request }) => {
+  const url = new URL(request.url);
+  const baseUrl = `${url.protocol}//${url.host}`;
+
+  const formatVersionedItem = (item: any, type: string) =>
+    `- [${item.data.name} - ${item.data.id} - ${item.data.version}](${baseUrl}/docs/${type}/${item.data.id}/${item.data.version}.md) - ${item.data.summary}`;
+
+  const formatSimpleItem = (item: any, type: string) =>
+    `- [${item.id.replace('.md', '')}](${baseUrl}/docs/${type}/${item.data.id}.md) - ${item.data.name}`;
+
+  const content = [
+    `# ${config.organizationName} EventCatalog Documentation\n`,
+    `> ${config.tagline}`,
+    '\n## Events',
+    events.map((item) => formatVersionedItem(item, 'events')).join(''),
+    '\n## Commands',
+    commands.map((item) => formatVersionedItem(item, 'commands')).join(''),
+    '\n## Queries',
+    queries.map((item) => formatVersionedItem(item, 'queries')).join(''),
+    '\n## Services',
+    services.map((item) => formatVersionedItem(item, 'services')).join(''),
+    '\n## Domains',
+    domains.map((item) => formatVersionedItem(item, 'domains')).join(''),
+    '\n## Teams',
+    teams.map((item) => formatSimpleItem(item, 'teams')).join('\n'),
+    '\n## Users',
+    users.map((item) => formatSimpleItem(item, 'users')).join('\n'),
+  ].join('\n');
+
+  return new Response(content, {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+  });
+};

--- a/eventcatalog/src/pages/docs/teams/[id].md.ts
+++ b/eventcatalog/src/pages/docs/teams/[id].md.ts
@@ -1,0 +1,40 @@
+// This file exposes the markdown for EventCatalog in the Url
+// For example http://localhost:3000/docs/events/OrderAmended/0.0.1 loads the Page and http://localhost:3000/docs/events/OrderAmended/0.0.1.md loads the markdown
+// This is used for the LLMs to load the markdown for the given item (llms.txt);
+
+import type { APIRoute } from 'astro';
+import { getCollection } from 'astro:content';
+import config from '@config';
+import fs from 'fs';
+
+const teams = await getCollection('teams');
+
+export async function getStaticPaths() {
+  // Just return empty array if LLMs are not enabled
+  if (!config.llmsTxt?.enabled) {
+    return [];
+  }
+
+  console.log(teams);
+
+  return teams.map((team) => ({
+    params: { type: 'teams', id: team.data.id },
+    props: { content: team },
+  }));
+}
+
+export const GET: APIRoute = async ({ params, props }) => {
+  // Just return empty array if LLMs are not enabled
+  if (!config.llmsTxt?.enabled) {
+    return new Response('llms.txt is not enabled for this Catalog.', { status: 404 });
+  }
+
+  console.log(props.context);
+
+  if (props?.content?.data?.pathToFile) {
+    const file = fs.readFileSync(props.content.data.pathToFile, 'utf8');
+    return new Response(file, { status: 200 });
+  }
+
+  return new Response('Not found', { status: 404 });
+};

--- a/eventcatalog/src/pages/docs/users/[id].md.ts
+++ b/eventcatalog/src/pages/docs/users/[id].md.ts
@@ -1,0 +1,36 @@
+// This file exposes the markdown for EventCatalog in the Url
+// For example http://localhost:3000/docs/events/OrderAmended/0.0.1 loads the Page and http://localhost:3000/docs/events/OrderAmended/0.0.1.md loads the markdown
+// This is used for the LLMs to load the markdown for the given item (llms.txt);
+
+import type { APIRoute } from 'astro';
+import { getCollection } from 'astro:content';
+import config from '@config';
+import fs from 'fs';
+
+const users = await getCollection('users');
+
+export async function getStaticPaths() {
+  // Just return empty array if LLMs are not enabled
+  if (!config.llmsTxt?.enabled) {
+    return [];
+  }
+
+  return users.map((user) => ({
+    params: { type: 'users', id: user.data.id },
+    props: { content: user },
+  }));
+}
+
+export const GET: APIRoute = async ({ params, props }) => {
+  // Just return empty array if LLMs are not enabled
+  if (!config.llmsTxt?.enabled) {
+    return new Response('llms.txt is not enabled for this Catalog.', { status: 404 });
+  }
+
+  if (props?.content?.data?.pathToFile) {
+    const file = fs.readFileSync(props.content.data.pathToFile, 'utf8');
+    return new Response(file, { status: 200 });
+  }
+
+  return new Response('Not found', { status: 404 });
+};

--- a/examples/default/eventcatalog.config.js
+++ b/examples/default/eventcatalog.config.js
@@ -40,4 +40,7 @@ export default {
     enabled: true,
     limit: 15,
   },
+  llmsTxt: {
+    enabled: true,
+  }
 };

--- a/src/eventcatalog.config.ts
+++ b/src/eventcatalog.config.ts
@@ -21,6 +21,9 @@ export interface Config {
     enabled: boolean;
     limit: number;
   };
+  llmsTxt?: {
+    enabled: boolean;
+  };
   logo?: {
     alt: string;
     src: string;


### PR DESCRIPTION
This feature enabled https://llmstxt.org/ into EventCatalog

Two new urls are added:

- /docs/llm/llms.txt
- /docs/llm/llms-full.txt

If you enable the feature (through your catalog, off by default) all your markdown is accessible to LLMs for parsing and asking questions etc.

Docs to follow with examples.