### PR TITLE
feat(core): added resource groups

### DIFF
--- a/.changeset/smart-grapes-develop.md
+++ b/.changeset/smart-grapes-develop.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": minor
+---
+
+feat(core): added resource groups

--- a/eventcatalog/src/components/Lists/CustomSideBarSectionList.astro
+++ b/eventcatalog/src/components/Lists/CustomSideBarSectionList.astro
@@ -1,0 +1,67 @@
+---
+import { buildUrl } from '@utils/url-builder';
+import { getCollection } from 'astro:content';
+import { getItemsFromCollectionByIdAndSemverOrLatest } from '@utils/collections/util';
+import PillListFlat from './PillListFlat';
+interface Props {
+  section?: {
+    title?: string;
+    limit?: number;
+    items: {
+      id: string;
+      type: string;
+      version?: string;
+    }[];
+  };
+}
+
+const { section } = Astro.props;
+const title = section?.title || 'Custom Section';
+const limit = section?.limit || 10;
+const sectionItems = section?.items || [];
+
+// Type-safe mapping of resource types to collection names
+const resourceToCollectionMap = {
+  service: 'services',
+  event: 'events',
+  command: 'commands',
+  query: 'queries',
+  domain: 'domains',
+  flow: 'flows',
+  channel: 'channels',
+  user: 'users',
+  team: 'teams',
+} as const; // Make this a const assertion
+
+// Array to store resolved related resources
+const resolvedResources = [];
+
+// Fetch related resources
+for (const resource of sectionItems) {
+  try {
+    // Use type assertion to ensure TypeScript understands this is a valid collection name
+    const collectionName = resourceToCollectionMap[resource.type as keyof typeof resourceToCollectionMap];
+
+    // Use getEntry instead of getCollection for single item lookup by ID
+    const allItemsInCollection = await getCollection(collectionName);
+    // @ts-ignore
+    const entryToMatchVersion = getItemsFromCollectionByIdAndSemverOrLatest(allItemsInCollection, resource.id, resource.version);
+    const entry = entryToMatchVersion[0];
+
+    if (entry) {
+      resolvedResources.push(entry);
+    }
+  } catch (error) {
+    console.error(`Failed to fetch related resource: ${resource.id} of type ${resource.type}`, error);
+  }
+}
+
+const sectionList = resolvedResources.map((p: any) => ({
+  label: `${p.data.name}`,
+  tag: `v${p.data.version}`,
+  collection: p.collection,
+  href: buildUrl(`/docs/${p.collection}/${p.data.id}/${p.data.version}`),
+}));
+---
+
+<PillListFlat title={`${title} (${sectionList.length})`} pills={sectionList} color="orange" limit={limit} client:load />

