### PR TITLE
fix(sidebar): fix duplicate search results and add grouping by type

### DIFF
--- a/.changeset/clever-foxes-search.md
+++ b/.changeset/clever-foxes-search.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": minor
+---
+
+Fixed duplicate search results in sidebar by filtering out unversioned node keys. Added grouping of search results by type with alphabetical sorting. Extracted shared `getBadgeClasses` utility for consistent theming using CSS variables. Added missing Channel type to filter mapping.

--- a/eventcatalog/src/components/SideNav/NestedSideBar/index.tsx
+++ b/eventcatalog/src/components/SideNav/NestedSideBar/index.tsx
@@ -9,26 +9,9 @@ import { saveState, loadState, saveCollapsedSections, loadCollapsedSections } fr
 import { useStore } from '@nanostores/react';
 import { sidebarStore } from '@stores/sidebar-store';
 import { favoritesStore, toggleFavorite as toggleFavoriteAction, type FavoriteItem } from '@stores/favorites-store';
+import { getBadgeClasses } from './utils';
 
 const cn = (...classes: (string | false | undefined)[]) => classes.filter(Boolean).join(' ');
-
-// ============================================
-// Badge color mapping (uses CSS variables from theme.css)
-// ============================================
-
-const getBadgeClasses = (badge: string): string => {
-  const badgeColors: Record<string, string> = {
-    domain: 'bg-[rgb(var(--ec-badge-domain-bg))] text-[rgb(var(--ec-badge-domain-text))]',
-    service: 'bg-[rgb(var(--ec-badge-service-bg))] text-[rgb(var(--ec-badge-service-text))]',
-    event: 'bg-[rgb(var(--ec-badge-event-bg))] text-[rgb(var(--ec-badge-event-text))]',
-    command: 'bg-[rgb(var(--ec-badge-command-bg))] text-[rgb(var(--ec-badge-command-text))]',
-    query: 'bg-[rgb(var(--ec-badge-query-bg))] text-[rgb(var(--ec-badge-query-text))]',
-    message: 'bg-[rgb(var(--ec-badge-message-bg))] text-[rgb(var(--ec-badge-message-text))]',
-    design: 'bg-[rgb(var(--ec-badge-design-bg))] text-[rgb(var(--ec-badge-design-text))]',
-    channel: 'bg-[rgb(var(--ec-badge-channel-bg))] text-[rgb(var(--ec-badge-channel-text))]',
-  };
-  return badgeColors[badge.toLowerCase()] || 'bg-[rgb(var(--ec-badge-default-bg))] text-[rgb(var(--ec-badge-default-text))]';
-};
 
 // ============================================
 // Component

--- a/eventcatalog/src/components/SideNav/NestedSideBar/utils.ts
+++ b/eventcatalog/src/components/SideNav/NestedSideBar/utils.ts
@@ -1,0 +1,19 @@
+// Shared utilities for NestedSideBar components
+
+/**
+ * Returns Tailwind classes for badge styling based on badge type.
+ * Uses CSS variables from theme.css for proper theming support.
+ */
+export const getBadgeClasses = (badge: string): string => {
+  const badgeColors: Record<string, string> = {
+    domain: 'bg-[rgb(var(--ec-badge-domain-bg))] text-[rgb(var(--ec-badge-domain-text))]',
+    service: 'bg-[rgb(var(--ec-badge-service-bg))] text-[rgb(var(--ec-badge-service-text))]',
+    event: 'bg-[rgb(var(--ec-badge-event-bg))] text-[rgb(var(--ec-badge-event-text))]',
+    command: 'bg-[rgb(var(--ec-badge-command-bg))] text-[rgb(var(--ec-badge-command-text))]',
+    query: 'bg-[rgb(var(--ec-badge-query-bg))] text-[rgb(var(--ec-badge-query-text))]',
+    message: 'bg-[rgb(var(--ec-badge-message-bg))] text-[rgb(var(--ec-badge-message-text))]',
+    design: 'bg-[rgb(var(--ec-badge-design-bg))] text-[rgb(var(--ec-badge-design-text))]',
+    channel: 'bg-[rgb(var(--ec-badge-channel-bg))] text-[rgb(var(--ec-badge-channel-text))]',
+  };
+  return badgeColors[badge.toLowerCase()] || 'bg-[rgb(var(--ec-badge-default-bg))] text-[rgb(var(--ec-badge-default-text))]';
+};


### PR DESCRIPTION
## What This PR Does

Fixes a bug where sidebar search results displayed duplicate entries for the same resource. Also improves the search results UX by grouping results by resource type (Domain, Service, Event, etc.) with visual section headers and counts.

Closes #1983

## Changes Overview

### Files Changed
- `eventcatalog/src/components/SideNav/NestedSideBar/SearchBar.tsx` - Fixed duplicate filtering, added grouping logic and updated rendering
- `eventcatalog/src/components/SideNav/NestedSideBar/index.tsx` - Refactored to use shared utility
- `eventcatalog/src/components/SideNav/NestedSideBar/utils.ts` - New shared utility file for badge styling

### Key Changes
- Filters out unversioned node keys to prevent duplicate search results
- Groups search results by type (Domain, Service, Event, etc.) with alphabetical sorting
- Displays type badges as section headers with result counts
- Extracted `getBadgeClasses` to a shared utility for consistent theming
- Fixed badge styling to use CSS variables instead of hardcoded colors (proper dark mode support)
- Added missing "Channel" type to the filter mapping

## How It Works

**Duplicate Fix:** The sidebar store creates both versioned keys (e.g., `domain:OrderService:1.0.0`) and unversioned keys (e.g., `domain:OrderService`) for the same resource. Previously, both matched during search and appeared as duplicates. Now, `searchableNodes` filters to only include versioned keys (those with 3+ colon-separated parts).

**Grouping:** After search results are computed, a new `groupedResults` memo groups them by badge type and sorts alphabetically. The UI renders each group with a colored badge header showing the type and count, followed by the individual results.

**Shared Utility:** The `getBadgeClasses` function was duplicated between `SearchBar.tsx` and `index.tsx`. It's now extracted to `utils.ts` and uses CSS variables for proper theming support.

## Breaking Changes

None

## Testing

- [ ] Manual testing performed - search in sidebar no longer shows duplicates
- [ ] Results are grouped by type with proper headers
- [ ] Dark mode theming works correctly for badges

## Additional Notes

The grouping uses alphabetical sorting rather than a hardcoded type order, making it automatically support any new collection types added in the future.

---
🤖 Generated with [Claude Code](https://claude.ai/code)