### PR TITLE
fix(core): style of sidebar labels

### DIFF
--- a/.changeset/mean-lemons-rescue.md
+++ b/.changeset/mean-lemons-rescue.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/core': patch
+---
+
+fix(core): style of sidebar labels

--- a/eventcatalog/src/components/Lists/ProtocolList.tsx
+++ b/eventcatalog/src/components/Lists/ProtocolList.tsx
@@ -41,7 +41,7 @@ const ProtocolList = ({ title, pills, emptyMessage, color = 'gray', ...props }: 
       <div className="mx-auto w-full max-w-lg divide-y divide-white/5 rounded-xl bg-white/5">
         <Disclosure as="div" className="pb-8" defaultOpen={pills.length <= 10}>
           <DisclosureButton className="group flex w-full items-center justify-start space-x-4">
-            <span className="text-sm text-black group-data-[hover]:text-black/80 capitalize"> {title} </span>
+            <span className="text-sm text-black font-semibold group-data-[hover]:text-black/80 capitalize"> {title} </span>
             <ChevronDownIcon className="size-5 ml-2 fill-black/60 group-data-[hover]:fill-black/50 group-data-[open]:rotate-180" />
           </DisclosureButton>
           <DisclosurePanel className="mt-2 text-sm/5 text-black/50">

--- a/eventcatalog/src/components/SideBars/ChannelSideBar.astro
+++ b/eventcatalog/src/components/SideBars/ChannelSideBar.astro
@@ -80,7 +80,7 @@ const messageList = (channel.data.messages ?? []).map((p) => ({
     {
       channel.data.versions && (
         <VersionList
-          title={`Channel versions (${channel.data.versions?.length})`}
+          title={`Versions (${channel.data.versions?.length})`}
           versions={channel.data.versions}
           collectionItem={channel}
         />
@@ -88,7 +88,7 @@ const messageList = (channel.data.messages ?? []).map((p) => ({
     }
 
     <OwnersList
-      title={`Channel owners (${filteredOwners.length})`}
+      title={`Owners (${filteredOwners.length})`}
       owners={ownersList}
       emptyMessage={`This channel does not have any documented owners.`}
       client:load
@@ -102,7 +102,7 @@ const messageList = (channel.data.messages ?? []).map((p) => ({
 
     {
       paramsList.length > 0 && (
-        <PillListFlat color="pink" title={`Channel parameters (${paramsList.length})`} pills={paramsList} client:load />
+        <PillListFlat color="pink" title={`Parameters (${paramsList.length})`} pills={paramsList} client:load />
       )
     }
 

--- a/eventcatalog/src/components/SideBars/DomainSideBar.astro
+++ b/eventcatalog/src/components/SideBars/DomainSideBar.astro
@@ -167,7 +167,7 @@ const ownersList = filteredOwners.map((o) => ({
       )
     }
     <OwnersList
-      title={`Domain owners (${ownersList.length})`}
+      title={`Owners (${ownersList.length})`}
       owners={ownersList}
       emptyMessage={`This domain does not have any documented owners.`}
       client:load

--- a/eventcatalog/src/components/SideBars/FlowSideBar.astro
+++ b/eventcatalog/src/components/SideBars/FlowSideBar.astro
@@ -40,7 +40,7 @@ const isRSSEnabled = config.rss?.enabled;
     {flow.data.versions && <VersionList versions={flow.data.versions} collectionItem={flow} />}
 
     <OwnersList
-      title={`Flow owners (${ownersList.length})`}
+      title={`Owners (${ownersList.length})`}
       owners={ownersList}
       emptyMessage={`This flow does not have any documented owners.`}
       client:load
@@ -49,7 +49,7 @@ const isRSSEnabled = config.rss?.enabled;
     {
       isRSSEnabled && (
         <div class="mx-auto pb-4 w-full max-w-lg divide-y divide-white/5 rounded-xl bg-white/5 border-b border-gray-100 mb-4">
-          <span class="text-sm text-black group-data-[hover]:text-black/80 capitalize">Flow RSS Feed</span>
+          <span class="text-sm text-black font-semibold group-data-[hover]:text-black/80 capitalize">Flow RSS Feed</span>
           <ul role="list" class="space-y-2 mt-2">
             <li class="has-tooltip rounded-md text-gray-600 group px-1 w-full hover:bg-gradient-to-l hover:from-purple-500 hover:to-purple-700 hover:text-white hover:font-normal  ">
               <a class={`flex items-center space-x-2`} target="_blank" href={buildUrl(`/rss/flows/rss.xml`)}>

--- a/eventcatalog/src/components/SideBars/MessageSideBar.astro
+++ b/eventcatalog/src/components/SideBars/MessageSideBar.astro
@@ -110,7 +110,7 @@ const schemaURL = path.join(publicPath, schemaFilePath || '');
       producerList.length > 0 && (
         <PillListFlat
           color="pink"
-          title={`${type} Producers (${producerList.length})`}
+          title={`Producers (${producerList.length})`}
           pills={producerList}
           emptyMessage={getProducerEmptyMessage(type)}
           client:load
@@ -121,7 +121,7 @@ const schemaURL = path.join(publicPath, schemaFilePath || '');
       consumerList.length > 0 && (
         <PillListFlat
           color="pink"
-          title={`${type} Consumers (${consumerList.length})`}
+          title={`Consumers (${consumerList.length})`}
           pills={consumerList}
           emptyMessage={getConsumerEmptyMessage(type)}
           client:load
@@ -137,7 +137,7 @@ const schemaURL = path.join(publicPath, schemaFilePath || '');
     {
       message.data.versions && (
         <VersionList
-          title={`${type} versions (${message.data.versions?.length})`}
+          title={`Versions (${message.data.versions?.length})`}
           versions={message.data.versions}
           collectionItem={message}
         />
@@ -145,7 +145,7 @@ const schemaURL = path.join(publicPath, schemaFilePath || '');
     }
 
     <OwnersList
-      title={`${type} owners (${ownersList.length})`}
+      title={`Owners (${ownersList.length})`}
       owners={ownersList}
       emptyMessage={`This ${type} does not have any documented owners.`}
       client:load
@@ -160,7 +160,7 @@ const schemaURL = path.join(publicPath, schemaFilePath || '');
     {
       isRSSEnabled && (
         <div class="mx-auto pb-8 w-full max-w-lg divide-y divide-white/5 rounded-xl bg-white/5">
-          <span class="text-sm text-black group-data-[hover]:text-black/80 capitalize">{type} RSS Feed</span>
+          <span class="text-sm text-black font-semibold group-data-[hover]:text-black/80 capitalize">{type} RSS Feed</span>
           <ul role="list" class="space-y-2 mt-2">
             <li class="has-tooltip rounded-md text-gray-600 group px-1 w-full hover:bg-gradient-to-l hover:from-purple-500 hover:to-purple-700 hover:text-white hover:font-normal  ">
               <a class={`flex items-center space-x-2`} target="_blank" href={buildUrl(`/rss/${message.collection}/rss.xml`)}>

--- a/eventcatalog/src/components/SideBars/ServiceSideBar.astro
+++ b/eventcatalog/src/components/SideBars/ServiceSideBar.astro
@@ -114,7 +114,7 @@ const schemaURL = join(publicPath, schemaFilePath || '');
     {service.data.specifications && <SpecificationsList collectionItem={service} />}
 
     <OwnersList
-      title={`Service owners (${ownersList.length})`}
+      title={`Owners (${ownersList.length})`}
       owners={ownersList}
       emptyMessage={`This service does not have any documented owners.`}
       client:load
@@ -129,7 +129,7 @@ const schemaURL = join(publicPath, schemaFilePath || '');
     {
       isRSSEnabled && (
         <div class="mx-auto pb-4 w-full max-w-lg divide-y divide-white/5 rounded-xl bg-white/5 border-b border-gray-100 mb-4">
-          <span class="text-sm text-black group-data-[hover]:text-black/80 capitalize">Services RSS Feed</span>
+          <span class="text-sm text-black font-semibold group-data-[hover]:text-black/80 capitalize">Services RSS Feed</span>
           <ul role="list" class="space-y-2 mt-2">
             <li class="has-tooltip rounded-md text-gray-600 group px-1 w-full hover:bg-gradient-to-l hover:from-purple-500 hover:to-purple-700 hover:text-white hover:font-normal  ">
               <a class={`flex items-center space-x-2`} target="_blank" href={buildUrl(`/rss/services/rss.xml`)}>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://www.eventcatalog.dev/docs/contributing/overview

Happy contributing!

-->

## Motivation

A small change to make style of sidebar labels consistent.
-  There is no need to have resource type in the label. If we are on a Service page, it is obvious that Owners stands for service owners. What we have right now:
   - ServiceSidebar: `Versions` but `Service Owners`
   - DomainSidebar: `Services` and `Versions` but `Domain Owners`
   - MessageSidebar: `QueryVersions`, `Query Owners`, ...
   - etc... 
- Make RSS and Channel protocols semibold to match other labels
