### PR TITLE
feat(watcher): add file watcher for chat and auth config files

### DIFF
--- a/.changeset/blue-waves-dance.md
+++ b/.changeset/blue-waves-dance.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Added file watcher support for `eventcatalog.chat.js` and `eventcatalog.auth.js` configuration files. Changes to these files during development will now trigger a refresh automatically.

--- a/src/map-catalog-to-astro.js
+++ b/src/map-catalog-to-astro.js
@@ -71,6 +71,8 @@ function isCatalogRelated(filePath) {
     [
       'eventcatalog.config.js', // config file at root
       'eventcatalog.styles.css', // custom styles file at root
+      'eventcatalog.chat.js', // chat configuration file at root
+      'eventcatalog.auth.js', // auth configuration file at root
       'components', // custom components
       'snippets', // custom snippets
       'public', // public assets


### PR DESCRIPTION
## What This PR Does

Adds file watcher support for `eventcatalog.chat.js` and `eventcatalog.auth.js` configuration files. Previously, changes to these files during development required a manual server restart. Now they trigger an automatic refresh.

Closes #1974

## Changes Overview

### Files Changed
- `src/map-catalog-to-astro.js` - Added chat and auth config files to the watched files list

### Key Changes
- Added `eventcatalog.chat.js` to the `isCatalogRelated()` function's watch list
- Added `eventcatalog.auth.js` to the `isCatalogRelated()` function's watch list

## How It Works

The `map-catalog-to-astro.js` file determines which files are "catalog related" and should be watched for changes. By adding the chat and auth config files to this list, the existing file watcher infrastructure will now automatically detect changes to these files and trigger a refresh.

## Breaking Changes

None

## Testing

- [ ] Manual testing - modify `eventcatalog.chat.js` during dev and verify refresh occurs
- [ ] Manual testing - modify `eventcatalog.auth.js` during dev and verify refresh occurs

---
🤖 Generated with [Claude Code](https://claude.ai/code)