### PR TITLE
Add enhanced Discover page with table filtering and tabbed navigation

### DIFF
--- a/.changeset/bright-tables-discover.md
+++ b/.changeset/bright-tables-discover.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": minor
+---
+
+Add new Discover page with enhanced table filtering and tabbed navigation for browsing catalog resources

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,28 @@ Resources are stored in content collections. Key collections:
 - `services`, `domains`, `flows`, `channels`, `entities`
 - `teams`, `users` (non-versioned)
 
+The whole astro collection schemas are in the `eventcatalog/src/content.config.ts` file.
+
+
+### Getting collection information
+
+We prefer to use the utility classes we have to get collection for example:
+
+```
+import { getEvents } from '@utils/collections/events';
+import { getCommands } from '@utils/collections/commands';
+import { getQueries } from '@utils/collections/queries';
+import { getServices } from '@utils/collections/services';
+import { getDomains } from '@utils/collections/domains';
+import { getFlows } from '@utils/collections/flows';
+import { getChannels } from '@utils/collections/channels';
+import { getEntities } from '@utils/collections/entities';
+import { getTeams } from '@utils/collections/teams';
+import { getUsers } from '@utils/collections/users';
+```
+
+Where you cant do that though you may use the `getCollection` and `getEntry` functions from the `astro:content` package.
+
 ```typescript
 // Getting collections
 import { getCollection, getEntry } from 'astro:content';
@@ -90,6 +112,8 @@ const event = await getEntry('events', 'OrderCreated-1.0.0');
 ### Versioning
 
 Most resources are versioned. Entry IDs follow the pattern: `{id}-{version}` (e.g., `OrderCreated-1.0.0`).
+
+When you need to get specific version or latest version you need to use the `getItemsFromCollectionByIdAndSemverOrLatest` utility function.
 
 ```typescript
 // Use existing utilities for version handling

