### PR TITLE
fix(search): respect base path and trailing slash config in search results

### DIFF
--- a/.changeset/warm-paths-glow.md
+++ b/.changeset/warm-paths-glow.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Fixed search results not respecting base path and trailing slash configuration. Search result URLs now correctly include the configured base path and trailing slash settings.

--- a/eventcatalog/src/components/Search/SearchModal.tsx
+++ b/eventcatalog/src/components/Search/SearchModal.tsx
@@ -26,6 +26,7 @@ import { StarIcon as StarIconSolid, CircleStackIcon } from '@heroicons/react/24/
 import { useStore } from '@nanostores/react';
 import { sidebarStore } from '../../stores/sidebar-store';
 import { favoritesStore, toggleFavorite as toggleFavoriteAction } from '../../stores/favorites-store';
+import { buildUrl } from '@utils/url-builder';
 
 const typeIcons: any = {
   Domain: RectangleGroupIcon,
@@ -94,7 +95,7 @@ const getUrlForItem = (node: any, key: string) => {
     pluralType = 'queries';
   }
 
-  return `/docs/${pluralType}/${id}/${version}`;
+  return buildUrl(`/docs/${pluralType}/${id}/${version}`);
 };
 
 export default function SearchModal() {


### PR DESCRIPTION
## What This PR Does

Fixes a bug where search results in the SearchModal (Cmd+K search) generated URLs that ignored the `base` path and `trailingSlash` configuration settings. Users with custom base paths (e.g., `/my/catalog/`) would get broken links when clicking search results.

Closes #1968

## Changes Overview

### Files Changed
- `eventcatalog/src/components/Search/SearchModal.tsx` - Added `buildUrl` import and wrapped URL construction

### Key Changes
- Imports the `buildUrl` utility from `@utils/url-builder`
- Wraps the hardcoded URL construction in `getUrlForItem()` with `buildUrl()` to properly apply base path and trailing slash settings

## How It Works

The `getUrlForItem()` function constructs URLs for search results when the node doesn't have a pre-built `href`. Previously, it returned hardcoded paths like `/docs/events/OrderCreated/1.0.0`.

Now it uses `buildUrl()` which:
1. Prepends the configured `base` path (e.g., `/my/catalog/`)
2. Appends trailing slash if `trailingSlash: true` is configured
3. Cleans up any double slashes

## Breaking Changes

None

## Testing

- [ ] Manual testing with `base` path configured
- [ ] Manual testing with `trailingSlash: true` configured
- [ ] Verify search results navigate to correct URLs

## Example

**Before (broken):**
```
Config: base: '/my/catalog/', trailingSlash: true
Search result URL: /docs/events/OrderCreated/1.0.0
```

**After (fixed):**
```
Config: base: '/my/catalog/', trailingSlash: true
Search result URL: /my/catalog/docs/events/OrderCreated/1.0.0/
```

---
🤖 Generated with [Claude Code](https://claude.ai/code)