### PR TITLE
feat(Schema): add optional language prop for code highlighting

### DIFF
--- a/.changeset/rare-hornets-push.md
+++ b/.changeset/rare-hornets-push.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+feat(core): added optional language prop for Schema component

--- a/.changeset/tender-countries-glow.md
+++ b/.changeset/tender-countries-glow.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+feat(Schema): add optional language prop for code highlighting

--- a/eventcatalog/src/components/MDX/Schema.astro
+++ b/eventcatalog/src/components/MDX/Schema.astro
@@ -10,9 +10,10 @@ interface Props {
   };
   title?: string;
   filePath: string;
+  lang?: string;
 }
 
-const { file = 'schema.json', catalog, title, filePath } = Astro.props;
+const { file = 'schema.json', catalog, title, filePath, lang = 'json' } = Astro.props;
 
 let code: string | null = null;
 
@@ -25,7 +26,7 @@ if (exists) {
 {
   code ? (
     <div class="not-prose max-w-4xl overflow-x-auto">
-      <Code code={code} title={title || file} lang="json" />
+      <Code code={code} title={title || file} lang={lang} />
     </div>
   ) : (
     <div class="italic">Tried to load schema from {path.join(catalog.filePath, file)}, but no schema can be found</div>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://www.eventcatalog.dev/docs/contributing/overview

Happy contributing!

-->

## Motivation

This pull request introduces a new optional `lang` property to the `Props` interface in the `Schema.astro` component. 