### PR TITLE
fix(core): use the node label in simple mode too

### DIFF
--- a/.changeset/small-bees-shake.md
+++ b/.changeset/small-bees-shake.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/core': patch
+---
+
+fix(core): use the node label in `simple` mode too

--- a/eventcatalog/src/components/MDX/NodeGraph/Nodes/Channel.tsx
+++ b/eventcatalog/src/components/MDX/NodeGraph/Nodes/Channel.tsx
@@ -106,7 +106,9 @@ export default function ChannelNode({ data, sourcePosition, targetPosition }: an
               </div>
               <div className="flex justify-between">
                 <span className="text-[10px] font-light block pt-0.5 pb-0.5 ">v{version}</span>
-                {mode === 'simple' && <span className="text-[10px] text-gray-500 font-light block pt-0.5 pb-0.5 ">Channel</span>}
+                {mode === 'simple' && (
+                  <span className="text-[10px] text-gray-500 font-light block pt-0.5 pb-0.5 ">{nodeLabel}</span>
+                )}
               </div>
             </div>
             {mode === 'full' && (

--- a/eventcatalog/src/components/MDX/NodeGraph/Nodes/Command.tsx
+++ b/eventcatalog/src/components/MDX/NodeGraph/Nodes/Command.tsx
@@ -54,7 +54,9 @@ export default function CommandNode({ data, sourcePosition, targetPosition }: an
             <span className="text-xs font-bold block pb-0.5">{name}</span>
             <div className="flex justify-between">
               <span className="text-[10px] font-light block pt-0.5 pb-0.5 ">v{version}</span>
-              {mode === 'simple' && <span className="text-[10px] text-gray-500 font-light block pt-0.5 pb-0.5 ">Command</span>}
+              {mode === 'simple' && (
+                <span className="text-[10px] text-gray-500 font-light block pt-0.5 pb-0.5 ">{nodeLabel}</span>
+              )}
             </div>
           </div>
           {mode === 'full' && (

--- a/eventcatalog/src/components/MDX/NodeGraph/Nodes/Custom.tsx
+++ b/eventcatalog/src/components/MDX/NodeGraph/Nodes/Custom.tsx
@@ -101,7 +101,7 @@ export default function UserNode({ data, sourcePosition, targetPosition }: any) 
 
             {(!summary || mode !== 'full') && (
               <div className="h-full ">
-                <span className="text-sm font-bold block pb-0.5 block w-full">{title}</span>
+                <span className="text-sm font-bold block pb-0.5 w-full">{title}</span>
               </div>
             )}
 

--- a/eventcatalog/src/components/MDX/NodeGraph/Nodes/Event.tsx
+++ b/eventcatalog/src/components/MDX/NodeGraph/Nodes/Event.tsx
@@ -52,7 +52,9 @@ export default function EventNode({ data, sourcePosition, targetPosition }: any)
             <span className="text-xs font-bold block pb-0.5">{name}</span>
             <div className="flex justify-between">
               <span className="text-[10px] font-light block pt-0.5 pb-0.5 ">v{version}</span>
-              {mode === 'simple' && <span className="text-[10px] text-gray-500 font-light block pt-0.5 pb-0.5 ">Event</span>}
+              {mode === 'simple' && (
+                <span className="text-[10px] text-gray-500 font-light block pt-0.5 pb-0.5 ">{nodeLabel}</span>
+              )}
             </div>
           </div>
           {mode === 'full' && (

--- a/eventcatalog/src/components/MDX/NodeGraph/Nodes/Query.tsx
+++ b/eventcatalog/src/components/MDX/NodeGraph/Nodes/Query.tsx
@@ -53,7 +53,9 @@ export default function QueryNode({ data, sourcePosition, targetPosition }: any)
             <span className="text-xs font-bold block pb-0.5">{name}</span>
             <div className="flex justify-between">
               <span className="text-[10px] font-light block pt-0.5 pb-0.5 ">v{version}</span>
-              {mode === 'simple' && <span className="text-[10px] text-gray-500 font-light block pt-0.5 pb-0.5 ">Query</span>}
+              {mode === 'simple' && (
+                <span className="text-[10px] text-gray-500 font-light block pt-0.5 pb-0.5 ">{nodeLabel}</span>
+              )}
             </div>
           </div>
           {mode === 'full' && (

--- a/eventcatalog/src/components/MDX/NodeGraph/Nodes/Service.tsx
+++ b/eventcatalog/src/components/MDX/NodeGraph/Nodes/Service.tsx
@@ -59,7 +59,9 @@ export default function ServiceNode({ data, sourcePosition, targetPosition }: an
               <span className="text-xs font-bold block pt-0.5 pb-0.5">{name}</span>
               <div className="flex justify-between">
                 <span className="text-[10px] font-light block pt-0.5 pb-0.5 ">v{version}</span>
-                {mode === 'simple' && <span className="text-[10px] text-gray-500 font-light block pt-0.5 pb-0.5 ">Service</span>}
+                {mode === 'simple' && (
+                  <span className="text-[10px] text-gray-500 font-light block pt-0.5 pb-0.5 ">{nodeLabel}</span>
+                )}
               </div>
             </div>
             {mode === 'full' && (

--- a/eventcatalog/src/components/MDX/NodeGraph/Nodes/User.tsx
+++ b/eventcatalog/src/components/MDX/NodeGraph/Nodes/User.tsx
@@ -47,7 +47,7 @@ export default function UserNode({ data, sourcePosition, targetPosition }: any) 
 
         {(!summary || mode !== 'full') && (
           <div className="h-full ">
-            <span className="text-sm font-bold block pb-0.5 block w-full">{name}</span>
+            <span className="text-sm font-bold block pb-0.5 w-full">{name}</span>
             {mode === 'simple' && (
               <div className="w-full text-right">
                 <span className=" w-full text-[10px] text-gray-500 font-light block pt-0.5 pb-0.5 ">Event</span>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://www.eventcatalog.dev/docs/contributing/overview

Happy contributing!

-->

## Motivation

As of now, the node label is used only in the full mode. This PR add is to the simple mode.
