### PR TITLE
fix: improve `basePathname` selection in `getTreeView`

### DIFF
--- a/.changeset/thirty-eagles-chew.md
+++ b/.changeset/thirty-eagles-chew.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix(core): improved `basePathname` selection in `getTreeView` for the sidebar

--- a/eventcatalog/src/components/SideNav/TreeView/getTreeView.ts
+++ b/eventcatalog/src/components/SideNav/TreeView/getTreeView.ts
@@ -137,7 +137,7 @@ function groupChildrenByType(parentNode: TreeNode) {
 const treeViewCache = new Map<string, TreeNode>();
 
 export function getTreeView({ projectDir, currentPath }: { projectDir: string; currentPath: string }): TreeNode {
-  const basePathname = currentPath.split('/')[1] as 'docs' | 'visualiser';
+  const basePathname = currentPath.split('/').find((p) => p === 'docs' || p === 'visualiser') || 'docs';
 
   const cacheKey = `${projectDir}:${basePathname}`;
   if (treeViewCache.has(cacheKey)) return treeViewCache.get(cacheKey)!;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://www.eventcatalog.dev/docs/contributing/overview

Happy contributing!

-->

## Motivation

This PR fixes an issue in `getTreeView` where `basePathname` was previously determined using a hardcoded index (`currentPath.split('/')[1]`). If the URL structure did not conform to expectations (e.g. using `base`), it could lead to incorrect values.

## Changes
- Updated `basePathname` to dynamically find the first occurrence of `'docs'` or `'visualiser'` in the split path.
- If neither is found, it defaults to `'docs'`.

## Related issues
Fix #1165.