### PR TITLE
refactor/asset-hydration

### DIFF
--- a/e2e/schema-download.spec.ts
+++ b/e2e/schema-download.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Schema Download', () => {
+  test('Should download schema file from message page', async ({ page }) => {
+    // Navigate to the message page
+    await page.goto('/docs/commands/AddInventory/0.0.3');
+
+    // Wait for the schema link to be visible
+    const schemaLink = page.getByRole('link', { name: 'Download schema' });
+    await expect(schemaLink).toBeVisible();
+
+    // Set up download listener
+    const downloadPromise = page.waitForEvent('download');
+
+    // Click the schema link
+    await schemaLink.click();
+
+    // Wait for the download to start
+    const download = await downloadPromise;
+
+    // Verify the downloaded file name
+    expect(download.suggestedFilename()).toBe('Add inventory(0.0.3)-schema.json');
+
+    // Ensure the download completes successfully
+    const downloadPath = await download.path();
+    expect(downloadPath).toBeTruthy();
+  });
+
+  test('Should download schema file from service page', async ({ page }) => {
+    // Navigate to the service page
+    await page.goto('/docs/services/OrdersService/0.0.3');
+
+    // Wait for the schema link to be visible
+    const schemaLink = page.getByRole('link', { name: 'Download schema' });
+    await expect(schemaLink).toBeVisible();
+
+    // Set up download listener
+    const downloadPromise = page.waitForEvent('download');
+
+    // Click the schema link
+    await schemaLink.click();
+
+    // Wait for the download to start
+    const download = await downloadPromise;
+
+    // Verify the downloaded file name
+    expect(download.suggestedFilename()).toBe('Orders Service(0.0.3)-openapi.yml');
+
+    // Ensure the download completes successfully
+    const downloadPath = await download.path();
+    expect(downloadPath).toBeTruthy();
+  });
+});

--- a/e2e/schema-viewer.spec.ts
+++ b/e2e/schema-viewer.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Schema Viewer', () => {
+  test('Should render schema viewer correctly', async ({ page }) => {
+    const pageUrl = '/docs/queries/GetSubscriptionStatus/0.0.2';
+
+    await page.goto(pageUrl);
+
+    await expect(page.locator('#GetSubscriptionStatus-SchemaViewer-portal')).toContainText('The unique identifier for the user.');
+  });
+});

--- a/e2e/specifications.spec.ts
+++ b/e2e/specifications.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Specifications', () => {
+  test('OpenAPI', async ({ page }) => {
+    const pageUrl = '/docs/services/OrdersService/0.0.3';
+
+    await page.goto(pageUrl);
+
+    const specLink = page.getByRole('link', { name: 'OpenAPI spec', exact: true });
+    await expect(specLink).toBeVisible();
+
+    await specLink.click();
+
+    await page.waitForURL(`${pageUrl}/spec`);
+
+    const title = page.getByText('Simple Task - API 1.0.2');
+    await expect(title).toBeVisible();
+  });
+
+  test('AsyncAPI', async ({ page }) => {
+    const pageUrl = '/docs/services/OrdersService/0.0.3';
+    await page.goto(pageUrl);
+
+    const specLink = page.getByRole('link', { name: 'AsyncAPI spec', exact: true });
+    await expect(specLink).toBeVisible();
+
+    await specLink.click();
+
+    await page.waitForURL(`${pageUrl}/asyncapi`);
+
+    const title = page.locator('#introduction').getByText('Order service 1.0.0');
+    await expect(title).toBeVisible();
+  });
+});

--- a/eventcatalog/astro.config.mjs
+++ b/eventcatalog/astro.config.mjs
@@ -7,6 +7,7 @@ import { mermaid } from "./src/remark-plugins/mermaid"
 import { join } from 'node:path';
 import remarkDirective from 'remark-directive';
 import { remarkDirectives } from "./src/remark-plugins/directives"
+import ecAssets from './src/integrations/assets/astro-integration-assets';
 
 import remarkComment from 'remark-comment'
 
@@ -53,6 +54,7 @@ export default defineConfig({
       gfm: true,
     }),
     pagefind(),
