### PR TITLE
Fix dev crashing in devcontainers on change

### DIFF
--- a/.changeset/tricky-walls-buy.md
+++ b/.changeset/tricky-walls-buy.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/core': patch
+---
+
+Fix dev crashing in devcontainers on change

--- a/eventcatalog/astro.config.mjs
+++ b/eventcatalog/astro.config.mjs
@@ -16,11 +16,12 @@ import expressiveCode from 'astro-expressive-code';
 
 const projectDirectory = process.env.PROJECT_DIR || process.cwd();
 const base = config.base || '/';
+const port = config.port || 3000;
 
 // https://astro.build/config
 export default defineConfig({
   base,
-  server: { port: config.port || 3000 },
+  server: { port: port },
 
   outDir: config.outDir ? join(projectDirectory, config.outDir) : join(projectDirectory, 'dist'),
 
@@ -68,6 +69,12 @@ export default defineConfig({
     },
     worker: {
       format: 'es',
+    },
+    server:{
+      host: "0.0.0.0",
+      hmr: { clientPort: port },
+      port: port,
+      watch: { usePolling: true }
     },
     build: {
       commonjsOptions: {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://www.eventcatalog.dev/docs/contributing/overview

Happy contributing!

-->

## Motivation

If you run eventcatalog in a devcontainer and run the following script:

eventcatalog dev -- --host

Then upon editing a file in the eventcatalog, the dev instance of eventcatalog will crash.
This is a known problem in astro as seen here: https://github.com/withastro/docs/issues/4003

## Solution

Add to the vite configuration in astro.config.mjs and this PR contributes this first part.

```javascript
server:{
    host: "0.0.0.0",
    hmr: { clientPort: <port> },
    port: <port>, 
    watch: { usePolling: true }
}
```

The second part of the solution cannot be done in eventcatalog, which is including the following in the .devcontainer file:

```
"forwardPorts": [4321, <port>],
"containerEnv": {
    "CHOKIDAR_USEPOLLING": "true"
} 
```