### PR TITLE
feat: add protocol check to tile component's href handling

### DIFF
--- a/.changeset/brave-seals-clap.md
+++ b/.changeset/brave-seals-clap.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+feat: add protocol check to tile component's href handling

--- a/eventcatalog/src/components/MDX/Tiles/Tile.astro
+++ b/eventcatalog/src/components/MDX/Tiles/Tile.astro
@@ -14,10 +14,16 @@ interface Props {
 const { href, icon, title, description, openWindow } = Astro.props;
 
 const IconComponent: ComponentType<{ className?: string }> | undefined = Icons[icon];
+
+function startsWithProtocol(str: string) {
+  // Regular expression to match common protocols (http, https, ftp, ws, etc.)
+  const regex = /^[a-zA-Z][a-zA-Z\d+\-.]*:\/\//;
+  return regex.test(str);
+}
 ---
 
 <a
-  href={buildUrl(href)}
+  href={startsWithProtocol(href) ? href : buildUrl(href)}
   target={openWindow ? '_blank' : '_self'}
   class="block bg-white border border-gray-200 rounded-lg p-6 transition-all duration-300 ease-in-out hover:shadow-md hover:border-primary focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-primary focus:ring-white"
 >


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://www.eventcatalog.dev/docs/contributing/overview

Happy contributing!

-->

## Motivation

It add a function to check if the href starts with a protocol (e.g., http, https, ftp). If the href passed is a valid absolute URLs, it is used directly in the anchor element. If not, the `buildUrl` utility is used to create the URL from the passed `href`.

Fix #1201
