### PR TITLE
fix(core): deprecated dates can now be strings

### DIFF
--- a/.changeset/healthy-carpets-grab.md
+++ b/.changeset/healthy-carpets-grab.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix(core): deprecated dates can now be strings

--- a/eventcatalog/src/content.config.ts
+++ b/eventcatalog/src/content.config.ts
@@ -130,7 +130,7 @@ const baseSchema = z.object({
     .union([
       z.object({
         message: z.string().optional(),
-        date: z.date().optional(),
+        date: z.union([z.string(), z.date()]).optional(),
       }),
       z.boolean().optional(),
     ])


### PR DESCRIPTION
Deprecated fields for resources (dates) can now be dates or strings.