### PR TITLE
feat(core): add FlowSidebar; flow changelog

### DIFF
--- a/.changeset/warm-wolves-tan.md
+++ b/.changeset/warm-wolves-tan.md
@@ -2,4 +2,4 @@
 '@eventcatalog/core': patch
 ---
 
-feat(core): add FlowSideBar; update changelogs to support flows
+feat(core): added sidebar to flow resource types and changelog support for flows

--- a/.changeset/warm-wolves-tan.md
+++ b/.changeset/warm-wolves-tan.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/core': patch
+---
+
+feat(core): add FlowSideBar; update changelogs to support flows

--- a/eventcatalog/src/components/SideBars/FlowSideBar.astro
+++ b/eventcatalog/src/components/SideBars/FlowSideBar.astro
@@ -1,0 +1,78 @@
+---
+import OwnersList from '@components/Lists/OwnersList';
+import VersionList from '@components/Lists/VersionList.astro';
+import {buildUrl} from '@utils/url-builder';
+import {getOwner} from '@utils/collections/owners';
+import type {CollectionEntry} from 'astro:content';
+import {ScrollText, Workflow, RssIcon} from 'lucide-react';
+import config from '@config';
+
+interface Props {
+  flow: CollectionEntry<'flows'>;
+}
+
+const {flow} = Astro.props;
+
+const ownersRaw = flow.data?.owners || [];
+const owners = await Promise.all<ReturnType<typeof getOwner>>(ownersRaw.map(getOwner));
+const filteredOwners = owners.filter((o) => o !== undefined);
+
+const ownersList = filteredOwners.map((o) => ({
+  label: o.data.name,
+  type: o.collection,
+  badge: o.collection === 'users' ? o.data.role : 'Team',
+  avatarUrl: o.collection === 'users' ? o.data.avatarUrl : '',
+  href: buildUrl(`/docs/${o.collection}/${o.data.id}`),
+}));
+
+const isRSSEnabled = config.rss?.enabled;
+---
+
+<aside class="sticky top-28 left-0 h-full overflow-y-auto pr-6 py-4">
+  <div id="sidebar-cta-portal" class="">
+    {flow.data.versions && <VersionList versions={flow.data.versions} collectionItem={flow}/>}
+
+    <OwnersList
+      title={`Flow owners (${ownersList.length})`}
+      owners={ownersList}
+      emptyMessage={`This flow does not have any documented owners.`}
+      client:load
+    />
+
+    {
+      isRSSEnabled && (
+        <div
+          class="mx-auto pb-4 w-full max-w-lg divide-y divide-white/5 rounded-xl bg-white/5 border-b border-gray-100 mb-4">
+          <span class="text-sm text-black group-data-[hover]:text-black/80 capitalize">Flow RSS Feed</span>
+          <ul role="list" class="space-y-2 mt-2">
+            <li
+              class="has-tooltip rounded-md text-gray-600 group px-1 w-full hover:bg-gradient-to-l hover:from-purple-500 hover:to-purple-700 hover:text-white hover:font-normal  ">
+              <a class={`flex items-center space-x-2`} target="_blank"
+                 href={buildUrl(`/rss/services/rss.xml`)}>
+                <RssIcon className="h-4 w-4 text-gray-800 group-hover:text-white" strokeWidth={1}/>
+                <span class="font-light text-sm truncate">RSS</span>
+              </a>
+            </li>
+          </ul>
+        </div>
+      )
+    }
+
+    <div class="space-y-2">
+      <a
+        href={buildUrl(`/visualiser/${flow.collection}/${flow.data.id}/${flow.data.version}`)}
+        class="flex items-center justify-center space-x-2 text-center rounded-md w-full bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-100/60 hover:text-primary"
+      >
+        <Workflow strokeWidth={2} size={16}/>
+        <span class="block">View in visualiser</span>
+      </a>
+      <a
+        href={buildUrl(`/docs/${flow.collection}/${flow.data.id}/${flow.data.latestVersion}/changelog`)}
+        class="flex items-center space-x-2 justify-center text-center rounded-md w-full bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-100/60 hover:text-primary"
+      >
+        <ScrollText strokeWidth={2} size={16}/>
+        <span class="block">Read changelog</span>
+      </a>
+    </div>
+  </div>
+</aside>

