### PR TITLE
feat(core): added environments switcher

### DIFF
--- a/eventcatalog/src/components/EnvironmentDropdown.tsx
+++ b/eventcatalog/src/components/EnvironmentDropdown.tsx
@@ -1,0 +1,135 @@
+import React, { useState, useEffect, useRef } from 'react';
+
+interface Environment {
+  name: string;
+  url: string;
+  description?: string;
+  shortName?: string;
+}
+
+interface EnvironmentDropdownProps {
+  environments: Environment[];
+}
+
+export const EnvironmentDropdown: React.FC<EnvironmentDropdownProps> = ({ environments }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [currentEnvironment, setCurrentEnvironment] = useState<Environment | null>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    // Check if current URL matches any environment
+    const currentUrl = window.location.origin;
+    const matchedEnv = environments.find((env) => {
+      // Normalize URLs for comparison
+      const envUrl = new URL(env.url).origin;
+      return envUrl === currentUrl;
+    });
+    setCurrentEnvironment(matchedEnv || null);
+  }, [environments]);
+
+  useEffect(() => {
+    // Handle click outside
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
+    // Handle escape key
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setIsOpen(false);
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('click', handleClickOutside);
+      document.addEventListener('keydown', handleEscape);
+    }
+
+    return () => {
+      document.removeEventListener('click', handleClickOutside);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [isOpen]);
+
+  const toggleDropdown = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setIsOpen(!isOpen);
+  };
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      <button
+        type="button"
+        onClick={toggleDropdown}
+        className="flex items-center space-x-1 text-sm font-medium text-gray-700 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-purple-500 rounded-md px-3 py-2"
+        aria-expanded={isOpen}
+        aria-haspopup="true"
+      >
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2"
+            d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9"
+          />
+        </svg>
+        <span>
+          Environments
+          {currentEnvironment && (
+            <span className="font-normal"> ({currentEnvironment.shortName || currentEnvironment.name})</span>
+          )}
+        </span>
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+      <div
+        className={`${isOpen ? '' : 'hidden'} absolute right-0 mt-2 w-64 bg-white rounded-md shadow-lg py-1 z-50 border border-gray-100 overflow-hidden z-20`}
+      >
+        {environments.map((env) => {
+          const isCurrentEnv = currentEnvironment?.name === env.name;
+
+          return (
+            <a
+              key={env.name}
+              href={env.url}
+              onClick={(e) => {
+                e.preventDefault();
+                // Construct the full URL with the current path when clicked
+                const currentPath = window.location.pathname + window.location.search + window.location.hash;
+                const targetUrl = new URL(env.url);
+                targetUrl.pathname = currentPath;
+                window.location.href = targetUrl.toString();
+              }}
+              className={`block px-4 py-3 text-sm transition-colors border-b border-gray-50 last:border-b-0 ${
+                isCurrentEnv ? 'bg-purple-50 text-purple-700 hover:bg-purple-100' : 'text-gray-700 hover:bg-gray-50'
+              }`}
+            >
+              <div className="flex items-center justify-between">
+                <div>
+                  <div className={`font-medium ${isCurrentEnv ? 'text-purple-700' : ''}`}>{env.name}</div>
+                  {env.description && (
+                    <div className={`text-xs font-light mt-1 ${isCurrentEnv ? 'text-purple-600' : 'text-gray-500'}`}>
+                      {env.description}
+                    </div>
+                  )}
+                </div>
+                {isCurrentEnv && (
+                  <svg className="w-4 h-4 text-purple-600 flex-shrink-0 ml-2" fill="currentColor" viewBox="0 0 20 20">
+                    <path
+                      fillRule="evenodd"
+                      d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                      clipRule="evenodd"
+                    />
+                  </svg>
+                )}
+              </div>
+            </a>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/eventcatalog/src/components/Header.astro
+++ b/eventcatalog/src/components/Header.astro
@@ -5,6 +5,7 @@ import { buildUrl } from '@utils/url-builder';
 import { showEventCatalogBranding, showCustomBranding } from '@utils/feature';
 import { getSession } from 'auth-astro/server';
 import { isAuthEnabled, isSSR } from '@utils/feature';
+import { EnvironmentDropdown } from './EnvironmentDropdown';
 
 let session = null;
 if (isAuthEnabled()) {
@@ -41,7 +42,10 @@ const repositoryUrl = catalog?.repositoryUrl || 'https://github.com/event-catalo
       <div class="hidden md:block w-3/12">
         {
           session ? (
-            <div class="flex justify-end pr-2">
+            <div class="flex items-center space-x-4 justify-end pr-2">
+              {catalog.environments && catalog.environments.length > 0 && (
+                <EnvironmentDropdown environments={catalog.environments} client:load />
+              )}
               <div class="relative">
                 <button
                   id="profile-menu-button"
@@ -89,6 +93,9 @@ const repositoryUrl = catalog?.repositoryUrl || 'https://github.com/event-catalo
           ) : (
             <>
               <div class="flex items-center space-x-4 justify-end pr-2">
+                {catalog.environments && catalog.environments.length > 0 && (
+                  <EnvironmentDropdown environments={catalog.environments} client:load />
+                )}
                 {isAuthEnabled() && (
                   <button
                     id="okta-signin-btn"

--- a/examples/default/eventcatalog.config.js
+++ b/examples/default/eventcatalog.config.js
@@ -107,10 +107,25 @@ export default {
     channels: {
       renderMode: 'flat'
     }
-  }
+  },
+  environments: [
+    {
+      name: 'Development',
+      url: 'https://demo.eventcatalog.dev',
+      description: 'Local development environment',
+      shortName: 'Dev'
+    },
+    {
+      name: 'Test',
+      url: 'https://demo.eventcatalog.dev',
+      description: 'Test environment for QA',
+      shortName: 'Test'
+    },
+    {
+      name: 'Production',
+      url: 'https://demo.eventcatalog.dev',
+      description: 'Production environment',
+      shortName: 'Prod'
+    },
+  ]
 };
-
-
-/**
- * TODO: Collapsed groups (collapsed: true)
- */

--- a/src/eventcatalog.config.ts
+++ b/src/eventcatalog.config.ts
@@ -106,4 +106,10 @@ export interface Config {
       renderMode?: 'flat' | 'single';
     };
   };
+  environments?: {
+    name: string;
+    url: string;
+    description?: string;
+    shortName?: string;
+  }[];
 }


### PR DESCRIPTION
Added new config variables that let you define environemnts.

This will show a dropdown in the header, and let you navigate between environemnts. Any query strings or paths will be persisted too.

```js
environments: [
    {
      name: 'Development',
      url: 'https://demo.eventcatalog.dev',
      description: 'Local development environment',
      shortName: 'Dev'
    },
    {
      name: 'Test',
      url: 'https://demo.eventcatalog.dev',
      description: 'Test environment for QA',
      shortName: 'Test'
    },
    {
      name: 'Production',
      url: 'https://demo.eventcatalog.dev',
      description: 'Production environment',
      shortName: 'Prod'
    },
  ]
```

<img width="397" alt="image" src="https://github.com/user-attachments/assets/bece95ba-49c3-45f6-a3e1-85ae61164e61" />
