### PR TITLE
feat(core): added ability to turn of visualizer per resource

### DIFF
--- a/.changeset/dull-beers-juggle.md
+++ b/.changeset/dull-beers-juggle.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+feat(core): added ability to turn of visualizer per resource

--- a/eventcatalog/src/components/SideNav/ListViewSideBar/utils.ts
+++ b/eventcatalog/src/components/SideNav/ListViewSideBar/utils.ts
@@ -57,6 +57,11 @@ export async function getResourcesForNavigation({ currentPath }: { currentPath: 
       href: buildUrl(`/${route}/${entity.collection}/${entity.data.id}/${entity.data.version}`),
     }));
 
+    // don't render items if we are in the visualiser and the item has visualiser set to false
+    if (currentPath.includes('visualiser') && item.data.visualiser === false) {
+      return acc;
+    }
+
     const navigationItem = {
       label: item.data.name,
       version: item.data.version,
@@ -78,6 +83,7 @@ export async function getResourcesForNavigation({ currentPath }: { currentPath: 
       entities: entitiesWithHref,
       specifications: isCollectionService ? getSpecificationsForService(item) : null,
       sidebar: item.data?.sidebar,
+      renderInVisualiser: item.data?.visualiser ?? true,
     };
 
     group.push(navigationItem);

--- a/eventcatalog/src/content.config.ts
+++ b/eventcatalog/src/content.config.ts
@@ -135,6 +135,7 @@ const baseSchema = z.object({
       z.boolean().optional(),
     ])
     .optional(),
+  visualiser: z.boolean().optional(),
   // Used by eventcatalog
   versions: z.array(z.string()).optional(),
   latestVersion: z.string().optional(),

--- a/eventcatalog/src/layouts/VerticalSideBarLayout.astro
+++ b/eventcatalog/src/layouts/VerticalSideBarLayout.astro
@@ -70,8 +70,13 @@ const getDefaultUrl = (route: string, defaultValue: string) => {
 
   for (const { data, key } of collections) {
     if (data.length > 0 && isCollectionVisibleInCatalog(key)) {
-      const item = data[0];
-      return buildUrl(`/${route}/${key}/${item.data.id}/${item.data.latestVersion}`);
+      // find the first item that has visualiser set to true
+      const item = data.find((item) => item.data.visualiser !== false);
+      if (item) {
+        return buildUrl(`/${route}/${key}/${item.data.id}/${item.data.latestVersion}`);
+      } else {
+        continue;
+      }
     }
   }
 

--- a/eventcatalog/src/pages/visualiser/[type]/[id]/[version]/index.astro
+++ b/eventcatalog/src/pages/visualiser/[type]/[id]/[version]/index.astro
@@ -19,17 +19,19 @@ export async function getStaticPaths() {
   const allItems = await Promise.all(itemTypes.map((type) => loaders[type]()));
 
   return allItems.flatMap((items, index) =>
-    items.map((item) => ({
-      params: {
-        type: itemTypes[index],
-        id: item.data.id,
-        version: item.data.version,
-      },
-      props: {
-        type: itemTypes[index],
-        ...item,
-      },
-    }))
+    items
+      .filter((item) => item.data.visualiser !== false)
+      .map((item) => ({
+        params: {
+          type: itemTypes[index],
+          id: item.data.id,
+          version: item.data.version,
+        },
+        props: {
+          type: itemTypes[index],
+          ...item,
+        },
+      }))
   );
 }
 

--- a/eventcatalog/src/pages/visualiser/[type]/[id]/index.astro
+++ b/eventcatalog/src/pages/visualiser/[type]/[id]/index.astro
@@ -11,6 +11,9 @@ import type { CollectionTypes } from '@types';
 export async function getStaticPaths() {
   const [events, commands, services, domains] = await Promise.all([getEvents(), getCommands(), getServices(), getDomains()]);
 
+  const resources = [...domains, ...events, ...services, ...commands];
+  const resourcesWithVisualiserEnabled = resources.filter((resource) => resource.data.visualiser !== false);
+
   const buildPages = (collection: CollectionEntry<CollectionTypes>[]) => {
     return collection.map((item) => ({
       params: {
@@ -24,7 +27,7 @@ export async function getStaticPaths() {
     }));
   };
 
-  return [...buildPages(domains), ...buildPages(events), ...buildPages(services), ...buildPages(commands)];
+  return [...buildPages(resourcesWithVisualiserEnabled)];
 }
 
 const props = Astro.props;


### PR DESCRIPTION
Fix for #1047

Added new property to all resources

```
visualiser: false/true
```

Setting the value to false will no longer render the page in the visualizer.