### PR TITLE
fix(core): add colors for missing types in NodeGraph legend

### DIFF
--- a/.changeset/afraid-lizards-draw.md
+++ b/.changeset/afraid-lizards-draw.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/core': patch
+---
+
+fix(core): add colors for missing types in NodeGraph legend

--- a/eventcatalog/src/components/MDX/NodeGraph/NodeGraph.tsx
+++ b/eventcatalog/src/components/MDX/NodeGraph/NodeGraph.tsx
@@ -230,21 +230,24 @@ const NodeGraphBuilder = ({
   );
 
   const getNodesByCollectionWithColors = useCallback((nodes: Node[]) => {
-    const colors = {
-      events: 'orange',
-      services: 'pink',
-      commands: 'blue',
-      queries: 'green',
-      channels: 'gray',
+    const colorClasses = {
+      events: 'bg-orange-600',
+      services: 'bg-pink-600',
+      commands: 'bg-blue-600',
+      queries: 'bg-green-600',
+      channels: 'bg-gray-600',
+      externalSystem: 'bg-pink-600',
+      actor: 'bg-yellow-500',
+      step: 'bg-gray-700',
     };
 
-    return nodes.reduce((acc: { [key: string]: { count: number; color: string } }, node) => {
+    return nodes.reduce((acc: { [key: string]: { count: number; colorClass: string } }, node) => {
       const collection = node.type;
       if (collection) {
         if (acc[collection]) {
           acc[collection].count += 1;
         } else {
-          acc[collection] = { count: 1, color: colors[collection as keyof typeof colors] || 'black' };
+          acc[collection] = { count: 1, colorClass: colorClasses[collection as keyof typeof colorClasses] || 'bg-black' };
         }
       }
       return acc;
@@ -346,13 +349,13 @@ const NodeGraphBuilder = ({
         <Panel position="bottom-right">
           <div className=" bg-white font-light px-4 text-[12px] shadow-md py-1 rounded-md">
             <ul className="m-0 p-0 ">
-              {Object.entries(legend).map(([key, { count, color }]) => (
+              {Object.entries(legend).map(([key, { count, colorClass }]) => (
                 <li
                   key={key}
                   className="flex space-x-2 items-center text-[10px] cursor-pointer hover:text-purple-600 hover:underline"
                   onClick={() => handleLegendClick(key)}
                 >
-                  <span className={`w-2 h-2 block`} style={{ backgroundColor: color }} />
+                  <span className={`w-2 h-2 block ${colorClass}`} />
                   <span className="block capitalize">
                     {key} ({count})
                   </span>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://www.eventcatalog.dev/docs/contributing/overview

Happy contributing!

-->

## Motivation

- add colors for missing types in NodeGraph legend
- use the midpoint color of the node gradient for easier association

<img width="147" alt="Screenshot 2025-04-04 at 11 59 41" src="https://github.com/user-attachments/assets/9f6b000b-c260-46e9-94d4-6c2f010cd84a" />
<img width="143" alt="Screenshot 2025-04-04 at 13 03 28" src="https://github.com/user-attachments/assets/b9455f20-e020-4fa8-a20e-8a503a071d15" />