--- a/eventcatalog/src/components/MDX/ResourceGroupTable/ResourceGroupTable.astro
+++ b/eventcatalog/src/components/MDX/ResourceGroupTable/ResourceGroupTable.astro
@@ -1,0 +1,126 @@
+---
+import type { CollectionEntry } from 'astro:content';
+import { getCollection } from 'astro:content';
+import { getItemsFromCollectionByIdAndSemverOrLatest } from '@utils/collections/util';
+import ResourceGroupTableClient from './ResourceGroupTable.client';
+import Admonition from '../Admonition';
+
+export interface Props extends CollectionEntry<'services'> {
+  limit?: number;
+  id: string;
+  showTags?: boolean;
+  showOwners?: boolean;
+  title?: string;
+  subtitle?: string;
+  description?: string;
+}
+
+const {
+  id,
+  limit,
+  showTags = false,
+  showOwners = false,
+  title = 'Resources',
+  subtitle,
+  description = 'Browse resources in this group or search by name, type, or description.',
+  ...resource
+} = Astro.props;
+
+// Find the requested resource group section by ID
+const section = resource.data.resourceGroups?.find((section: any) => section.id === id);
+
+const collection = Astro.props.collection as 'services' | 'domains';
+
+// Type-safe mapping of resource types to collection names
+const resourceToCollectionMap = {
+  service: 'services',
+  event: 'events',
+  command: 'commands',
+  query: 'queries',
+  domain: 'domains',
+  flow: 'flows',
+  channel: 'channels',
+  user: 'users',
+  team: 'teams',
+} as const;
+
+// This will hold our processed resources for the client component
+const resolvedResources: any[] = [];
+
+// Process each resource item in the section
+if (section?.items) {
+  for (const item of section.items) {
+    // Get the collection name from the resource type
+    const collectionName = resourceToCollectionMap[item.type as keyof typeof resourceToCollectionMap];
+
+    if (!collectionName) continue;
+
+    try {
+      // Get all items in the collection
+      const allItemsInCollection = await getCollection(collectionName);
+
+      // Find the specific version of the resource
+      const matchedItems = getItemsFromCollectionByIdAndSemverOrLatest(allItemsInCollection as any, item.id, item.version);
+
+      if (matchedItems.length > 0) {
+        const entry = matchedItems[0] as any;
+
+        // Create a simplified resource object for the client component
+        resolvedResources.push({
+          id: entry.data?.id || entry.id || item.id,
+          name: entry.data?.name || item.id,
+          version: entry.data?.version || item.version || '1.0.0',
+          collection: entry.collection || collectionName,
+          type: item.type,
+          summary: entry.data?.summary || '',
+          description: entry.data?.description || '',
+          owners: entry.data?.owners || [],
+          tags: entry.data?.tags || [],
+        });
+      }
+    } catch (error) {
+      console.error(`Error processing resource ${item.id} of type ${item.type}:`, error);
+    }
+  }
+}
+---
+
+{
+  resolvedResources.length > 0 && (
+    <ResourceGroupTableClient
+      client:load
+      resources={resolvedResources}
+      limit={limit}
+      title={title}
+      subtitle={subtitle}
+      description={description}
+      showTags={showTags}
+      showOwners={showOwners}
+    />
+  )
+}
+
+{
+  !resolvedResources.length && (
+    <Admonition type="warning">
+      <div>
+        {`<ResourceGroupTable/>`} cannot find any resources in your catalog for the resource group with id {id}.
+      </div>
+    </Admonition>
+  )
+}
+
+{
+  !section && (
+    <Admonition type="warning">
+      <div>
+        <span class="font-bold">
+          {`<ResourceGroupTable/>`} cannot find the resource group with id {id}.
+        </span>
+        <span class="block">
+          Please make sure the id is correct and the resource group is defined in this {collection.slice(0, -1)}.
+        </span>
+      </div>
+    </Admonition>
+  )
+}

--- a/eventcatalog/src/components/MDX/components.tsx
+++ b/eventcatalog/src/components/MDX/components.tsx
@@ -13,6 +13,7 @@ import OpenAPI from '@components/MDX/OpenAPI/OpenAPI.astro';
 import AsyncAPI from '@components/MDX/AsyncAPI/AsyncAPI.astro';
 import ChannelInformation from '@components/MDX/ChannelInformation/ChannelInformation';
 import MessageTable from '@components/MDX/MessageTable/MessageTable.astro';
+import ResourceGroupTable from '@components/MDX/ResourceGroupTable/ResourceGroupTable.astro';
 import Tabs from '@components/MDX/Tabs/Tabs.astro';
 import TabItem from '@components/MDX/Tabs/TabItem.astro';
 
@@ -41,6 +42,7 @@ const components = (props: any) => {
     SchemaViewer: (mdxProp: any) => SchemaViewerPortal({ ...props.data, ...mdxProp }),
     Schema: (mdxProp: any) => jsx(Schema, { ...props, ...mdxProp }),
     MessageTable: (mdxProp: any) => jsx(MessageTable, { ...props, ...mdxProp }),
+    ResourceGroupTable: (mdxProp: any) => jsx(ResourceGroupTable, { ...props, ...mdxProp }),
   };
 };
 

--- a/eventcatalog/src/components/SideBars/DomainSideBar.astro
+++ b/eventcatalog/src/components/SideBars/DomainSideBar.astro
@@ -4,6 +4,7 @@ import PillListFlat from '@components/Lists/PillListFlat';
 import RepositoryList from '@components/Lists/RepositoryList.astro';
 import VersionList from '@components/Lists/VersionList.astro';
 import { getUbiquitousLanguage, getMessagesForDomain } from '@utils/collections/domains';
+import CustomSideBarSectionList from '@components/Lists/CustomSideBarSectionList.astro';
 import { getOwner } from '@utils/collections/owners';
 import { buildUrl } from '@utils/url-builder';
 import type { CollectionEntry } from 'astro:content';
