### PR TITLE
feat(core): fixes and improvements for ResourceLink

### DIFF
--- a/.changeset/fair-plums-march.md
+++ b/.changeset/fair-plums-march.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/core': patch
+---
+
+feat(core): fixes and improvements for ResourceLink

--- a/eventcatalog/src/components/MDX/ResourceLink/ResourceLink.astro
+++ b/eventcatalog/src/components/MDX/ResourceLink/ResourceLink.astro
@@ -8,6 +8,7 @@ const collection = resourceToCollectionMap[type as keyof typeof resourceToCollec
 
 let slotHTML = await Astro.slots.render('default');
 let href = '#';
+let linkHasError = false;
 
 try {
   if (collection === 'users' || collection === 'teams') {
@@ -18,6 +19,7 @@ try {
     href = buildUrl(`/docs/${collection}/${id}`);
   } else {
     const resourcesCollection = await getCollection(collection);
+
     const resources = getItemsFromCollectionByIdAndSemverOrLatest(resourcesCollection, id, version);
     const resource = resources[0];
 
@@ -26,7 +28,23 @@ try {
   }
 } catch (error) {
   console.error(`Failed to fetch related resource: ${id} of type ${type}`, error);
+  linkHasError = true;
+  slotHTML = id;
 }
 ---
 
-<a href={href} class="text-purple-500 hover:text-purple-700">{slotHTML}</a>
+{
+  linkHasError && (
+    <a href={href} class="text-red-500 hover:text-red-700">
+      ⚠️ {slotHTML} (broken link)
+    </a>
+  )
+}
+
+{
+  !linkHasError && (
+    <a href={href} class="text-purple-500 hover:text-purple-700">
+      {slotHTML}
+    </a>
+  )
+}

--- a/eventcatalog/src/components/MDX/ResourceLink/ResourceLink.astro
+++ b/eventcatalog/src/components/MDX/ResourceLink/ResourceLink.astro
@@ -1,23 +1,32 @@
 ---
 import { buildUrl } from '@utils/url-builder';
-import { resourceToCollectionMap } from '@utils/collections/util';
+import { getItemsFromCollectionByIdAndSemverOrLatest, resourceToCollectionMap } from '@utils/collections/util';
+import { getCollection } from 'astro:content';
 
 const { id, version, type } = Astro.props;
 const collection = resourceToCollectionMap[type as keyof typeof resourceToCollectionMap];
+
+let slotHTML = await Astro.slots.render('default');
+let href = '#';
+
+try {
+  if (collection === 'users' || collection === 'teams') {
+    const resources = await getCollection(collection, (resource) => resource.data.id === id);
+    const resource = resources[0];
+
+    slotHTML = slotHTML || resource.data.name;
+    href = buildUrl(`/docs/${collection}/${id}`);
+  } else {
+    const resourcesCollection = await getCollection(collection);
+    const resources = getItemsFromCollectionByIdAndSemverOrLatest(resourcesCollection, id, version);
+    const resource = resources[0];
+
+    slotHTML = slotHTML || resource.data.name;
+    href = buildUrl(`/docs/${collection}/${id}/${resource.data.version}`);
+  }
+} catch (error) {
+  console.error(`Failed to fetch related resource: ${id} of type ${type}`, error);
+}
 ---
 
-{
-  version && (
-    <a href={buildUrl(`/docs/${collection}/${id}/${version}`)} class="text-purple-500 hover:text-purple-700">
-      <slot />
-    </a>
-  )
-}
-
-{
-  !version && (
-    <a href={buildUrl(`/docs/${collection}/${id}`)} class="text-purple-500 hover:text-purple-700">
-      <slot />
-    </a>
-  )
-}
+<a href={href} class="text-purple-500 hover:text-purple-700">{slotHTML}</a>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://www.eventcatalog.dev/docs/contributing/overview

Happy contributing!

-->

## Changes

- (fix) Avoid trailing and leading whitespaces. Trailing underline appears when text is placed directly after the component.
```
<ResourceLink type="domain" id="Orders">Orders</ResourceLink> test
```
<img width="132" alt="Screenshot 2025-04-02 at 19 42 32" src="https://github.com/user-attachments/assets/d52f9367-cb04-4e72-b2c1-c6db962cdc11" />
<img width="749" alt="Screenshot 2025-04-02 at 19 42 56" src="https://github.com/user-attachments/assets/09889072-492e-4212-876d-bd825717b03d" />

- (fix|improvement) When no version is specified, point to the latest version instead of `/docs/${collection}/${id}`. 
  - The redirect pages are not generated for flows and queries ([source](https://github.com/event-catalog/eventcatalog/blob/main/eventcatalog/src/pages/docs/%5Btype%5D/%5Bid%5D/index.astro#L34)). The current implementation just points to a non existing page. 
  - This also avoids the needless intermediate redirect 
- (improvement) Fallback to resource name if no slot content provided.  I’d assume in most cases users will want to use the name, not custom text. By the way, the example in the [documentation](https://www.eventcatalog.dev/docs/development/components/components/resource-link) `<ResourceLink id="InventoryService" type="service" />` is a bit confusing - as-is, it produces no visible link 😄 
- (improvement) Log if failed to resolve the resource. Will help to catch mistakes in documentation. I wonder if it would be better to just fail and force the author to correct the mistake right away.



