### PR TITLE
(feat) add ability to restrict which entities are shown on the Entity…

### DIFF
--- a/eventcatalog/src/components/MDX/EntityMap/EntityMap.astro
+++ b/eventcatalog/src/components/MDX/EntityMap/EntityMap.astro
@@ -5,7 +5,7 @@ import Admonition from '@components/MDX/Admonition';
 import NodeGraph from '../NodeGraph/NodeGraph';
 import { getVersionFromCollection } from '@utils/collections/versions';
 
-const { id, version = 'latest', maxHeight, includeKey = true } = Astro.props;
+const { id, version = 'latest', maxHeight, includeKey = true, entities } = Astro.props;
 
 // Find the flow for the given id and version
 const domains = await getDomains();
@@ -15,6 +15,7 @@ const domain = domainCollection[0];
 const { nodes, edges } = await getNodesAndEdges({
   id: id,
   version: domain?.data?.version,
+  ...(entities ? { entities } : {}), // Pass entities if provided
 });
 ---
 

--- a/eventcatalog/tsconfig.json
+++ b/eventcatalog/tsconfig.json
@@ -19,6 +19,7 @@
     },
     "jsx": "react-jsx",
     "jsxImportSource": "react",
-    "types": ["vitest/globals"]
+    "types": ["vitest/globals"],
+    "lib": [ "dom", "dom.iterable", "es2016", "esnext" ]
   }
 }


### PR DESCRIPTION
…Map by  passing in an array of valid Entity Ids i.e <EntityMap id="domain-id" entities="{['entityA','entityB']}"/>

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://www.eventcatalog.dev/docs/contributing/overview

Happy contributing!

-->

## Motivation

The Node Graphs can become quite large. On a Service page for example I wish to show a limited set of Entities that the service works with rather than all the Entities that are part of the domain
