### PR TITLE
feat: add Chromatic component

### DIFF
--- a/eventcatalog/src/components/MDX/Chromatic/Chromatic.astro
+++ b/eventcatalog/src/components/MDX/Chromatic/Chromatic.astro
@@ -1,0 +1,58 @@
+---
+import Admonition from '@components/MDX/Admonition';
+
+interface Props {
+  title?: string;
+  height: string;
+  appId: string;
+  uploadHash: string;
+  id: string;
+  singleStory: boolean;
+  viewMode: 'story' | 'docs';
+}
+
+const { title, height = '500', appId, uploadHash, id, viewMode = 'story', singleStory = true } = Astro.props;
+
+if (viewMode !== 'story' && viewMode !== 'docs') {
+  throw new Error(`Invalid viewMode: ${viewMode}. Allowed values are "story" or "docs".`);
+}
+
+const params = {
+  id: id,
+  viewMode: viewMode,
+  singleStory: `${singleStory}`,
+};
+
+const url = new URL(`https://${appId}-${uploadHash}.chromatic.com/iframe.html`);
+Object.entries(params).forEach(([key, value]) => {
+  if (value !== undefined) {
+    url.searchParams.set(key, value);
+  }
+});
+---
+
+{
+  !appId && !uploadHash && id && (
+    <Admonition type="warning">
+      <div>
+        <span class="block font-bold">{`<Chromatic />`} failed to load</span>
+        <span class="block">Please provide appId, uploadHash and id to use the Chromatic component.</span>
+      </div>
+    </Admonition>
+  )
+}
+
+{
+  appId && uploadHash && id && (
+    <div>
+      {title && (
+        <h3 id={`${title}-chromatic-title`} class="text-3xl font-bold">
+          {title}
+        </h3>
+      )}
+      <div class="relative">
+        <iframe class="border border-gray-200 rounded-md" src={url.href} width="100%" height={height} />
+      </div>
+    </div>
+  )
+}

--- a/eventcatalog/src/components/MDX/components.tsx
+++ b/eventcatalog/src/components/MDX/components.tsx
@@ -19,6 +19,7 @@ import TabItem from '@components/MDX/Tabs/TabItem.astro';
 import ResourceLink from '@components/MDX/ResourceLink/ResourceLink.astro';
 import Link from '@components/MDX/Link/Link.astro';
 import Miro from '@components/MDX/Miro/Miro.astro';
+import Chromatic from './Chromatic/Chromatic.astro';
 //  Portals: required for server/client components
 import NodeGraphPortal from '@components/MDX/NodeGraph/NodeGraphPortal';
 import SchemaViewerPortal from '@components/MDX/SchemaViewer/SchemaViewerPortal';
@@ -48,6 +49,7 @@ const components = (props: any) => {
     Tile,
     Tiles,
     Miro: (mdxProp: any) => jsx(Miro, { ...props, ...mdxProp }),
+    Chromatic: (mdxProp: any) => jsx(Chromatic, { ...props, ...mdxProp }),
   };
 };
 

--- a/examples/default/domains/Orders/index.mdx
+++ b/examples/default/domains/Orders/index.mdx
@@ -33,7 +33,6 @@ resourceGroups:
 import Footer from '@catalog/components/footer.astro';
 
 
-
 :::warning
 
 Please ensure all services are **updated** to the latest version for compatibility and performance improvements.
@@ -93,4 +92,14 @@ Documented flow when a user makes a payment within the order domain
 
 <ResourceGroupTable id="related-resources" limit={4} showOwners={true} title="Core resources for the Orders domain" description="Resources that are related to the Orders domain, you may find them useful" />
 
+
+## Related resources
+
+<Chromatic title="Shadow Box cta" appId="5ccbc373887ca40020446347" uploadHash="bysekhynzd" id="shadowboxcta--default" viewMode="docs" singleStory="false"  />
+
+<Chromatic title="Avatar" appId="5ccbc373887ca40020446347" uploadHash="bysekhynzd" id="avatar--large" />
+
 <Footer />
+
+
+```


### PR DESCRIPTION
## Motivation


This pull request introduces a new `Chromatic` component to the project and integrates it into the existing codebase. The changes include the creation of the `Chromatic` component, its importation into the components list, and its usage in the `Orders` domain documentation.

### Introduction of `Chromatic` component:

* [`eventcatalog/src/components/MDX/Chromatic/Chromatic.astro`](diffhunk://#diff-c1fcd7257396d7777fe31123ade0e3ad42577fa71398abdee55109128e670b8cR1-R58): Added a new `Chromatic` component that embeds a Chromatic iframe and handles various properties such as `title`, `height`, `appId`, `uploadHash`, `id`, and `viewMode`. It includes validation for `viewMode` and displays an admonition if required properties are missing.


![Screenshot 2025-04-08 at 19 11 47](https://github.com/user-attachments/assets/6ef07f84-b65a-4d6b-ad5e-7fe1b78bc18e)