### PR TITLE
fix(core): tabs now support optional title param

### DIFF
--- a/.changeset/wild-bees-report.md
+++ b/.changeset/wild-bees-report.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix(core): tabs now support optional title param

--- a/eventcatalog/src/components/MDX/Tabs/Tabs.astro
+++ b/eventcatalog/src/components/MDX/Tabs/Tabs.astro
@@ -17,7 +17,8 @@ const tabItems: TabItem[] = await Promise.all(
     .filter((item: string) => item.trim())
     .map(async (item: string, index: number) => {
       const titleMatch = item.match(/button>([^<]+)</);
-      const title = titleMatch ? titleMatch[1].trim() : `Tab ${index + 1}`;
+      let title = titleMatch ? titleMatch[1].trim() : ``;
+      title = title || `Tab ${index + 1}`;
       const content = item.replace(/<button>[^<]+<\/button>/, '');
       return {
         title,


### PR DESCRIPTION
@XaaXaaX found an issue with tabs, this fixes that issue.

In a TabItem has no "title' it will still render the tab heading (default)