### PR TITLE
Fix visualizer edge direction when channel version not found

### DIFF
--- a/.changeset/brave-pandas-dance.md
+++ b/.changeset/brave-pandas-dance.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Fix visualizer showing incorrect "subscribed by" edge when producer references non-existent channel version

--- a/eventcatalog/src/utils/node-graphs/message-node-graph.ts
+++ b/eventcatalog/src/utils/node-graphs/message-node-graph.ts
@@ -788,13 +788,13 @@ export const getNodesAndEdgesForProducedMessage = ({
       const channel = findInMap(map, sourceChannel.id, sourceChannel.version) as CollectionEntry<'channels'>;
 
       if (!channel) {
-        // No channel found, we just connect the message to the source directly
+        // No channel found, we just connect the source directly to the message
         edges.push(
           createEdge({
-            id: generatedIdForEdge(message, source),
-            source: messageId,
-            target: generateIdForNode(source),
-            label: getEdgeLabelForMessageAsSource(message),
+            id: generatedIdForEdge(source, message),
+            source: generateIdForNode(source),
+            target: messageId,
+            label: getEdgeLabelForServiceAsTarget(message),
             data: { customColor: getColorFromString(message.data.id), rootSourceAndTarget },
           })
         );


### PR DESCRIPTION
## What This PR Does

Fixes a bug in the visualizer where services incorrectly appeared to both publish AND subscribe to an event when the service referenced a channel version that doesn't exist. The root cause was reversed edge direction in the fallback code path of `getNodesAndEdgesForProducedMessage()`.

## Changes Overview

### Files Changed
- `eventcatalog/src/utils/node-graphs/message-node-graph.ts` - Core fix for edge direction
- `eventcatalog/src/utils/__tests__/messages/node-graph.spec.ts` - Test coverage for the bug fix
- `eventcatalog/src/enterprise/mcp/__tests__/mcp-server.spec.ts` - Fixed test mocks for hono and MCP SDK
- `.changeset/brave-pandas-dance.md` - Changeset for version bump

### Key Changes
- Swapped `source` and `target` in the fallback edge when channel version is not found
- Changed label function from `getEdgeLabelForMessageAsSource` to `getEdgeLabelForServiceAsTarget`
- Added comprehensive test case for the non-existent channel version scenario
- Improved MCP test mocks to use regular functions instead of `vi.fn()` to prevent `resetAllMocks()` from breaking the mocks

## How It Works

When a service publishes a message to a channel, the visualizer creates edges to show the flow. If the specified channel version doesn't exist, a fallback edge is created directly between the service and message. Previously, this edge was incorrectly created as `message -> service` (implying subscription). The fix changes it to `service -> message` (correctly showing publication).

## Breaking Changes

None

## Testing

- [x] Unit tests added for the specific bug scenario
- [x] All 467 tests pass
- [x] Manual testing with InventoryService example referencing non-existent channel version

## Checklist

- [x] Code follows project conventions
- [x] Tests updated
- [x] No console errors

🤖 Generated with [Claude Code](https://claude.ai/code)