### PR TITLE
fix/glob-loaders-lookup-node modules

### DIFF
--- a/.changeset/light-planes-work.md
+++ b/.changeset/light-planes-work.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix(core): astro loaders no longer read node_modules

--- a/eventcatalog/src/content.config.ts
+++ b/eventcatalog/src/content.config.ts
@@ -14,7 +14,7 @@ export const projectDirBase = (() => {
 
 const pages = defineCollection({
   loader: glob({
-    pattern: ['**/pages/*.(md|mdx)'],
+    pattern: ['**/pages/*.(md|mdx)', '!**/node_modules/**'],
     base: projectDirBase,
   }),
   schema: z
@@ -43,7 +43,7 @@ const resourcePointer = z.object({
 
 const changelogs = defineCollection({
   loader: glob({
-    pattern: ['**/changelog.(md|mdx)'],
+    pattern: ['**/changelog.(md|mdx)', '!**/node_modules/**'],
     base: projectDirBase,
   }),
   schema: z.object({
@@ -133,7 +133,7 @@ const flowStep = z
 
 const flows = defineCollection({
   loader: glob({
-    pattern: ['**/flows/*/index.(md|mdx)', '**/flows/*/versioned/*/index.(md|mdx)'],
+    pattern: ['**/flows/*/index.(md|mdx)', '**/flows/*/versioned/*/index.(md|mdx)', '!**/node_modules/**'],
     base: projectDirBase,
     generateId: ({ data }) => {
       return `${data.id}-${data.version}`;
@@ -203,7 +203,7 @@ const flows = defineCollection({
 
 const events = defineCollection({
   loader: glob({
-    pattern: ['**/events/*/index.(md|mdx)', '**/events/*/versioned/*/index.(md|mdx)'],
+    pattern: ['**/events/*/index.(md|mdx)', '**/events/*/versioned/*/index.(md|mdx)', '!**/node_modules/**'],
     base: projectDirBase,
     generateId: ({ data, ...rest }) => {
       return `${data.id}-${data.version}`;
@@ -222,7 +222,7 @@ const events = defineCollection({
 
 const commands = defineCollection({
   loader: glob({
-    pattern: ['**/commands/*/index.(md|mdx)', '**/commands/*/versioned/*/index.(md|mdx)'],
+    pattern: ['**/commands/*/index.(md|mdx)', '**/commands/*/versioned/*/index.(md|mdx)', '!**/node_modules/**'],
     base: projectDirBase,
     generateId: ({ data }) => {
       return `${data.id}-${data.version}`;
@@ -241,7 +241,7 @@ const commands = defineCollection({
 
 const queries = defineCollection({
   loader: glob({
-    pattern: ['**/queries/*/index.(md|mdx)', '**/queries/*/versioned/*/index.(md|mdx)'],
+    pattern: ['**/queries/*/index.(md|mdx)', '**/queries/*/versioned/*/index.(md|mdx)', '!**/node_modules/**'],
     base: projectDirBase,
     generateId: ({ data }) => {
       return `${data.id}-${data.version}`;
@@ -309,7 +309,7 @@ const domains = defineCollection({
 
 const channels = defineCollection({
   loader: glob({
-    pattern: ['**/channels/*/index.(md|mdx)', '**/channels/*/versioned/*/index.(md|mdx)'],
+    pattern: ['**/channels/*/index.(md|mdx)', '**/channels/*/versioned/*/index.(md|mdx)', '!**/node_modules/**'],
     base: projectDirBase,
     generateId: ({ data }) => {
       return `${data.id}-${data.version}`;

--- a/scripts/build-ci.js
+++ b/scripts/build-ci.js
@@ -27,4 +27,9 @@ execSync(`cross-env NODE_ENV=CI PROJECT_DIR=${projectDIR} CATALOG_DIR=${catalogD
 // Type check
 execSync(`pnpm exec astro check --minimumSeverity error --root ${catalogDir}`, {
   stdio: 'inherit',
+  env: {
+    ...process.env,
+    CATALOG_DIR: catalogDir,
+    PROJECT_DIR: projectDIR,
+  },
 });

--- a/scripts/build-ci.js
+++ b/scripts/build-ci.js
@@ -28,7 +28,6 @@ execSync(`cross-env NODE_ENV=CI PROJECT_DIR=${projectDIR} CATALOG_DIR=${catalogD
 execSync(`pnpm exec astro check --minimumSeverity error --root ${catalogDir}`, {
   stdio: 'inherit',
   env: {
-    ...process.env,
     CATALOG_DIR: catalogDir,
     PROJECT_DIR: projectDIR,
   },


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://www.eventcatalog.dev/docs/contributing/overview

Happy contributing!

-->

## Motivation

Glob patterns without a base path (e.g., `**/changelog.(md|mdx)`) cause the Astro loader to search inside `node_modules/`, as noted by @otbe in #1285.
This PR updates the glob patterns to explicitly exclude `node_modules`.

## Related Issue
- Closes #1285 
