### PR TITLE
fix(core): fix versions list in changelog

### DIFF
--- a/.changeset/flat-days-smile.md
+++ b/.changeset/flat-days-smile.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/core': patch
+---
+
+fix(core): fix versions list in changelog

--- a/eventcatalog/src/pages/docs/[type]/[id]/[version]/changelog/index.astro
+++ b/eventcatalog/src/pages/docs/[type]/[id]/[version]/changelog/index.astro
@@ -17,7 +17,7 @@ import mdxComponents from '@components/MDX/components';
 import 'diff2html/bundles/css/diff2html.min.css';
 
 import { buildUrl } from '@utils/url-builder';
-import { getVersionForCollectionItem, getPreviousVersion } from '@utils/collections/util';
+import { getPreviousVersion } from '@utils/collections/util';
 import { getDiffsForCurrentAndPreviousVersion } from '@utils/collections/file-diffs';
 import VerticalSideBarLayout from '@layouts/VerticalSideBarLayout.astro';
 import { ClientRouter } from 'astro:transitions';
@@ -35,7 +35,6 @@ export async function getStaticPaths() {
       },
       props: {
         type: itemTypes[index],
-        allVersionsForItem: getVersionForCollectionItem(item, items).versions,
         allCollectionItems: items,
         ...item,
       },
@@ -67,7 +66,7 @@ const logsToRender = await Promise.all(renderedLogs);
 
 const logListPromise = logsToRender.map(async (log, index) => {
   const currentLogVersion = log.data.version;
-  const previousLogVersion = log.data.version ? getPreviousVersion(log.data.version, props.allVersionsForItem) : '';
+  const previousLogVersion = log.data.version ? getPreviousVersion(log.data.version, data.versions) : '';
   return {
     id: log.id,
     url: buildUrl(`/docs/${props.collection}/${props.data.id}`),

--- a/eventcatalog/src/pages/docs/[type]/[id]/[version]/changelog/index.astro
+++ b/eventcatalog/src/pages/docs/[type]/[id]/[version]/changelog/index.astro
@@ -17,7 +17,7 @@ import mdxComponents from '@components/MDX/components';
 import 'diff2html/bundles/css/diff2html.min.css';
 
 import { buildUrl } from '@utils/url-builder';
-import { getVersions, getPreviousVersion } from '@utils/collections/util';
+import { getVersionForCollectionItem, getPreviousVersion } from '@utils/collections/util';
 import { getDiffsForCurrentAndPreviousVersion } from '@utils/collections/file-diffs';
 import VerticalSideBarLayout from '@layouts/VerticalSideBarLayout.astro';
 import { ClientRouter } from 'astro:transitions';
@@ -35,7 +35,7 @@ export async function getStaticPaths() {
       },
       props: {
         type: itemTypes[index],
-        allVersionsForCollection: getVersions(items).versions,
+        allVersionsForItem: getVersionForCollectionItem(item, items).versions,
         allCollectionItems: items,
         ...item,
       },
@@ -67,7 +67,7 @@ const logsToRender = await Promise.all(renderedLogs);
 
 const logListPromise = logsToRender.map(async (log, index) => {
   const currentLogVersion = log.data.version;
-  const previousLogVersion = log.data.version ? getPreviousVersion(log.data.version, props.allVersionsForCollection) : '';
+  const previousLogVersion = log.data.version ? getPreviousVersion(log.data.version, props.allVersionsForItem) : '';
   return {
     id: log.id,
     url: buildUrl(`/docs/${props.collection}/${props.data.id}`),


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://www.eventcatalog.dev/docs/contributing/overview

Happy contributing!

-->

## Motivation

When rendering changelog pages, the version list includes versions from all items in the collection, rather than only the item the changelog is being generated for. This causes the previous version to be calculated incorrectly, resulting in a missing diff between the current and the actual previous version.

For example:
- the resource for which the changelog is being generated has versions 2.0.0 and 1.0.0.
- there is another resource in the same collection with version 1.5.0.

In this case, the system incorrectly identifies 1.5.0 as the previous version instead of 1.0.0, resulting in the diff being calculated between 2.0.0 and 1.5.0.