### PR TITLE
fix: add missing mdx components to changelog pages

### DIFF
--- a/.changeset/sweet-carrots-lie.md
+++ b/.changeset/sweet-carrots-lie.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix(core): changelogs now support EventCatalog components

--- a/eventcatalog/src/pages/docs/[type]/[id]/[version]/changelog/index.astro
+++ b/eventcatalog/src/pages/docs/[type]/[id]/[version]/changelog/index.astro
@@ -13,6 +13,7 @@ import {
 } from '@heroicons/react/24/outline';
 import { pageDataLoader } from '@utils/page-loaders/page-data-loader';
 import { render, getEntry } from 'astro:content';
+import mdxComponents from '@components/MDX/components';
 import 'diff2html/bundles/css/diff2html.min.css';
 
 import { buildUrl } from '@utils/url-builder';
@@ -226,7 +227,7 @@ const pages = [
                     </div>
                   )}
                   <div class="prose prose-md !max-w-none py-2">
-                    <log.Content />
+                    <log.Content components={mdxComponents(props)} />
                   </div>
                   {log.diffs && log.diffs.map((diff) => <div id="diff-container" set:html={diff} />)}
                 </div>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://www.eventcatalog.dev/docs/contributing/overview

Happy contributing!

-->

## Motivation

Changelog pages don't pass MDX components, leading to missing import errors, as noted in #1339.

## Related Issues
- Closes #1339 
