### PR TITLE
fix(core): fix copy button for trialing slash catalogs

### DIFF
--- a/.changeset/metal-ears-relate.md
+++ b/.changeset/metal-ears-relate.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix(core): fix copy button for trialing slash catalogs

--- a/eventcatalog/src/components/CopyAsMarkdown.tsx
+++ b/eventcatalog/src/components/CopyAsMarkdown.tsx
@@ -2,7 +2,7 @@ import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import { Copy, FileText, MessageCircleQuestion, ChevronDownIcon, ExternalLink, PenSquareIcon } from 'lucide-react';
 import React, { useState, isValidElement } from 'react';
 import type { Schema } from '@utils/collections/schemas';
-import { buildUrl } from '@utils/url-builder';
+import { buildUrl, toMarkdownUrl } from '@utils/url-builder';
 
 // Type allows either a component type (like Lucide icon) or a pre-rendered element (like <img>)
 type IconInput = React.ElementType | React.ReactElement;
@@ -74,7 +74,7 @@ export function CopyPageMenu({
 
   // get the url of the current page
   const url = window.location.href;
-  const markdownUrl = url + '.mdx';
+  const markdownUrl = toMarkdownUrl(url);
 
   // Determine the default action based on what's available
   const getDefaultAction = () => {
@@ -290,7 +290,7 @@ export function CopyPageMenu({
         {availableActions.chat && (
           <DropdownMenu.Item
             className="cursor-pointer hover:bg-gray-100 focus:outline-none focus:bg-gray-100"
-            onSelect={() => window.open(buildUrl(`/chat?query=${chatQuery}`))}
+            onSelect={() => window.open(buildUrl(`/chat`) + `?query=${chatQuery}`)}
           >
             <MenuItemContent
               icon={MessageCircleQuestion}

--- a/eventcatalog/src/utils/__tests__/url-builder.spec.ts
+++ b/eventcatalog/src/utils/__tests__/url-builder.spec.ts
@@ -1,4 +1,4 @@
-import { buildEditUrlForResource, buildUrl, buildUrlWithParams } from '../url-builder';
+import { buildEditUrlForResource, buildUrl, buildUrlWithParams, toMarkdownUrl } from '../url-builder';
 
 declare global {
   interface Window {
@@ -127,6 +127,20 @@ describe('url-builder', () => {
         './examples/default/domains/E-Commerce/index.mdx'
       );
       expect(url).toBe('https://github.com/eventcatalog/eventcatalog/edit/main/examples/default/domains/E-Commerce/index.mdx');
+    });
+  });
+
+  describe('toMarkdownUrl', () => {
+    it('should add .mdx to the url when trailing slash is false', () => {
+      const url = toMarkdownUrl('example.com');
+      expect(url).toBe('example.com.mdx');
+    });
+
+    it('should add .mdx/ to the url when trailing slash is true', () => {
+      // @ts-ignore
+      global.__EC_TRAILING_SLASH__ = true;
+      const url = toMarkdownUrl('example.com');
+      expect(url).toBe('example.com.mdx/');
     });
   });
 });

--- a/eventcatalog/src/utils/url-builder.ts
+++ b/eventcatalog/src/utils/url-builder.ts
@@ -48,3 +48,15 @@ export const buildEditUrlForResource = (editUrl: string, filePath: string) => {
   const cleanFilePath = filePath.replace(/^\.\.?\//g, '');
   return `${editUrl}/${cleanFilePath}`;
 };
+
+// Takes a given url and returns the .mdx url
+export const toMarkdownUrl = (url: string) => {
+  const trailingSlash = __EC_TRAILING_SLASH__;
+
+  if (trailingSlash) {
+    const urlWithoutTrailingSlash = url.replace(/\/$/, '');
+    return urlWithoutTrailingSlash + '.mdx/';
+  }
+
+  return url + '.mdx';
+};


### PR DESCRIPTION
Fix for #1714

The generated URL for markdown now takes into consideration the trialing slash configuration for catalogs.