### PR TITLE
fix(core): schema viewer now renders in the correct location

### DIFF
--- a/eventcatalog/src/components/MDX/SchemaViewer/SchemaViewerRoot.astro
+++ b/eventcatalog/src/components/MDX/SchemaViewer/SchemaViewerRoot.astro
@@ -117,6 +117,11 @@ try {
   }
 
   // on DOM ready, move the SchemaViewerClient to the portal
+  document.addEventListener('DOMContentLoaded', () => {
+    schemas.forEach(moveSchemaViewerToPortal);
+  });
+
+  // on DOM ready, move the SchemaViewerClient to the portal
   document.addEventListener('astro:page-load', () => {
     schemas.forEach(moveSchemaViewerToPortal);
   });


### PR DESCRIPTION
Fix for #1659

We now move the SchemaViewer on astro pageload and dom content loaded (in case its a fresh load here)