### PR TITLE
chore(core): architecture pages now single column

### DIFF
--- a/.changeset/sixty-ladybugs-wonder.md
+++ b/.changeset/sixty-ladybugs-wonder.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+chore(core): architecture pages now single column

--- a/eventcatalog/src/components/Grids/ServiceGrid.tsx
+++ b/eventcatalog/src/components/Grids/ServiceGrid.tsx
@@ -186,7 +186,7 @@ const DomainSection = memo(
                 </div>
               )}
 
-              <div className="grid grid-cols-1 sm:grid-cols-1 lg:grid-cols-1 xl:grid-cols-2 gap-6">
+              <div className="grid grid-cols-1 sm:grid-cols-1 lg:grid-cols-1 xl:grid-cols-1 gap-6">
                 {subdomainServices.map((service) => (
                   <ServiceCard
                     key={service.data.id}
@@ -386,7 +386,7 @@ export default function ServiceGrid({ services, domains, embeded }: ServiceGridP
                 />
               ))
           ) : (
-            <div className={`grid grid-cols-1 sm:grid-cols-1 lg:grid-cols-1 xl:grid-cols-${embeded ? 1 : 2} gap-6`}>
+            <div className={`grid grid-cols-1 sm:grid-cols-1 lg:grid-cols-1 xl:grid-cols-1 gap-6`}>
               {paginatedServices.map((service) => (
                 <ServiceCard key={service.data.id} service={service} urlParams={urlParams} selectedTypes={selectedTypes} />
               ))}


### PR DESCRIPTION
Some feedback from folks, that the architecture (Two) columns we causing issues, with long message names.

Suggestion was to move to single columns for these pages, which I'm happy with.

If anyone reading this wants two back again, we can add a toggle in the future. Until then single columns it is! Cheers!