--- a/eventcatalog/src/components/SideBars/FlowSideBar.astro
+++ b/eventcatalog/src/components/SideBars/FlowSideBar.astro
@@ -1,17 +1,17 @@
 ---
 import OwnersList from '@components/Lists/OwnersList';
 import VersionList from '@components/Lists/VersionList.astro';
-import {buildUrl} from '@utils/url-builder';
-import {getOwner} from '@utils/collections/owners';
-import type {CollectionEntry} from 'astro:content';
-import {ScrollText, Workflow, RssIcon} from 'lucide-react';
+import { buildUrl } from '@utils/url-builder';
+import { getOwner } from '@utils/collections/owners';
+import type { CollectionEntry } from 'astro:content';
+import { ScrollText, Workflow, RssIcon } from 'lucide-react';
 import config from '@config';
 
 interface Props {
   flow: CollectionEntry<'flows'>;
 }
 
-const {flow} = Astro.props;
+const { flow } = Astro.props;
 
 const ownersRaw = flow.data?.owners || [];
 const owners = await Promise.all<ReturnType<typeof getOwner>>(ownersRaw.map(getOwner));
@@ -30,7 +30,7 @@ const isRSSEnabled = config.rss?.enabled;
 
 <aside class="sticky top-28 left-0 h-full overflow-y-auto pr-6 py-4">
   <div id="sidebar-cta-portal" class="">
-    {flow.data.versions && <VersionList versions={flow.data.versions} collectionItem={flow}/>}
+    {flow.data.versions && <VersionList versions={flow.data.versions} collectionItem={flow} />}
 
     <OwnersList
       title={`Flow owners (${ownersList.length})`}
