### PR TITLE
fix(core): no longer compress css

### DIFF
--- a/.changeset/moody-eyes-suffer.md
+++ b/.changeset/moody-eyes-suffer.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix(core): no longer compress css

--- a/eventcatalog/astro.config.mjs
+++ b/eventcatalog/astro.config.mjs
@@ -79,11 +79,7 @@ export default defineConfig({
     config.output !== 'server' && pagefind(),
     config.output !== 'server' && compress && (await import("astro-compress")).default({
       Logger: 0,
-      Exclude: [
-        (File) =>
-          // Fix for https://github.com/event-catalog/eventcatalog/issues/1600
-					File.includes("TreeView"),
-      ],
+      CSS: false,
     }),
   ].filter(Boolean),
   vite: {


### PR DESCRIPTION
CSS compress seems to be causing issues in the project e.g custom styles, z index issues. (e.g https://github.com/event-catalog/eventcatalog/issues/1598)

Turning this off for EventCatalog (at least for now).