### PR TITLE
feat(schema-viewer): display constant values in schema viewer

### DIFF
--- a/.changeset/clever-scissors-admire.md
+++ b/.changeset/clever-scissors-admire.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix(core): SchemaViewer now display constant values

--- a/eventcatalog/src/components/MDX/SchemaViewer/SchemaProperty.astro
+++ b/eventcatalog/src/components/MDX/SchemaViewer/SchemaProperty.astro
@@ -57,6 +57,13 @@ const contentId = `prop-${name}-${level}-${Math.random().toString(36).substring(
             {details.format ? `<${details.format}>` : ''}
             {details._refPath && <span class="text-blue-600 ml-1">→ {details._refName || details._refPath}</span>}
             {details._refNotFound && <span class="text-red-600 ml-1">❌ ref not found</span>}
+            {
+              details.const !== undefined && (
+                <span>
+                  constant: <code>{details.const}</code>
+                </span>
+              )
+            }
           </span>
         </div>
         {isRequired && <span class="text-red-600 text-xs ml-3 flex-shrink-0">required</span>}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://www.eventcatalog.dev/docs/contributing/overview

Happy contributing!

-->

## Motivation

JSON Schema supports the [const keyword](https://json-schema.org/understanding-json-schema/reference/const). This can be useful to represent values that don't change, e.g. a version number embedded within a message.

Where a value is constant, having this show in the Schema Viewer is valuable.

## Open questions

* At the moment none of the examples have this const keyword to demonstrate the feature, I'm happy to add this but I wanted to align before doing that. I could be add version numbers within messages to one (or more) messages within the existing examples.
* One test is failing on my machine, which seems unrelated to my changes, and appears to be due to a missing file. I can't see how that file should be generated.

```

 FAIL |@eventcatalog/astro|  src/enterprise/eventcatalog-chat/__tests__/utils/ai.spec.ts [ eventcatalog/src/enterprise/eventcatalog-chat/__tests__/utils/ai.spec.ts ]
Error: ENOENT: no such file or directory, open 'examples/default/public/ai/documents.json'
 ❯ src/enterprise/eventcatalog-chat/utils/ai.ts:9:33
      7| 
      8| const AI_EMBEDDINGS_PATH = path.join(process.env.PROJECT_DIR || proces…
      9| const documents = JSON.parse(fs.readFileSync(path.join(AI_EMBEDDINGS_P…
       |                                 ^
     10| const embeddings = JSON.parse(fs.readFileSync(path.join(AI_EMBEDDINGS_…
     11| 
 ❯ src/enterprise/eventcatalog-chat/__tests__/utils/ai.spec.ts:20:25
```