@@ -26,6 +27,8 @@ const owners = await Promise.all<ReturnType<typeof getOwner>>(ownersRaw.map(getO
 const filteredOwners = owners.filter((o) => o !== undefined);
 
 const messagesForDomain = await getMessagesForDomain(domain);
+
+const resourceGroups = domain.data?.resourceGroups || [];
 
 const serviceList = services.map((p) => ({
   label: p.data.name,
@@ -73,6 +76,11 @@ const ownersList = filteredOwners.map((o) => ({
 
 <aside class="sticky top-28 left-0 space-y-8 h-full overflow-y-auto py-4">
   <div>
+    {
+      resourceGroups
+        .filter((section) => section.items.length > 0 && section.sidebar)
+        .map((section) => <CustomSideBarSectionList section={section} />)
+    }
     <PillListFlat
       title={`Services (${services.length})`}
       pills={serviceList}

--- a/eventcatalog/src/components/SideBars/FlowSideBar.astro
+++ b/eventcatalog/src/components/SideBars/FlowSideBar.astro
@@ -6,7 +6,7 @@ import { getOwner } from '@utils/collections/owners';
 import type { CollectionEntry } from 'astro:content';
 import { ScrollText, Workflow, RssIcon } from 'lucide-react';
 import config from '@config';
-
+import CustomSideBarSectionList from '@components/Lists/CustomSideBarSectionList.astro';
 interface Props {
   flow: CollectionEntry<'flows'>;
 }
@@ -16,6 +16,8 @@ const { flow } = Astro.props;
 const ownersRaw = flow.data?.owners || [];
 const owners = await Promise.all<ReturnType<typeof getOwner>>(ownersRaw.map(getOwner));
 const filteredOwners = owners.filter((o) => o !== undefined);
+
+const resourceGroups = flow.data?.resourceGroups || [];
 
 const ownersList = filteredOwners.map((o) => ({
   label: o.data.name,
@@ -30,6 +32,11 @@ const isRSSEnabled = config.rss?.enabled;
 
 <aside class="sticky top-28 left-0 h-full overflow-y-auto pr-6 py-4">
   <div id="sidebar-cta-portal" class="">
+    {
+      resourceGroups
+        .filter((section) => section.items.length > 0 && section.sidebar)
+        .map((section) => <CustomSideBarSectionList section={section} />)
+    }
     {flow.data.versions && <VersionList versions={flow.data.versions} collectionItem={flow} />}
 
     <OwnersList

--- a/eventcatalog/src/components/SideBars/MessageSideBar.astro
+++ b/eventcatalog/src/components/SideBars/MessageSideBar.astro
@@ -9,6 +9,7 @@ import { buildUrl } from '@utils/url-builder';
 import { FileDownIcon, ScrollText, Workflow, RssIcon } from 'lucide-react';
 import RepositoryList from '@components/Lists/RepositoryList.astro';
 import { getOwner } from '@utils/collections/owners';
+import CustomSideBarSectionList from '@components/Lists/CustomSideBarSectionList.astro';
 import config from '@config';
 
 interface Props {
@@ -24,6 +25,8 @@ const channels = (message.data.messageChannels as CollectionEntry<'channels'>[])
 const ownersRaw = message.data?.owners || [];
 const owners = await Promise.all<ReturnType<typeof getOwner>>(ownersRaw.map(getOwner));
 const filteredOwners = owners.filter((o) => o !== undefined);
+
+const resourceGroups = message.data?.resourceGroups || [];
 
 const producerList = producers.map((p) => ({
   label: `${p.data.name}`,
@@ -98,6 +101,11 @@ const schemaURL = path.join(publicPath, schemaFilePath || '');
 
 <aside class="sticky top-28 left-0 space-y-8 h-full overflow-y-auto py-4">
   <div class="">
+    {
+      resourceGroups
+        .filter((section) => section.items.length > 0 && section.sidebar)
+        .map((section) => <CustomSideBarSectionList section={section} />)
+    }
     {
       producerList.length > 0 && (
         <PillListFlat

--- a/eventcatalog/src/components/SideBars/ServiceSideBar.astro
+++ b/eventcatalog/src/components/SideBars/ServiceSideBar.astro
@@ -3,6 +3,7 @@ import OwnersList from '@components/Lists/OwnersList';
 import PillListFlat from '@components/Lists/PillListFlat';
 import RepositoryList from '@components/Lists/RepositoryList.astro';
 import SpecificationsList from '@components/Lists/SpecificationsList.astro';
+import CustomSideBarSectionList from '@components/Lists/CustomSideBarSectionList.astro';
 import VersionList from '@components/Lists/VersionList.astro';
 import { buildUrl } from '@utils/url-builder';
 import { getOwner } from '@utils/collections/owners';
@@ -10,7 +11,6 @@ import type { CollectionEntry } from 'astro:content';
 import { ScrollText, Workflow, FileDownIcon, Code, Link, RssIcon } from 'lucide-react';
 import { join } from 'node:path';
 import config from '@config';
-
 interface Props {
   service: CollectionEntry<'services'>;
 }
@@ -25,6 +25,8 @@ const receives = (service.data.receives as CollectionEntry<'events'>[]) || [];
 const ownersRaw = service.data?.owners || [];
 const owners = await Promise.all<ReturnType<typeof getOwner>>(ownersRaw.map(getOwner));
 const filteredOwners = owners.filter((o) => o !== undefined);
+
+const resourceGroups = service.data?.resourceGroups || [];
 
 const sendsList = sends
   .sort((a, b) => a.collection.localeCompare(b.collection))
@@ -66,6 +68,11 @@ const schemaURL = join(publicPath, schemaFilePath || '');
 
 <aside class="sticky top-28 left-0 h-full overflow-y-auto pr-6 py-4">
   <div id="sidebar-cta-portal" class="">
+    {
+      resourceGroups
+        .filter((section) => section.items.length > 0 && section.sidebar)
+        .map((section) => <CustomSideBarSectionList section={section} />)
+    }
     <PillListFlat
       title={`Receives Messages (${receivesList.length})`}
       pills={receivesList}

--- a/eventcatalog/src/components/Tables/columns/ServiceTableColumns.tsx
+++ b/eventcatalog/src/components/Tables/columns/ServiceTableColumns.tsx
@@ -1,9 +1,9 @@
-import { ServerIcon, BoltIcon, ChatBubbleLeftIcon } from '@heroicons/react/24/solid';
+import { ServerIcon } from '@heroicons/react/24/solid';
 import { createColumnHelper } from '@tanstack/react-table';
 import { useMemo, useState } from 'react';
 import { filterByName, filterCollectionByName } from '../filters/custom-filters';
 import { buildUrl } from '@utils/url-builder';
-import { getColorAndIconForMessageType } from './MessageTableColumns';
+import { getColorAndIconForCollection } from '@utils/collections/icons';
 import { createBadgesColumn } from './SharedColumns';
 import type { TData } from '../Table';
 
@@ -66,10 +66,9 @@ export const columns = () => [
       const receiversWithIcons = useMemo(
         () =>
           receives?.map((consumer) => {
-            const type = consumer.collection.slice(0, -1);
             return {
               ...consumer,
-              ...getColorAndIconForMessageType(type),
+              ...getColorAndIconForCollection(consumer.collection),
             };
           }) || [],
         [receives]
@@ -131,10 +130,9 @@ export const columns = () => [
       const sendersWithIcons = useMemo(
         () =>
           sends?.map((sender) => {
-            const type = sender.collection.slice(0, -1);
             return {
               ...sender,
-              ...getColorAndIconForMessageType(type),
+              ...getColorAndIconForCollection(sender.collection),
             };
           }) || [],
         [sends]

--- a/eventcatalog/src/components/Tables/columns/TeamsTableColumns.tsx
+++ b/eventcatalog/src/components/Tables/columns/TeamsTableColumns.tsx
@@ -5,25 +5,10 @@ import { filterByName, filterCollectionByName } from '../filters/custom-filters'
 import { buildUrl } from '@utils/url-builder';
 import type { TData } from '../Table';
 import type { CollectionUserTypes } from '@types';
-import { User, Users } from 'lucide-react';
 import type { CollectionEntry } from 'astro:content';
 import { ServerIcon, BoltIcon, ChatBubbleLeftIcon } from '@heroicons/react/24/solid';
 
 const columnHelper = createColumnHelper<TData<CollectionUserTypes>>();
-
-export const getColorAndIconForMessageType = (type: string) => {
-  switch (type) {
-    case 'event':
-      return { color: 'orange', Icon: BoltIcon };
-    case 'command':
-      return { color: 'blue', Icon: ChatBubbleLeftIcon };
-    case 'querie':
-    case 'query':
-      return { color: 'green', Icon: MagnifyingGlassIcon };
-    default:
-      return { color: 'gray', Icon: ChatBubbleLeftIcon };
-  }
-};
 
 export const columns = () => [
   columnHelper.accessor('data.name', {

--- a/eventcatalog/src/content.config.ts
+++ b/eventcatalog/src/content.config.ts
@@ -35,6 +35,12 @@ const channelPointer = z
   })
   .merge(pointer);
 
+const resourcePointer = z.object({
+  id: z.string(),
+  version: z.string().optional().default('latest'),
+  type: z.enum(['service', 'event', 'command', 'query', 'flow', 'channel', 'domain', 'user', 'team']),
+});
+
 const changelogs = defineCollection({
   loader: glob({
     pattern: ['**/changelog.(md|mdx)'],
@@ -87,6 +93,17 @@ const baseSchema = z.object({
     })
     .optional(),
   hidden: z.boolean().optional(),
+  resourceGroups: z
+    .array(
+      z.object({
+        id: z.string().optional(),
+        title: z.string().optional(),
+        items: z.array(resourcePointer),
+        limit: z.number().optional().default(10),
+        sidebar: z.boolean().optional().default(true),
+      })
+    )
+    .optional(),
   // Used by eventcatalog
   versions: z.array(z.string()).optional(),
   latestVersion: z.string().optional(),

--- a/eventcatalog/src/utils/collections/icons.ts
+++ b/eventcatalog/src/utils/collections/icons.ts
@@ -43,3 +43,32 @@ export const getIconForCollection = (collection: string) => {
       return ServerIcon;
   }
 };
+
+export const getColorAndIconForCollection = (collection: string) => {
+  const icon = getIconForCollection(collection);
+
+  switch (collection) {
+    case 'events':
+      return { color: 'orange', Icon: icon };
+    case 'commands':
+      return { color: 'blue', Icon: icon };
+    case 'queries':
+      return { color: 'green', Icon: icon };
+    case 'flows':
+      return { color: 'teal', Icon: icon };
+    case 'teams':
+      return { color: 'red', Icon: icon };
+    case 'users':
+      return { color: 'gray', Icon: icon };
+    case 'channels':
+      return { color: 'purple', Icon: icon };
+    case 'ubiquitousLanguages':
+      return { color: 'green', Icon: icon };
+    case 'domains':
+      return { color: 'yellow', Icon: icon };
+    case 'services':
+      return { color: 'pink', Icon: icon };
+    default:
+      return { color: 'gray', Icon: icon };
+  }
+};

--- a/eventcatalog/src/utils/collections/services.ts
+++ b/eventcatalog/src/utils/collections/services.ts
@@ -21,10 +21,10 @@ let cachedServices: Record<string, Service[]> = {
 export const getServices = async ({ getAllVersions = true }: Props = {}): Promise<Service[]> => {
   const cacheKey = getAllVersions ? 'allVersions' : 'currentVersions';
 
-  // // Check if we have cached domains for this specific getAllVersions value
-  // if (cachedServices[cacheKey].length > 0) {
-  //   return cachedServices[cacheKey];
-  // }
+  // Check if we have cached domains for this specific getAllVersions value
+  if (cachedServices[cacheKey].length > 0) {
+    return cachedServices[cacheKey];
+  }
 
   // Get services that are not versioned
   const services = await getCollection('services', (service) => {

--- a/examples/default/domains/Orders/index.mdx
+++ b/examples/default/domains/Orders/index.mdx
@@ -14,11 +14,25 @@ badges:
   - content: New domain
     backgroundColor: blue
     textColor: blue
+resourceGroups:
+  - id: related-resources
+    title: Core resources
+    items:
+      - id: InventoryService
+        type: service
+      - id: OrdersService
+        type: service
+      - id: NotificationService
+        type: service
+      - id: ShippingService
+        type: service
 ---
 
 import Footer from '@catalog/components/footer.astro';
 
 ## Overview
+
+
 
 :::warning
 
@@ -69,5 +83,7 @@ Documented flow when a user cancels their subscription.
 Documented flow when a user makes a payment within the order domain
 
 <Flow id="PaymentFlow" version="latest" includeKey={false} />
+
+<ResourceGroupTable id="related-resources" limit={4} showOwners={true} title="Core resources for the Orders domain" description="Resources that are related to the Orders domain, you may find them useful" />
 
 <Footer />


### PR DESCRIPTION
Added new `resourceGroups` property to all resources in EventCatalog.

## What are Resource Groups

The ability to link any resource with any resource in eventcatalog. This comes with two new things a custom sidebar and also new table to show on your pages.

## Why?

This new functionality was added to give people flexibility to connect resources together. An example would be to have a domain list a group of messages together, or cross domain services. You can put them into there own resource, and have EventCatalog render these.

A few folks have asked about ways to customize how there resources are connected be it in there DDD environment or the way they handle domains/services and messages. This lets people explore new patterns, and governance patterns, whilst keep the models the same.

Docs, pics and examples coming.