### PR TITLE
fix: Redirects to latest version now work correctly when basePath is used

### DIFF
--- a/.changeset/quick-apricots-clean.md
+++ b/.changeset/quick-apricots-clean.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix(core): Redirects to latest version now work correctly when basePath is used

--- a/eventcatalog/src/pages/docs/[type]/[id]/index.astro
+++ b/eventcatalog/src/pages/docs/[type]/[id]/index.astro
@@ -44,7 +44,7 @@ const props = Astro.props;
 const pageTitle = `${props.collection} | ${props.data.name}`.replace(/^\w/, (c) => c.toUpperCase());
 
 const { pathname } = Astro.url;
-const redirectUrl = buildUrl(pathname + '/' + props.data.latestVersion);
+const redirectUrl = buildUrl(pathname + '/' + props.data.latestVersion, false, true);
 ---
 
 <!doctype html>

--- a/eventcatalog/src/pages/visualiser/[type]/[id]/index.astro
+++ b/eventcatalog/src/pages/visualiser/[type]/[id]/index.astro
@@ -32,8 +32,7 @@ const pageTitle = `${props.collection} | ${props.data.name}`.replace(/^\w/, (c) 
 
 const { pathname } = Astro.url;
 
-// redirect with any search params too
-const redirectUrl = buildUrl(pathname + '/' + props.data.latestVersion);
+const redirectUrl = buildUrl(pathname + '/' + props.data.latestVersion, false, true);
 ---
 
 <!doctype html>
@@ -48,6 +47,7 @@ const redirectUrl = buildUrl(pathname + '/' + props.data.latestVersion);
 
 <script define:vars={{ redirectUrl }}>
   document.addEventListener('DOMContentLoaded', () => {
+    // redirect with any search params too
     const searchParams = window.location.search;
     const fullRedirectUrl = redirectUrl + searchParams;
     window.location.href = fullRedirectUrl;

--- a/eventcatalog/src/utils/url-builder.ts
+++ b/eventcatalog/src/utils/url-builder.ts
@@ -3,14 +3,14 @@ const cleanUrl = (url: string) => {
 };
 
 // Custom URL builder as Astro does not support this stuff out the box
-export const buildUrl = (url: string, ignoreTrailingSlash = false) => {
+export const buildUrl = (url: string, ignoreTrailingSlash = false, urlAlreadyIncludesBaseUrl = false) => {
   // Should a trailingSlash be added to urls?
   const trailingSlash = __EC_TRAILING_SLASH__;
 
   let newUrl = url;
 
   // If the base URL is not the root, we need to append it
-  if (import.meta.env.BASE_URL !== '/') {
+  if (import.meta.env.BASE_URL !== '/' && !urlAlreadyIncludesBaseUrl) {
     newUrl = `${import.meta.env.BASE_URL}${url}`;
   }
 


### PR DESCRIPTION
## Motivation

Links on the new architecture screen ("View in visualizer" and "Read documentation") link to a service/domain without verion. The redirect code was broken as it would duplicate the base path (which would generate an incorrect link)

This PR fixes that issue
