### PR TITLE
fix: update getCollection filter function to match `changelog.mdx`

### DIFF
--- a/.changeset/sharp-pillows-press.md
+++ b/.changeset/sharp-pillows-press.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+core(fix): update getCollection filter function to match `changelog.mdx`

--- a/e2e/changelog.spec.ts
+++ b/e2e/changelog.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Changelog', () => {
+  test(
+    'render versions correctly',
+    {
+      annotation: {
+        type: 'issue',
+        description: 'https://github.com/event-catalog/eventcatalog/issues/1200#issuecomment-2733012789',
+      },
+    },
+    async ({ page }) => {
+      await page.goto('/docs/services/OrdersService/0.0.3/changelog');
+
+      await Promise.all([
+        expect(page.getByRole('link', { name: '0.0.3' })).toBeVisible(), // version
+        expect(page.getByText('openapi.yml CHANGED')).toBeVisible(), // file diff
+        expect(page.getByRole('link', { name: '0.0.2' })).toBeVisible(), // version
+      ]);
+    }
+  );
+});

--- a/eventcatalog/src/utils/collections/changelogs.ts
+++ b/eventcatalog/src/utils/collections/changelogs.ts
@@ -10,8 +10,10 @@ export const getChangeLogs = async (item: CollectionEntry<CollectionTypes>): Pro
   // Get all logs for collection type and filter by given collection
   const logs = await getCollection('changelogs', (log) => {
     const collectionDirectory = path.dirname(item?.filePath || '');
-    const isRootChangeLog = path.join(collectionDirectory, 'changelog.md') === log.filePath;
-    const isVersionedChangeLog = log.filePath?.includes(path.join(collectionDirectory, 'versioned'));
+    const isRootChangeLog = path.join(collectionDirectory, 'changelog.mdx') === log.filePath;
+    // Ensure the path follows <collectionDirectory>/versioned/<version>/changelog.mdx
+    const versionedPathPattern = new RegExp(`${collectionDirectory}/versioned/[^/]+/changelog\\.mdx$`);
+    const isVersionedChangeLog = versionedPathPattern.test(log.filePath!);
     return log.id.includes(`${collection}/`) && (isRootChangeLog || isVersionedChangeLog);
   });
 
@@ -19,7 +21,7 @@ export const getChangeLogs = async (item: CollectionEntry<CollectionTypes>): Pro
     // Check if there is a version in the url
     const isVersioned = log.id.includes('versioned');
 
-    const parts = log.id.split('/');
+    const parts = log.filePath!.split('/');
     // hack to get the version of the id (url)
     const version = parts[parts.length - 2];
     return {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -32,7 +32,7 @@ export default defineConfig({
     trace: 'on-first-retry',
   },
   webServer: {
-    command: 'pnpm run preview -- --root examples/default --port 3000',
+    command: 'pnpm run preview --root examples/default --port 3000',
     url: 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
   },


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://www.eventcatalog.dev/docs/contributing/overview

Happy contributing!

-->

## Motivation

After updating to Astro's glob loaders, the changelog stopped working as expected, as noted by @Jessewb786 in [this comment](https://github.com/event-catalog/eventcatalog/issues/1200#issuecomment-2733012789).  

This PR fixes the issue by making the necessary adjustments to the changelog logic. Additionally, it adds a simple end-to-end (E2E) test to ensure the behavior remains consistent moving forward.  

_Note: you can check the issue by navigating to https://demo.eventcatalog.dev/docs/services/OrdersService/0.0.3/changelog_
