### PR TITLE
fix(core): fix protocol icon nullability issue

### DIFF
--- a/.changeset/late-points-laugh.md
+++ b/.changeset/late-points-laugh.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix(core): fix protocol icon nullability issue

--- a/eventcatalog/src/utils/protocols.tsx
+++ b/eventcatalog/src/utils/protocols.tsx
@@ -10,6 +10,6 @@ const protocolIcons = Object.keys(ProtocolIcons).reduce(
 );
 
 export const getIconForProtocol = (icon: string) => {
-  const Icon = protocolIcons[icon.replace('-', '').toLowerCase()];
+  const Icon = protocolIcons[icon?.replace('-', '').toLowerCase()];
   return Icon ? (props: any) => <span {...props} dangerouslySetInnerHTML={{ __html: Icon }} /> : null;
 };


### PR DESCRIPTION
## Motivation
The protocol icon caused graphe being empty , giving following error in browser console 
<img width="713" alt="Screenshot 2025-05-07 at 17 06 49" src="https://github.com/user-attachments/assets/3230de9f-bd3e-43d9-860d-8b174098857f" />

The issue is happening only if a channel does not provide protocols property in markdown