+    ecAssets(),
   ],
   vite: {
     define: {

--- a/eventcatalog/src/components/MDX/SchemaViewer/SchemaViewer.astro
+++ b/eventcatalog/src/components/MDX/SchemaViewer/SchemaViewer.astro
@@ -1,11 +1,18 @@
 ---
-const { catalog, id } = Astro.props;
 import fs from 'node:fs/promises';
 import { existsSync } from 'fs';
 import yaml from 'js-yaml';
 import path from 'path';
 import SchemaViewerClient from './SchemaViewer';
 import Admonition from '../Admonition';
+
+interface Props {
+  id: string;
+  filePath: string;
+}
+
+const { id, filePath } = Astro.props;
+
 let schemas = [];
 
 function findSchemaViewers(document: string) {
@@ -37,12 +44,12 @@ function findSchemaViewers(document: string) {
 }
 
 try {
-  const file = await fs.readFile(catalog.astroContentFilePath, 'utf-8');
+  const file = await fs.readFile(filePath, 'utf-8');
   const schemaViewers = findSchemaViewers(file);
 
   // Loop around all the possible SchemaViewers in the file.
   const getAllComponents = schemaViewers.map(async (schemaViewerProps: any) => {
-    const schemaPath = path.join(catalog.filePath, schemaViewerProps.file);
+    const schemaPath = path.join(path.dirname(filePath), schemaViewerProps.file);
     const exists = existsSync(schemaPath);
     let schema;
     let render = true;

--- a/eventcatalog/src/components/SideBars/MessageSideBar.astro
+++ b/eventcatalog/src/components/SideBars/MessageSideBar.astro
@@ -3,13 +3,15 @@ import type { CollectionEntry } from 'astro:content';
 import PillListFlat from '@components/Lists/PillListFlat';
 import OwnersList from '@components/Lists/OwnersList';
 import type { CollectionMessageTypes } from '@types';
-import * as path from 'path';
+import path from 'node:path';
+import fs from 'node:fs';
 import VersionList from '@components/Lists/VersionList.astro';
 import { buildUrl } from '@utils/url-builder';
 import { FileDownIcon, ScrollText, Workflow, RssIcon } from 'lucide-react';
 import RepositoryList from '@components/Lists/RepositoryList.astro';
 import { getOwner } from '@utils/collections/owners';
 import config from '@config';
+import { getAsset } from 'src/integrations/assets/get-asset';
 
 interface Props {
   message: CollectionEntry<CollectionMessageTypes>;
@@ -89,10 +91,9 @@ const type = getType(message.collection);
 
 const isRSSEnabled = config.rss?.enabled;
 
-// @ts-ignore
-const publicPath = message?.catalog?.publicPath;
 const schemaFilePath = message?.data?.schemaPath;
-const schemaURL = path.join(publicPath, schemaFilePath || '');
+const schema = schemaFilePath && getAsset(path.join(path.dirname(message.data.pathToFile!), schemaFilePath));
+const schemaURL = schema ? schema.getURL() : undefined;
 ---
 
 <aside class="sticky top-28 left-0 space-y-8 h-full overflow-y-auto py-4">
@@ -166,7 +167,7 @@ const schemaURL = path.join(publicPath, schemaFilePath || '');
 
     <div class="space-y-2">
       {
-        message?.data?.schemaPath && (
+        schemaURL && (
           <a
             href={buildUrl(schemaURL, true)}
             download={`${message.data.name}(${message.data.version})-${schemaFilePath}`}

--- a/eventcatalog/src/components/SideBars/ServiceSideBar.astro
+++ b/eventcatalog/src/components/SideBars/ServiceSideBar.astro
@@ -8,8 +8,10 @@ import { buildUrl } from '@utils/url-builder';
 import { getOwner } from '@utils/collections/owners';
 import type { CollectionEntry } from 'astro:content';
 import { ScrollText, Workflow, FileDownIcon, Code, Link, RssIcon } from 'lucide-react';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import config from '@config';
+import { existsSync } from 'node:fs';
+import { getAsset } from 'src/integrations/assets/get-asset';
 
 interface Props {
   service: CollectionEntry<'services'>;
@@ -58,10 +60,9 @@ const ownersList = filteredOwners.map((o) => ({
 
 const isRSSEnabled = config.rss?.enabled;
 
-// @ts-ignore
-const publicPath = service?.catalog?.publicPath;
 const schemaFilePath = service?.data?.schemaPath;
-const schemaURL = join(publicPath, schemaFilePath || '');
+const schema = schemaFilePath && getAsset(join(dirname(service.data.pathToFile!), schemaFilePath));
+const schemaURL = schema ? schema.getURL() : undefined;
 ---
 
 <aside class="sticky top-28 left-0 h-full overflow-y-auto pr-6 py-4">
@@ -115,7 +116,7 @@ const schemaURL = join(publicPath, schemaFilePath || '');
 
     <div class="space-y-2">
       {
-        service?.data?.schemaPath && (
+        schemaURL && (
           <a
             href={buildUrl(schemaURL, true)}
             download={`${service.data.name}(${service.data.version})-${schemaFilePath}`}

--- a/eventcatalog/src/integrations/assets/astro-integration-assets.ts
+++ b/eventcatalog/src/integrations/assets/astro-integration-assets.ts
@@ -1,0 +1,57 @@
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { pipeline } from 'node:stream/promises';
+import type { AstroIntegration } from 'astro';
+import { createReadStream, createWriteStream } from 'node:fs';
+import { mkdir } from 'node:fs/promises';
+import sirv from 'sirv';
+
+export default function ecAssets(): AstroIntegration {
+  // TODO: Make `/_assets/` a configurable path.
+  const ASSETS_DIR = '/_assets/';
+
+  globalThis.ecAsset = {
+    /**
+     * asset paths relative to the PROJECT_DIR that should be copied
+     * into the `/_assets/` directory.
+     */
+    assets: new Set<string>(),
+  };
+
+  return {
+    name: 'ec:assets',
+    hooks: {
+      'astro:server:setup': ({ server, logger }) => {
+        const serve = sirv(process.env.PROJECT_DIR!, {
+          dev: true, // sirv not cache assets in dev mode.
+          etag: true,
+        });
+
+        server.middlewares.use((req, res, next) => {
+          if (req.url?.startsWith(ASSETS_DIR)) {
+            req.url = req.url!.replace(ASSETS_DIR, '/');
+            serve(req, res, next);
+          } else {
+            next();
+          }
+        });
+      },
+      'astro:build:done': async ({ dir, logger }) => {
+        const outDir = fileURLToPath(new URL(join('.', ASSETS_DIR), dir));
+        logger.info(`Copying assets to ${outDir}`);
+
+        for (const asset of globalThis.ecAsset.assets) {
+          const assetPath = join(process.env.PROJECT_DIR!, asset);
+          const outPath = join(outDir, asset);
+
+          logger.debug(`Copying asset ${assetPath} to ${outPath}`);
+
+          await mkdir(dirname(outPath), { recursive: true });
+          await pipeline(createReadStream(assetPath), createWriteStream(outPath));
+        }
+
+        logger.info(`Copied ${globalThis.ecAsset.assets.size} assets successfully.`);
+      },
+    },
+  };
+}

--- a/eventcatalog/src/integrations/assets/get-asset.ts
+++ b/eventcatalog/src/integrations/assets/get-asset.ts
@@ -1,0 +1,27 @@
+import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+
+export function getAsset(assetPath: string) {
+  if (!existsSync(assetPath)) {
+    console.warn(`Asset ${assetPath} does not exist.`);
+    return;
+  }
+
+  return {
+    getURL() {
+      // We assume that the asset path starts with the project directory path.
+      const assetPathWithoutBase = assetPath.slice(process.env.PROJECT_DIR!.length);
+
+      // Mark the asset to be copied to the output directory.
+      globalThis?.ecAsset?.assets?.add(assetPathWithoutBase);
+
+      return '/_assets/' + assetPathWithoutBase.replace(/^\\/, '').replace(/\\/g, '/');
+    },
+
+    getContents() {
+      // Sometimes we need the contents of the asset instead of copying it
+      // to the public directory.
+      return readFile(assetPath, 'utf-8');
+    },
+  };
+}

--- a/eventcatalog/src/integrations/assets/types.ts
+++ b/eventcatalog/src/integrations/assets/types.ts
@@ -1,0 +1,7 @@
+declare global {
+  var ecAsset: {
+    assets: Set<string>;
+  };
+}
+
+export {};

--- a/eventcatalog/src/pages/docs/[type]/[id]/[version]/asyncapi/index.astro
+++ b/eventcatalog/src/pages/docs/[type]/[id]/[version]/asyncapi/index.astro
@@ -15,6 +15,7 @@ import { pageDataLoader } from '@utils/page-loaders/page-data-loader';
 import type { CollectionEntry } from 'astro:content';
 import VerticalSideBarLayout from '@layouts/VerticalSideBarLayout.astro';
 import Config from '@utils/eventcatalog-config/catalog';
+import { getAsset } from 'src/integrations/assets/get-asset';
 
 export async function getStaticPaths() {
   const itemTypes: PageTypes[] = ['events', 'commands', 'queries', 'services', 'domains'];
@@ -38,16 +39,15 @@ export async function getStaticPaths() {
   );
 }
 
-// @ts-ignore
-const { catalog, data } = Astro.props;
+const { data } = Astro.props;
 const fileName = data.specifications?.asyncapiPath || 'asyncapi.yaml';
-const pathToSpec = path.join(catalog.publicPath, fileName);
-const pathOnDisk = path.join(process.cwd(), 'public', pathToSpec);
-const fileContent = readFileSync(pathOnDisk, 'utf-8');
+const pathOnDisk = path.join(path.dirname(data.pathToFile!), fileName);
+const spec = getAsset(pathOnDisk);
+const fileContent = spec ? await spec.getContents() : undefined;
 
 // AsyncAPI parser will parser schemas for users, they can turn this off.
 const parseSchemas = Config?.asyncAPI?.renderParsedSchemas ?? true;
-const parsed = await new Parser({ schemaParsers: [AvroSchemaParser()] }).parse(fileContent, { parseSchemas });
+const parsed = await new Parser({ schemaParsers: [AvroSchemaParser()] }).parse(fileContent!, { parseSchemas });
 const stringified = parsed.document?.json();
 const config: ConfigInterface = { show: { sidebar: true, errors: true } };
 

--- a/eventcatalog/src/pages/docs/[type]/[id]/[version]/index.astro
+++ b/eventcatalog/src/pages/docs/[type]/[id]/[version]/index.astro
@@ -197,8 +197,7 @@ const badges = [getBadge(), ...contentBadges, ...getSpecificationBadges()];
           <Content components={components(props)} />
         </div>
         <div>
-          <!-- @ts-ignore -->
-          <SchemaViewer id={props.data.id} catalog={props.catalog} />
+          <SchemaViewer id={props.data.id} filePath={props.data.pathToFile!} />
           <NodeGraph
             id={props.data.id}
             collection={props.collection}

--- a/eventcatalog/src/pages/docs/[type]/[id]/[version]/spec/index.astro
+++ b/eventcatalog/src/pages/docs/[type]/[id]/[version]/spec/index.astro
@@ -9,6 +9,7 @@ import { buildUrl } from '@utils/url-builder';
 import { pageDataLoader } from '@utils/page-loaders/page-data-loader';
 import VerticalSideBarLayout from '@layouts/VerticalSideBarLayout.astro';
 import './_styles.css';
+import { getAsset } from 'src/integrations/assets/get-asset';
 
 export async function getStaticPaths() {
   const itemTypes: PageTypes[] = ['events', 'commands', 'queries', 'services', 'domains'];
@@ -33,27 +34,25 @@ export async function getStaticPaths() {
   );
 }
 
-// @ts-ignore
-const { data, catalog } = Astro.props;
+const { data } = Astro.props;
 const fileName = data.specifications?.openapiPath || 'openapi.yml';
-const pathToSpec = path.join(catalog.publicPath, fileName);
-const pathOnDisk = path.join(process.cwd(), 'public', pathToSpec);
-const fileExists = fs.existsSync(pathOnDisk);
+const pathOnDisk = path.join(path.dirname(data.pathToFile!), fileName);
+const spec = getAsset(pathOnDisk);
 ---
 
 <VerticalSideBarLayout title="OpenAPI Spec">
   {
-    !fileExists ? (
+    !spec ? (
       <div class="text-center h-screen  flex flex-col justify-center ">
         <DocumentMinusIcon className="mx-auto h-12 w-12 text-gray-400" />
         <h3 class="mt-2 text-sm font-semibold text-gray-900">No OpenAPI spec file found</h3>
         <p class="mt-1 text-xs text-gray-400">
-          Could not find OpenAPI file for {data.name} in {`/${catalog.path}`}
+          Could not find OpenAPI file for {data.name} in {path.dirname(pathOnDisk)}
         </p>
       </div>
     ) : (
       <rapi-doc
-        spec-url={buildUrl(pathToSpec, true)}
+        spec-url={buildUrl(spec.getURL(), true)}
         render-style="read"
         show-header="false"
         allow-authentication="true"

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "rimraf": "^5.0.7",
     "semver": "7.6.3",
     "shelljs": "^0.8.5",
+    "sirv": "^3.0.1",
     "tailwindcss": "^3.4.3",
     "typescript": "^5.4.5",
     "unist-util-visit": "^5.0.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -32,7 +32,7 @@ export default defineConfig({
     trace: 'on-first-retry',
   },
   webServer: {
-    command: 'pnpm run preview -- --root examples/default --port 3000',
+    command: 'pnpm run preview --root examples/default --port 3000',
     url: 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,6 +176,9 @@ importers:
       shelljs:
         specifier: ^0.8.5
         version: 0.8.5
+      sirv:
+        specifier: ^3.0.1
+        version: 3.0.1
       tailwindcss:
         specifier: ^3.4.3
         version: 3.4.17
@@ -245,7 +248,7 @@ importers:
         version: 8.3.6(jiti@1.21.7)(postcss@8.5.1)(typescript@5.7.3)(yaml@2.7.0)
       vite-tsconfig-paths:
         specifier: ^4.3.2
-        version: 4.3.2(typescript@5.7.3)(vite@6.1.0(@types/node@20.17.17)(jiti@1.21.7)(yaml@2.7.0))
+        version: 4.3.2(typescript@5.7.3)(vite@6.2.0(@types/node@20.17.17)(jiti@1.21.7)(yaml@2.7.0))
       vitest:
         specifier: 2.1.6
         version: 2.1.6(@types/node@20.17.17)(jiti@1.21.7)(jsdom@26.0.0)(yaml@2.7.0)
@@ -6365,8 +6368,8 @@ packages:
   simple-wcswidth@1.0.1:
     resolution: {integrity: sha512-xMO/8eNREtaROt7tJvWJqHBDTMFN4eiQ5I4JRMuilwfnFcV5W9u7RUkueNkdw0jPqGMX36iCywelS5yilTuOxg==}
 
-  sirv@3.0.0:
-    resolution: {integrity: sha512-BPwJGUeDaDCHihkORDchNyyTvWFhcusy1XMmhEVTQTwGeybFbp8YEmB+njbPnth1FibULBSBVwCQni25XlCUDg==}
+  sirv@3.0.1:
+    resolution: {integrity: sha512-FoqMu0NCGBLCcAkS1qA+XJIQTR6/JHfQXl+uGteNCQ76T91DMUjPa9xfmeqMY3z80nLSg9yQmNjK0Px6RWsH/A==}
     engines: {node: '>=18'}
 
   sisteransi@1.0.5:
@@ -10586,7 +10589,7 @@ snapshots:
       '@pagefind/default-ui': 1.3.0
       astro: 5.4.1(@types/node@20.17.17)(jiti@1.21.7)(rollup@4.34.6)(typescript@5.7.3)(yaml@2.7.0)
       pagefind: 1.3.0
-      sirv: 3.0.0
+      sirv: 3.0.1
 
   astro-seo@0.8.4(prettier-plugin-astro@0.14.1)(prettier@3.5.0)(typescript@5.7.3):
     dependencies:
@@ -14905,7 +14908,7 @@ snapshots:
 
   simple-wcswidth@1.0.1: {}
 
-  sirv@3.0.0:
+  sirv@3.0.1:
     dependencies:
       '@polka/url': 1.0.0-next.28
       mrmime: 2.0.0
@@ -15646,13 +15649,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite-tsconfig-paths@4.3.2(typescript@5.7.3)(vite@6.1.0(@types/node@20.17.17)(jiti@1.21.7)(yaml@2.7.0)):
+  vite-tsconfig-paths@4.3.2(typescript@5.7.3)(vite@6.2.0(@types/node@20.17.17)(jiti@1.21.7)(yaml@2.7.0)):
     dependencies:
       debug: 4.4.0
       globrex: 0.1.2
       tsconfck: 3.1.5(typescript@5.7.3)
     optionalDependencies:
-      vite: 6.1.0(@types/node@20.17.17)(jiti@1.21.7)(yaml@2.7.0)
+      vite: 6.2.0(@types/node@20.17.17)(jiti@1.21.7)(yaml@2.7.0)
     transitivePeerDependencies:
       - supports-color
       - typescript

--- a/src/__tests__/catalog-to-astro-content-directory.spec.ts
+++ b/src/__tests__/catalog-to-astro-content-directory.spec.ts
@@ -56,16 +56,6 @@ describe('catalog-to-astro-content-directory', () => {
           true
         );
       });
-
-      it('when an event has a schema file along side it, that is copied to the correct location', async () => {
-        expect(existsSync(path.join(CATALOG_FILES_DIR, 'events', 'Order/OrderAmended', 'schema.json'))).toBe(true);
-      });
-
-      it('when an event has been versioned and that version has a schema file along side it, that is copied to the correct location', async () => {
-        expect(
-          existsSync(path.join(CATALOG_FILES_DIR, 'events', 'Inventory/InventoryAdjusted', 'versioned', '0.0.1', 'schema.avro'))
-        ).toBe(true);
-      });
     });
 
     describe('events within the /services directory', () => {
@@ -78,19 +68,11 @@ describe('catalog-to-astro-content-directory', () => {
           existsSync(path.join(ASTRO_CONTENT_DIRECTORY, 'events', 'PaymentAccepted', 'versioned', '0.0.1', 'index.mdx'))
         ).toBe(true);
       });
-
-      it('when an event has a schema file along side it, that is copied to the correct location', async () => {
-        expect(existsSync(path.join(CATALOG_FILES_DIR, 'events', 'PaymentAccepted', 'schema.json'))).toBe(true);
-      });
     });
 
     describe('events within the /domain directory', () => {
       it('when an event is inside a domain folder it copies the event into the correct location', async () => {
         expect(existsSync(path.join(ASTRO_CONTENT_DIRECTORY, 'events', 'PaymentDomainTestEvent1', 'index.mdx'))).toBe(true);
-      });
-
-      it('when an event has a schema file along side it, that is copied to the correct location', async () => {
-        expect(existsSync(path.join(CATALOG_FILES_DIR, 'events', 'PaymentDomainTestEvent1', 'schema.json'))).toBe(true);
       });
     });
   });
@@ -104,16 +86,6 @@ describe('catalog-to-astro-content-directory', () => {
         expect(
           existsSync(path.join(ASTRO_CONTENT_DIRECTORY, 'commands', 'AddInventory', 'versioned', '0.0.1', 'index.mdx'))
         ).toBe(true);
-      });
-
-      it('when an command has a schema file along side it, that is copied to the correct location', async () => {
-        expect(existsSync(path.join(CATALOG_FILES_DIR, 'commands', 'AddInventory', 'schema.json'))).toBe(true);
-      });
-
-      it('when an command has been versioned and that version has a schema file along side it, that is copied to the correct location', async () => {
-        expect(existsSync(path.join(CATALOG_FILES_DIR, 'commands', 'AddInventory', 'versioned', '0.0.1', 'schema.json'))).toBe(
-          true
-        );
       });
     });
   });
@@ -129,10 +101,6 @@ describe('catalog-to-astro-content-directory', () => {
           existsSync(path.join(ASTRO_CONTENT_DIRECTORY, 'services', 'PaymentService', 'versioned', '0.0.1', 'index.mdx'))
         ).toBe(true);
       });
-
-      it('when a service has a file within its directory (not markdown file, e.g AsyncAPI), it copies this version into the correct location', async () => {
-        expect(existsSync(path.join(CATALOG_FILES_DIR, 'services', 'PaymentService', 'asyncapi.yml'))).toBe(true);
-      });
     });
     describe('services within the /domains directory', () => {
       it('takes services from the users catalog (which are in a domains folder) and puts it into the expected directory structure', async () => {
@@ -143,10 +111,6 @@ describe('catalog-to-astro-content-directory', () => {
         expect(
           existsSync(path.join(ASTRO_CONTENT_DIRECTORY, 'services', 'ExternalPaymentService', 'versioned', '0.0.1', 'index.mdx'))
         ).toBe(true);
-      });
-
-      it('when a service has a file within its directory (not markdown file, e.g AsyncAPI), it copies this version into the correct location', async () => {
-        expect(existsSync(path.join(CATALOG_FILES_DIR, 'services', 'ExternalPaymentService', 'asyncapi.yml'))).toBe(true);
       });
     });
   });
@@ -161,10 +125,6 @@ describe('catalog-to-astro-content-directory', () => {
         expect(existsSync(path.join(ASTRO_CONTENT_DIRECTORY, 'domains', 'Payment', 'versioned', '0.0.1', 'index.mdx'))).toBe(
           true
         );
-      });
-
-      it('when a domain has a file within its directory (not markdown file, e.g AsyncAPI), it copies this version into the correct location', async () => {
-        expect(existsSync(path.join(CATALOG_FILES_DIR, 'domains', 'Payment', 'asyncapi.yml'))).toBe(true);
       });
     });
 

--- a/src/map-catalog-to-astro.js
+++ b/src/map-catalog-to-astro.js
@@ -116,34 +116,8 @@ function getBaseTargetPaths(filePath) {
       return [path.join('src', 'content')];
     }
 
-    // This is a workaround to differentiate between a file and a directory.
-    // Of course this is not the best solution. But how differentiate? `fs.stats`
-    // could be used, but sometimes the filePath references a deleted file/directory
-    // which causes an error when using `fs.stats`.
-    const hasExtension = (str) => /\.[a-zA-Z0-9]{2,}$/.test(str);
-
-    // Assets files
-    if (hasExtension(filePath)) {
-      return [path.join('public', 'generated'), path.join('src', 'catalog-files')];
-    }
-
-    /**
-     * @parcel/watcher throttle and coalesce events for performance reasons.
-     *
-     * Consider the following:
-     *    The user deletes a large `services/` dir from eventcatalog.
-     *    The @parcel/watcher could emit only one delete event of the
-     *    `services/` directory.
-     *
-     * In this situation we need delete all files from
-     * - `public/generated/services/`
-     * - `src/catalog-files/services/`
-     * - `src/content/services/`
-     *
-     * TODO: What happens if services contains commands/events inside of it??? How handle this?
-     */
-    // Directories
-    return [path.join('public', 'generated'), path.join('src', 'catalog-files'), path.join('src', 'content')];
+    // It should not be mapped to an astro file. Just return an empty array.
+    return [];
   }
 
   // Custom components


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://www.eventcatalog.dev/docs/contributing/overview

Happy contributing!

-->

## Motivation

As we move to the new Astro content layer, assets need to be properly hydrated in the catalog. 

## Changes
1. Introduces a custom Astro integration to handle assets efficiently:
    - Serves assets during `dev` mode using a middleware.
    - Copies assets to the output directory in `build` mode.
2. Adds a new `getAsset` utility that returns an object with two methods:
    - `getURL` - Generates a public URL for the asset and marks it for copying during the build process.
    - `getContents` - Reads and returns the asset's contents as a string using `fs.readFile`.
  
   _**Note:** The getAsset utility must be used to explicitly mark assets for copying during the build. This prevents unnecessary copying of all assets in PROJECT_DIR, ensuring that only assets referenced via getURL (which generates a public URL) are included in the final build._
3. Updates all asset references to use the new `getAsset` utility.
4. Adds e2e tests to verify asset handling remains intact.
5. Removes outdated tests related to the previous asset hydration logic.
6. Removes asset mapping in `map-to-catalog`, as it's no longer necessary.