### PR TITLE
fix(core): now loads the eventcatalog stylesheet

### DIFF
--- a/.changeset/silly-cycles-buy.md
+++ b/.changeset/silly-cycles-buy.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix(core): now loads the eventcatalog stylesheet

--- a/eventcatalog/src/layouts/VerticalSideBarLayout.astro
+++ b/eventcatalog/src/layouts/VerticalSideBarLayout.astro
@@ -45,6 +45,11 @@ const customDocs = await getCollection('customPages');
 
 import { isEventCatalogUpgradeEnabled } from '@utils/feature';
 
+// Try and load any custom styles if they exist
+try {
+  await import('../../eventcatalog.styles.css');
+} catch (error) {}
+
 const currentPath = Astro.url.pathname;
 
 const catalogHasDefaultLandingPageForDocs = await hasLandingPageForDocs();

--- a/src/catalog-to-astro-content-directory.js
+++ b/src/catalog-to-astro-content-directory.js
@@ -45,6 +45,11 @@ export const catalogToAstro = async (source, astroDir) => {
   // Verify required fields are in the catalog config file
   await verifyRequiredFieldsAreInCatalogConfigFile(source);
 
+  // If there is no eventcatalog.styles.css file, create one
+  if (!fs.existsSync(path.join(source, 'eventcatalog.styles.css'))) {
+    fs.writeFileSync(path.join(source, 'eventcatalog.styles.css'), '');
+  }
+
   await copyFiles(source, astroDir);
 };
 


### PR DESCRIPTION
EventCatalog will now load the `eventcatalog.styles.css` style sheet.