### PR TITLE
feature(core) Add server host binding property

### DIFF
--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="astro/client" />
+/// <reference path="content.d.ts" />

--- a/.changeset/pretty-pumas-cheer.md
+++ b/.changeset/pretty-pumas-cheer.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/core': minor
+---
+
+Add server host binding property

--- a/eventcatalog/astro.config.mjs
+++ b/eventcatalog/astro.config.mjs
@@ -15,12 +15,11 @@ import config from './eventcatalog.config';
 import expressiveCode from 'astro-expressive-code';
 
 const projectDirectory = process.env.PROJECT_DIR || process.cwd();
-const base = config.base || '/';
 
 // https://astro.build/config
 export default defineConfig({
-  base,
-  server: { port: config.port || 3000 },
+  base: config.server.base,
+  server: { port: config.server.port || 3000, host: config.server.host || '0.0.0.0' },
 
   // output: config.output || 'static',
 

--- a/examples/default/eventcatalog.config.js
+++ b/examples/default/eventcatalog.config.js
@@ -7,7 +7,10 @@ export default {
   homepageLink: 'https://eventcatalog.dev',
   editUrl: 'https://github.com/event-catalog/eventcatalog/edit/main',
   repositoryUrl: 'https://github.com/event-catalog/eventcatalog',
-  port: 3000,
+  server: {
+    port: 3000,
+    base: '/'
+  },
   outDir: 'dist',
   // output: 'server',
   logo: {

--- a/examples/default/eventcatalog.config.js
+++ b/examples/default/eventcatalog.config.js
@@ -18,7 +18,6 @@ export default {
     src: '/logo.png',
     text: 'FlowMart',
   },
-  base: '/',
   trailingSlash: false,
   mermaid: {
     iconPacks: ['logos'],

--- a/src/eventcatalog.config.ts
+++ b/src/eventcatalog.config.ts
@@ -44,8 +44,11 @@ export interface Config {
   editUrl: string;
   repositoryUrl?: string;
   landingPage?: string;
-  base?: string;
-  port?: string;
+  server?: {
+    base?: '/';
+    port?: 3000;
+    host?: '0.0.0.0';
+  };
   trailingSlash?: boolean;
   output?: 'server' | 'static';
   rss?: {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://www.eventcatalog.dev/docs/contributing/overview

Happy contributing!

-->

## Motivation

Add server host binding property, for correctly staring nodejs/astro server with specific IP defined in configuration file.

