### PR TITLE
fix(core): enums and items now shown on entity properties map

### DIFF
--- a/.changeset/eighty-seas-glow.md
+++ b/.changeset/eighty-seas-glow.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix(core): enums and items now shown on entity properties map

--- a/eventcatalog/src/content.config.ts
+++ b/eventcatalog/src/content.config.ts
@@ -500,6 +500,12 @@ const entities = defineCollection({
             references: z.string().optional(),
             referencesIdentifier: z.string().optional(),
             relationType: z.string().optional(),
+            enum: z.array(z.string()).optional(),
+            items: z
+              .object({
+                type: z.string(),
+              })
+              .optional(),
           })
         )
         .optional(),


### PR DESCRIPTION
Fix for #1691

Enums and items are now shown correctly in the properties table.

<img width="1049" height="578" alt="image" src="https://github.com/user-attachments/assets/6b1a187b-e2a2-44e2-9cfe-4f3add133fe3" />
