### PR TITLE
fix: Icon images now also work when a base path is used

### DIFF
--- a/eventcatalog/src/components/SideNav/ListViewSideBar/index.tsx
+++ b/eventcatalog/src/components/SideNav/ListViewSideBar/index.tsx
@@ -94,7 +94,7 @@ const ServiceItem = React.memo(
           >
             <span className="truncate flex items-center gap-1">AsyncAPI specification</span>
             <span className="text-purple-600 ml-2 text-[10px] uppercase font-medium bg-gray-50 px-4 py-0.5 rounded">
-              <img src="/icons/asyncapi.svg" className="w-4 h-4" />
+              <img src={buildUrl("/icons/asyncapi.svg", true)} className="w-4 h-4" />
             </span>
           </a>
         )}
@@ -109,7 +109,7 @@ const ServiceItem = React.memo(
           >
             <span className="truncate flex items-center gap-1">OpenAPI specification</span>
             <span className="text-green-600 ml-2 text-[10px] uppercase font-medium bg-gray-50 px-4 py-0.5 rounded">
-              <img src="/icons/openapi.svg" className="w-4 h-4" />
+              <img src={buildUrl("/icons/openapi.svg", true)} className="w-4 h-4" />
             </span>
           </a>
         )}

--- a/eventcatalog/src/pages/docs/teams/[id]/index.astro
+++ b/eventcatalog/src/pages/docs/teams/[id]/index.astro
@@ -95,7 +95,7 @@ const ownedQueriesList = queries.map((p) => ({
               {
                 props.data.slackDirectMessageUrl && (
                   <div class="flex space-x-1 items-center text-xs text-gray-500 font-bold hover:underline hover:text-primary">
-                    <img src="/slack-icon.svg" class="w-4 h-3" />
+                    <img src={buildUrl("/slack-icon.svg", true)} class="w-4 h-3" />
                     <a href={`${props.data.slackDirectMessageUrl}`}>Send DM on Slack</a>
                   </div>
                 )
@@ -103,7 +103,7 @@ const ownedQueriesList = queries.map((p) => ({
               {
                 props.data.msTeamsDirectMessageUrl && (
                   <div class="flex space-x-1 items-center text-xs text-gray-500 font-bold hover:underline hover:text-primary">
-                    <img src="/icons/ms-teams.svg" class="w-4 h-4" />
+                    <img src={buildUrl("/icons/ms-teams.svg", true)} class="w-4 h-4" />
                     <a href={`${props.data.msTeamsDirectMessageUrl}`} target="_blank" rel="noopener noreferrer">
                       Send DM on Teams
                     </a>

--- a/eventcatalog/src/pages/docs/users/[id]/index.astro
+++ b/eventcatalog/src/pages/docs/users/[id]/index.astro
@@ -86,7 +86,7 @@ const associatedTeams = teams.map((o) => ({
                 {
                   props.data.slackDirectMessageUrl && (
                     <div class="flex space-x-1 items-center text-xs text-gray-500 font-bold hover:underline hover:text-primary">
-                      <img src="/slack-icon.svg" class="w-4 h-3" />
+                      <img src={buildUrl("/slack-icon.svg", true)} class="w-4 h-3" />
                       <a href={`${props.data.slackDirectMessageUrl}`}>Send DM on Slack</a>
                     </div>
                   )
@@ -94,7 +94,7 @@ const associatedTeams = teams.map((o) => ({
                 {
                   props.data.msTeamsDirectMessageUrl && (
                     <div class="flex space-x-1 items-center text-xs text-gray-500 font-bold hover:underline hover:text-primary">
-                      <img src="/icons/ms-teams.svg" class="w-4 h-4" />
+                      <img src={buildUrl("/icons/ms-teams.svg", true)} class="w-4 h-4" />
                       <a href={`${props.data.msTeamsDirectMessageUrl}`} target="_blank" rel="noopener noreferrer">
                         Send DM on Teams
                       </a>


### PR DESCRIPTION
## Motivation

This fixes a bug where icons were not being loaded when a base path was configured.

I tested this by configuring a `base` path in the default example and by running `pnpm run start:catalog`

Not sure how to create an automated test for this...
