### PR TITLE
fix(core): propagate vite error in eventcatalog build correctly

### DIFF
--- a/.changeset/unlucky-numbers-invent.md
+++ b/.changeset/unlucky-numbers-invent.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/core': patch
+---
+
+fix(core): propagate vite error in eventcatalog build correctly

--- a/src/eventcatalog.ts
+++ b/src/eventcatalog.ts
@@ -214,7 +214,7 @@ program
 
     // Ignore any "Empty collection" messages, it's OK to have them
     const windowsCommand = `npx astro build ${command.args.join(' ').trim()} | findstr /V "The collection"`;
-    const unixCommand = `npx astro build ${command.args.join(' ').trim()} 2>&1 | grep -v "The collection.*does not exist"`;
+    const unixCommand = `bash -c "set -o pipefail; npx astro build ${command.args.join(' ').trim()} 2>&1 | grep -v \\"The collection.*does not exist\\""`;
 
     const buildCommand = process.platform === 'win32' ? windowsCommand : unixCommand;
 


### PR DESCRIPTION
## Motivation

Our gitlab pipelines showed as successful even though the eventcatalog build failed. The problem lies with the unix command executed with `execSync`. It's a small fix, just adding `bash -c "set -o pipefail;`
