### PR TITLE
feat(core): collapse everything except domains in TreeView

### DIFF
--- a/.changeset/little-tables-pick.md
+++ b/.changeset/little-tables-pick.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/core': patch
+---
+
+feat(core): collapse everything except domains in TreeView

--- a/eventcatalog/src/components/SideNav/TreeView/getTreeView.ts
+++ b/eventcatalog/src/components/SideNav/TreeView/getTreeView.ts
@@ -115,8 +115,8 @@ function groupChildrenByType(parentNode: TreeNode) {
     acc[n.type].push(n);
   });
 
-  // Collapse all messages
-  const AUTO_EXPANDED_TYPES = ['domains', 'services', 'channels'];
+  // Collapse everything except domains
+  const AUTO_EXPANDED_TYPES = ['domains'];
 
   parentNode.children = Object.entries(acc)
     // Order label nodes by RESOURCE_TYPES


### PR DESCRIPTION
- collapses everything except domains in TreeView 

## Motivation

Hey there! I really appreciate you for making such a fantastic tool!

The current implementation of TreeView automatically expands domains, services, and channels (see [getTreeView.ts#L119](https://github.com/event-catalog/eventcatalog/blob/main/eventcatalog/src/components/SideNav/TreeView/getTreeView.ts#L119)). Although this makes sense for domains, it can diminish the user experience when a domain contains a large number of services, as it becomes harder to view and access other components within that domain.

I've chosen the simplest solution for now, but I'm happy to explore other approaches if you're generally open to the idea.

Alternative solutions:

- only auto-collapse if there are more than X services
- make the list [getTreeView.ts#L119](https://github.com/event-catalog/eventcatalog/blob/main/eventcatalog/src/components/SideNav/TreeView/getTreeView.ts#L119) configurable via eventcatalog.config.js


