### PR TITLE
fix/windows-path-issue-tree-view

### DIFF
--- a/.changeset/nervous-students-happen.md
+++ b/.changeset/nervous-students-happen.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix(core): fixed issue for new sidebar for windows

--- a/eventcatalog/src/components/SideNav/TreeView/getTreeView.ts
+++ b/eventcatalog/src/components/SideNav/TreeView/getTreeView.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import os from 'node:os';
 import gm from 'gray-matter';
 import { globSync } from 'glob';
 import type { CollectionKey } from 'astro:content';
@@ -49,7 +50,7 @@ function buildTreeOfDir(directory: string, parentNode: TreeNode, options: { igno
 
   const resourceType = getResourceType(directory);
 
-  const markdownFiles = globSync(path.join(directory, '/*.md'));
+  const markdownFiles = globSync(path.join(directory, '/*.md'), { windowsPathsNoEscape: os.platform() === 'win32' });
   const isResourceIgnored = options?.ignore && resourceType && options.ignore.includes(resourceType);
 
   if (markdownFiles.length > 0 && !isResourceIgnored) {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://www.eventcatalog.dev/docs/contributing/overview

Happy contributing!

-->

## Motivation

This PR addresses a bug where `globSync` fails on Windows due to path escaping issues. The fix ensures that `windowsPathsNoEscape: true` is set when running on Windows (`os.platform() === 'win32'`).

## Changes
- Imported `os` from `node:os` to detect the platform.
- Updated `globSync` to use `windowsPathNoEspace` when on Windows.