--- a/eventcatalog/src/components/EnvironmentDropdown.tsx
+++ b/eventcatalog/src/components/EnvironmentDropdown.tsx
@@ -86,7 +86,7 @@ export const EnvironmentDropdown: React.FC<EnvironmentDropdownProps> = ({ enviro
         </svg>
       </button>
       <div
-        className={`${isOpen ? '' : 'hidden'} absolute right-0 mt-2 w-64 bg-[rgb(var(--ec-dropdown-bg))] rounded-md shadow-lg py-1 z-50 border border-[rgb(var(--ec-dropdown-border))] overflow-hidden z-20`}
+        className={`${isOpen ? '' : 'hidden'} absolute right-0 mt-2 w-64 bg-[rgb(var(--ec-dropdown-bg))] rounded-md shadow-lg py-1 border border-[rgb(var(--ec-dropdown-border))] overflow-hidden z-[100]`}
       >
         {environments.map((env) => {
           const isCurrentEnv = currentEnvironment?.name === env.name;

--- a/eventcatalog/src/components/Tables/Discover/DiscoverTable.tsx
+++ b/eventcatalog/src/components/Tables/Discover/DiscoverTable.tsx
@@ -1,0 +1,816 @@
+import {
+  flexRender,
+  getCoreRowModel,
+  getFacetedMinMaxValues,
+  getFacetedRowModel,
+  getFacetedUniqueValues,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  useReactTable,
+  type ColumnFiltersState,
+} from '@tanstack/react-table';
+import { ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight, SearchX, X, Search, Users } from 'lucide-react';
+import { UserIcon } from '@heroicons/react/24/outline';
+import { useMemo, useState } from 'react';
+import type { TableConfiguration } from '@types';
+import { isSameVersion } from '@utils/collections/util';
+import { FilterDropdown, CheckboxItem } from './FilterComponents';
+import DebouncedInput from '../DebouncedInput';
+import { getDiscoverColumns } from './columns';
+
+export type CollectionType = 'events' | 'commands' | 'queries' | 'services' | 'domains' | 'flows' | 'containers';
+
+export interface DiscoverTableData {
+  collection: string;
+  domains?: Array<{ id: string; name: string; version: string }>;
+  owners?: Array<{ id: string; name: string; type?: 'user' | 'team' }>;
+  hasSpecifications?: boolean;
+  hasOwners?: boolean;
+  hasRepository?: boolean;
+  isDeprecated?: boolean;
+  hasDataDependencies?: boolean;
+  data: {
+    id: string;
+    name: string;
+    summary?: string;
+    version: string;
+    latestVersion?: string;
+    draft?: boolean | { title?: string; message: string };
+    badges?: Array<{
+      id?: string;
+      content: string;
+      backgroundColor?: string;
+      textColor?: string;
+    }>;
+    producers?: Array<any>;
+    consumers?: Array<any>;
+    receives?: Array<any>;
+    sends?: Array<any>;
+    services?: Array<any>;
+    servicesThatWriteToContainer?: Array<any>;
+    servicesThatReadFromContainer?: Array<any>;
+  };
+}
+
+export interface PropertyOption {
+  id: string;
+  label: string;
+}
+
+export interface DiscoverTableProps<T extends DiscoverTableData> {
+  data: T[];
+  collectionType: CollectionType;
+  collectionLabel: string;
+  domains?: Array<{ id: string; name: string; version: string }>;
+  owners?: Array<{ id: string; name: string; type?: 'user' | 'team' }>;
+  producers?: Array<{ id: string; name: string }>;
+  consumers?: Array<{ id: string; name: string }>;
+  propertyOptions?: PropertyOption[];
+  tableConfiguration?: TableConfiguration;
+  showDomainsFilter?: boolean;
+  showOwnersFilter?: boolean;
+  showProducersFilter?: boolean;
+  showConsumersFilter?: boolean;
+}
+
+export function DiscoverTable<T extends DiscoverTableData>({
+  data: initialData,
+  collectionType,
+  collectionLabel,
+  domains = [],
+  owners = [],
+  producers = [],
+  consumers = [],
+  propertyOptions = [],
+  tableConfiguration,
+  showDomainsFilter = true,
+  showOwnersFilter = true,
+  showProducersFilter = false,
+  showConsumersFilter = false,
+}: DiscoverTableProps<T>) {
+  // Generate columns inside the React component to avoid hydration issues
+  const columns = useMemo(
+    () => getDiscoverColumns(collectionType, tableConfiguration ?? { columns: {} }),
+    [collectionType, tableConfiguration]
+  );
+  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+  const [globalFilter, setGlobalFilter] = useState('');
+  const [tableFilter, setTableFilter] = useState('');
+  const [showOnlyLatest, setShowOnlyLatest] = useState(true);
+  const [onlyShowDrafts, setOnlyShowDrafts] = useState(false);
+  const [selectedDomains, setSelectedDomains] = useState<string[]>([]);
+  const [selectedOwners, setSelectedOwners] = useState<string[]>([]);
+  const [selectedProducers, setSelectedProducers] = useState<string[]>([]);
+  const [selectedConsumers, setSelectedConsumers] = useState<string[]>([]);
+  const [selectedBadges, setSelectedBadges] = useState<string[]>([]);
+  const [selectedProperties, setSelectedProperties] = useState<string[]>([]);
+
+  // Collect unique badges from all items
+  const allBadges = useMemo(() => {
+    const badgeMap = new Map<string, { content: string; backgroundColor?: string; textColor?: string; count: number }>();
+    initialData.forEach((item) => {
+      const badges = item.data?.badges || [];
+      badges.forEach((badge: any) => {
+        const existing = badgeMap.get(badge.content);
+        if (existing) {
+          existing.count++;
+        } else {
+          badgeMap.set(badge.content, {
+            content: badge.content,
+            backgroundColor: badge.backgroundColor,
+            textColor: badge.textColor,
+            count: 1,
+          });
+        }
+      });
+    });
+    return Array.from(badgeMap.values()).sort((a, b) => b.count - a.count);
+  }, [initialData]);
+
+  // Filter data based on all filter states
+  const filteredData = useMemo(() => {
+    return initialData.filter((row) => {
+      // Check if item is a draft
+      const isDraft = row.data.draft === true || (typeof row.data.draft === 'object' && row.data.draft !== null);
+
+      // Draft filter
+      if (onlyShowDrafts && !isDraft) {
+        return false;
+      }
+
+      if (onlyShowDrafts) {
+        return true;
+      }
+
+      // Latest version filter
+      if (showOnlyLatest && !isSameVersion(row.data.version, row.data.latestVersion)) {
+        return false;
+      }
+
+      // Domain filter
+      if (selectedDomains.length > 0) {
+        const itemDomains = row.domains || [];
+        const hasMatchingDomain = itemDomains.some((d) => selectedDomains.includes(d.id));
+        if (!hasMatchingDomain) {
+          return false;
+        }
+      }
+
+      // Owner filter
+      if (selectedOwners.length > 0) {
+        const itemOwners = row.owners || [];
+        const hasMatchingOwner = itemOwners.some((o) => selectedOwners.includes(o.id));
+        if (!hasMatchingOwner) {
+          return false;
+        }
+      }
+
+      // Producer filter
+      if (selectedProducers.length > 0) {
+        const itemProducers = row.data.producers || [];
+        const hasMatchingProducer = itemProducers.some((p: any) => selectedProducers.includes(p.data?.id || p.id));
+        if (!hasMatchingProducer) {
+          return false;
+        }
+      }
+
+      // Consumer filter
+      if (selectedConsumers.length > 0) {
+        const itemConsumers = row.data.consumers || [];
+        const hasMatchingConsumer = itemConsumers.some((c: any) => selectedConsumers.includes(c.data?.id || c.id));
+        if (!hasMatchingConsumer) {
+          return false;
+        }
+      }
+
+      // Badge filter
+      if (selectedBadges.length > 0) {
+        const itemBadges = row.data?.badges || [];
+        const hasMatchingBadge = itemBadges.some((badge: any) => selectedBadges.includes(badge.content));
+        if (!hasMatchingBadge) {
+          return false;
+        }
+      }
+
+      // Property filters
+      if (selectedProperties.length > 0) {
+        for (const prop of selectedProperties) {
+          // Generic property checks
+          if (prop === 'hasSpecifications' && !row.hasSpecifications) return false;
+          if (prop === 'hasOwners' && !row.hasOwners) return false;
+          if (prop === 'hasRepository' && !row.hasRepository) return false;
+          if (prop === 'hasDataDependencies' && !row.hasDataDependencies) return false;
+          if (prop === 'isDeprecated' && !row.isDeprecated) return false;
+
+          // Message-specific checks
+          if (prop === 'hasProducers') {
+            const producers = row.data.producers || [];
+            if (producers.length === 0) return false;
+          }
+          if (prop === 'hasConsumers') {
+            const consumers = row.data.consumers || [];
+            if (consumers.length === 0) return false;
+          }
+          if (prop === 'hasMessages') {
+            const sends = row.data.sends || [];
+            const receives = row.data.receives || [];
+            if (sends.length === 0 && receives.length === 0) return false;
+          }
+
+          // Service-specific checks
+          if (prop === 'hasServices') {
+            const services = row.data.services || [];
+            if (services.length === 0) return false;
+          }
+
+          // Container-specific checks
+          if (prop === 'hasWriters') {
+            const writers = row.data.servicesThatWriteToContainer || [];
+            if (writers.length === 0) return false;
+          }
+          if (prop === 'hasReaders') {
+            const readers = row.data.servicesThatReadFromContainer || [];
+            if (readers.length === 0) return false;
+          }
+        }
+      }
+
+      // Global search filter (sidebar)
+      if (globalFilter) {
+        const searchLower = globalFilter.toLowerCase();
+        const nameMatch = row.data.name.toLowerCase().includes(searchLower);
+        const summaryMatch = row.data.summary?.toLowerCase().includes(searchLower);
+        if (!nameMatch && !summaryMatch) {
+          return false;
+        }
+      }
+
+      // Table filter (header)
+      if (tableFilter) {
+        const searchLower = tableFilter.toLowerCase();
+        const nameMatch = row.data.name.toLowerCase().includes(searchLower);
+        const summaryMatch = row.data.summary?.toLowerCase().includes(searchLower);
+        if (!nameMatch && !summaryMatch) {
+          return false;
+        }
+      }
+
+      return true;
+    });
+  }, [
+    initialData,
+    showOnlyLatest,
+    onlyShowDrafts,
+    selectedDomains,
+    selectedOwners,
+    selectedProducers,
+    selectedConsumers,
+    selectedBadges,
+    selectedProperties,
+    globalFilter,
+    tableFilter,
+  ]);
+
+  const table = useReactTable({
+    data: filteredData,
+    columns,
+    onColumnFiltersChange: setColumnFilters,
+    getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getFacetedRowModel: getFacetedRowModel(),
+    getFacetedUniqueValues: getFacetedUniqueValues(),
+    getFacetedMinMaxValues: getFacetedMinMaxValues(),
+    getPaginationRowModel: getPaginationRowModel(),
+    state: {
+      columnFilters,
+      columnVisibility: Object.fromEntries(
+        Object.entries(tableConfiguration?.columns ?? {}).map(([key, value]) => [key, value.visible ?? true])
+      ),
+    },
+  });
+
+  const totalResults = table.getPrePaginationRowModel().rows.length;
+  const hasResults = table.getRowModel().rows.length > 0;
+
+  // Count items per domain for the filter
+  const domainCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    initialData.forEach((item) => {
+      const itemDomains = item.domains || [];
+      itemDomains.forEach((d) => {
+        counts[d.id] = (counts[d.id] || 0) + 1;
+      });
+    });
+    return counts;
+  }, [initialData]);
+
+  // Count items per owner for the filter
+  const ownerCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    initialData.forEach((item) => {
+      const itemOwners = item.owners || [];
+      itemOwners.forEach((o) => {
+        counts[o.id] = (counts[o.id] || 0) + 1;
+      });
+    });
+    return counts;
+  }, [initialData]);
+
+  // Count items per producer for the filter
+  const producerCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    initialData.forEach((item) => {
+      const itemProducers = item.data.producers || [];
+      itemProducers.forEach((p: any) => {
+        const id = p.data?.id || p.id;
+        if (id) counts[id] = (counts[id] || 0) + 1;
+      });
+    });
+    return counts;
+  }, [initialData]);
+
+  // Count items per consumer for the filter
+  const consumerCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    initialData.forEach((item) => {
+      const itemConsumers = item.data.consumers || [];
+      itemConsumers.forEach((c: any) => {
+        const id = c.data?.id || c.id;
+        if (id) counts[id] = (counts[id] || 0) + 1;
+      });
+    });
+    return counts;
+  }, [initialData]);
+
+  const toggleDomain = (domainId: string) => {
+    setSelectedDomains((prev) => (prev.includes(domainId) ? prev.filter((id) => id !== domainId) : [...prev, domainId]));
+  };
+
+  const toggleOwner = (ownerId: string) => {
+    setSelectedOwners((prev) => (prev.includes(ownerId) ? prev.filter((id) => id !== ownerId) : [...prev, ownerId]));
+  };
+
+  const toggleProducer = (producerId: string) => {
+    setSelectedProducers((prev) => (prev.includes(producerId) ? prev.filter((id) => id !== producerId) : [...prev, producerId]));
+  };
+
+  const toggleConsumer = (consumerId: string) => {
+    setSelectedConsumers((prev) => (prev.includes(consumerId) ? prev.filter((id) => id !== consumerId) : [...prev, consumerId]));
+  };
+
+  const toggleBadge = (badgeContent: string) => {
+    setSelectedBadges((prev) => (prev.includes(badgeContent) ? prev.filter((b) => b !== badgeContent) : [...prev, badgeContent]));
+  };
+
+  const toggleProperty = (propertyId: string) => {
+    setSelectedProperties((prev) => (prev.includes(propertyId) ? prev.filter((p) => p !== propertyId) : [...prev, propertyId]));
+  };
+
+  const clearAllFilters = () => {
+    setSelectedDomains([]);
+    setSelectedOwners([]);
+    setSelectedProducers([]);
+    setSelectedConsumers([]);
+    setSelectedBadges([]);
+    setSelectedProperties([]);
+    setShowOnlyLatest(true);
+    setOnlyShowDrafts(false);
+    setGlobalFilter('');
+    setTableFilter('');
+    setColumnFilters([]);
+  };
+
+  const activeFilterCount =
+    selectedDomains.length +
+    selectedOwners.length +
+    selectedProducers.length +
+    selectedConsumers.length +
+    selectedBadges.length +
+    selectedProperties.length +
+    (!showOnlyLatest ? 1 : 0) +
+    (onlyShowDrafts ? 1 : 0);
+
+  // Get selected domain names for display
+  const selectedDomainNames = selectedDomains.map((id) => domains.find((d) => d.id === id)?.name || id);
+
+  // Get selected owner names for display
+  const selectedOwnerNames = selectedOwners.map((id) => owners.find((o) => o.id === id)?.name || id);
+
+  // Get selected producer names for display
+  const selectedProducerNames = selectedProducers.map((id) => producers.find((p) => p.id === id)?.name || id);
+
+  // Get selected consumer names for display
+  const selectedConsumerNames = selectedConsumers.map((id) => consumers.find((c) => c.id === id)?.name || id);
+
+  // Filter producers/consumers to only show those with count > 0
+  const filteredProducers = producers.filter((p) => (producerCounts[p.id] || 0) > 0);
+  const filteredConsumers = consumers.filter((c) => (consumerCounts[c.id] || 0) > 0);
+
+  // Get selected property labels for display
+  const selectedPropertyLabels = selectedProperties.map((id) => propertyOptions.find((p) => p.id === id)?.label || id);
+
+  return (
+    <div className="flex gap-8 items-start">
+      {/* Filter Sidebar */}
+      <div className="w-72 flex-shrink-0 space-y-6 p-4 bg-[rgb(var(--ec-card-bg,var(--ec-page-bg)))] border border-[rgb(var(--ec-page-border))] rounded-xl">
+        {/* Search */}
+        <DebouncedInput
+          type="text"
+          value={globalFilter}
+          onChange={(value) => setGlobalFilter(String(value))}
+          placeholder={`Search ${collectionLabel.toLowerCase()}...`}
+          className="w-full px-3 py-2 text-sm bg-[rgb(var(--ec-input-bg))] text-[rgb(var(--ec-input-text))] border border-[rgb(var(--ec-page-border))] rounded-lg placeholder:text-[rgb(var(--ec-input-placeholder))] focus:outline-none focus:ring-2 focus:ring-[rgb(var(--ec-accent)/0.2)] focus:border-[rgb(var(--ec-accent))] transition-colors"
+        />
+
+        {/* Message Filters Section */}
+        {(showProducersFilter || showConsumersFilter) && (filteredProducers.length > 0 || filteredConsumers.length > 0) && (
+          <div className="space-y-2">
+            <h3 className="text-[11px] font-bold uppercase tracking-widest text-[rgb(var(--ec-page-text-muted))]">
+              Message Filters
+            </h3>
+
+            {/* Producers Filter */}
+            {showProducersFilter && filteredProducers.length > 0 && (
+              <div>
+                <label className="block text-xs font-medium text-[rgb(var(--ec-page-text-muted))] mb-1.5">Producers</label>
+                <FilterDropdown
+                  label="Select producers..."
+                  selectedItems={selectedProducerNames}
+                  onClear={() => setSelectedProducers([])}
+                  onRemoveItem={(name) => {
+                    const producer = filteredProducers.find((p) => p.name === name);
+                    if (producer) toggleProducer(producer.id);
+                  }}
+                >
+                  {filteredProducers.map((producer) => (
+                    <CheckboxItem
+                      key={producer.id}
+                      label={producer.name}
+                      checked={selectedProducers.includes(producer.id)}
+                      onChange={() => toggleProducer(producer.id)}
+                      count={producerCounts[producer.id] || 0}
+                    />
+                  ))}
+                </FilterDropdown>
+              </div>
+            )}
+
+            {/* Consumers Filter */}
+            {showConsumersFilter && filteredConsumers.length > 0 && (
+              <div>
+                <label className="block text-xs font-medium text-[rgb(var(--ec-page-text-muted))] mb-1.5">Consumers</label>
+                <FilterDropdown
+                  label="Select consumers..."
+                  selectedItems={selectedConsumerNames}
+                  onClear={() => setSelectedConsumers([])}
+                  onRemoveItem={(name) => {
+                    const consumer = filteredConsumers.find((c) => c.name === name);
+                    if (consumer) toggleConsumer(consumer.id);
+                  }}
+                >
+                  {filteredConsumers.map((consumer) => (
+                    <CheckboxItem
+                      key={consumer.id}
+                      label={consumer.name}
+                      checked={selectedConsumers.includes(consumer.id)}
+                      onChange={() => toggleConsumer(consumer.id)}
+                      count={consumerCounts[consumer.id] || 0}
+                    />
+                  ))}
+                </FilterDropdown>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Catalog Filters Section */}
+        <div className="space-y-2">
+          <h3 className="text-[11px] font-bold uppercase tracking-widest text-[rgb(var(--ec-page-text-muted))]">
+            Catalog Filters
+          </h3>
+
+          {/* Domains Filter */}
+          {showDomainsFilter && domains.length > 0 && (
+            <div>
+              <label className="block text-xs font-medium text-[rgb(var(--ec-page-text-muted))] mb-1.5">Domains</label>
+              <FilterDropdown
+                label="Select domains..."
+                selectedItems={selectedDomainNames}
+                onClear={() => setSelectedDomains([])}
+                onRemoveItem={(name) => {
+                  const domain = domains.find((d) => d.name === name);
+                  if (domain) toggleDomain(domain.id);
+                }}
+              >
+                {domains.map((domain) => (
+                  <CheckboxItem
+                    key={domain.id}
+                    label={domain.name}
+                    checked={selectedDomains.includes(domain.id)}
+                    onChange={() => toggleDomain(domain.id)}
+                    count={domainCounts[domain.id] || 0}
+                  />
+                ))}
+              </FilterDropdown>
+            </div>
+          )}
+
+          {/* Owners Filter */}
+          {showOwnersFilter && owners.length > 0 && (
+            <div>
+              <label className="block text-xs font-medium text-[rgb(var(--ec-page-text-muted))] mb-1.5">Owners</label>
+              <FilterDropdown
+                label="Select owners..."
+                selectedItems={selectedOwnerNames}
+                onClear={() => setSelectedOwners([])}
+                onRemoveItem={(name) => {
+                  const owner = owners.find((o) => o.name === name);
+                  if (owner) toggleOwner(owner.id);
+                }}
+              >
+                {/* Users section */}
+                {owners.filter((o) => o.type !== 'team').length > 0 && (
+                  <>
+                    <div className="px-2 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-[rgb(var(--ec-page-text-muted))] flex items-center gap-1.5">
+                      <UserIcon className="w-3 h-3" />
+                      Users
+                    </div>
+                    {owners
+                      .filter((o) => o.type !== 'team')
+                      .map((owner) => (
+                        <CheckboxItem
+                          key={owner.id}
+                          label={owner.name}
+                          checked={selectedOwners.includes(owner.id)}
+                          onChange={() => toggleOwner(owner.id)}
+                          count={ownerCounts[owner.id] || 0}
+                        />
+                      ))}
+                  </>
+                )}
+                {/* Teams section */}
+                {owners.filter((o) => o.type === 'team').length > 0 && (
+                  <>
+                    <div className="px-2 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-[rgb(var(--ec-page-text-muted))] flex items-center gap-1.5 mt-2 border-t border-[rgb(var(--ec-page-border))] pt-2">
+                      <Users className="w-3 h-3" />
+                      Teams
+                    </div>
+                    {owners
+                      .filter((o) => o.type === 'team')
+                      .map((owner) => (
+                        <CheckboxItem
+                          key={owner.id}
+                          label={owner.name}
+                          checked={selectedOwners.includes(owner.id)}
+                          onChange={() => toggleOwner(owner.id)}
+                          count={ownerCounts[owner.id] || 0}
+                        />
+                      ))}
+                  </>
+                )}
+              </FilterDropdown>
+            </div>
+          )}
+
+          {/* Badges Filter */}
+          {allBadges.length > 0 && (
+            <div>
+              <label className="block text-xs font-medium text-[rgb(var(--ec-page-text-muted))] mb-1.5">Badges</label>
+              <FilterDropdown
+                label="Select badges..."
+                selectedItems={selectedBadges}
+                onClear={() => setSelectedBadges([])}
+                onRemoveItem={(badge) => toggleBadge(badge)}
+              >
+                {allBadges.map((badge) => (
+                  <CheckboxItem
+                    key={badge.content}
+                    label={badge.content}
+                    checked={selectedBadges.includes(badge.content)}
+                    onChange={() => toggleBadge(badge.content)}
+                    count={badge.count}
+                  />
+                ))}
+              </FilterDropdown>
+            </div>
+          )}
+
+          {/* Properties Filter */}
+          {propertyOptions.length > 0 && (
+            <div>
+              <label className="block text-xs font-medium text-[rgb(var(--ec-page-text-muted))] mb-1.5">Properties</label>
+              <FilterDropdown
+                label="Select properties..."
+                selectedItems={selectedPropertyLabels}
+                onClear={() => setSelectedProperties([])}
+                onRemoveItem={(label) => {
+                  const prop = propertyOptions.find((p) => p.label === label);
+                  if (prop) toggleProperty(prop.id);
+                }}
+              >
+                {propertyOptions.map((option) => (
+                  <CheckboxItem
+                    key={option.id}
+                    label={option.label}
+                    checked={selectedProperties.includes(option.id)}
+                    onChange={() => toggleProperty(option.id)}
+                  />
+                ))}
+              </FilterDropdown>
+            </div>
+          )}
+
+          {/* Version Filter */}
+          <div>
+            <label className="block text-xs font-medium text-[rgb(var(--ec-page-text-muted))] mb-1.5">Version</label>
+            <FilterDropdown
+              label="Select version..."
+              selectedItems={[...(showOnlyLatest ? ['Latest only'] : []), ...(onlyShowDrafts ? ['Drafts only'] : [])]}
+              onClear={() => {
+                setShowOnlyLatest(true);
+                setOnlyShowDrafts(false);
+              }}
+              onRemoveItem={(item) => {
+                if (item === 'Latest only') setShowOnlyLatest(false);
+                if (item === 'Drafts only') setOnlyShowDrafts(false);
+              }}
+            >
+              <CheckboxItem
+                label="Latest version only"
+                checked={showOnlyLatest}
+                onChange={() => setShowOnlyLatest(!showOnlyLatest)}
+              />
+              <CheckboxItem label="Drafts only" checked={onlyShowDrafts} onChange={() => setOnlyShowDrafts(!onlyShowDrafts)} />
+            </FilterDropdown>
+          </div>
+        </div>
+
+        {/* Results & Clear */}
+        <div className="flex items-center justify-between pt-4 mt-2 border-t border-[rgb(var(--ec-page-border))]">
+          <span className="text-sm text-[rgb(var(--ec-page-text-muted))]">
+            <span className="font-semibold text-[rgb(var(--ec-page-text))]">{totalResults}</span> results
+          </span>
+          {activeFilterCount > 0 && (
+            <button onClick={clearAllFilters} className="text-xs font-medium text-[rgb(var(--ec-accent))] hover:underline">
+              Clear all
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Main Table */}
+      <div className="flex-1 min-w-0">
+        {/* Table Header */}
+        <div className="flex items-center justify-between mb-5">
+          <h2 className="text-xl font-bold text-[rgb(var(--ec-page-text))]">
+            {collectionLabel}{' '}
+            <span className="text-base text-[rgb(var(--ec-page-text-muted))] font-normal ml-1">({totalResults})</span>
+          </h2>
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-[rgb(var(--ec-icon-color))]" />
+            <input
+              type="text"
+              value={tableFilter}
+              onChange={(e) => setTableFilter(e.target.value)}
+              placeholder="Filter..."
+              className="pl-9 pr-3 py-1.5 text-sm w-48 bg-[rgb(var(--ec-input-bg))] text-[rgb(var(--ec-input-text))] border border-[rgb(var(--ec-page-border))] rounded-lg placeholder:text-[rgb(var(--ec-input-placeholder))] focus:outline-none focus:ring-2 focus:ring-[rgb(var(--ec-accent)/0.2)] focus:border-[rgb(var(--ec-accent))] transition-colors"
+            />
+            {tableFilter && (
+              <button
+                onClick={() => setTableFilter('')}
+                className="absolute right-2 top-1/2 -translate-y-1/2 p-0.5 text-[rgb(var(--ec-icon-color))] hover:text-[rgb(var(--ec-page-text))]"
+              >
+                <X className="w-3.5 h-3.5" />
+              </button>
+            )}
+          </div>
+        </div>
+
+        {/* Table */}
+        <div className="rounded-xl border border-[rgb(var(--ec-page-border))] overflow-hidden shadow-sm">
+          <table className="min-w-full divide-y divide-[rgb(var(--ec-page-border))]">
+            <thead className="bg-[rgb(var(--ec-content-hover))] sticky top-0 z-10 border-b-2 border-[rgb(var(--ec-page-border))]">
+              {table.getHeaderGroups().map((headerGroup, index) => (
+                <tr key={`${headerGroup}-${index}`}>
+                  {headerGroup.headers.map((header) => (
+                    <th
+                      key={`${header.id}`}
+                      className="px-4 py-3.5 text-left text-[11px] font-bold text-[rgb(var(--ec-page-text-muted))] uppercase tracking-widest"
+                    >
+                      <div className="flex flex-col gap-2">
+                        <div>{header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}</div>
+                      </div>
+                    </th>
+                  ))}
+                </tr>
+              ))}
+            </thead>
+
+            <tbody className="bg-[rgb(var(--ec-card-bg,var(--ec-page-bg)))] divide-y divide-[rgb(var(--ec-page-border)/0.5)]">
+              {hasResults ? (
+                table.getRowModel().rows.map((row, index) => (
+                  <tr
+                    key={`${row.id}-${index}`}
+                    className={`group hover:bg-[rgb(var(--ec-accent)/0.04)] transition-all duration-150 border-l-2 border-transparent hover:border-[rgb(var(--ec-accent))] ${
+                      index % 2 === 1 ? 'bg-[rgb(var(--ec-page-bg)/0.5)]' : ''
+                    }`}
+                  >
+                    {row.getVisibleCells().map((cell) => (
+                      <td
+                        key={cell.id}
+                        className={`px-4 py-4 text-sm text-[rgb(var(--ec-page-text))] ${cell.column.columnDef.meta?.className || ''}`}
+                      >
+                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                      </td>
+                    ))}
+                  </tr>
+                ))
+              ) : (
+                <tr>
+                  <td colSpan={table.getAllColumns().length} className="px-4 py-12 text-center">
+                    <div className="flex flex-col items-center justify-center text-[rgb(var(--ec-page-text-muted))]">
+                      <SearchX className="w-10 h-10 text-[rgb(var(--ec-icon-color))] mb-3 opacity-50" />
+                      <p className="text-sm font-medium text-[rgb(var(--ec-page-text-muted))]">No results found</p>
+                      <p className="text-xs text-[rgb(var(--ec-icon-color))] mt-1">Try adjusting your search or filters</p>
+                      {activeFilterCount > 0 && (
+                        <button onClick={clearAllFilters} className="mt-3 text-sm text-[rgb(var(--ec-accent))] hover:underline">
+                          Clear all filters
+                        </button>
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Pagination */}
+        <div className="flex items-center justify-between px-1 py-4">
+          <div className="text-sm text-[rgb(var(--ec-page-text-muted))]">
+            {totalResults > 0 && (
+              <span>
+                Showing <span className="font-medium text-[rgb(var(--ec-page-text))]">{table.getRowModel().rows.length}</span> of{' '}
+                <span className="font-medium text-[rgb(var(--ec-page-text))]">{totalResults}</span> results
+              </span>
+            )}
+          </div>
+          <div className="flex items-center gap-2">
+            <div className="flex items-center rounded-lg border border-[rgb(var(--ec-page-border))] bg-[rgb(var(--ec-card-bg,var(--ec-page-bg)))]">
+              <button
+                className="p-2 text-[rgb(var(--ec-icon-color))] hover:text-[rgb(var(--ec-page-text))] hover:bg-[rgb(var(--ec-content-hover))] disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent transition-colors rounded-l-lg"
+                onClick={() => table.setPageIndex(0)}
+                disabled={!table.getCanPreviousPage()}
+                title="First page"
+              >
+                <ChevronsLeft className="w-4 h-4" />
+              </button>
+              <button
+                className="p-2 text-[rgb(var(--ec-icon-color))] hover:text-[rgb(var(--ec-page-text))] hover:bg-[rgb(var(--ec-content-hover))] disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent transition-colors border-l border-[rgb(var(--ec-page-border))]"
+                onClick={() => table.previousPage()}
+                disabled={!table.getCanPreviousPage()}
+                title="Previous page"
+              >
+                <ChevronLeft className="w-4 h-4" />
+              </button>
+              <span className="px-3 py-2 text-sm text-[rgb(var(--ec-page-text-muted))] border-l border-r border-[rgb(var(--ec-page-border))] min-w-[100px] text-center">
+                Page{' '}
+                <span className="font-medium text-[rgb(var(--ec-page-text))]">{table.getState().pagination.pageIndex + 1}</span>{' '}
+                of <span className="font-medium text-[rgb(var(--ec-page-text))]">{table.getPageCount() || 1}</span>
+              </span>
+              <button
+                className="p-2 text-[rgb(var(--ec-icon-color))] hover:text-[rgb(var(--ec-page-text))] hover:bg-[rgb(var(--ec-content-hover))] disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent transition-colors border-r border-[rgb(var(--ec-page-border))]"
+                onClick={() => table.nextPage()}
+                disabled={!table.getCanNextPage()}
+                title="Next page"
+              >
+                <ChevronRight className="w-4 h-4" />
+              </button>
+              <button
+                className="p-2 text-[rgb(var(--ec-icon-color))] hover:text-[rgb(var(--ec-page-text))] hover:bg-[rgb(var(--ec-content-hover))] disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent transition-colors rounded-r-lg"
+                onClick={() => table.setPageIndex(table.getPageCount() - 1)}
+                disabled={!table.getCanNextPage()}
+                title="Last page"
+              >
+                <ChevronsRight className="w-4 h-4" />
+              </button>
+            </div>
+            <select
+              value={table.getState().pagination.pageSize}
+              onChange={(e) => {
+                table.setPageSize(Number(e.target.value));
+              }}
+              className="px-3 py-2 text-sm text-[rgb(var(--ec-page-text-muted))] bg-[rgb(var(--ec-card-bg,var(--ec-page-bg)))] border border-[rgb(var(--ec-page-border))] rounded-lg hover:border-[rgb(var(--ec-icon-color))] focus:outline-none focus:ring-2 focus:ring-[rgb(var(--ec-accent)/0.2)] transition-colors"
+            >
+              {[10, 20, 30, 40, 50].map((pageSize) => (
+                <option key={pageSize} value={pageSize}>
+                  {pageSize} per page
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/eventcatalog/src/components/Tables/Discover/FilterComponents.tsx
+++ b/eventcatalog/src/components/Tables/Discover/FilterComponents.tsx
@@ -1,0 +1,161 @@
+import { useState, useRef, useEffect } from 'react';
+import { X, ChevronUp, ChevronDown } from 'lucide-react';
+import { CheckIcon } from '@heroicons/react/24/outline';
+
+// Filter Dropdown Component
+export interface FilterDropdownProps {
+  label: string;
+  selectedItems: string[];
+  onClear: () => void;
+  onRemoveItem?: (item: string) => void;
+  children: React.ReactNode;
+}
+
+export const FilterDropdown = ({ label, selectedItems, onClear, onRemoveItem, children }: FilterDropdownProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const hasSelection = selectedItems.length > 0;
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [isOpen]);
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={() => setIsOpen(!isOpen)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            setIsOpen(!isOpen);
+          }
+        }}
+        className={`w-full flex items-center justify-between px-3 py-2 text-sm rounded-lg border transition-colors cursor-pointer ${
+          hasSelection || isOpen
+            ? 'border-[rgb(var(--ec-accent))] bg-[rgb(var(--ec-accent)/0.05)]'
+            : 'border-[rgb(var(--ec-page-border))] bg-[rgb(var(--ec-input-bg))] hover:border-[rgb(var(--ec-icon-color))]'
+        }`}
+      >
+        <div className="flex items-center gap-2 flex-1 min-w-0 flex-wrap">
+          {hasSelection ? (
+            <div className="flex flex-wrap gap-1 items-center">
+              {selectedItems.map((item) => (
+                <span
+                  key={item}
+                  className="inline-flex items-center gap-1 px-2 py-0.5 text-xs bg-[rgb(var(--ec-accent)/0.15)] text-[rgb(var(--ec-accent))] rounded-full"
+                >
+                  {item}
+                  {onRemoveItem && (
+                    <span
+                      role="button"
+                      tabIndex={0}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onRemoveItem(item);
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          onRemoveItem(item);
+                        }
+                      }}
+                      className="hover:text-[rgb(var(--ec-page-text))] cursor-pointer"
+                    >
+                      <X className="w-3 h-3" />
+                    </span>
+                  )}
+                </span>
+              ))}
+            </div>
+          ) : (
+            <span className="text-[rgb(var(--ec-page-text-muted))]">{label}</span>
+          )}
+        </div>
+        <div className="flex items-center gap-1 flex-shrink-0 ml-2">
+          {hasSelection && (
+            <span
+              role="button"
+              tabIndex={0}
+              onClick={(e) => {
+                e.stopPropagation();
+                onClear();
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  onClear();
+                }
+              }}
+              className="p-0.5 hover:bg-[rgb(var(--ec-content-hover))] rounded cursor-pointer"
+            >
+              <X className="w-3.5 h-3.5 text-[rgb(var(--ec-icon-color))]" />
+            </span>
+          )}
+          {isOpen ? (
+            <ChevronUp className="w-4 h-4 text-[rgb(var(--ec-icon-color))]" />
+          ) : (
+            <ChevronDown className="w-4 h-4 text-[rgb(var(--ec-icon-color))]" />
+          )}
+        </div>
+      </div>
+
+      {isOpen && (
+        <div className="absolute z-20 left-0 right-0 mt-1 bg-[rgb(var(--ec-card-bg,var(--ec-page-bg)))] border border-[rgb(var(--ec-page-border))] rounded-lg shadow-lg overflow-hidden">
+          <div className="max-h-64 overflow-y-auto p-2">{children}</div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+// Checkbox Item Component
+export interface CheckboxItemProps {
+  label: string;
+  checked: boolean;
+  onChange: () => void;
+  count?: number;
+  icon?: React.ReactNode;
+}
+
+export const CheckboxItem = ({ label, checked, onChange, count, icon }: CheckboxItemProps) => (
+  <button
+    onClick={onChange}
+    className={`w-full flex items-center gap-2 px-2 py-1.5 rounded-md text-left transition-colors ${
+      checked ? 'bg-[rgb(var(--ec-accent)/0.1)]' : 'hover:bg-[rgb(var(--ec-content-hover))]'
+    }`}
+  >
+    <div
+      className={`w-4 h-4 flex-shrink-0 rounded border flex items-center justify-center transition-colors ${
+        checked
+          ? 'bg-[rgb(var(--ec-accent))] border-[rgb(var(--ec-accent))]'
+          : 'border-[rgb(var(--ec-page-border))] bg-[rgb(var(--ec-input-bg))]'
+      }`}
+    >
+      {checked && <CheckIcon className="w-3 h-3 text-white" />}
+    </div>
+    {icon && <span className="flex-shrink-0 text-[rgb(var(--ec-icon-color))]">{icon}</span>}
+    <span
+      className={`text-sm flex-1 truncate ${checked ? 'font-medium text-[rgb(var(--ec-page-text))]' : 'text-[rgb(var(--ec-page-text))]'}`}
+    >
+      {label}
+    </span>
+    {count !== undefined && <span className="text-xs text-[rgb(var(--ec-page-text-muted))]">{count}</span>}
+  </button>
+);

--- a/eventcatalog/src/components/Tables/Discover/columns.tsx
+++ b/eventcatalog/src/components/Tables/Discover/columns.tsx
@@ -1,0 +1,565 @@
+import { createColumnHelper } from '@tanstack/react-table';
+import { useMemo, useState } from 'react';
+import {
+  ServerIcon,
+  BoltIcon,
+  ChatBubbleLeftIcon,
+  MagnifyingGlassIcon,
+  RectangleGroupIcon,
+  QueueListIcon,
+  DocumentTextIcon,
+  MapIcon,
+} from '@heroicons/react/24/solid';
+import { ArrowDownIcon, ArrowUpIcon } from '@heroicons/react/24/outline';
+import { DatabaseIcon } from 'lucide-react';
+import * as Tooltip from '@radix-ui/react-tooltip';
+import { buildUrl } from '@utils/url-builder';
+import { getColorAndIconForCollection } from '@utils/collections/icons';
+import FavoriteButton from '@components/FavoriteButton';
+import type { DiscoverTableData, CollectionType } from './DiscoverTable';
+import type { TableConfiguration } from '@types';
+
+// Color mapping to ensure Tailwind classes are included in the build
+const colorClasses: Record<string, string> = {
+  orange: 'text-orange-500',
+  blue: 'text-blue-500',
+  green: 'text-green-500',
+  pink: 'text-pink-500',
+  yellow: 'text-yellow-500',
+  teal: 'text-teal-500',
+  purple: 'text-purple-500',
+  red: 'text-red-500',
+  gray: 'text-gray-500',
+};
+
+// Reusable tooltip wrapper component
+const ActionTooltip = ({ children, label }: { children: React.ReactNode; label: string }) => (
+  <Tooltip.Provider delayDuration={200}>
+    <Tooltip.Root>
+      <Tooltip.Trigger asChild>{children}</Tooltip.Trigger>
+      <Tooltip.Portal>
+        <Tooltip.Content
+          className="bg-[rgb(var(--ec-page-text))] text-[rgb(var(--ec-page-bg))] rounded px-2 py-1 text-xs shadow-md z-50"
+          side="top"
+          sideOffset={5}
+        >
+          {label}
+          <Tooltip.Arrow className="fill-[rgb(var(--ec-page-text))]" />
+        </Tooltip.Content>
+      </Tooltip.Portal>
+    </Tooltip.Root>
+  </Tooltip.Provider>
+);
+
+const columnHelper = createColumnHelper<DiscoverTableData>();
+
+// Badge cell component (proper React component to use hooks)
+const BadgesCell = ({ badges }: { badges: Array<{ content: string; backgroundColor?: string; textColor?: string }> }) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  if (!badges || badges.length === 0) return <span className="text-xs text-[rgb(var(--ec-icon-color))]">-</span>;
+
+  const visibleItems = isExpanded ? badges : badges.slice(0, 3);
+  const hiddenCount = badges.length - 3;
+
+  return (
+    <div className="flex flex-col gap-1 items-start">
+      {visibleItems.map((badge, index) => (
+        <span
+          key={`${badge.content}-${index}`}
+          className="inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-md max-w-[140px] truncate border border-[rgb(var(--ec-accent)/0.5)] text-[rgb(var(--ec-page-text))] bg-transparent"
+          title={badge.content}
+        >
+          {badge.content}
+        </span>
+      ))}
+      {hiddenCount > 0 && (
+        <button onClick={() => setIsExpanded(!isExpanded)} className="text-xs text-[rgb(var(--ec-accent))] hover:underline">
+          {isExpanded ? 'less' : `+${hiddenCount}`}
+        </button>
+      )}
+    </div>
+  );
+};
+
+// Shared badge column
+const createBadgesColumn = (tableConfiguration: TableConfiguration) =>
+  columnHelper.accessor((row) => row.data.badges, {
+    id: 'badges',
+    header: () => <span>{tableConfiguration?.columns?.badges?.label || 'Badges'}</span>,
+    cell: (info) => <BadgesCell badges={info.getValue() || []} />,
+    meta: {
+      showFilter: false,
+    },
+  });
+
+// Shared actions column
+const createActionsColumn = (collectionType: CollectionType, tableConfiguration: TableConfiguration) =>
+  columnHelper.accessor('data.name', {
+    id: 'actions',
+    header: () => <span></span>,
+    cell: (info) => {
+      const item = info.row.original;
+      const href = buildUrl(`/docs/${item.collection}/${item.data.id}/${item.data.version}`);
+      const nodeKey = `${item.collection}-${item.data.id}-${item.data.version}`;
+      const badgeLabel = collectionType.charAt(0).toUpperCase() + collectionType.slice(1, -1);
+
+      return (
+        <div className="flex items-center gap-0.5">
+          <ActionTooltip label="View documentation">
+            <a
+              className="p-1.5 text-[rgb(var(--ec-icon-color))] hover:text-[rgb(var(--ec-accent))] hover:bg-[rgb(var(--ec-accent)/0.1)] rounded-md transition-colors"
+              href={href}
+            >
+              <DocumentTextIcon className="w-4 h-4" />
+            </a>
+          </ActionTooltip>
+          <ActionTooltip label="View in visualiser">
+            <a
+              className="p-1.5 text-[rgb(var(--ec-icon-color))] hover:text-[rgb(var(--ec-accent))] hover:bg-[rgb(var(--ec-accent)/0.1)] rounded-md transition-colors"
+              href={buildUrl(`/visualiser/${item.collection}/${item.data.id}/${item.data.version}`)}
+            >
+              <MapIcon className="w-4 h-4" />
+            </a>
+          </ActionTooltip>
+          <ActionTooltip label="Add to favorites">
+            <span>
+              <FavoriteButton nodeKey={nodeKey} title={item.data.name} badge={badgeLabel} href={href} size="sm" />
+            </span>
+          </ActionTooltip>
+        </div>
+      );
+    },
+    meta: {
+      showFilter: false,
+    },
+  });
+
+// Shared summary column
+const createSummaryColumn = (tableConfiguration: TableConfiguration) =>
+  columnHelper.accessor('data.summary', {
+    id: 'summary',
+    header: () => <span>{tableConfiguration?.columns?.summary?.label || 'Summary'}</span>,
+    cell: (info) => {
+      const summary = info.renderValue() as string;
+      const isDraft = info.row.original.data.draft;
+      const displayText = `${summary || ''}${isDraft ? ' (Draft)' : ''}`;
+      return (
+        <span className="text-sm text-[rgb(var(--ec-icon-color))] line-clamp-2" title={displayText}>
+          {displayText}
+        </span>
+      );
+    },
+    meta: {
+      showFilter: false,
+      className: 'max-w-md',
+    },
+  });
+
+// Collection list cell renderer (for producers, consumers, services, etc.)
+const CollectionListCell = ({
+  items,
+  emptyText = '-',
+  maxVisible = 3,
+}: {
+  items: Array<{ collection: string; data: { id: string; name: string; version: string } }> | undefined;
+  emptyText?: string;
+  maxVisible?: number;
+}) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const itemsWithIcons = useMemo(
+    () =>
+      items?.map((item) => ({
+        ...item,
+        ...getColorAndIconForCollection(item.collection),
+      })) || [],
+    [items]
+  );
+
+  if (!items || items.length === 0) return <span className="text-xs text-[rgb(var(--ec-icon-color))]">{emptyText}</span>;
+
+  const visibleItems = isExpanded ? itemsWithIcons : itemsWithIcons.slice(0, maxVisible);
+  const hiddenCount = itemsWithIcons.length - maxVisible;
+
+  return (
+    <div className="flex flex-col gap-1">
+      {visibleItems.map((item, index: number) => (
+        <a
+          key={`${item.data.id}-${index}`}
+          href={buildUrl(`/docs/${item.collection}/${item.data.id}/${item.data.version}`)}
+          className="group inline-flex items-center gap-1.5 text-xs hover:text-[rgb(var(--ec-accent))] transition-colors"
+        >
+          <item.Icon className={`h-3.5 w-3.5 ${colorClasses[item.color] || 'text-gray-500'} flex-shrink-0`} />
+          <span className="truncate max-w-[120px]" title={item.data.name}>
+            {item.data.name}
+          </span>
+        </a>
+      ))}
+      {hiddenCount > 0 && (
+        <button
+          onClick={() => setIsExpanded(!isExpanded)}
+          className="text-xs text-[rgb(var(--ec-accent))] hover:underline text-left"
+        >
+          {isExpanded ? 'Show less' : `+${hiddenCount} more`}
+        </button>
+      )}
+    </div>
+  );
+};
+
+// ============================================================================
+// EVENT COLUMNS
+// ============================================================================
+export const getEventColumns = (tableConfiguration: TableConfiguration) => [
+  columnHelper.accessor('data.name', {
+    id: 'name',
+    header: () => <span>{tableConfiguration?.columns?.name?.label || 'Event'}</span>,
+    cell: (info) => {
+      const item = info.row.original;
+      const isLatestVersion = item.data.version === item.data.latestVersion;
+      return (
+        <a
+          href={buildUrl(`/docs/${item.collection}/${item.data.id}/${item.data.version}`)}
+          className="group inline-flex items-center gap-2 hover:text-[rgb(var(--ec-accent))] transition-colors"
+        >
+          <BoltIcon className="h-4 w-4 text-orange-500 flex-shrink-0" />
+          <span className="text-sm font-semibold text-[rgb(var(--ec-page-text))] group-hover:text-[rgb(var(--ec-accent))]">
+            {item.data.name}
+          </span>
+          {!isLatestVersion && <span className="text-xs text-[rgb(var(--ec-icon-color))]">v{item.data.version}</span>}
+        </a>
+      );
+    },
+    meta: {
+      filterVariant: 'name',
+    },
+  }),
+  createSummaryColumn(tableConfiguration),
+  columnHelper.accessor('data.producers', {
+    id: 'producers',
+    header: () => <span>Producers</span>,
+    cell: (info) => <CollectionListCell items={info.getValue()} />,
+    meta: {
+      showFilter: false,
+    },
+  }),
+  columnHelper.accessor('data.consumers', {
+    id: 'consumers',
+    header: () => <span>Consumers</span>,
+    cell: (info) => <CollectionListCell items={info.getValue()} />,
+    meta: {
+      showFilter: false,
+    },
+  }),
+  createBadgesColumn(tableConfiguration),
+  createActionsColumn('events', tableConfiguration),
+];
+
+// ============================================================================
+// COMMAND COLUMNS
+// ============================================================================
+export const getCommandColumns = (tableConfiguration: TableConfiguration) => [
+  columnHelper.accessor('data.name', {
+    id: 'name',
+    header: () => <span>{tableConfiguration?.columns?.name?.label || 'Command'}</span>,
+    cell: (info) => {
+      const item = info.row.original;
+      const isLatestVersion = item.data.version === item.data.latestVersion;
+      return (
+        <a
+          href={buildUrl(`/docs/${item.collection}/${item.data.id}/${item.data.version}`)}
+          className="group inline-flex items-center gap-2 hover:text-[rgb(var(--ec-accent))] transition-colors"
+        >
+          <ChatBubbleLeftIcon className="h-4 w-4 text-blue-500 flex-shrink-0" />
+          <span className="text-sm font-semibold text-[rgb(var(--ec-page-text))] group-hover:text-[rgb(var(--ec-accent))]">
+            {item.data.name}
+          </span>
+          {!isLatestVersion && <span className="text-xs text-[rgb(var(--ec-icon-color))]">v{item.data.version}</span>}
+        </a>
+      );
+    },
+    meta: {
+      filterVariant: 'name',
+    },
+  }),
+  createSummaryColumn(tableConfiguration),
+  columnHelper.accessor('data.producers', {
+    id: 'producers',
+    header: () => <span>Producers</span>,
+    cell: (info) => <CollectionListCell items={info.getValue()} />,
+    meta: {
+      showFilter: false,
+    },
+  }),
+  columnHelper.accessor('data.consumers', {
+    id: 'consumers',
+    header: () => <span>Consumers</span>,
+    cell: (info) => <CollectionListCell items={info.getValue()} />,
+    meta: {
+      showFilter: false,
+    },
+  }),
+  createBadgesColumn(tableConfiguration),
+  createActionsColumn('commands', tableConfiguration),
+];
+
+// ============================================================================
+// QUERY COLUMNS
+// ============================================================================
+export const getQueryColumns = (tableConfiguration: TableConfiguration) => [
+  columnHelper.accessor('data.name', {
+    id: 'name',
+    header: () => <span>{tableConfiguration?.columns?.name?.label || 'Query'}</span>,
+    cell: (info) => {
+      const item = info.row.original;
+      const isLatestVersion = item.data.version === item.data.latestVersion;
+      return (
+        <a
+          href={buildUrl(`/docs/${item.collection}/${item.data.id}/${item.data.version}`)}
+          className="group inline-flex items-center gap-2 hover:text-[rgb(var(--ec-accent))] transition-colors"
+        >
+          <MagnifyingGlassIcon className="h-4 w-4 text-green-500 flex-shrink-0" />
+          <span className="text-sm font-semibold text-[rgb(var(--ec-page-text))] group-hover:text-[rgb(var(--ec-accent))]">
+            {item.data.name}
+          </span>
+          {!isLatestVersion && <span className="text-xs text-[rgb(var(--ec-icon-color))]">v{item.data.version}</span>}
+        </a>
+      );
+    },
+    meta: {
+      filterVariant: 'name',
+    },
+  }),
+  createSummaryColumn(tableConfiguration),
+  columnHelper.accessor('data.producers', {
+    id: 'producers',
+    header: () => <span>Producers</span>,
+    cell: (info) => <CollectionListCell items={info.getValue()} />,
+    meta: {
+      showFilter: false,
+    },
+  }),
+  columnHelper.accessor('data.consumers', {
+    id: 'consumers',
+    header: () => <span>Consumers</span>,
+    cell: (info) => <CollectionListCell items={info.getValue()} />,
+    meta: {
+      showFilter: false,
+    },
+  }),
+  createBadgesColumn(tableConfiguration),
+  createActionsColumn('queries', tableConfiguration),
+];
+
+// ============================================================================
+// SERVICE COLUMNS
+// ============================================================================
+export const getServiceColumns = (tableConfiguration: TableConfiguration) => [
+  columnHelper.accessor('data.name', {
+    id: 'name',
+    header: () => <span>{tableConfiguration?.columns?.name?.label || 'Service'}</span>,
+    cell: (info) => {
+      const item = info.row.original;
+      const isLatestVersion = item.data.version === item.data.latestVersion;
+      return (
+        <a
+          href={buildUrl(`/docs/${item.collection}/${item.data.id}/${item.data.version}`)}
+          className="group inline-flex items-center gap-2 hover:text-[rgb(var(--ec-accent))] transition-colors"
+        >
+          <ServerIcon className="h-4 w-4 text-pink-500 flex-shrink-0" />
+          <span className="text-sm font-semibold text-[rgb(var(--ec-page-text))] group-hover:text-[rgb(var(--ec-accent))]">
+            {item.data.name}
+          </span>
+          {!isLatestVersion && <span className="text-xs text-[rgb(var(--ec-icon-color))]">v{item.data.version}</span>}
+        </a>
+      );
+    },
+    meta: {
+      filterVariant: 'name',
+    },
+  }),
+  createSummaryColumn(tableConfiguration),
+  columnHelper.accessor('data.receives', {
+    id: 'receives',
+    header: () => (
+      <span className="flex items-center gap-1">
+        <ArrowDownIcon className="w-3.5 h-3.5" />
+        Receives
+      </span>
+    ),
+    cell: (info) => <CollectionListCell items={info.getValue()} />,
+    meta: {
+      showFilter: false,
+    },
+  }),
+  columnHelper.accessor('data.sends', {
+    id: 'sends',
+    header: () => (
+      <span className="flex items-center gap-1">
+        <ArrowUpIcon className="w-3.5 h-3.5" />
+        Sends
+      </span>
+    ),
+    cell: (info) => <CollectionListCell items={info.getValue()} />,
+    meta: {
+      showFilter: false,
+    },
+  }),
+  createBadgesColumn(tableConfiguration),
+  createActionsColumn('services', tableConfiguration),
+];
+
+// ============================================================================
+// DOMAIN COLUMNS
+// ============================================================================
+export const getDomainColumns = (tableConfiguration: TableConfiguration) => [
+  columnHelper.accessor('data.name', {
+    id: 'name',
+    header: () => <span>{tableConfiguration?.columns?.name?.label || 'Domain'}</span>,
+    cell: (info) => {
+      const item = info.row.original;
+      const isLatestVersion = item.data.version === item.data.latestVersion;
+      return (
+        <a
+          href={buildUrl(`/docs/${item.collection}/${item.data.id}/${item.data.version}`)}
+          className="group inline-flex items-center gap-2 hover:text-[rgb(var(--ec-accent))] transition-colors"
+        >
+          <RectangleGroupIcon className="h-4 w-4 text-yellow-500 flex-shrink-0" />
+          <span className="text-sm font-semibold text-[rgb(var(--ec-page-text))] group-hover:text-[rgb(var(--ec-accent))]">
+            {item.data.name}
+          </span>
+          {!isLatestVersion && <span className="text-xs text-[rgb(var(--ec-icon-color))]">v{item.data.version}</span>}
+        </a>
+      );
+    },
+    meta: {
+      filterVariant: 'name',
+    },
+  }),
+  createSummaryColumn(tableConfiguration),
+  columnHelper.accessor('data.services', {
+    id: 'services',
+    header: () => <span>Services</span>,
+    cell: (info) => <CollectionListCell items={info.getValue()} />,
+    meta: {
+      showFilter: false,
+    },
+  }),
+  createBadgesColumn(tableConfiguration),
+  createActionsColumn('domains', tableConfiguration),
+];
+
+// ============================================================================
+// FLOW COLUMNS
+// ============================================================================
+export const getFlowColumns = (tableConfiguration: TableConfiguration) => [
+  columnHelper.accessor('data.name', {
+    id: 'name',
+    header: () => <span>{tableConfiguration?.columns?.name?.label || 'Flow'}</span>,
+    cell: (info) => {
+      const item = info.row.original;
+      const isLatestVersion = item.data.version === item.data.latestVersion;
+      return (
+        <a
+          href={buildUrl(`/docs/${item.collection}/${item.data.id}/${item.data.version}`)}
+          className="group inline-flex items-center gap-2 hover:text-[rgb(var(--ec-accent))] transition-colors"
+        >
+          <QueueListIcon className="h-4 w-4 text-teal-500 flex-shrink-0" />
+          <span className="text-sm font-semibold text-[rgb(var(--ec-page-text))] group-hover:text-[rgb(var(--ec-accent))]">
+            {item.data.name}
+          </span>
+          {!isLatestVersion && <span className="text-xs text-[rgb(var(--ec-icon-color))]">v{item.data.version}</span>}
+        </a>
+      );
+    },
+    meta: {
+      filterVariant: 'name',
+    },
+  }),
+  createSummaryColumn(tableConfiguration),
+  createBadgesColumn(tableConfiguration),
+  createActionsColumn('flows', tableConfiguration),
+];
+
+// ============================================================================
+// CONTAINER (DATA) COLUMNS
+// ============================================================================
+export const getContainerColumns = (tableConfiguration: TableConfiguration) => [
+  columnHelper.accessor('data.name', {
+    id: 'name',
+    header: () => <span>{tableConfiguration?.columns?.name?.label || 'Data'}</span>,
+    cell: (info) => {
+      const item = info.row.original;
+      const isLatestVersion = item.data.version === item.data.latestVersion;
+      return (
+        <a
+          href={buildUrl(`/docs/${item.collection}/${item.data.id}/${item.data.version}`)}
+          className="group inline-flex items-center gap-2 hover:text-[rgb(var(--ec-accent))] transition-colors"
+        >
+          <DatabaseIcon className="h-4 w-4 text-blue-500 flex-shrink-0" />
+          <span className="text-sm font-semibold text-[rgb(var(--ec-page-text))] group-hover:text-[rgb(var(--ec-accent))]">
+            {item.data.name}
+          </span>
+          {!isLatestVersion && <span className="text-xs text-[rgb(var(--ec-icon-color))]">v{item.data.version}</span>}
+        </a>
+      );
+    },
+    meta: {
+      filterVariant: 'name',
+    },
+  }),
+  createSummaryColumn(tableConfiguration),
+  columnHelper.accessor('data.servicesThatWriteToContainer', {
+    id: 'writes',
+    header: () => (
+      <span className="flex items-center gap-1">
+        <ArrowDownIcon className="w-3.5 h-3.5" />
+        Writes
+      </span>
+    ),
+    cell: (info) => <CollectionListCell items={info.getValue()} />,
+    meta: {
+      showFilter: false,
+    },
+  }),
+  columnHelper.accessor('data.servicesThatReadFromContainer', {
+    id: 'reads',
+    header: () => (
+      <span className="flex items-center gap-1">
+        <ArrowUpIcon className="w-3.5 h-3.5" />
+        Reads
+      </span>
+    ),
+    cell: (info) => <CollectionListCell items={info.getValue()} />,
+    meta: {
+      showFilter: false,
+    },
+  }),
+  createBadgesColumn(tableConfiguration),
+  createActionsColumn('containers', tableConfiguration),
+];
+
+// ============================================================================
+// COLUMN GETTER BY COLLECTION TYPE
+// ============================================================================
+export const getDiscoverColumns = (collectionType: CollectionType, tableConfiguration: TableConfiguration) => {
+  switch (collectionType) {
+    case 'events':
+      return getEventColumns(tableConfiguration);
+    case 'commands':
+      return getCommandColumns(tableConfiguration);
+    case 'queries':
+      return getQueryColumns(tableConfiguration);
+    case 'services':
+      return getServiceColumns(tableConfiguration);
+    case 'domains':
+      return getDomainColumns(tableConfiguration);
+    case 'flows':
+      return getFlowColumns(tableConfiguration);
+    case 'containers':
+      return getContainerColumns(tableConfiguration);
+    default:
+      return [];
+  }
+};

--- a/eventcatalog/src/components/Tables/Discover/index.ts
+++ b/eventcatalog/src/components/Tables/Discover/index.ts
@@ -1,0 +1,4 @@
+export { DiscoverTable } from './DiscoverTable';
+export type { DiscoverTableData, DiscoverTableProps, CollectionType, PropertyOption } from './DiscoverTable';
+export { FilterDropdown, CheckboxItem } from './FilterComponents';
+export type { FilterDropdownProps, CheckboxItemProps } from './FilterComponents';

--- a/eventcatalog/src/components/Tables/columns/ContainersTableColumns.tsx
+++ b/eventcatalog/src/components/Tables/columns/ContainersTableColumns.tsx
@@ -45,7 +45,7 @@ export const columns = (tableConfiguration: TableConfiguration) => [
     cell: (info) => {
       const summary = info.renderValue() as string;
       return (
-        <span className="text-sm text-[rgb(var(--ec-page-text-muted))] line-clamp-2" title={summary || ''}>
+        <span className="text-sm text-[rgb(var(--ec-icon-color))] line-clamp-2" title={summary || ''}>
           {summary}
         </span>
       );

--- a/eventcatalog/src/components/Tables/columns/DomainTableColumns.tsx
+++ b/eventcatalog/src/components/Tables/columns/DomainTableColumns.tsx
@@ -46,7 +46,7 @@ export const columns = (tableConfiguration: TableConfiguration) => [
       const isDraft = info.row.original.data.draft;
       const displayText = `${summary || ''}${isDraft ? ' (Draft)' : ''}`;
       return (
-        <span className="text-sm text-[rgb(var(--ec-page-text-muted))] line-clamp-2" title={displayText}>
+        <span className="text-sm text-[rgb(var(--ec-icon-color))] line-clamp-2" title={displayText}>
           {displayText}
         </span>
       );

--- a/eventcatalog/src/components/Tables/columns/FlowTableColumns.tsx
+++ b/eventcatalog/src/components/Tables/columns/FlowTableColumns.tsx
@@ -43,7 +43,7 @@ export const columns = (tableConfiguration: TableConfiguration) => [
     cell: (info) => {
       const summary = info.renderValue() as string;
       return (
-        <span className="text-sm text-[rgb(var(--ec-page-text-muted))] line-clamp-2" title={summary || ''}>
+        <span className="text-sm text-[rgb(var(--ec-icon-color))] line-clamp-2" title={summary || ''}>
           {summary}
         </span>
       );

--- a/eventcatalog/src/components/Tables/columns/MessageTableColumns.tsx
+++ b/eventcatalog/src/components/Tables/columns/MessageTableColumns.tsx
@@ -64,7 +64,7 @@ export const columns = (tableConfiguration: TableConfiguration) => [
       const isDraft = info.row.original.data.draft;
       const displayText = `${summary || ''}${isDraft ? ' (Draft)' : ''}`;
       return (
-        <span className="text-sm text-[rgb(var(--ec-page-text-muted))] line-clamp-2" title={displayText}>
+        <span className="text-sm text-[rgb(var(--ec-icon-color))] line-clamp-2" title={displayText}>
           {displayText}
         </span>
       );

--- a/eventcatalog/src/components/Tables/columns/SharedColumns.tsx
+++ b/eventcatalog/src/components/Tables/columns/SharedColumns.tsx
@@ -1,9 +1,7 @@
 import { createColumnHelper } from '@tanstack/react-table';
-import { Tag } from 'lucide-react';
 import { useState } from 'react';
 import { filterByBadge } from '../filters/custom-filters';
 import type { TCollectionTypes, TData } from '../Table';
-import { getIcon } from '@utils/badges';
 import type { TableConfiguration } from '@types';
 
 export const createBadgesColumn = <T extends { data: Pick<TData<U>['data'], 'badges'> }, U extends TCollectionTypes>(
@@ -18,38 +16,25 @@ export const createBadgesColumn = <T extends { data: Pick<TData<U>['data'], 'bad
       const badges = item.data.badges || [];
       const [isExpanded, setIsExpanded] = useState(false);
 
-      if (badges?.length === 0 || !badges)
-        return (
-          <span className="inline-flex items-center px-2 py-1 text-xs text-[rgb(var(--ec-icon-color))] bg-[rgb(var(--ec-content-hover))] rounded-md border border-[rgb(var(--ec-page-border))]">
-            No badges
-          </span>
-        );
+      if (badges?.length === 0 || !badges) return <span className="text-xs text-[rgb(var(--ec-icon-color))]">-</span>;
 
-      const visibleItems = isExpanded ? badges : badges.slice(0, 4);
-      const hiddenCount = badges.length - 4;
+      const visibleItems = isExpanded ? badges : badges.slice(0, 3);
+      const hiddenCount = badges.length - 3;
 
       return (
-        <div className="flex flex-wrap gap-1.5 items-center">
-          {visibleItems.map((badge, index) => {
-            const IconComponent = badge.icon ? getIcon(badge.icon) : null;
-            return (
-              <span
-                key={`${badge.id}-${index}`}
-                className="inline-flex items-center rounded-md border border-[rgb(var(--ec-page-border))] bg-[rgb(var(--ec-card-bg,var(--ec-page-bg)))] hover:border-[rgb(var(--ec-accent))] hover:bg-[rgb(var(--ec-accent-subtle))] transition-colors"
-              >
-                <span className={`flex items-center justify-center w-6 h-6 bg-${badge.backgroundColor}-500 rounded-l-md`}>
-                  {IconComponent ? <IconComponent className="h-3 w-3 text-white" /> : <Tag className="h-3 w-3 text-white" />}
-                </span>
-                <span className="px-2 py-1 text-xs text-[rgb(var(--ec-page-text))]">{badge.content}</span>
-              </span>
-            );
-          })}
-          {hiddenCount > 0 && (
-            <button
-              onClick={() => setIsExpanded(!isExpanded)}
-              className="text-xs text-[rgb(var(--ec-icon-color))] hover:text-[rgb(var(--ec-page-text))] px-2 py-1 rounded hover:bg-[rgb(var(--ec-content-hover))] transition-colors"
+        <div className="flex flex-wrap gap-1 items-center">
+          {visibleItems.map((badge, index) => (
+            <span
+              key={`${badge.id}-${index}`}
+              className="inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-md border border-[rgb(var(--ec-accent)/0.5)] text-[rgb(var(--ec-page-text))] bg-transparent"
+              title={badge.content}
             >
-              {isExpanded ? 'Show less' : `+${hiddenCount} more`}
+              {badge.content}
+            </span>
+          ))}
+          {hiddenCount > 0 && (
+            <button onClick={() => setIsExpanded(!isExpanded)} className="text-xs text-[rgb(var(--ec-accent))] hover:underline">
+              {isExpanded ? 'less' : `+${hiddenCount}`}
             </button>
           )}
         </div>

--- a/eventcatalog/src/layouts/VerticalSideBarLayout.astro
+++ b/eventcatalog/src/layouts/VerticalSideBarLayout.astro
@@ -131,7 +131,7 @@ const navigationItems = [
     id: '/discover',
     label: 'Explore',
     icon: TableProperties,
-    href: buildUrl('/discover/events'),
+    href: buildUrl('/discover/domains'),
     current: currentPath.includes('/discover/'),
   },
   {

--- a/eventcatalog/src/pages/discover/[type]/_index.data.ts
+++ b/eventcatalog/src/pages/discover/[type]/_index.data.ts
@@ -10,13 +10,15 @@ export class Page extends HybridPage {
 
   static async getStaticPaths(): Promise<Array<{ params: any; props: any }>> {
     const { getFlows } = await import('@utils/collections/flows');
+    const { getServices } = await import('@utils/collections/services');
 
     const loaders = {
       ...pageDataLoader,
       flows: getFlows,
+      services: getServices,
     };
 
-    const itemTypes = ['events', 'commands', 'queries', 'services', 'domains', 'flows', 'containers'] as const;
+    const itemTypes = ['events', 'commands', 'queries', 'domains', 'services', 'flows', 'containers'] as const;
     const allItems = await Promise.all(itemTypes.map((type) => loaders[type]()));
 
     return allItems.flatMap((items, index) => ({
@@ -38,10 +40,12 @@ export class Page extends HybridPage {
     }
 
     const { getFlows } = await import('@utils/collections/flows');
+    const { getServices } = await import('@utils/collections/services');
 
     const loaders = {
       ...pageDataLoader,
       flows: getFlows,
+      services: getServices,
     };
 
     // @ts-ignore

--- a/eventcatalog/src/pages/discover/[type]/index.astro
+++ b/eventcatalog/src/pages/discover/[type]/index.astro
@@ -1,7 +1,21 @@
 ---
-import type { CollectionEntry } from 'astro:content';
-import type { CollectionTypes } from '@types';
-import DiscoverLayout, { type Props as DiscoverLayoutProps } from '@layouts/DiscoverLayout.astro';
+import { QueueListIcon, RectangleGroupIcon, BoltIcon, ChatBubbleLeftIcon } from '@heroicons/react/24/outline';
+import ServerIcon from '@heroicons/react/24/outline/ServerIcon';
+import { MagnifyingGlassIcon } from '@heroicons/react/20/solid';
+import { DatabaseIcon } from 'lucide-react';
+import { getCommands } from '@utils/collections/commands';
+import { getDomains, getDomainsForService } from '@utils/collections/domains';
+import { getFlows } from '@utils/collections/flows';
+import { getEvents } from '@utils/collections/events';
+import { getServices } from '@utils/collections/services';
+import { getQueries } from '@utils/collections/queries';
+import { getContainers } from '@utils/collections/containers';
+import { getUsers } from '@utils/collections/users';
+import { getTeams } from '@utils/collections/teams';
+import { buildUrl } from '@utils/url-builder';
+import VerticalSideBarLayout from '@layouts/VerticalSideBarLayout.astro';
+import { DiscoverTable, type DiscoverTableData, type CollectionType } from '@components/Tables/Discover';
+import config from '@config';
 import { Page } from './_index.data';
 
 export const prerender = Page.prerender;
@@ -9,12 +23,165 @@ export const getStaticPaths = Page.getStaticPaths;
 
 const { type, data } = await Page.getData(Astro);
 
-let title = `${type} (${data.length})`;
+// Fetch all collections for tabs
+const events = await getEvents();
+const queries = await getQueries();
+const commands = await getCommands();
+const services = await getServices();
+const domains = await getDomains({ getAllVersions: false });
+const flows = await getFlows();
+const containers = await getContainers();
+const users = await getUsers();
+const teams = await getTeams();
 
-if (type === 'containers') {
-  title = `Data (${data.length})`;
-}
+// Create lookup maps for users and teams
+const userMap = new Map(users.map((u) => [u.data.id, u]));
+const teamMap = new Map(teams.map((t) => [t.data.id, t]));
 
+// Type configuration for property options
+const typeConfig: Record<
+  string,
+  {
+    label: string;
+    propertyOptions: Array<{ id: string; label: string }>;
+  }
+> = {
+  events: {
+    label: 'Events',
+    propertyOptions: [
+      { id: 'hasProducers', label: 'Has Producers' },
+      { id: 'hasConsumers', label: 'Has Consumers' },
+      { id: 'hasOwners', label: 'Has Owners' },
+      { id: 'isDeprecated', label: 'Is Deprecated' },
+    ],
+  },
+  commands: {
+    label: 'Commands',
+    propertyOptions: [
+      { id: 'hasProducers', label: 'Has Producers' },
+      { id: 'hasConsumers', label: 'Has Consumers' },
+      { id: 'hasOwners', label: 'Has Owners' },
+      { id: 'isDeprecated', label: 'Is Deprecated' },
+    ],
+  },
+  queries: {
+    label: 'Queries',
+    propertyOptions: [
+      { id: 'hasProducers', label: 'Has Producers' },
+      { id: 'hasConsumers', label: 'Has Consumers' },
+      { id: 'hasOwners', label: 'Has Owners' },
+      { id: 'isDeprecated', label: 'Is Deprecated' },
+    ],
+  },
+  domains: {
+    label: 'Domains',
+    propertyOptions: [
+      { id: 'hasServices', label: 'Has Services' },
+      { id: 'hasOwners', label: 'Has Owners' },
+      { id: 'isSubdomain', label: 'Is Subdomain' },
+      { id: 'isDeprecated', label: 'Is Deprecated' },
+    ],
+  },
+  services: {
+    label: 'Services',
+    propertyOptions: [
+      { id: 'hasSpecifications', label: 'Has Specifications' },
+      { id: 'hasOwners', label: 'Has Owners' },
+      { id: 'hasRepository', label: 'Has Repository' },
+      { id: 'hasDataDependencies', label: 'Has Data Dependencies' },
+      { id: 'isDeprecated', label: 'Is Deprecated' },
+    ],
+  },
+  flows: {
+    label: 'Flows',
+    propertyOptions: [
+      { id: 'hasOwners', label: 'Has Owners' },
+      { id: 'isDeprecated', label: 'Is Deprecated' },
+    ],
+  },
+  containers: {
+    label: 'Data',
+    propertyOptions: [
+      { id: 'hasOwners', label: 'Has Owners' },
+      { id: 'hasWriters', label: 'Has Writers' },
+      { id: 'hasReaders', label: 'Has Readers' },
+      { id: 'isDeprecated', label: 'Is Deprecated' },
+    ],
+  },
+};
+
+const currentTypeConfig = typeConfig[type] || typeConfig.events;
+
+// @ts-ignore
+const tableConfiguration = config[type as keyof typeof config]?.tableConfiguration ?? { columns: {} };
+
+const tabs = [
+  {
+    label: `Domains (${domains.length})`,
+    href: buildUrl('/discover/domains'),
+    isActive: type === 'domains',
+    icon: RectangleGroupIcon,
+    activeColor: 'yellow',
+    enabled: domains.length > 0,
+    visible: domains.length > 0,
+  },
+  {
+    label: `Services (${services.length})`,
+    href: buildUrl('/discover/services'),
+    isActive: type === 'services',
+    icon: ServerIcon,
+    activeColor: 'pink',
+    enabled: services.length > 0,
+    visible: services.length > 0,
+  },
+  {
+    label: `Data (${containers.length})`,
+    href: buildUrl('/discover/containers'),
+    isActive: type === 'containers',
+    icon: DatabaseIcon,
+    activeColor: 'blue',
+    enabled: containers.length > 0,
+    visible: containers.length > 0,
+  },
+  {
+    label: `Events (${events.length})`,
+    href: buildUrl('/discover/events'),
+    isActive: type === 'events',
+    icon: BoltIcon,
+    activeColor: 'orange',
+    enabled: events.length > 0,
+    visible: events.length > 0,
+  },
+  {
+    label: `Queries (${queries.length})`,
+    href: buildUrl('/discover/queries'),
+    isActive: type === 'queries',
+    icon: MagnifyingGlassIcon,
+    activeColor: 'green',
+    enabled: queries.length > 0,
+    visible: queries.length > 0,
+  },
+  {
+    label: `Commands (${commands.length})`,
+    href: buildUrl('/discover/commands'),
+    isActive: type === 'commands',
+    icon: ChatBubbleLeftIcon,
+    activeColor: 'blue',
+    enabled: commands.length > 0,
+    visible: commands.length > 0,
+  },
+  {
+    label: `Flows (${flows.length})`,
+    href: buildUrl('/discover/flows'),
+    isActive: type === 'flows',
+    icon: QueueListIcon,
+    activeColor: 'teal',
+    enabled: flows.length > 0,
+    visible: flows.length > 0,
+  },
+];
+
+// Map data to match the expected structure for the table
 function mapToItem(i: any) {
   return {
     collection: i.collection,
@@ -25,39 +192,191 @@ function mapToItem(i: any) {
     },
   };
 }
+
+// Helper to map owner references with type detection
+function mapOwner(o: any) {
+  if (!o) return null;
+  const id = typeof o === 'string' ? o : o.data?.id || o.id || o;
+
+  // Look up in users first, then teams
+  const user = userMap.get(id);
+  if (user) {
+    return { id, name: user.data.name || id, type: 'user' as const };
+  }
+
+  const team = teamMap.get(id);
+  if (team) {
+    return { id, name: team.data.name || id, type: 'team' as const };
+  }
+
+  // Fallback if not found in either
+  const name = typeof o === 'string' ? o : o.data?.name || o.name || id;
+  return { id, name, type: 'user' as const };
+}
+
+// Helper to check if service has specifications
+function hasSpecifications(service: any): boolean {
+  const specs = service.data?.specifications;
+  if (!specs) return false;
+  if (Array.isArray(specs)) return specs.length > 0;
+  return !!(specs.openapiPath || specs.asyncapiPath || specs.graphqlPath);
+}
+
+// Build a Set of subdomain IDs (domains that are nested within other domains)
+const allSubdomainIds = new Set(
+  domains.flatMap((d: any) => (d.data?.domains || []).map((sd: any) => sd.data?.id || sd.id)).filter(Boolean)
+);
+
+// For services, enrich with domain information
+const enrichedData =
+  type === 'services'
+    ? await Promise.all(
+        data.map(async (service: any) => {
+          const serviceDomains = await getDomainsForService(service);
+          return {
+            ...service,
+            enrichedDomains: serviceDomains.map((d: any) => ({
+              id: d.data.id,
+              name: d.data.name,
+              version: d.data.version,
+            })),
+          };
+        })
+      )
+    : data;
+
+const tableData = enrichedData.map((d: any) => ({
+  collection: d.collection,
+  owners: (d.data?.owners || []).map(mapOwner).filter(Boolean),
+  hasOwners: (d.data?.owners || []).length > 0,
+  hasServices: type === 'domains' ? (d.data?.services || []).length > 0 : false,
+  isSubdomain: type === 'domains' ? allSubdomainIds.has(d.data.id) : false,
+  // Service-specific properties
+  domains: type === 'services' ? d.enrichedDomains : undefined,
+  hasSpecifications: type === 'services' ? hasSpecifications(d) : false,
+  hasRepository: type === 'services' ? !!d.data?.repository?.url : false,
+  hasDataDependencies: type === 'services' ? (d.data?.writesTo || []).length > 0 || (d.data?.readsFrom || []).length > 0 : false,
+  isDeprecated: d.data?.deprecated === true || (typeof d.data?.deprecated === 'object' && d.data?.deprecated !== null),
+  data: {
+    id: d.data.id,
+    name: d.data.name,
+    summary: d.data?.summary,
+    version: d.data.version,
+    latestVersion: d.data?.latestVersion,
+    draft: d.data?.draft,
+    badges: d.data?.badges,
+    producers: d.data?.producers?.map(mapToItem) ?? [],
+    consumers: d.data?.consumers?.map(mapToItem) ?? [],
+    receives: d.data?.receives?.map(mapToItem) ?? [],
+    sends: d.data?.sends?.map(mapToItem) ?? [],
+    services: d.data?.services?.map(mapToItem) ?? [],
+    servicesThatWriteToContainer: d.data?.servicesThatWriteToContainer?.map(mapToItem) ?? [],
+    servicesThatReadFromContainer: d.data?.servicesThatReadFromContainer?.map(mapToItem) ?? [],
+  },
+}));
+
+// Get unique owners from all items
+const uniqueOwners = Array.from(new Map(tableData.flatMap((d: any) => d.owners || []).map((o: any) => [o.id, o])).values()).sort(
+  (a: any, b: any) => a.name.localeCompare(b.name)
+);
+
+// Get unique producers (services) for message types
+// Check for duplicate names and add version if needed
+const servicesByName = new Map<string, typeof services>();
+services.forEach((s) => {
+  const name = s.data.name;
+  if (!servicesByName.has(name)) servicesByName.set(name, []);
+  servicesByName.get(name)!.push(s);
+});
+
+const uniqueProducers = services
+  .map((s) => {
+    const hasDuplicateName = (servicesByName.get(s.data.name)?.length ?? 0) > 1;
+    const isLatest = s.data.version === s.data.latestVersion;
+    const versionLabel = isLatest ? 'latest' : `v${s.data.version}`;
+    return {
+      id: s.data.id,
+      name: hasDuplicateName ? `${s.data.name} (${versionLabel})` : s.data.name,
+    };
+  })
+  .sort((a, b) => a.name.localeCompare(b.name));
+
+// Show producers/consumers filter only for events, commands, queries
+const showProducersFilter = ['events', 'commands', 'queries'].includes(type);
+const showConsumersFilter = ['events', 'commands', 'queries'].includes(type);
+
+// Consumers are the same services list
+const uniqueConsumers = uniqueProducers;
+
+// Get unique domains for the services filter
+const uniqueDomains = domains.map((d) => ({
+  id: d.data.id,
+  name: d.data.name,
+  version: d.data.version,
+}));
+
+// Show domains filter only for services
+const showDomainsFilter = type === 'services';
+
+const title = `${currentTypeConfig.label} (${data.length})`;
 ---
 
-<DiscoverLayout
-  title={title}
-  subtitle={`Find, filter and search for any ${type} in your system.`}
-  data={data.map(
-    (d: CollectionEntry<CollectionTypes>) =>
-      ({
-        collection: d.collection,
-        data: {
-          id: d.data.id,
-          name: d.data.name,
-          summary: d.data?.summary,
-          version: d.data.version,
-          latestVersion: d.data?.latestVersion,
-          draft: d.data?.draft,
-          badges: d.data?.badges,
-          // @ts-ignore
-          consumers: d.data?.consumers?.map(mapToItem) ?? [],
-          // @ts-ignore
-          producers: d.data?.producers?.map(mapToItem) ?? [],
-          // @ts-ignore
-          receives: d.data?.receives?.map(mapToItem) ?? [],
-          // @ts-ignore
-          sends: d.data?.sends?.map(mapToItem) ?? [],
-          // @ts-ignore
-          services: d.data?.services?.map(mapToItem) ?? [],
-          // @ts-ignore
-          servicesThatWriteToContainer: d.data?.servicesThatWriteToContainer?.map(mapToItem) ?? [],
-          // @ts-ignore
-          servicesThatReadFromContainer: d.data?.servicesThatReadFromContainer?.map(mapToItem) ?? [],
-        },
-      }) as DiscoverLayoutProps<typeof type>['data'][0]
-  )}
-  type={type}
-/>
+<VerticalSideBarLayout title={`Explore | ${title}`} showNestedSideBar={false}>
+  <main class="ml-0 bg-[rgb(var(--ec-page-bg))] min-h-content">
+    <div id="discover-collection-tabs">
+      <div class="hidden sm:block">
+        <div class="border-b border-[rgb(var(--ec-page-border))]">
+          <nav class="flex space-x-8 -mb-0.5 pl-6" aria-label="Tabs">
+            {
+              tabs
+                .filter((tab) => tab.visible)
+                .map((tab) => (
+                  <a
+                    href={tab.href}
+                    class:list={[
+                      'group inline-flex items-center py-4 px-1 text-sm font-light text-[rgb(var(--ec-page-text))]',
+                      tab.isActive && 'border-b-[2px] border-[rgb(var(--ec-accent))] text-[rgb(var(--ec-accent))]',
+                      !tab.isActive && 'opacity-70 hover:opacity-100',
+                      !tab.enabled && 'disabled',
+                    ]}
+                    aria-current="page"
+                  >
+                    <tab.icon
+                      className={`w-6 h-6 -ml-0.5 mr-2 ${tab.isActive ? 'text-[rgb(var(--ec-accent))]' : 'text-[rgb(var(--ec-icon-color))]'}`}
+                    />
+                    <span>{tab.label}</span>
+                  </a>
+                ))
+            }
+          </nav>
+        </div>
+      </div>
+    </div>
+
+    <div class="py-4 px-6 md:pr-10">
+      <DiscoverTable
+        data={tableData as DiscoverTableData[]}
+        collectionType={type as CollectionType}
+        collectionLabel={currentTypeConfig.label}
+        domains={uniqueDomains}
+        owners={uniqueOwners as Array<{ id: string; name: string; type?: 'user' | 'team' }>}
+        producers={uniqueProducers}
+        consumers={uniqueConsumers}
+        propertyOptions={currentTypeConfig.propertyOptions}
+        tableConfiguration={tableConfiguration}
+        showDomainsFilter={showDomainsFilter}
+        showProducersFilter={showProducersFilter}
+        showConsumersFilter={showConsumersFilter}
+        client:only="react"
+      />
+    </div>
+  </main>
+</VerticalSideBarLayout>
+
+<style>
+  a.disabled {
+    pointer-events: none;
+    cursor: default;
+    opacity: 0.25;
+  }
+</style>


### PR DESCRIPTION
## What This PR Does

This PR introduces a completely redesigned Discover page with enhanced table filtering capabilities and a tabbed navigation interface. Users can now browse and filter catalog resources (domains, services, events, commands, queries, flows, and data containers) with powerful filtering options including owner, domain, producer/consumer filters, and property-based filtering.

## Changes Overview

### Key Changes
- Add new `DiscoverTable` component with comprehensive filtering UI
- Add `FilterComponents` with reusable dropdown and checkbox components
- Add collection-specific column definitions for all resource types
- Implement tabbed navigation showing counts for each collection type
- Update default Explore link to point to `/discover/domains`
- Fix theming violations by removing `dark:` Tailwind variants
- Replace dynamic Tailwind classes with static color mapping
- Add proper TypeScript types to replace `as any` assertions
- Update CLAUDE.md with improved collection utility documentation

## How It Works

The new Discover page uses a client-side React table (`@tanstack/react-table`) with:

1. **Tabbed Navigation**: Shows all collection types (Domains, Services, Data, Events, Queries, Commands, Flows) with item counts, allowing quick switching between resource types.

2. **Filter Sidebar**: Provides multiple filter categories:
   - Text search across names
   - Owner filtering (users/teams)
   - Domain filtering (for services)
   - Producer/Consumer filtering (for messages)
   - Property-based boolean filters (has specifications, is deprecated, etc.)

3. **Smart Defaults**: Shows only latest versions by default with option to show all versions, and can filter to drafts only.

4. **Collection-specific Columns**: Each resource type has tailored columns showing relevant relationships (producers/consumers for events, receives/sends for services, etc.)

## Breaking Changes

None

## Additional Notes

- The new table components are in `eventcatalog/src/components/Tables/Discover/`
- Uses CSS variables for theming compatibility (`--ec-*` pattern)
- Filter state is maintained client-side for responsive filtering

🤖 Generated with [Claude Code](https://claude.ai/code)