### PR TITLE
fix(sidebar): handle favorites removal for deleted nodes and add theme support

### DIFF
--- a/.changeset/friendly-waves-glow.md
+++ b/.changeset/friendly-waves-glow.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix sidebar favorites removal for deleted nodes and add theme support to plans and custom docs pages

--- a/eventcatalog/src/components/SideNav/NestedSideBar/index.tsx
+++ b/eventcatalog/src/components/SideNav/NestedSideBar/index.tsx
@@ -8,7 +8,12 @@ import SearchBar from './SearchBar';
 import { saveState, loadState, saveCollapsedSections, loadCollapsedSections } from './storage';
 import { useStore } from '@nanostores/react';
 import { sidebarStore } from '@stores/sidebar-store';
-import { favoritesStore, toggleFavorite as toggleFavoriteAction, type FavoriteItem } from '@stores/favorites-store';
+import {
+  favoritesStore,
+  toggleFavorite as toggleFavoriteAction,
+  removeFavorite as removeFavoriteAction,
+  type FavoriteItem,
+} from '@stores/favorites-store';
 import { getBadgeClasses } from './utils';
 
 const cn = (...classes: (string | false | undefined)[]) => classes.filter(Boolean).join(' ');
@@ -1098,7 +1103,12 @@ export default function NestedSideBar() {
                           <div
                             onClick={(e) => {
                               e.stopPropagation();
-                              if (node) toggleFavorite(fav.nodeKey, node);
+                              if (node) {
+                                toggleFavorite(fav.nodeKey, node);
+                              } else {
+                                // Node no longer exists, remove directly using nodeKey
+                                removeFavoriteAction(fav.nodeKey);
+                              }
                             }}
                             className="flex items-center justify-center w-5 h-5 text-amber-400 hover:text-amber-500 rounded transition-colors cursor-pointer"
                           >

--- a/eventcatalog/src/enterprise/plans/index.astro
+++ b/eventcatalog/src/enterprise/plans/index.astro
@@ -17,45 +17,47 @@ import {
 ---
 
 <VerticalSideBarLayout title="EventCatalog Pro" showNestedSideBar={false}>
-  <div class="min-h-[calc(100vh-60px)] bg-white">
+  <div class="min-h-[calc(100vh-60px)] bg-[rgb(var(--ec-page-bg))]">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
       {/* Hero Section */}
       <div class="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center mb-16">
         <div>
-          <div class="inline-flex items-center px-4 py-2 rounded-full bg-purple-100 text-purple-700 font-medium text-sm mb-6">
+          <div
+            class="inline-flex items-center px-4 py-2 rounded-full bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300 font-medium text-sm mb-6"
+          >
             <Rocket className="w-4 h-4 mr-2" />
             Upgrade your Catalog
           </div>
-          <h1 class="text-4xl font-bold text-gray-900 tracking-tight mb-4">Supercharge your EventCatalog</h1>
-          <p class="text-xl text-gray-600 mb-8">
+          <h1 class="text-4xl font-bold text-[rgb(var(--ec-page-text))] tracking-tight mb-4">Supercharge your EventCatalog</h1>
+          <p class="text-xl text-[rgb(var(--ec-page-text-muted))] mb-8">
             Unlock advanced features like automated docs (e.g OpenAPI, AsyncAPI), Custom documentation, AI assistant, and catalog
             federation — all designed to help you scale without complexity.
           </p>
 
           {/* Integration Sources */}
           <div class="mb-8">
-            <p class="text-sm font-medium text-gray-500 mb-4">Generate documentation from:</p>
+            <p class="text-sm font-medium text-[rgb(var(--ec-page-text-muted))] mb-4">Generate documentation from:</p>
             <div class="grid grid-cols-2 md:grid-cols-3 gap-4">
               <a
                 href="https://www.eventcatalog.dev/integrations/openapi"
-                class="flex items-center space-x-2 bg-gray-50 rounded-lg px-4 py-2 hover:bg-gray-100 transition-colors duration-150"
+                class="flex items-center space-x-2 bg-[rgb(var(--ec-content-hover))] rounded-lg px-4 py-2 hover:bg-[rgb(var(--ec-content-active))] transition-colors duration-150"
               >
                 <img src="/icons/openapi.svg" alt="OpenAPI" class="w-6 h-6" />
-                <span class="text-sm font-medium">OpenAPI</span>
+                <span class="text-sm font-medium text-[rgb(var(--ec-page-text))]">OpenAPI</span>
               </a>
               <a
                 href="https://www.eventcatalog.dev/integrations/asyncapi"
-                class="flex items-center space-x-2 bg-gray-50 rounded-lg px-4 py-2 hover:bg-gray-100 transition-colors duration-150"
+                class="flex items-center space-x-2 bg-[rgb(var(--ec-content-hover))] rounded-lg px-4 py-2 hover:bg-[rgb(var(--ec-content-active))] transition-colors duration-150"
               >
                 <img src="/icons/asyncapi.svg" alt="AsyncAPI" class="w-6 h-6" />
-                <span class="text-sm font-medium">AsyncAPI</span>
+                <span class="text-sm font-medium text-[rgb(var(--ec-page-text))]">AsyncAPI</span>
               </a>
               <a
                 href="https://www.eventcatalog.dev/integrations"
-                class="flex items-center space-x-2 bg-gray-50 rounded-lg px-4 py-2 hover:bg-gray-100 transition-colors duration-150"
+                class="flex items-center space-x-2 bg-[rgb(var(--ec-content-hover))] rounded-lg px-4 py-2 hover:bg-[rgb(var(--ec-content-active))] transition-colors duration-150"
               >
-                <Component className="w-6 h-6 text-purple-600" />
-                <span class="text-sm font-medium">And more...</span>
+                <Component className="w-6 h-6 text-purple-600 dark:text-purple-400" />
+                <span class="text-sm font-medium text-[rgb(var(--ec-page-text))]">And more...</span>
               </a>
             </div>
           </div>
@@ -77,110 +79,123 @@ import {
             <a
               href="https://www.eventcatalog.dev"
               target="_blank"
-              class="inline-flex items-center justify-center px-6 py-3 border border-gray-300 text-base font-medium rounded-lg text-gray-700 bg-white hover:bg-gray-50 transition-colors duration-150"
+              class="inline-flex items-center justify-center px-6 py-3 border border-[rgb(var(--ec-page-border))] text-base font-medium rounded-lg text-[rgb(var(--ec-page-text))] bg-[rgb(var(--ec-card-bg))] hover:bg-[rgb(var(--ec-content-hover))] transition-colors duration-150"
             >
               View documentation
             </a>
           </div>
-          <p class="text-sm text-gray-500">Try free for 14 days, no credit card required</p>
+          <p class="text-sm text-[rgb(var(--ec-page-text-muted))]">Try free for 14 days, no credit card required</p>
         </div>
 
         <div class="relative">
           <img
             src="/images/eventcatalog-upgrade.png"
             alt="EventCatalog Pro"
-            class="w-full rounded-xl shadow-lg border border-gray-200"
+            class="w-full rounded-xl shadow-lg border border-[rgb(var(--ec-page-border))]"
           />
         </div>
       </div>
 
       {/* Why upgrade section */}
       <div class="mb-16">
-        <h2 class="text-2xl font-semibold text-gray-900 mb-8">Why upgrade EventCatalog?</h2>
+        <h2 class="text-2xl font-semibold text-[rgb(var(--ec-page-text))] mb-8">Why upgrade EventCatalog?</h2>
         <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
-          <div class="bg-white rounded-xl p-6 shadow-sm border border-gray-200">
-            <div class="w-12 h-12 bg-purple-100 rounded-lg flex items-center justify-center mb-4">
-              <ScrollText className="w-6 h-6 text-purple-600" />
+          <div class="bg-[rgb(var(--ec-card-bg))] rounded-xl p-6 shadow-sm border border-[rgb(var(--ec-page-border))]">
+            <div class="w-12 h-12 bg-purple-100 dark:bg-purple-900/30 rounded-lg flex items-center justify-center mb-4">
+              <ScrollText className="w-6 h-6 text-purple-600 dark:text-purple-400" />
             </div>
-            <h3 class="text-lg font-semibold text-gray-900 mb-2">A living source of truth</h3>
-            <p class="text-gray-600">Keep docs in sync with your systems, ensuring your team always has accurate information.</p>
+            <h3 class="text-lg font-semibold text-[rgb(var(--ec-page-text))] mb-2">A living source of truth</h3>
+            <p class="text-[rgb(var(--ec-page-text-muted))]">
+              Keep docs in sync with your systems, ensuring your team always has accurate information.
+            </p>
           </div>
 
-          <div class="bg-white rounded-xl p-6 shadow-sm border border-gray-200">
-            <div class="w-12 h-12 bg-purple-100 rounded-lg flex items-center justify-center mb-4">
-              <Users className="w-6 h-6 text-purple-600" />
+          <div class="bg-[rgb(var(--ec-card-bg))] rounded-xl p-6 shadow-sm border border-[rgb(var(--ec-page-border))]">
+            <div class="w-12 h-12 bg-purple-100 dark:bg-purple-900/30 rounded-lg flex items-center justify-center mb-4">
+              <Users className="w-6 h-6 text-purple-600 dark:text-purple-400" />
             </div>
-            <h3 class="text-lg font-semibold text-gray-900 mb-2">Shared system understanding</h3>
-            <p class="text-gray-600">Align teams and reduce tribal knowledge with centralized architecture documentation.</p>
+            <h3 class="text-lg font-semibold text-[rgb(var(--ec-page-text))] mb-2">Shared system understanding</h3>
+            <p class="text-[rgb(var(--ec-page-text-muted))]">
+              Align teams and reduce tribal knowledge with centralized architecture documentation.
+            </p>
           </div>
 
-          <div class="bg-white rounded-xl p-6 shadow-sm border border-gray-200">
-            <div class="w-12 h-12 bg-purple-100 rounded-lg flex items-center justify-center mb-4">
-              <Component className="w-6 h-6 text-purple-600" />
+          <div class="bg-[rgb(var(--ec-card-bg))] rounded-xl p-6 shadow-sm border border-[rgb(var(--ec-page-border))]">
+            <div class="w-12 h-12 bg-purple-100 dark:bg-purple-900/30 rounded-lg flex items-center justify-center mb-4">
+              <Component className="w-6 h-6 text-purple-600 dark:text-purple-400" />
             </div>
-            <h3 class="text-lg font-semibold text-gray-900 mb-2">Architecture that scales</h3>
-            <p class="text-gray-600">Grow without losing context of complexity, making architectural decisions easy to find.</p>
+            <h3 class="text-lg font-semibold text-[rgb(var(--ec-page-text))] mb-2">Architecture that scales</h3>
+            <p class="text-[rgb(var(--ec-page-text-muted))]">
+              Grow without losing context of complexity, making architectural decisions easy to find.
+            </p>
           </div>
         </div>
       </div>
 
       {/* Documentation Journey Section */}
       <div class="mb-16">
-        <h2 class="text-2xl font-semibold text-gray-900 mb-4">Scales with your team and architecture</h2>
-        <p class="text-gray-600 mb-8 max-w-3xl">
+        <h2 class="text-2xl font-semibold text-[rgb(var(--ec-page-text))] mb-4">Scales with your team and architecture</h2>
+        <p class="text-[rgb(var(--ec-page-text-muted))] mb-8 max-w-3xl">
           From scattered documentation to a well-governed system, EventCatalog helps you control complexity with well governed
           documentation for your teams. Choose the plan that fits your needs.
         </p>
 
         <div class="relative py-8">
           {/* Journey Line */}
-          <div class="absolute top-1/2 left-0 w-full h-1 bg-purple-200 transform -translate-y-1/2 hidden md:block"></div>
+          <div
+            class="absolute top-1/2 left-0 w-full h-1 bg-purple-200 dark:bg-purple-900/50 transform -translate-y-1/2 hidden md:block"
+          >
+          </div>
 
           <div class="grid grid-cols-1 md:grid-cols-4 gap-8 relative">
             {/* Stage 1 */}
-            <div class="bg-white rounded-xl p-6 shadow-sm border border-gray-200 relative">
+            <div class="bg-[rgb(var(--ec-card-bg))] rounded-xl p-6 shadow-sm border border-[rgb(var(--ec-page-border))] relative">
               <div
-                class="w-12 h-12 bg-purple-100 rounded-full flex items-center justify-center mb-4 mx-auto md:absolute md:-top-6 md:left-1/2 md:transform md:-translate-x-1/2"
+                class="w-12 h-12 bg-purple-100 dark:bg-purple-900/30 rounded-full flex items-center justify-center mb-4 mx-auto md:absolute md:-top-6 md:left-1/2 md:transform md:-translate-x-1/2"
               >
-                <Github className="w-6 h-6 text-purple-600" />
+                <Github className="w-6 h-6 text-purple-600 dark:text-purple-400" />
               </div>
-              <h3 class="text-lg font-semibold text-gray-900 mb-2 text-center">Community Edition</h3>
-              <p class="text-gray-600 text-sm text-center">You're just beginning to document services, domains, and events.</p>
+              <h3 class="text-lg font-semibold text-[rgb(var(--ec-page-text))] mb-2 text-center">Community Edition</h3>
+              <p class="text-[rgb(var(--ec-page-text-muted))] text-sm text-center">
+                You're just beginning to document services, domains, and events.
+              </p>
             </div>
 
             {/* Stage 2 */}
-            <div class="bg-white rounded-xl p-6 shadow-sm border border-gray-200 relative">
+            <div class="bg-[rgb(var(--ec-card-bg))] rounded-xl p-6 shadow-sm border border-[rgb(var(--ec-page-border))] relative">
               <div
-                class="w-12 h-12 bg-purple-100 rounded-full flex items-center justify-center mb-4 mx-auto md:absolute md:-top-6 md:left-1/2 md:transform md:-translate-x-1/2"
+                class="w-12 h-12 bg-purple-100 dark:bg-purple-900/30 rounded-full flex items-center justify-center mb-4 mx-auto md:absolute md:-top-6 md:left-1/2 md:transform md:-translate-x-1/2"
               >
-                <Flag className="w-6 h-6 text-purple-600" />
+                <Flag className="w-6 h-6 text-purple-600 dark:text-purple-400" />
               </div>
-              <h3 class="text-lg font-semibold text-gray-900 mb-2 text-center">Starter Plan</h3>
-              <p class="text-gray-600 text-sm text-center">For teams formalizing their architecture documentation</p>
+              <h3 class="text-lg font-semibold text-[rgb(var(--ec-page-text))] mb-2 text-center">Starter Plan</h3>
+              <p class="text-[rgb(var(--ec-page-text-muted))] text-sm text-center">
+                For teams formalizing their architecture documentation
+              </p>
             </div>
 
             {/* Stage 3 */}
-            <div class="bg-white rounded-xl p-6 shadow-sm border border-gray-200 relative">
+            <div class="bg-[rgb(var(--ec-card-bg))] rounded-xl p-6 shadow-sm border border-[rgb(var(--ec-page-border))] relative">
               <div
-                class="w-12 h-12 bg-purple-100 rounded-full flex items-center justify-center mb-4 mx-auto md:absolute md:-top-6 md:left-1/2 md:transform md:-translate-x-1/2"
+                class="w-12 h-12 bg-purple-100 dark:bg-purple-900/30 rounded-full flex items-center justify-center mb-4 mx-auto md:absolute md:-top-6 md:left-1/2 md:transform md:-translate-x-1/2"
               >
-                <Network className="w-6 h-6 text-purple-600" />
+                <Network className="w-6 h-6 text-purple-600 dark:text-purple-400" />
               </div>
-              <h3 class="text-lg font-semibold text-gray-900 mb-2 text-center">Scale Plan</h3>
-              <p class="text-gray-600 text-sm text-center">
+              <h3 class="text-lg font-semibold text-[rgb(var(--ec-page-text))] mb-2 text-center">Scale Plan</h3>
+              <p class="text-[rgb(var(--ec-page-text-muted))] text-sm text-center">
                 Built for teams scaling across domains and integrating with external systems
               </p>
             </div>
 
             {/* Stage 4 */}
-            <div class="bg-white rounded-xl p-6 shadow-sm border border-gray-200 relative">
+            <div class="bg-[rgb(var(--ec-card-bg))] rounded-xl p-6 shadow-sm border border-[rgb(var(--ec-page-border))] relative">
               <div
-                class="w-12 h-12 bg-purple-100 rounded-full flex items-center justify-center mb-4 mx-auto md:absolute md:-top-6 md:left-1/2 md:transform md:-translate-x-1/2"
+                class="w-12 h-12 bg-purple-100 dark:bg-purple-900/30 rounded-full flex items-center justify-center mb-4 mx-auto md:absolute md:-top-6 md:left-1/2 md:transform md:-translate-x-1/2"
               >
-                <Rocket className="w-6 h-6 text-purple-600" />
+                <Rocket className="w-6 h-6 text-purple-600 dark:text-purple-400" />
               </div>
-              <h3 class="text-lg font-semibold text-gray-900 mb-2 text-center">Enterprise Plan</h3>
-              <p class="text-gray-600 text-sm text-center">
+              <h3 class="text-lg font-semibold text-[rgb(var(--ec-page-text))] mb-2 text-center">Enterprise Plan</h3>
+              <p class="text-[rgb(var(--ec-page-text-muted))] text-sm text-center">
                 Designed for organizations building and governing complex event platforms
               </p>
             </div>
@@ -188,92 +203,104 @@ import {
 
           {/* Mobile Progress Indicators */}
           <div class="flex justify-center items-center space-x-2 mt-4 md:hidden">
-            <div class="w-2 h-2 rounded-full bg-purple-600"></div>
-            <div class="w-2 h-2 rounded-full bg-purple-400"></div>
-            <div class="w-2 h-2 rounded-full bg-purple-300"></div>
-            <div class="w-2 h-2 rounded-full bg-purple-200"></div>
+            <div class="w-2 h-2 rounded-full bg-purple-600 dark:bg-purple-400"></div>
+            <div class="w-2 h-2 rounded-full bg-purple-400 dark:bg-purple-500"></div>
+            <div class="w-2 h-2 rounded-full bg-purple-300 dark:bg-purple-600"></div>
+            <div class="w-2 h-2 rounded-full bg-purple-200 dark:bg-purple-700"></div>
           </div>
         </div>
       </div>
 
       {/* Features Section */}
       <div class="mb-16">
-        <h2 class="text-2xl font-semibold text-gray-900 mb-8">Save time with EventCatalog</h2>
+        <h2 class="text-2xl font-semibold text-[rgb(var(--ec-page-text))] mb-8">Save time with EventCatalog</h2>
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-          <div class="bg-white rounded-xl p-6 shadow-sm border border-gray-200">
-            <div class="w-12 h-12 bg-blue-100 rounded-lg flex items-center justify-center mb-4">
-              <ScrollText className="w-6 h-6 text-blue-600" />
+          <div class="bg-[rgb(var(--ec-card-bg))] rounded-xl p-6 shadow-sm border border-[rgb(var(--ec-page-border))]">
+            <div class="w-12 h-12 bg-blue-100 dark:bg-blue-900/30 rounded-lg flex items-center justify-center mb-4">
+              <ScrollText className="w-6 h-6 text-blue-600 dark:text-blue-400" />
             </div>
-            <h3 class="text-lg font-semibold text-gray-900 mb-2">Custom Documentation</h3>
-            <p class="text-gray-600">Add ADRs, runbooks, and technical guidelines to create a centralized knowledge hub.</p>
+            <h3 class="text-lg font-semibold text-[rgb(var(--ec-page-text))] mb-2">Custom Documentation</h3>
+            <p class="text-[rgb(var(--ec-page-text-muted))]">
+              Add ADRs, runbooks, and technical guidelines to create a centralized knowledge hub.
+            </p>
           </div>
 
-          <div class="bg-white rounded-xl p-6 shadow-sm border border-gray-200">
-            <div class="w-12 h-12 bg-green-100 rounded-lg flex items-center justify-center mb-4">
-              <Bot className="w-6 h-6 text-green-600" />
+          <div class="bg-[rgb(var(--ec-card-bg))] rounded-xl p-6 shadow-sm border border-[rgb(var(--ec-page-border))]">
+            <div class="w-12 h-12 bg-green-100 dark:bg-green-900/30 rounded-lg flex items-center justify-center mb-4">
+              <Bot className="w-6 h-6 text-green-600 dark:text-green-400" />
             </div>
-            <h3 class="text-lg font-semibold text-gray-900 mb-2">AI Assistant</h3>
-            <p class="text-gray-600">Chat with your catalog to quickly find information about your architecture.</p>
+            <h3 class="text-lg font-semibold text-[rgb(var(--ec-page-text))] mb-2">AI Assistant</h3>
+            <p class="text-[rgb(var(--ec-page-text-muted))]">
+              Chat with your catalog to quickly find information about your architecture.
+            </p>
           </div>
 
-          <div class="bg-white rounded-xl p-6 shadow-sm border border-gray-200">
-            <div class="w-12 h-12 bg-purple-100 rounded-lg flex items-center justify-center mb-4">
-              <Component className="w-6 h-6 text-purple-600" />
+          <div class="bg-[rgb(var(--ec-card-bg))] rounded-xl p-6 shadow-sm border border-[rgb(var(--ec-page-border))]">
+            <div class="w-12 h-12 bg-purple-100 dark:bg-purple-900/30 rounded-lg flex items-center justify-center mb-4">
+              <Component className="w-6 h-6 text-purple-600 dark:text-purple-400" />
             </div>
-            <h3 class="text-lg font-semibold text-gray-900 mb-2">Federation</h3>
-            <p class="text-gray-600">Connect multiple catalogs into a unified view for centralized visibility across teams.</p>
+            <h3 class="text-lg font-semibold text-[rgb(var(--ec-page-text))] mb-2">Federation</h3>
+            <p class="text-[rgb(var(--ec-page-text-muted))]">
+              Connect multiple catalogs into a unified view for centralized visibility across teams.
+            </p>
           </div>
 
-          <div class="bg-white rounded-xl p-6 shadow-sm border border-gray-200">
-            <div class="w-12 h-12 bg-indigo-100 rounded-lg flex items-center justify-center mb-4">
-              <Code className="w-6 h-6 text-indigo-600" />
+          <div class="bg-[rgb(var(--ec-card-bg))] rounded-xl p-6 shadow-sm border border-[rgb(var(--ec-page-border))]">
+            <div class="w-12 h-12 bg-indigo-100 dark:bg-indigo-900/30 rounded-lg flex items-center justify-center mb-4">
+              <Code className="w-6 h-6 text-indigo-600 dark:text-indigo-400" />
             </div>
-            <h3 class="text-lg font-semibold text-gray-900 mb-2">IDE Integration</h3>
-            <p class="text-gray-600">Access EventCatalog directly from your IDE for seamless documentation while coding.</p>
+            <h3 class="text-lg font-semibold text-[rgb(var(--ec-page-text))] mb-2">IDE Integration</h3>
+            <p class="text-[rgb(var(--ec-page-text-muted))]">
+              Access EventCatalog directly from your IDE for seamless documentation while coding.
+            </p>
           </div>
 
-          <div class="bg-white rounded-xl p-6 shadow-sm border border-gray-200">
-            <div class="w-12 h-12 bg-yellow-100 rounded-lg flex items-center justify-center mb-4">
-              <Cpu className="w-6 h-6 text-yellow-600" />
+          <div class="bg-[rgb(var(--ec-card-bg))] rounded-xl p-6 shadow-sm border border-[rgb(var(--ec-page-border))]">
+            <div class="w-12 h-12 bg-yellow-100 dark:bg-yellow-900/30 rounded-lg flex items-center justify-center mb-4">
+              <Cpu className="w-6 h-6 text-yellow-600 dark:text-yellow-400" />
             </div>
-            <h3 class="text-lg font-semibold text-gray-900 mb-2">Automated Documentation</h3>
-            <p class="text-gray-600">
+            <h3 class="text-lg font-semibold text-[rgb(var(--ec-page-text))] mb-2">Automated Documentation</h3>
+            <p class="text-[rgb(var(--ec-page-text-muted))]">
               Generate and maintain documentation automatically with integrations for AsyncAPI and OpenAPI.
             </p>
           </div>
 
-          <div class="bg-white rounded-xl p-6 shadow-sm border border-gray-200">
-            <div class="w-12 h-12 bg-red-100 rounded-lg flex items-center justify-center mb-4">
-              <LifeBuoy className="w-6 h-6 text-red-600" />
+          <div class="bg-[rgb(var(--ec-card-bg))] rounded-xl p-6 shadow-sm border border-[rgb(var(--ec-page-border))]">
+            <div class="w-12 h-12 bg-red-100 dark:bg-red-900/30 rounded-lg flex items-center justify-center mb-4">
+              <LifeBuoy className="w-6 h-6 text-red-600 dark:text-red-400" />
             </div>
-            <h3 class="text-lg font-semibold text-gray-900 mb-2">Priority Support</h3>
-            <p class="text-gray-600">Get priority email support and assistance from the EventCatalog team.</p>
+            <h3 class="text-lg font-semibold text-[rgb(var(--ec-page-text))] mb-2">Priority Support</h3>
+            <p class="text-[rgb(var(--ec-page-text-muted))]">
+              Get priority email support and assistance from the EventCatalog team.
+            </p>
           </div>
         </div>
       </div>
 
       {/* Questions Section */}
       <div class="mt-16">
-        <h2 class="text-2xl font-semibold text-gray-900 mb-8">Questions about EventCatalog?</h2>
+        <h2 class="text-2xl font-semibold text-[rgb(var(--ec-page-text))] mb-8">Questions about EventCatalog?</h2>
         <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
-          <div class="bg-white rounded-xl p-6 shadow-sm border border-gray-200">
-            <h3 class="text-lg font-semibold text-gray-900 mb-2">Request a Demo</h3>
-            <p class="text-gray-600 mb-4">See EventCatalog in action with a personalized demo from our team.</p>
+          <div class="bg-[rgb(var(--ec-card-bg))] rounded-xl p-6 shadow-sm border border-[rgb(var(--ec-page-border))]">
+            <h3 class="text-lg font-semibold text-[rgb(var(--ec-page-text))] mb-2">Request a Demo</h3>
+            <p class="text-[rgb(var(--ec-page-text-muted))] mb-4">
+              See EventCatalog in action with a personalized demo from our team.
+            </p>
             <a
               href="mailto:hello@eventcatalog.dev"
-              class="text-purple-600 hover:text-purple-700 font-medium inline-flex items-center"
+              class="text-purple-600 dark:text-purple-400 hover:text-purple-700 dark:hover:text-purple-300 font-medium inline-flex items-center"
             >
               Schedule a demo
               <ExternalLink className="w-4 h-4 ml-1.5" />
             </a>
           </div>
 
-          <div class="bg-white rounded-xl p-6 shadow-sm border border-gray-200">
-            <h3 class="text-lg font-semibold text-gray-900 mb-2">Join the community</h3>
-            <p class="text-gray-600 mb-4">Join our growing community on Discord. Over 1000+ members.</p>
+          <div class="bg-[rgb(var(--ec-card-bg))] rounded-xl p-6 shadow-sm border border-[rgb(var(--ec-page-border))]">
+            <h3 class="text-lg font-semibold text-[rgb(var(--ec-page-text))] mb-2">Join the community</h3>
+            <p class="text-[rgb(var(--ec-page-text-muted))] mb-4">Join our growing community on Discord. Over 1000+ members.</p>
             <a
               href="https://discord.gg/3rjaZMmrAm"
-              class="text-purple-600 hover:text-purple-700 font-medium inline-flex items-center"
+              class="text-purple-600 dark:text-purple-400 hover:text-purple-700 dark:hover:text-purple-300 font-medium inline-flex items-center"
             >
               Join the community
               <ExternalLink className="w-4 h-4 ml-1.5" />

--- a/eventcatalog/src/pages/docs/custom/feature.astro
+++ b/eventcatalog/src/pages/docs/custom/feature.astro
@@ -4,19 +4,21 @@ import { BookOpenIcon, FileText } from 'lucide-react';
 ---
 
 <VerticalSideBarLayout title="Custom Documentation" showNestedSideBar={false}>
-  <div class="min-h-[calc(100vh-60px)] bg-white">
+  <div class="min-h-[calc(100vh-60px)] bg-[rgb(var(--ec-page-bg))]">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
       {/* Hero Section */}
       <div class="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center mb-16">
         <div>
-          <div class="inline-flex items-center px-4 py-2 rounded-full bg-blue-100 text-blue-700 font-medium text-sm mb-6">
+          <div
+            class="inline-flex items-center px-4 py-2 rounded-full bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300 font-medium text-sm mb-6"
+          >
             <FileText className="w-4 h-4 mr-2" />
             New: Bring your documentation into EventCatalog
           </div>
-          <h1 class="text-4xl font-bold text-gray-900 tracking-tight mb-4">
+          <h1 class="text-4xl font-bold text-[rgb(var(--ec-page-text))] tracking-tight mb-4">
             Document Everything. Share Knowledge. Build Better.
           </h1>
-          <p class="text-xl text-gray-600 mb-8">
+          <p class="text-xl text-[rgb(var(--ec-page-text-muted))] mb-8">
             Add your own documentation to EventCatalog — from ADRs and system guides to runbooks and onboarding material. Connect
             your knowledge to your architecture.
           </p>
@@ -37,14 +39,14 @@ import { BookOpenIcon, FileText } from 'lucide-react';
             <a
               href="https://www.eventcatalog.cloud"
               target="_blank"
-              class="inline-flex items-center justify-center px-6 py-3 border border-gray-300 text-base font-medium rounded-lg text-gray-700 bg-white hover:bg-gray-50 transition-colors duration-150"
+              class="inline-flex items-center justify-center px-6 py-3 border border-[rgb(var(--ec-page-border))] text-base font-medium rounded-lg text-[rgb(var(--ec-page-text))] bg-[rgb(var(--ec-card-bg))] hover:bg-[rgb(var(--ec-content-hover))] transition-colors duration-150"
             >
               Try for free
             </a>
           </div>
-          <p class="text-sm text-gray-500">
+          <p class="text-sm text-[rgb(var(--ec-page-text-muted))]">
             Available with EventCatalog Starter or Scale plans
-            <a href="https://www.eventcatalog.dev/pricing" class="text-blue-600 font-medium block"
+            <a href="https://www.eventcatalog.dev/pricing" class="text-blue-600 dark:text-blue-400 font-medium block"
               >Try free for 14 days, no credit card required</a
             >
           </p>
@@ -62,7 +64,7 @@ import { BookOpenIcon, FileText } from 'lucide-react';
             <img
               src="/images/custom-docs-placeholder.png"
               alt="Custom Documentation Preview"
-              class="rounded-xl shadow-xl border border-gray-200"
+              class="rounded-xl shadow-xl border border-[rgb(var(--ec-page-border))]"
             />
           </div>
         </div>
@@ -70,75 +72,79 @@ import { BookOpenIcon, FileText } from 'lucide-react';
 
       {/* Features Section */}
       <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
-        <div class="bg-white rounded-xl p-6 shadow-sm border border-gray-200">
-          <div class="w-12 h-12 bg-blue-100 rounded-lg flex items-center justify-center mb-4">
-            <svg class="w-6 h-6 text-blue-600" viewBox="0 0 24 24" fill="currentColor">
+        <div class="bg-[rgb(var(--ec-card-bg))] rounded-xl p-6 shadow-sm border border-[rgb(var(--ec-page-border))]">
+          <div class="w-12 h-12 bg-blue-100 dark:bg-blue-900/30 rounded-lg flex items-center justify-center mb-4">
+            <svg class="w-6 h-6 text-blue-600 dark:text-blue-400" viewBox="0 0 24 24" fill="currentColor">
               <path d="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zM6 20V4h7v5h5v11H6z"></path>
             </svg>
           </div>
-          <h3 class="text-lg font-semibold text-gray-900 mb-2">Centralized Knowledge</h3>
-          <p class="text-gray-600">
+          <h3 class="text-lg font-semibold text-[rgb(var(--ec-page-text))] mb-2">Centralized Knowledge</h3>
+          <p class="text-[rgb(var(--ec-page-text-muted))]">
             Keep architecture decisions, system guides, and runbooks in one place — easy to access, easy to trust.
           </p>
         </div>
 
-        <div class="bg-white rounded-xl p-6 shadow-sm border border-gray-200">
-          <div class="w-12 h-12 bg-blue-100 rounded-lg flex items-center justify-center mb-4">
-            <svg class="w-6 h-6 text-blue-600" viewBox="0 0 24 24" fill="currentColor">
+        <div class="bg-[rgb(var(--ec-card-bg))] rounded-xl p-6 shadow-sm border border-[rgb(var(--ec-page-border))]">
+          <div class="w-12 h-12 bg-blue-100 dark:bg-blue-900/30 rounded-lg flex items-center justify-center mb-4">
+            <svg class="w-6 h-6 text-blue-600 dark:text-blue-400" viewBox="0 0 24 24" fill="currentColor">
               <path
                 d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-5 14H7v-2h7v2zm3-4H7v-2h10v2zm0-4H7V7h10v2z"
               ></path>
             </svg>
           </div>
-          <h3 class="text-lg font-semibold text-gray-900 mb-2">Rich Formatting</h3>
-          <p class="text-gray-600">
+          <h3 class="text-lg font-semibold text-[rgb(var(--ec-page-text))] mb-2">Rich Formatting</h3>
+          <p class="text-[rgb(var(--ec-page-text-muted))]">
             Use Markdown, diagrams, code blocks, and EventCatalog components to create structured, useful documentation.
           </p>
         </div>
 
-        <div class="bg-white rounded-xl p-6 shadow-sm border border-gray-200">
-          <div class="w-12 h-12 bg-blue-100 rounded-lg flex items-center justify-center mb-4">
-            <svg class="w-6 h-6 text-blue-600" viewBox="0 0 24 24" fill="currentColor">
+        <div class="bg-[rgb(var(--ec-card-bg))] rounded-xl p-6 shadow-sm border border-[rgb(var(--ec-page-border))]">
+          <div class="w-12 h-12 bg-blue-100 dark:bg-blue-900/30 rounded-lg flex items-center justify-center mb-4">
+            <svg class="w-6 h-6 text-blue-600 dark:text-blue-400" viewBox="0 0 24 24" fill="currentColor">
               <path d="M18 2H6c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zM6 4h5v8l-2.5-1.5L6 12V4z"
               ></path>
             </svg>
           </div>
-          <h3 class="text-lg font-semibold text-gray-900 mb-2">Version Control</h3>
-          <p class="text-gray-600">Track changes and ensure your documentation grows alongside your system.</p>
+          <h3 class="text-lg font-semibold text-[rgb(var(--ec-page-text))] mb-2">Version Control</h3>
+          <p class="text-[rgb(var(--ec-page-text-muted))]">
+            Track changes and ensure your documentation grows alongside your system.
+          </p>
         </div>
 
-        <div class="bg-white rounded-xl p-6 shadow-sm border border-gray-200">
-          <div class="w-12 h-12 bg-blue-100 rounded-lg flex items-center justify-center mb-4">
-            <svg class="w-6 h-6 text-blue-600" viewBox="0 0 24 24" fill="currentColor">
+        <div class="bg-[rgb(var(--ec-card-bg))] rounded-xl p-6 shadow-sm border border-[rgb(var(--ec-page-border))]">
+          <div class="w-12 h-12 bg-blue-100 dark:bg-blue-900/30 rounded-lg flex items-center justify-center mb-4">
+            <svg class="w-6 h-6 text-blue-600 dark:text-blue-400" viewBox="0 0 24 24" fill="currentColor">
               <path
                 d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"
               ></path>
             </svg>
           </div>
-          <h3 class="text-lg font-semibold text-gray-900 mb-2">Documentation Ownership</h3>
-          <p class="text-gray-600">Assign and track document owners, making it easy to find the right person in seconds.</p>
+          <h3 class="text-lg font-semibold text-[rgb(var(--ec-page-text))] mb-2">Documentation Ownership</h3>
+          <p class="text-[rgb(var(--ec-page-text-muted))]">
+            Assign and track document owners, making it easy to find the right person in seconds.
+          </p>
         </div>
 
-        <div class="bg-white rounded-xl p-6 shadow-sm border border-gray-200">
-          <div class="w-12 h-12 bg-blue-100 rounded-lg flex items-center justify-center mb-4">
-            <svg class="w-6 h-6 text-blue-600" viewBox="0 0 24 24" fill="currentColor">
+        <div class="bg-[rgb(var(--ec-card-bg))] rounded-xl p-6 shadow-sm border border-[rgb(var(--ec-page-border))]">
+          <div class="w-12 h-12 bg-blue-100 dark:bg-blue-900/30 rounded-lg flex items-center justify-center mb-4">
+            <svg class="w-6 h-6 text-blue-600 dark:text-blue-400" viewBox="0 0 24 24" fill="currentColor">
               <path d="M3 9h14V7H3v2zm0 4h14v-2H3v2zm0 4h14v-2H3v2zm16 0h2v-2h-2v2zm0-10v2h2V7h-2zm0 6h2v-2h-2v2z"></path>
             </svg>
           </div>
-          <h3 class="text-lg font-semibold text-gray-900 mb-2">Customizable Sidebars</h3>
-          <p class="text-gray-600">
+          <h3 class="text-lg font-semibold text-[rgb(var(--ec-page-text))] mb-2">Customizable Sidebars</h3>
+          <p class="text-[rgb(var(--ec-page-text-muted))]">
             Auto-generated and fully customizable navigation sidebars to organize your documentation perfectly.
           </p>
         </div>
 
-        <div class="bg-white rounded-xl p-6 shadow-sm border border-gray-200">
-          <div class="w-12 h-12 bg-blue-100 rounded-lg flex items-center justify-center mb-4">
-            <svg class="w-6 h-6 text-blue-600" viewBox="0 0 24 24" fill="currentColor">
+        <div class="bg-[rgb(var(--ec-card-bg))] rounded-xl p-6 shadow-sm border border-[rgb(var(--ec-page-border))]">
+          <div class="w-12 h-12 bg-blue-100 dark:bg-blue-900/30 rounded-lg flex items-center justify-center mb-4">
+            <svg class="w-6 h-6 text-blue-600 dark:text-blue-400" viewBox="0 0 24 24" fill="currentColor">
               <path d="M20 2H4c-1.1 0-2 .9-2 2v18l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm0 14H6l-2 2V4h16v12z"></path>
             </svg>
           </div>
-          <h3 class="text-lg font-semibold text-gray-900 mb-2">EventCatalog Chat</h3>
-          <p class="text-gray-600">
+          <h3 class="text-lg font-semibold text-[rgb(var(--ec-page-text))] mb-2">EventCatalog Chat</h3>
+          <p class="text-[rgb(var(--ec-page-text-muted))]">
             Interact with your documentation using AI-powered chat to find answers quickly and efficiently.
           </p>
         </div>
@@ -149,7 +155,7 @@ import { BookOpenIcon, FileText } from 'lucide-react';
         <a
           href="https://www.eventcatalog.dev/docs/development/guides/customize-sidebars/application-sidebar"
           target="_blank"
-          class="text-sm text-gray-400 hover:text-gray-500 transition-colors duration-150"
+          class="text-sm text-[rgb(var(--ec-page-text-muted))] hover:text-[rgb(var(--ec-page-text))] transition-colors duration-150"
         >
           Not ready for custom documentation? You can hide this feature in settings
         </a>


### PR DESCRIPTION
## What This PR Does

Fixes an issue where favorited items in the sidebar could not be removed if the underlying node no longer exists. Also adds proper dark mode theme support to the Plans and Custom Documentation feature pages.

## Changes Overview

### Key Changes
- **Sidebar favorites fix**: When a favorited node is deleted from the catalog, clicking the star icon to unfavorite now correctly removes it using `removeFavoriteAction` instead of failing silently
- **Plans page theming**: Replace hardcoded colors (`bg-white`, `text-gray-900`, etc.) with CSS variables (`--ec-page-bg`, `--ec-page-text`, etc.) for proper dark mode support
- **Custom docs page theming**: Apply the same CSS variable pattern to the custom documentation feature page

## How It Works

For the favorites fix, the code now checks if the node exists before calling `toggleFavorite`. If the node doesn't exist (was deleted), it directly calls `removeFavoriteAction` with the nodeKey to remove the stale favorite entry.

For the theming updates, all hardcoded Tailwind color classes are replaced with CSS variable references following EventCatalog's theming conventions:
- `bg-white` → `bg-[rgb(var(--ec-page-bg))]`
- `text-gray-900` → `text-[rgb(var(--ec-page-text))]`
- `text-gray-600` → `text-[rgb(var(--ec-page-text-muted))]`
- `border-gray-200` → `border-[rgb(var(--ec-page-border))]`
- Color accent classes also include dark mode variants

## Breaking Changes

None

## Additional Notes

The theme changes ensure these pages respect the user's dark mode preference and any custom themes configured in EventCatalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)