### PR TITLE
feat(core): added ability to embed any nodegraph in your docs

### DIFF
--- a/.changeset/four-games-juggle.md
+++ b/.changeset/four-games-juggle.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+feat(core): added ability to embed any nodegraph in your docs

--- a/eventcatalog/src/pages/docs/[type]/[id]/[version]/index.astro
+++ b/eventcatalog/src/pages/docs/[type]/[id]/[version]/index.astro
@@ -8,6 +8,8 @@ import NodeGraph from '@components/MDX/NodeGraph/NodeGraph.astro';
 import SchemaViewer from '@components/MDX/SchemaViewer/SchemaViewerRoot.astro';
 import Admonition from '@components/MDX/Admonition';
 
+import { resourceToCollectionMap, collectionToResourceMap } from '@utils/collections/util';
+
 // SideBars
 import ServiceSideBar from '@components/SideBars/ServiceSideBar.astro';
 import MessageSideBar from '@components/SideBars/MessageSideBar.astro';
@@ -41,6 +43,8 @@ import { buildUrl } from '@utils/url-builder';
 import { getSchemasFromResource } from '@utils/collections/schemas';
 import { isEventCatalogChatEnabled, isMarkdownDownloadEnabled } from '@utils/feature';
 
+import { getMDXComponentsByName } from '@utils/markdown';
+
 import config from '@config';
 
 export async function getStaticPaths() {
@@ -65,6 +69,7 @@ export async function getStaticPaths() {
 const props = Astro.props;
 
 const { Content } = await render(props);
+
 // const { Content } = await props.render();
 
 // Capitalize the first letter of a string
@@ -189,6 +194,15 @@ const generatePromptForResource = (props: any) => {
     Please tell me more about the ${props.collection.slice(0, props.collection.length - 1)} -  ${props.data.name} v${props.data.version} in this catalog.
   `;
 };
+
+// Handle node graphs in the markdown
+let nodeGraphs = getMDXComponentsByName(props.body || '', 'NodeGraph') || [];
+
+nodeGraphs.push({
+  id: props.data.id,
+  version: props.data.version,
+  type: collectionToResourceMap[props.collection as keyof typeof collectionToResourceMap],
+});
 ---
 
 <VerticalSideBarLayout title={pageTitle} description={props.data.summary}>
@@ -319,7 +333,29 @@ const generatePromptForResource = (props: any) => {
           <!-- @ts-ignore -->
           <!-- <SchemaViewer id={props.data.id} catalog={props.catalog} filePath={props.filePath} /> -->
           <SchemaViewer id={props.data.id} filePath={props.filePath} />
-          <NodeGraph
+
+          {
+            nodeGraphs.length > 0 &&
+              nodeGraphs.map((nodeGraph: any) => {
+                const collection = resourceToCollectionMap[nodeGraph.type as keyof typeof resourceToCollectionMap];
+                return (
+                  <NodeGraph
+                    id={nodeGraph.id}
+                    version={nodeGraph.version}
+                    collection={collection}
+                    title={nodeGraph.title}
+                    mode="simple"
+                    linksToVisualiser={true}
+                    href={{
+                      label: 'Open in Visualiser',
+                      url: buildUrl(`/visualiser/${collection}/${nodeGraph.id}/${nodeGraph.version}`),
+                    }}
+                  />
+                );
+              })
+          }
+
+          <!-- <NodeGraph
             id={props.data.id}
             collection={props.collection}
             version={props.data.version}
@@ -329,7 +365,7 @@ const generatePromptForResource = (props: any) => {
               label: 'Open in Visualiser',
               url: buildUrl(`/visualiser/${props.collection}/${props.data.id}/${props.data.version}`),
             }}
-          />
+          /> -->
         </div>
         <Footer />
       </div>

--- a/eventcatalog/src/pages/docs/[type]/[id]/[version]/index.astro
+++ b/eventcatalog/src/pages/docs/[type]/[id]/[version]/index.astro
@@ -354,18 +354,6 @@ nodeGraphs.push({
                 );
               })
           }
-
-          <!-- <NodeGraph
-            id={props.data.id}
-            collection={props.collection}
-            version={props.data.version}
-            mode="simple"
-            linksToVisualiser={true}
-            href={{
-              label: 'Open in Visualiser',
-              url: buildUrl(`/visualiser/${props.collection}/${props.data.id}/${props.data.version}`),
-            }}
-          /> -->
         </div>
         <Footer />
       </div>

--- a/eventcatalog/src/utils/collections/util.ts
+++ b/eventcatalog/src/utils/collections/util.ts
@@ -110,6 +110,18 @@ export const resourceToCollectionMap = {
   team: 'teams',
 } as const;
 
+export const collectionToResourceMap = {
+  services: 'service',
+  events: 'event',
+  commands: 'command',
+  queries: 'query',
+  domains: 'domain',
+  flows: 'flow',
+  channels: 'channel',
+  users: 'user',
+  teams: 'team',
+} as const;
+
 export const getDeprecatedDetails = (item: CollectionEntry<CollectionTypes>) => {
   let options = {
     isMarkedAsDeprecated: false,

--- a/examples/default/domains/E-Commerce/index.mdx
+++ b/examples/default/domains/E-Commerce/index.mdx
@@ -59,6 +59,10 @@ The E-Commerce domain is the core business domain of FlowMart, our modern digita
 
 ## Domain Overview
 
+The E-Commerce domain encapsulates all the core business logic for the FlowMart e-commerce platform. It is built on event-driven microservices architecture.
+
+<NodeGraph  />
+
 FlowMart's E-Commerce domain is built on event-driven microservices architecture, enabling:
 - Real-time inventory management across multiple warehouses
 - Seamless payment processing with multiple providers
@@ -67,7 +71,16 @@ FlowMart's E-Commerce domain is built on event-driven microservices architecture
 - Subscription-based shopping experiences
 - Advanced fraud detection and prevention
 
-## Sub domains
+## Core Domains for E-Commerce
+
+The <ResourceLink id="Orders" type="domain">Orders</ResourceLink> and <ResourceLink id="Subscription" type="domain">Subscription</ResourceLink> domains are core domains for the E-Commerce domain.
+
+<span class="not-prose">They are used to manage the orders and subscriptions for the E-Commerce domain.</span>
+
+<div class="grid grid-cols-2 gap-4 not-prose">
+  <NodeGraph id="Orders" version="0.0.3" type="domain" />
+  <NodeGraph id="Subscription" version="0.0.1" type="domain" />
+</div>
 
 The E-Commerce domain is built on the following sub domains:
 
@@ -76,26 +89,12 @@ The E-Commerce domain is built on the following sub domains:
 - <ResourceLink id="Subscription" type="domain">Subscription</ResourceLink> - Generic subscription domain handling users subscriptions
 
 
-
 ## Target Architecture (Event Storming Results)
 
 Our target architecture was defined through collaborative event storming sessions with product, engineering, and business stakeholders. This represents our vision for FlowMart's commerce capabilities.
 
 <Miro boardId="uXjVIHCImos=/" moveToWidget="3074457347671667709" edit={false} />
 
-## Target Architecture (Lucid Chart)
-
-First we used Lucid to create a detailed target architecture diagram, but moved to use EventStorming results for the final target architecture.
-
-Here is a reference to the Lucid diagram for the target architecture:
-
-<Lucid diagramId="e29f42a0-67e2-4f80-b0d7-6922bb7dd9c5" />
-
-## Current Production Architecture
-
-Our current event-driven architecture powering FlowMart's shopping experience:
-
-<NodeGraph />
 
 ### Order Processing Flow
 


### PR DESCRIPTION
Added ability to embed more than one node graph in docs.

<img width="1337" alt="Screenshot 2025-05-05 at 16 48 41" src="https://github.com/user-attachments/assets/32028ed1-d960-4ced-bef6-ddf96ffb4ae4" />


Example
```
<div class="grid grid-cols-2 gap-4 not-prose">
  <NodeGraph id="Orders" version="0.0.3" type="domain" />
  <NodeGraph id="Subscription" version="0.0.1" type="domain" />
</div>
```