### PR TITLE
fix(core): fixed a bug with schema viewer not supporting schemas defined with "$ref"

### DIFF
--- a/.changeset/grumpy-experts-wave.md
+++ b/.changeset/grumpy-experts-wave.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/core': patch
+---
+
+fixed a bug where schema viewer did not support ref definitions

--- a/.changeset/grumpy-experts-wave.md
+++ b/.changeset/grumpy-experts-wave.md
@@ -2,4 +2,4 @@
 '@eventcatalog/core': patch
 ---
 
-fixed a bug where schema viewer did not support ref definitions
+fix(core): fixed a bug where schema viewer did not support ref definitions

--- a/eventcatalog/src/components/MDX/SchemaViewer/SchemaViewer.astro
+++ b/eventcatalog/src/components/MDX/SchemaViewer/SchemaViewer.astro
@@ -48,6 +48,22 @@ function mergeAllOfSchemas(schema: any) {
 }
 
 function processSchema(schema: any) {
+  // Handle $ref
+  if (schema.$ref) {
+    // Only support local refs like "#/definitions/xyz"
+    const refPath = schema.$ref;
+    if (refPath.startsWith('#/definitions/')) {
+      const defName = refPath.replace('#/definitions/', '');
+      const definitions = schema.definitions;
+      if (definitions && definitions[defName]) {
+        // Recursively process the referenced schema
+        return processSchema(definitions[defName]);
+      }
+    }
+    // If not found, return as is
+    return schema;
+  }
+
   if (schema.allOf) {
     return mergeAllOfSchemas(schema);
   }


### PR DESCRIPTION
Attempts to fix https://github.com/event-catalog/eventcatalog/issues/1448

It looks like that when the `SchemaViewer` component was processing the schema being passed in, it was not taking into account the refs property and loading the associated definitions.

This PR adds support for refs when processing schemas now in the `SchemaViewer` component.

#### Example JSON Schema:
```
{
  "$ref": "#/definitions/exampleSchema",
  "definitions": {
    "exampleSchema": {
      "type": "object",
      "properties": {
        "employeeNumber": {
          "type": "string",
          "minLength": 1,
          "description": "Employee number, must be at least 1 character long."
        },
        "submitterText": {
          "type": "string",
          "minLength": 1,
          "description": "Text submitted by the user, must be at least 1 character long."
        }
      },
      "required": [
        "employeeNumber",
        "submitterText"
      ],
      "additionalProperties": false
    }
  },
  "$schema": "http://json-schema.org/draft-07/schema#"
}
```

#### Before this PR
<img width="674" alt="image" src="https://github.com/user-attachments/assets/96c2f5cf-2210-4f7a-aeea-ed9480d155b7" />


#### After this PR
<img width="674" alt="image" src="https://github.com/user-attachments/assets/417c3ece-5893-4b03-afc7-714e4313a20f" />

