### PR TITLE
feat(core): added edit links into resource pages

### DIFF
--- a/.changeset/witty-carrots-film.md
+++ b/.changeset/witty-carrots-film.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+feat(core): added edit links into resource pages

--- a/eventcatalog/src/components/CopyAsMarkdown.tsx
+++ b/eventcatalog/src/components/CopyAsMarkdown.tsx
@@ -1,6 +1,5 @@
-import { Button } from '@headlessui/react';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
-import { Copy, FileText, MessageCircleQuestion, ChevronDownIcon, ExternalLink } from 'lucide-react';
+import { Copy, FileText, MessageCircleQuestion, ChevronDownIcon, ExternalLink, PenSquareIcon } from 'lucide-react';
 import React, { useState, isValidElement } from 'react';
 import type { Schema } from '@utils/collections/schemas';
 import { buildUrl } from '@utils/url-builder';
@@ -47,10 +46,12 @@ export function CopyPageMenu({
   schemas,
   chatQuery,
   chatEnabled = false,
+  editUrl,
 }: {
   schemas: Schema[];
   chatQuery?: string;
   chatEnabled: boolean;
+  editUrl: string;
 }) {
   const [buttonText, setButtonText] = useState('Copy page');
 
@@ -136,6 +137,20 @@ export function CopyPageMenu({
           <MenuItemContent icon={Copy} title="Copy page" description="Copy page as Markdown for LLMs" />
         </DropdownMenu.Item>
 
+        {editUrl && (
+          <DropdownMenu.Item
+            className="cursor-pointer hover:bg-gray-100 focus:outline-none focus:bg-gray-100"
+            onSelect={() => window.open(editUrl, '_blank')}
+          >
+            <MenuItemContent
+              icon={PenSquareIcon}
+              title="Edit page"
+              description="Edit the contents of this page"
+              external={true}
+            />
+          </DropdownMenu.Item>
+        )}
+
         {schemas.map((schema) => {
           const title =
             schema.format === 'asyncapi'
@@ -166,6 +181,7 @@ export function CopyPageMenu({
             </DropdownMenu.Item>
           );
         })}
+
         <DropdownMenu.Item
           className="cursor-pointer hover:bg-gray-100 focus:outline-none focus:bg-gray-100"
           onSelect={() => window.open(markdownUrl, '_blank')}

--- a/eventcatalog/src/content.config.ts
+++ b/eventcatalog/src/content.config.ts
@@ -105,6 +105,7 @@ const baseSchema = z.object({
     ])
     .optional(),
   hidden: z.boolean().optional(),
+  editUrl: z.string().optional(),
   resourceGroups: z
     .array(
       z.object({

--- a/eventcatalog/src/pages/docs/[type]/[id]/[version]/index.astro
+++ b/eventcatalog/src/pages/docs/[type]/[id]/[version]/index.astro
@@ -30,7 +30,7 @@ import {
   MagnifyingGlassIcon,
 } from '@heroicons/react/24/outline';
 import { ArrowsRightLeftIcon } from '@heroicons/react/20/solid';
-import { Box, Boxes } from 'lucide-react';
+import { Box, Boxes, SquarePenIcon } from 'lucide-react';
 import type { CollectionTypes } from '@types';
 
 import { render } from 'astro:content';
@@ -38,7 +38,7 @@ import type { CollectionEntry } from 'astro:content';
 
 import { getIcon } from '@utils/badges';
 import { getDeprecatedDetails } from '@utils/collections/util';
-import { buildUrl } from '@utils/url-builder';
+import { buildUrl, buildEditUrlForResource } from '@utils/url-builder';
 import { getSchemasFromResource } from '@utils/collections/schemas';
 import { isEventCatalogChatEnabled, isMarkdownDownloadEnabled } from '@utils/feature';
 
@@ -57,6 +57,8 @@ const { Content } = await render(props);
 
 const pageTitle = `${props.collection} | ${props.data.name}`.replace(/^\w/, (c) => c.toUpperCase());
 const contentBadges = props.data.badges || [];
+const editUrl =
+  props.data.editUrl || (config.editUrl && props?.filePath ? buildEditUrlForResource(config.editUrl, props?.filePath) : '');
 
 const getContentBadges = () =>
   contentBadges.map((badge: any) => ({
@@ -218,6 +220,7 @@ nodeGraphs.push({
                       schemas={schemasForResource}
                       chatQuery={generatePromptForResource(props)}
                       chatEnabled={isEventCatalogChatEnabled()}
+                      editUrl={editUrl}
                     />
                   </div>
                 )
@@ -362,6 +365,20 @@ nodeGraphs.push({
           }
         </div>
         <Footer />
+        <!-- Add edit this page button  with icon and text-->
+        <div class="flex justify-end">
+          <!-- Built with EventCatalog -->
+          {
+            editUrl && (
+              <div class="flex justify-end">
+                <a href={editUrl} class="text-sm text-gray-700 hover:text-gray-700 border border-gray-200 rounded-md p-2">
+                  <SquarePenIcon className="w-4 h-4 inline-block mr-1" />
+                  Edit this page
+                </a>
+              </div>
+            )
+          }
+        </div>
       </div>
       <aside class="hidden lg:block sticky top-0 pb-10 w-96 overflow-y-auto py-2" data-pagefind-ignore>
         <!-- @ts-ignore -->

--- a/eventcatalog/src/utils/__tests__/url-builder.spec.ts
+++ b/eventcatalog/src/utils/__tests__/url-builder.spec.ts
@@ -1,4 +1,4 @@
-import { buildUrl, buildUrlWithParams } from '../url-builder';
+import { buildEditUrlForResource, buildUrl, buildUrlWithParams } from '../url-builder';
 
 declare global {
   interface Window {
@@ -101,6 +101,32 @@ describe('url-builder', () => {
         key4: 'value4',
       });
       expect(url).toBe('example.com?key1=value1&key4=value4');
+    });
+  });
+
+  describe('buildEditUrlForResource', () => {
+    it('should build a basic url', () => {
+      const url = buildEditUrlForResource(
+        'https://github.com/eventcatalog/eventcatalog/edit/main',
+        'examples/default/domains/E-Commerce/index.mdx'
+      );
+      expect(url).toBe('https://github.com/eventcatalog/eventcatalog/edit/main/examples/default/domains/E-Commerce/index.mdx');
+    });
+
+    it('should remove ../ from the filepath', () => {
+      const url = buildEditUrlForResource(
+        'https://github.com/eventcatalog/eventcatalog/edit/main',
+        '../examples/default/domains/E-Commerce/index.mdx'
+      );
+      expect(url).toBe('https://github.com/eventcatalog/eventcatalog/edit/main/examples/default/domains/E-Commerce/index.mdx');
+    });
+
+    it('should remove ./ from the filepath', () => {
+      const url = buildEditUrlForResource(
+        'https://github.com/eventcatalog/eventcatalog/edit/main',
+        './examples/default/domains/E-Commerce/index.mdx'
+      );
+      expect(url).toBe('https://github.com/eventcatalog/eventcatalog/edit/main/examples/default/domains/E-Commerce/index.mdx');
     });
   });
 });

--- a/eventcatalog/src/utils/url-builder.ts
+++ b/eventcatalog/src/utils/url-builder.ts
@@ -42,3 +42,9 @@ export const buildUrlWithParams = (baseUrl: string, params: Record<string, strin
 
   return `${buildUrl(baseUrl)}?${queryString}`;
 };
+
+export const buildEditUrlForResource = (editUrl: string, filePath: string) => {
+  // filepath may have ../ or ./ in it, so we need to remove it
+  const cleanFilePath = filePath.replace(/^\.\.?\//g, '');
+  return `${editUrl}/${cleanFilePath}`;
+};


### PR DESCRIPTION
Fix for https://github.com/event-catalog/eventcatalog/issues/1605

- Added Edit Page in the dropdown for all pages (Copy Page)
- Added Edit Page button at the bottom of all pages

<img width="1045" height="409" alt="image" src="https://github.com/user-attachments/assets/7c74e2e5-33e0-4c27-945e-bbcc5c7fa9d6" />
