### PR TITLE
feature(core) Add support for avsc files in diffs

### DIFF
--- a/.changeset/stupid-dancers-occur.md
+++ b/.changeset/stupid-dancers-occur.md
@@ -2,4 +2,4 @@
 '@eventcatalog/core': patch
 ---
 
-Add support for avsc files in diffs
+feat(core): added support for avsc files in diffs

--- a/.changeset/stupid-dancers-occur.md
+++ b/.changeset/stupid-dancers-occur.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/core': patch
+---
+
+Add support for avsc files in diffs

--- a/eventcatalog/src/utils/collections/file-diffs.ts
+++ b/eventcatalog/src/utils/collections/file-diffs.ts
@@ -6,7 +6,7 @@ import { getItemsFromCollectionByIdAndSemverOrLatest } from './util';
 import type { CollectionEntry } from 'astro:content';
 import type { CollectionTypes } from '@types';
 
-const FILE_EXTENSIONS_TO_INCLUDE = ['.json', '.avro', '.yaml', '.yml', '.proto', '.pb', '.pbjson', '.pb.go'];
+const FILE_EXTENSIONS_TO_INCLUDE = ['.json', '.avsc', '.avro', '.yaml', '.yml', '.proto', '.pb', '.pbjson', '.pb.go'];
 
 /**
  * Generates a diff string in a unified diff format for two versions of a file.


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://www.eventcatalog.dev/docs/contributing/overview

Happy contributing!

-->

## Motivation


Original AVRO-tool generate files with extension `avsc`, when it is used parameter `idl2schemata`. This merge request add support for avsc file diffs.
