### PR TITLE
fix(core): prevent icon shrinking in PillListFlat.tsx

### DIFF
--- a/.changeset/happy-parents-drop.md
+++ b/.changeset/happy-parents-drop.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/core': patch
+---
+
+fix(core): prevent icon shrinking in PillListFlat.tsx

--- a/eventcatalog/src/components/Lists/PillListFlat.tsx
+++ b/eventcatalog/src/components/Lists/PillListFlat.tsx
@@ -46,7 +46,7 @@ const PillList = ({ title, pills, emptyMessage, color = 'gray', limit = 10, ...p
                   >
                     <a className={`leading-3`} href={href}>
                       <span className="space-x-2 flex items-center">
-                        {Icon && <Icon className={`h-4 w-4`} />}
+                        {Icon && <Icon className="h-4 w-4 shrink-0" />}
                         <span className="font-light text-sm truncate">
                           {item.label} {item.tag && <>({item.tag})</>}
                         </span>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://www.eventcatalog.dev/docs/contributing/overview

Happy contributing!

-->


## Motivation

When a resource name is too long, it makes the icon shrink. 

Before:
<img width="250" alt="Screenshot 2025-04-02 at 12 09 29" src="https://github.com/user-attachments/assets/d8cb0f9a-5d7d-4a22-884a-27b1c3a22b26" /><img width="250" alt="Screenshot 2025-04-02 at 12 10 05" src="https://github.com/user-attachments/assets/d9cfc260-81d7-4d31-9976-be9e4b7f86a8" />

After:
<img width="250" alt="Screenshot 2025-04-02 at 12 10 32" src="https://github.com/user-attachments/assets/eee40ee8-74d7-40bd-97bc-37c13b8663d1" /><img width="250" alt="Screenshot 2025-04-02 at 12 10 18" src="https://github.com/user-attachments/assets/fb573510-2d56-4d69-9b3b-30922338f627" />

> [!WARNING]
> Please let me know if this isn't the right way to fix the issue. I'm not a web developer 😅 