@@ -41,15 +41,12 @@ const isRSSEnabled = config.rss?.enabled;
 
     {
       isRSSEnabled && (
-        <div
-          class="mx-auto pb-4 w-full max-w-lg divide-y divide-white/5 rounded-xl bg-white/5 border-b border-gray-100 mb-4">
+        <div class="mx-auto pb-4 w-full max-w-lg divide-y divide-white/5 rounded-xl bg-white/5 border-b border-gray-100 mb-4">
           <span class="text-sm text-black group-data-[hover]:text-black/80 capitalize">Flow RSS Feed</span>
           <ul role="list" class="space-y-2 mt-2">
-            <li
-              class="has-tooltip rounded-md text-gray-600 group px-1 w-full hover:bg-gradient-to-l hover:from-purple-500 hover:to-purple-700 hover:text-white hover:font-normal  ">
-              <a class={`flex items-center space-x-2`} target="_blank"
-                 href={buildUrl(`/rss/services/rss.xml`)}>
-                <RssIcon className="h-4 w-4 text-gray-800 group-hover:text-white" strokeWidth={1}/>
+            <li class="has-tooltip rounded-md text-gray-600 group px-1 w-full hover:bg-gradient-to-l hover:from-purple-500 hover:to-purple-700 hover:text-white hover:font-normal  ">
+              <a class={`flex items-center space-x-2`} target="_blank" href={buildUrl(`/rss/services/rss.xml`)}>
+                <RssIcon className="h-4 w-4 text-gray-800 group-hover:text-white" strokeWidth={1} />
                 <span class="font-light text-sm truncate">RSS</span>
               </a>
             </li>
@@ -63,14 +60,14 @@ const isRSSEnabled = config.rss?.enabled;
         href={buildUrl(`/visualiser/${flow.collection}/${flow.data.id}/${flow.data.version}`)}
         class="flex items-center justify-center space-x-2 text-center rounded-md w-full bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-100/60 hover:text-primary"
       >
-        <Workflow strokeWidth={2} size={16}/>
+        <Workflow strokeWidth={2} size={16} />
         <span class="block">View in visualiser</span>
       </a>
       <a
         href={buildUrl(`/docs/${flow.collection}/${flow.data.id}/${flow.data.latestVersion}/changelog`)}
         class="flex items-center space-x-2 justify-center text-center rounded-md w-full bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-100/60 hover:text-primary"
       >
-        <ScrollText strokeWidth={2} size={16}/>
+        <ScrollText strokeWidth={2} size={16} />
         <span class="block">Read changelog</span>
       </a>
     </div>

--- a/eventcatalog/src/components/SideBars/FlowSideBar.astro
+++ b/eventcatalog/src/components/SideBars/FlowSideBar.astro
@@ -45,7 +45,7 @@ const isRSSEnabled = config.rss?.enabled;
           <span class="text-sm text-black group-data-[hover]:text-black/80 capitalize">Flow RSS Feed</span>
           <ul role="list" class="space-y-2 mt-2">
             <li class="has-tooltip rounded-md text-gray-600 group px-1 w-full hover:bg-gradient-to-l hover:from-purple-500 hover:to-purple-700 hover:text-white hover:font-normal  ">
-              <a class={`flex items-center space-x-2`} target="_blank" href={buildUrl(`/rss/services/rss.xml`)}>
+              <a class={`flex items-center space-x-2`} target="_blank" href={buildUrl(`/rss/flows/rss.xml`)}>
                 <RssIcon className="h-4 w-4 text-gray-800 group-hover:text-white" strokeWidth={1} />
                 <span class="font-light text-sm truncate">RSS</span>
               </a>

--- a/eventcatalog/src/pages/docs/[type]/[id]/[version]/changelog/index.astro
+++ b/eventcatalog/src/pages/docs/[type]/[id]/[version]/changelog/index.astro
@@ -4,7 +4,12 @@ import Footer from '@layouts/Footer.astro';
 import type { PageTypes } from '@types';
 import { getChangeLogs } from '@utils/collections/changelogs';
 import {
-    RectangleGroupIcon, ServerIcon, BoltIcon, ChatBubbleLeftIcon, MagnifyingGlassIcon, QueueListIcon
+  RectangleGroupIcon,
+  ServerIcon,
+  BoltIcon,
+  ChatBubbleLeftIcon,
+  MagnifyingGlassIcon,
+  QueueListIcon,
 } from '@heroicons/react/24/outline';
 import { pageDataLoader } from '@utils/page-loaders/page-data-loader';
 import { render, getEntry } from 'astro:content';

--- a/eventcatalog/src/pages/docs/[type]/[id]/[version]/changelog/index.astro
+++ b/eventcatalog/src/pages/docs/[type]/[id]/[version]/changelog/index.astro
@@ -3,7 +3,9 @@ import Footer from '@layouts/Footer.astro';
 
 import type { PageTypes } from '@types';
 import { getChangeLogs } from '@utils/collections/changelogs';
-import { RectangleGroupIcon, ServerIcon, BoltIcon, ChatBubbleLeftIcon, MagnifyingGlassIcon } from '@heroicons/react/24/outline';
+import {
+    RectangleGroupIcon, ServerIcon, BoltIcon, ChatBubbleLeftIcon, MagnifyingGlassIcon, QueueListIcon
+} from '@heroicons/react/24/outline';
 import { pageDataLoader } from '@utils/page-loaders/page-data-loader';
 import { render, getEntry } from 'astro:content';
 import 'diff2html/bundles/css/diff2html.min.css';
@@ -15,7 +17,7 @@ import VerticalSideBarLayout from '@layouts/VerticalSideBarLayout.astro';
 import { ClientRouter } from 'astro:transitions';
 
 export async function getStaticPaths() {
-  const itemTypes: PageTypes[] = ['events', 'commands', 'queries', 'services', 'domains'];
+  const itemTypes: PageTypes[] = ['events', 'commands', 'queries', 'services', 'domains', 'flows'];
   const allItems = await Promise.all(itemTypes.map((type) => pageDataLoader[type]()));
 
   return allItems.flatMap((items, index) =>
@@ -44,7 +46,7 @@ const logs = await getChangeLogs(props);
 const { data } = props;
 const latestVersion = data.latestVersion;
 
-const renderedLogs = await logs.map(async (log) => {
+const renderedLogs = logs.map(async (log) => {
   const logEntry = await getEntry('changelogs', log.id);
   const { Content } = await render(logEntry as any);
   return {
@@ -103,6 +105,9 @@ const getBadge = () => {
       icon: RectangleGroupIcon,
       class: 'text-yellow-400',
     };
+  }
+  if (props.collection === 'flows') {
+    return { backgroundColor: 'teal', textColor: 'teal', content: 'Flow', icon: QueueListIcon, class: 'text-teal-400' };
   }
 };
 

--- a/eventcatalog/src/pages/docs/[type]/[id]/[version]/index.astro
+++ b/eventcatalog/src/pages/docs/[type]/[id]/[version]/index.astro
@@ -11,12 +11,12 @@ import ServiceSideBar from '@components/SideBars/ServiceSideBar.astro';
 import MessageSideBar from '@components/SideBars/MessageSideBar.astro';
 import DomainSideBar from '@components/SideBars/DomainSideBar.astro';
 import ChannelSideBar from '@components/SideBars/ChannelSideBar.astro';
+import FlowSideBar from '@components/SideBars/FlowSideBar.astro';
 
 import { QueueListIcon, RectangleGroupIcon, ServerIcon, BoltIcon, ChatBubbleLeftIcon } from '@heroicons/react/24/outline';
 import type { PageTypes } from '@types';
 
 import { buildUrl } from '@utils/url-builder';
-import { getFlows } from '@utils/collections/flows';
 import { pageDataLoader } from '@utils/page-loaders/page-data-loader';
 import { ClientRouter } from 'astro:transitions';
 import { render } from 'astro:content';
@@ -24,16 +24,9 @@ import { ArrowsRightLeftIcon } from '@heroicons/react/20/solid';
 
 import config from '@config';
 
-type PageTypesWithFlows = PageTypes | 'flows';
-
 export async function getStaticPaths() {
-  const loaders = {
-    ...pageDataLoader,
-    flows: getFlows,
-  };
-
-  const itemTypes: PageTypesWithFlows[] = ['events', 'commands', 'queries', 'services', 'domains', 'flows', 'channels'];
-  const allItems = await Promise.all(itemTypes.map((type) => loaders[type]()));
+  const itemTypes: PageTypes[] = ['events', 'commands', 'queries', 'services', 'domains', 'flows', 'channels'];
+  const allItems = await Promise.all(itemTypes.map((type) => pageDataLoader[type]()));
 
   return allItems.flatMap((items, index) =>
     items.map((item) => ({
@@ -225,6 +218,7 @@ const badges = [getBadge(), ...contentBadges, ...getSpecificationBadges()];
         {props?.collection === 'services' && <ServiceSideBar service={props} />}
         {props?.collection === 'domains' && <DomainSideBar domain={props} />}
         {props?.collection === 'channels' && <ChannelSideBar channel={props} />}
+        {props?.collection === 'flows' && <FlowSideBar flow={props} />}
       </aside>
     </div>
     <ClientRouter />

--- a/eventcatalog/src/types/index.ts
+++ b/eventcatalog/src/types/index.ts
@@ -1,4 +1,4 @@
 export type CollectionTypes = 'commands' | 'events' | 'queries' | 'domains' | 'services' | 'flows' | 'channels';
 export type CollectionMessageTypes = 'commands' | 'events' | 'queries';
 export type CollectionUserTypes = 'users';
-export type PageTypes = 'events' | 'commands' | 'queries' | 'services' | 'domains' | 'channels';
+export type PageTypes = 'events' | 'commands' | 'queries' | 'services' | 'domains' | 'channels' | 'flows';

--- a/eventcatalog/src/utils/page-loaders/page-data-loader.ts
+++ b/eventcatalog/src/utils/page-loaders/page-data-loader.ts
@@ -4,7 +4,7 @@ import { getDomains } from '@utils/collections/domains';
 import { getCommands, getEvents } from '@utils/messages';
 import { getQueries } from '@utils/queries';
 import { getServices } from '@utils/collections/services';
-import { getFlows } from '@utils/collections/flows.ts';
+import { getFlows } from '@utils/collections/flows';
 import type { CollectionEntry } from 'astro:content';
 
 export const pageDataLoader: Record<PageTypes, () => Promise<CollectionEntry<CollectionTypes>[]>> = {

--- a/eventcatalog/src/utils/page-loaders/page-data-loader.ts
+++ b/eventcatalog/src/utils/page-loaders/page-data-loader.ts
@@ -4,7 +4,7 @@ import { getDomains } from '@utils/collections/domains';
 import { getCommands, getEvents } from '@utils/messages';
 import { getQueries } from '@utils/queries';
 import { getServices } from '@utils/collections/services';
-import { getFlows } from "@utils/collections/flows.ts";
+import { getFlows } from '@utils/collections/flows.ts';
 import type { CollectionEntry } from 'astro:content';
 
 export const pageDataLoader: Record<PageTypes, () => Promise<CollectionEntry<CollectionTypes>[]>> = {

--- a/eventcatalog/src/utils/page-loaders/page-data-loader.ts
+++ b/eventcatalog/src/utils/page-loaders/page-data-loader.ts
@@ -4,6 +4,7 @@ import { getDomains } from '@utils/collections/domains';
 import { getCommands, getEvents } from '@utils/messages';
 import { getQueries } from '@utils/queries';
 import { getServices } from '@utils/collections/services';
+import { getFlows } from "@utils/collections/flows.ts";
 import type { CollectionEntry } from 'astro:content';
 
 export const pageDataLoader: Record<PageTypes, () => Promise<CollectionEntry<CollectionTypes>[]>> = {
@@ -13,4 +14,5 @@ export const pageDataLoader: Record<PageTypes, () => Promise<CollectionEntry<Col
   services: getServices,
   domains: getDomains,
   channels: getChannels,
+  flows: getFlows,
 };

--- a/examples/default/domains/Payment/flows/PaymentProcessed/index.mdx
+++ b/examples/default/domains/Payment/flows/PaymentProcessed/index.mdx
@@ -3,6 +3,8 @@ id: PaymentFlow
 name: Payment Flow for customers
 version: 1.0.0
 summary: Business flow for processing payments in an e-commerce platform
+owners:
+    - dboyne
 steps:
     - id: "customer_place_order"
       title: Customer places order

--- a/examples/default/domains/Subscriptions/flows/CancelSubscription/changelog.mdx
+++ b/examples/default/domains/Subscriptions/flows/CancelSubscription/changelog.mdx
@@ -2,4 +2,4 @@
 createdAt: 2024-08-20
 ---
 
-Document what happens when subscription cancellation succeeds or fails.
+Send an email to the customer confirming the successful cancellation.

--- a/examples/default/domains/Subscriptions/flows/CancelSubscription/changelog.mdx
+++ b/examples/default/domains/Subscriptions/flows/CancelSubscription/changelog.mdx
@@ -1,0 +1,5 @@
+---
+createdAt: 2024-08-20
+---
+
+Document what happens when subscription cancellation succeeds or fails.

--- a/examples/default/domains/Subscriptions/flows/CancelSubscription/index.mdx
+++ b/examples/default/domains/Subscriptions/flows/CancelSubscription/index.mdx
@@ -3,13 +3,15 @@ id: "CancelSubscription"
 name: "User Cancels Subscription"
 version: "1.0.0"
 summary: "Flow for when a user has cancelled a subscription"
+owners:
+  - subscriptions-management
 steps:
   - id: "cancel_subscription_initiated"
     title: "Cancels Subscription"
     summary: "User cancels their subscription"
     actor:
       name: "User"
-    next_step: 
+    next_step:
       id: "cancel_subscription_request"
       label: "Initiate subscription cancellation"
 
@@ -18,7 +20,7 @@ steps:
     message:
       id: "CancelSubscription"
       version: "0.0.1"
-    next_step: 
+    next_step:
       id: "subscription_service"
       label: "Proceed to subscription service"
 
@@ -28,7 +30,7 @@ steps:
       name: "Stripe"
       summary: "3rd party payment system"
       url: "https://stripe.com/"
-    next_step: 
+    next_step:
       id: "subscription_service"
       label: "Return to subscription service"
 

--- a/examples/default/domains/Subscriptions/flows/CancelSubscription/versioned/0.0.1/index.mdx
+++ b/examples/default/domains/Subscriptions/flows/CancelSubscription/versioned/0.0.1/index.mdx
@@ -3,13 +3,15 @@ id: "CancelSubscription"
 name: "User Cancels Subscription"
 version: "0.0.1"
 summary: "Flow for when a user has cancelled a subscription"
+owners:
+  - subscriptions-management
 steps:
   - id: "cancel_subscription_initiated"
     title: "Cancels Subscription"
     summary: "User cancels their subscription"
     actor:
       name: "User"
-    next_step: 
+    next_step:
       id: "cancel_subscription_request"
       label: "Initiate subscription cancellation"
 
@@ -18,7 +20,7 @@ steps:
     message:
       id: "CancelSubscription"
       version: "0.0.1"
-    next_step: 
+    next_step:
       id: "subscription_service"
       label: "Proceed to subscription service"
 
@@ -28,7 +30,7 @@ steps:
       name: "Stripe"
       summary: "3rd party payment system"
       url: "https://stripe.com/"
-    next_step: 
+    next_step:
       id: "subscription_service"
       label: "Return to subscription service"
 

--- a/examples/default/domains/Subscriptions/flows/SubscriptionRenewed/index.mdx
+++ b/examples/default/domains/Subscriptions/flows/SubscriptionRenewed/index.mdx
@@ -3,6 +3,8 @@ id: "SubscriptionRenewed"
 name: "Subscription Renewal Flow"
 version: "1.0.0"
 summary: "Business flow for automatic subscription renewals and related processes"
+owners:
+  - subscriptions-management
 steps:
   - id: "renewal_timer_triggered"
     title: "Renewal Period Reached"
@@ -210,7 +212,7 @@ steps:
         backoff_interval: "24 hours"
         current_attempt: 1
     next_steps:
-      - id: "payment_initiated" 
+      - id: "payment_initiated"
         label: "Retry payment"
       - id: "subscription_grace_period"
         label: "Max retries exceeded"


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://www.eventcatalog.dev/docs/contributing/overview

Happy contributing!

-->

## Motivation

Currently, Flow pages lack a sidebar. It would be helpful to have one that displays previous versions, similar to other resources.

Related issue: https://github.com/event-catalog/eventcatalog/issues/1199

## Changes

- add FlowSideBar with bare minimum information: versions, owners, RSS, visualizer and changelog buttons

<img width="371" alt="Screenshot 2025-03-21 at 14 22 31" src="https://github.com/user-attachments/assets/e62a0bf2-835f-4078-b0af-208beb280621" />

- generate flow changelog page

<img width="461" alt="Screenshot 2025-03-21 at 15 43 13" src="https://github.com/user-attachments/assets/eb61d380-3bc4-44a8-978e-3e5472b9ed37" />

## Notes

Additional information can be added later, such as a list of services or messages referenced in the flow.





