### PR TITLE
Environment variable to Increase static page generation timeout

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "linked": [],
   "access": "public",
-  "baseBranch": "master",
+  "baseBranch": "v1",
   "updateInternalDependencies": "patch",
   "ignore": ["website"]
 }

--- a/.changeset/many-apes-mate.md
+++ b/.changeset/many-apes-mate.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/core': minor
+---
+
+Added Environment variable to Increase static page generation timeout

--- a/packages/eventcatalog/next.config.js
+++ b/packages/eventcatalog/next.config.js
@@ -1,7 +1,8 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const config = require('./eventcatalog.config');
 
-module.exports = {
+module.exports = {  
+  staticPageGenerationTimeout: parseInt(process.env.STATIC_PAGE_GENERATION_TIMEOUT || '60', 10), // Use an environment variable or use the default to 60 seconds.
   reactStrictMode: true,
   basePath: config.basePath,
   trailingSlash: config.trailingSlash,


### PR DESCRIPTION
## Motivation
Encountered a timeout error in static page generation due to number of events to be generated.  The fix is to provide an env variable to increase the timeout.

...
warn  - Restarted static page generation for /404 because it took more than 60 seconds
warn  - Restarted static page generation for /500 because it took more than 60 seconds
> Build error occurred
Error: Static page generation for /domains is still timing out after 3 attempts. See more info here https://nextjs.org/docs/messages/static-page-generation-timeout
    at onRestart (/builds/platform-services/dfs/dfs-catalog/node_modules/next/dist/build/index.js:588:35)
    at Worker.exportPage (/builds/platform-services/dfs/dfs-catalog/node_modules/next/dist/lib/worker.js:48:40)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async /builds/platform-services/dfs/dfs-catalog/node_modules/next/dist/export/index.js:317:32
    at async Span.traceAsyncFn (/builds/platform-services/dfs/dfs-catalog/node_modules/next/dist/trace/trace.js:79:20)
    at async Promise.all (index 2)
    at async /builds/platform-services/dfs/dfs-catalog/node_modules/next/dist/export/index.js:312:9
    at async Span.traceAsyncFn (/builds/platform-services/dfs/dfs-catalog/node_modules/next/dist/trace/trace.js:79:20)
    at async /builds/platform-services/dfs/dfs-catalog/node_modules/next/dist/build/index.js:1230:21
    at async Span.traceAsyncFn (/builds/platform-services/dfs/dfs-catalog/node_modules/next/dist/trace/trace.js:79:20)
Error: Command failed: cross-env PROJECT_DIR='/builds/platform-services/dfs/dfs-catalog' npm run build
    at genericNodeError (node:internal/errors:984:15)
    at wrappedFn (node:internal/errors:538:14)
    at checkExecSyncError (node:child_process:891:11)
    at execSync (node:child_process:963:15)
    at Command.<anonymous> (/builds/platform-services/dfs/dfs-catalog/node_modules/@eventcatalog/core/bin/eventcatalog.js:60:5)
    at Command.listener (/builds/platform-services/dfs/dfs-catalog/node_modules/commander/index.js:370:29)
    at Command.emit (node:events:524:28)
    at Command.parseArgs (/builds/platform-services/dfs/dfs-catalog/node_modules/commander/index.js:892:12)
    at Command.parse (/builds/platform-services/dfs/dfs-catalog/node_modules/commander/index.js:642:21)
    at run (/builds/platform-services/dfs/dfs-catalog/node_modules/@eventcatalog/core/bin/eventcatalog.js:115:7) {
  status: 1,
  signal: null,
  output: [ null, null, null ],
  pid: 583,
  stdout: null,
  stderr: null
}
error Command failed with exit code 1
