### PR TITLE
fix: Ensure the url-builder adds trailing slash in the correct place …

### DIFF
--- a/.changeset/purple-gifts-work.md
+++ b/.changeset/purple-gifts-work.md
@@ -2,4 +2,4 @@
 "@eventcatalog/core": patch
 ---
 
-Fixes broken architecture pages when the trailing slash feature was enabled
+fix(core): fixed broken architecture pages when the trailing slash feature was enabled

--- a/.changeset/purple-gifts-work.md
+++ b/.changeset/purple-gifts-work.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Fixes broken architecture pages when the trailing slash feature was enabled

--- a/eventcatalog/src/utils/__tests__/url-builder.spec.ts
+++ b/eventcatalog/src/utils/__tests__/url-builder.spec.ts
@@ -78,6 +78,13 @@ describe('url-builder', () => {
       expect(url).toBe('example.com?key=value');
     });
 
+    it('should handle trailing slash when enabled', () => {
+      // @ts-ignore
+      global.__EC_TRAILING_SLASH__ = true;
+      const url = buildUrlWithParams('example.com', { key: 'value' });
+      expect(url).toBe('example.com/?key=value');
+    });
+
     it('should build url with multiple query parameters', () => {
       const url = buildUrlWithParams('example.com', {
         key1: 'value1',

--- a/eventcatalog/src/utils/url-builder.ts
+++ b/eventcatalog/src/utils/url-builder.ts
@@ -40,5 +40,5 @@ export const buildUrlWithParams = (baseUrl: string, params: Record<string, strin
     .map(([key, value]) => `${key}=${value}`)
     .join('&');
 
-  return buildUrl(`${baseUrl}?${queryString}`);
+  return `${buildUrl(baseUrl)}?${queryString}`;
 };


### PR DESCRIPTION
Ensure the url-builder adds trailing slash in the correct place when query params are used


## Motivation

Fixes broken architecture pages when the trailing slash feature was enabled

Fixes https://github.com/event-catalog/eventcatalog/issues/1228
