### PR TITLE
fix(core): resolve SchemaViewer path resolution for relative paths

### DIFF
--- a/eventcatalog/src/components/MDX/SchemaViewer/SchemaViewerRoot.astro
+++ b/eventcatalog/src/components/MDX/SchemaViewer/SchemaViewerRoot.astro
@@ -7,12 +7,12 @@ import path from 'path';
 import SchemaViewerClient from './SchemaViewer.astro';
 import Admonition from '../Admonition';
 import { getMDXComponentsByName } from '@utils/markdown';
-import { getAbsoluteFilePathForAstroFile } from '@utils/files';
+import { getAbsoluteFilePathForAstroFile, resolveProjectPath } from '@utils/files';
 
 let schemas = [];
 
 try {
-  const absoluteFilePath = getAbsoluteFilePathForAstroFile(filePath, filePath.split(path.sep).pop());
+  const absoluteFilePath = resolveProjectPath(filePath);
   const file = await fs.readFile(absoluteFilePath, 'utf-8');
   const schemaViewers = getMDXComponentsByName(file, 'SchemaViewer');
 

--- a/eventcatalog/src/utils/files.ts
+++ b/eventcatalog/src/utils/files.ts
@@ -1,6 +1,30 @@
 import path from 'node:path';
 
 /**
+ * Resolves a file path relative to PROJECT_DIR, handling ../ paths correctly
+ * @param filePath - The path to resolve
+ * @param projectDir - The project directory to resolve relative to
+ * @returns The resolved absolute path
+ */
+export const resolveProjectPath = (filePath: string, projectDir: string = process.env.PROJECT_DIR || process.cwd()): string => {
+  if (filePath.startsWith('../')) {
+    const pathAfterDotDot = filePath.substring(3);
+    const projectDirName = path.basename(projectDir);
+    const projectParentName = path.basename(path.dirname(projectDir));
+    
+    if (pathAfterDotDot.startsWith(`${projectParentName}/${projectDirName}/`)) {
+      const remainingPath = pathAfterDotDot.substring(`${projectParentName}/${projectDirName}/`.length);
+      return path.join(projectDir, remainingPath);
+    } else {
+      const projectParent = path.dirname(projectDir);
+      return path.join(projectParent, pathAfterDotDot);
+    }
+  }
+  return path.join(projectDir, filePath);
+};
+
+
+/**
  * Using the Astro filePath, this returns the absolute path to the file
  *
  * The astro file path does not return the absolute path to the file, it returns the relative path to the file.
@@ -14,30 +38,10 @@ export const getAbsoluteFilePathForAstroFile = (filePath: string, fileName?: str
   const PROJECT_DIR = process.env.PROJECT_DIR || process.cwd();
 
   if (fileName) {
-    const safeRelativePath = path.posix.relative('/', path.resolve('/', filePath));
-
-    // Check for overlapping path segments
-    const projectDirSegments = PROJECT_DIR.split(path.sep);
-    const relativePathSegments = safeRelativePath.split(path.posix.sep);
-
-    // Find the longest matching suffix of PROJECT_DIR with prefix of relative path
-    let overlapLength = 0;
-    for (let i = 1; i <= Math.min(projectDirSegments.length, relativePathSegments.length); i++) {
-      const projectSuffix = projectDirSegments.slice(-i);
-      const relativPrefix = relativePathSegments.slice(0, i);
-
-      if (projectSuffix.join(path.sep) === relativPrefix.join(path.posix.sep)) {
-        overlapLength = i;
-      }
-    }
-
-    // Remove overlapping segments from the relative path
-    const cleanedRelativePath = relativePathSegments.slice(overlapLength).join(path.posix.sep);
-    const absoluteFilePath = path.join(PROJECT_DIR, cleanedRelativePath);
-
-    const directory = path.dirname(absoluteFilePath || '');
+    const resolvedFilePath = resolveProjectPath(filePath, PROJECT_DIR);
+    const directory = path.dirname(resolvedFilePath);
     return path.join(directory, fileName);
   }
 
-  return path.join(PROJECT_DIR, filePath);
+  return resolveProjectPath(filePath, PROJECT_DIR);
 };


### PR DESCRIPTION
Fixes SchemaViewer components failing to load schema files with paths starting with ../. The issue was caused by inconsistent path resolution logic in SchemaViewerRoot.astro.

- Added resolveProjectPath function to handle ../ paths correctly
- Updated getAbsoluteFilePathForAstroFile to use the new path resolution logic
- SchemaViewerRoot.astro now uses resolveProjectPath for consistent path handling

Fixes #1644

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://www.eventcatalog.dev/docs/contributing/overview

Happy contributing!

-->

## Motivation

(Write your motivation here.)
