### PR TITLE
feat(core): compressing build is now optional

### DIFF
--- a/.changeset/afraid-onions-applaud.md
+++ b/.changeset/afraid-onions-applaud.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+feat(core): compressing build is now optional

--- a/eventcatalog/astro.config.mjs
+++ b/eventcatalog/astro.config.mjs
@@ -20,6 +20,7 @@ import expressiveCode from 'astro-expressive-code';
 const projectDirectory = process.env.PROJECT_DIR || process.cwd();
 const base = config.base || '/';
 const host = config.host || false;
+const compress = config.compress || true;
 
 // https://astro.build/config
 export default defineConfig({
@@ -76,7 +77,7 @@ export default defineConfig({
       gfm: true,
     }),
     config.output !== 'server' && pagefind(),
-    config.output !== 'server' && (await import("astro-compress")).default({
+    config.output !== 'server' && compress && (await import("astro-compress")).default({
       Logger: 0,
     }),
   ].filter(Boolean),

--- a/src/eventcatalog.config.ts
+++ b/src/eventcatalog.config.ts
@@ -65,6 +65,7 @@ export interface Config {
     renderParsedSchemas?: boolean;
   };
   mdxOptimize?: boolean;
+  compress?: boolean;
   sidebar?: SideBarConfig[];
   docs: {
     sidebar: {


### PR DESCRIPTION
Fix for #1579, compress is now optional, but enabled by default.

To turn off you need to add this to `eventcatalog.config.js`

```
compress: false
```