### PR TITLE
feat(mdx): add inline resource references with hover tooltips

### DIFF
--- a/.changeset/swift-ravens-dance.md
+++ b/.changeset/swift-ravens-dance.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Add inline resource references with wiki-style syntax and hover tooltips. Use `[[type|ResourceName]]` syntax to create interactive links that display resource details on hover.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The **recommended** way to install the latest version of EventCatalog is by runn
 npx @eventcatalog/create-eventcatalog@latest my-catalog
 ```
 
-Looking for help? Start with our [Getting Started](https://www.eventcatalog.dev/docs/development/starting-a-new-project/installation) guide
+Looking for help? Start with our [Getting Started](https://www.eventcatalog.dev/docs/development/getting-started/installation) guide
 
 ## Documentation
 Visit our [official documentation](https://www.eventcatalog.dev/docs/development/getting-started).

--- a/eventcatalog/astro.config.mjs
+++ b/eventcatalog/astro.config.mjs
@@ -9,6 +9,7 @@ import { plantuml } from "./src/remark-plugins/plantuml"
 import { join } from 'node:path';
 import remarkDirective from 'remark-directive';
 import { remarkDirectives } from "./src/remark-plugins/directives"
+import { remarkResourceRef } from "./src/remark-plugins/resource-ref"
 import node from '@astrojs/node';
 import remarkComment from 'remark-comment'
 import rehypeSlug from 'rehype-slug';
@@ -70,7 +71,7 @@ export default defineConfig({
     mdx({
       // https://docs.astro.build/en/guides/integrations-guide/mdx/#optimize
       optimize: config.mdxOptimize || false,
-      remarkPlugins: [remarkDirective, remarkDirectives, remarkComment, mermaid, plantuml],
+      remarkPlugins: [remarkDirective, remarkDirectives, remarkComment, mermaid, plantuml, remarkResourceRef],
       rehypePlugins: [
         [rehypeExpressiveCode, {
             ...expressiveCodeConfig,

--- a/eventcatalog/src/components/MDX/ResourceRef/ResourceRef.astro
+++ b/eventcatalog/src/components/MDX/ResourceRef/ResourceRef.astro
@@ -1,0 +1,477 @@
+---
+/**
+ * Inline resource reference component with hover tooltip.
+ *
+ * Usage via remark plugin:
+ * [[service|OrderService]] -> Links to OrderService with tooltip
+ * [[Order]] -> Shorthand, defaults to entity type
+ */
+import { buildUrl } from '@utils/url-builder';
+import {
+  getItemsFromCollectionByIdAndSemverOrLatest,
+  resourceToCollectionMap,
+  getDeprecatedDetails,
+} from '@utils/collections/util';
+import { getCollection } from 'astro:content';
+import { getServiceSpecifications, getSpecUrl, getSpecLabel } from '@components/Grids/specification-utils';
+
+interface Props {
+  type:
+    | 'entity'
+    | 'service'
+    | 'event'
+    | 'command'
+    | 'query'
+    | 'domain'
+    | 'flow'
+    | 'channel'
+    | 'diagram'
+    | 'container'
+    | 'user'
+    | 'team';
+  version?: string;
+}
+
+const { type = 'entity', version } = Astro.props;
+
+// Get resource ID from slot content
+const slotContent = await Astro.slots.render('default');
+const resourceId = slotContent.trim();
+
+// Map type to collection name
+const collection = resourceToCollectionMap[type as keyof typeof resourceToCollectionMap];
+
+// Type-specific styling using CSS variables from theme.css
+// Maps to --ec-badge-{type}-text variables for consistency
+const typeStyles: Record<string, { borderColor: string; label: string }> = {
+  entity: { borderColor: 'var(--ec-badge-query-text)', label: 'Entity' }, // purple
+  service: { borderColor: 'var(--ec-badge-service-text)', label: 'Service' }, // pink
+  event: { borderColor: 'var(--ec-badge-event-text)', label: 'Event' }, // amber/orange
+  command: { borderColor: 'var(--ec-badge-command-text)', label: 'Command' }, // pink
+  query: { borderColor: 'var(--ec-badge-query-text)', label: 'Query' }, // purple
+  domain: { borderColor: 'var(--ec-badge-domain-text)', label: 'Domain' }, // yellow
+  flow: { borderColor: 'var(--ec-badge-design-text)', label: 'Flow' }, // teal
+  channel: { borderColor: 'var(--ec-badge-channel-text)', label: 'Channel' }, // indigo
+  diagram: { borderColor: 'var(--ec-badge-default-text)', label: 'Diagram' }, // gray
+  container: { borderColor: 'var(--ec-badge-default-text)', label: 'Container' }, // gray
+  user: { borderColor: 'var(--ec-badge-default-text)', label: 'User' }, // gray
+  team: { borderColor: 'var(--ec-badge-default-text)', label: 'Team' }, // gray
+};
+
+// SVG icons for each type (from heroicons outline)
+const typeIcons: Record<string, string> = {
+  entity:
+    '<path stroke-linecap="round" stroke-linejoin="round" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" />', // Box/cube
+  service:
+    '<path stroke-linecap="round" stroke-linejoin="round" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01" />', // Server
+  event:
+    '<path stroke-linecap="round" stroke-linejoin="round" d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z" />', // Bolt
+  command:
+    '<path stroke-linecap="round" stroke-linejoin="round" d="M8.625 12a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0H8.25m4.125 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0H12m4.125 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0h-.375M21 12c0 4.556-4.03 8.25-9 8.25a9.764 9.764 0 01-2.555-.337A5.972 5.972 0 015.41 20.97a5.969 5.969 0 01-.474-.065 4.48 4.48 0 00.978-2.025c.09-.457-.133-.901-.467-1.226C3.93 16.178 3 14.189 3 12c0-4.556 4.03-8.25 9-8.25s9 3.694 9 8.25z" />', // ChatBubble
+  query:
+    '<path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />', // MagnifyingGlass
+  domain:
+    '<path stroke-linecap="round" stroke-linejoin="round" d="M2.25 7.125C2.25 6.504 2.754 6 3.375 6h6c.621 0 1.125.504 1.125 1.125v3.75c0 .621-.504 1.125-1.125 1.125h-6a1.125 1.125 0 01-1.125-1.125v-3.75zM14.25 8.625c0-.621.504-1.125 1.125-1.125h5.25c.621 0 1.125.504 1.125 1.125v8.25c0 .621-.504 1.125-1.125 1.125h-5.25a1.125 1.125 0 01-1.125-1.125v-8.25zM3.75 16.125c0-.621.504-1.125 1.125-1.125h5.25c.621 0 1.125.504 1.125 1.125v2.25c0 .621-.504 1.125-1.125 1.125h-5.25a1.125 1.125 0 01-1.125-1.125v-2.25z" />', // RectangleGroup
+  flow: '<path stroke-linecap="round" stroke-linejoin="round" d="M3.75 12h16.5m-16.5 3.75h16.5M3.75 19.5h16.5M5.625 4.5h12.75a1.875 1.875 0 010 3.75H5.625a1.875 1.875 0 010-3.75z" />', // QueueList
+  channel:
+    '<path stroke-linecap="round" stroke-linejoin="round" d="M7.5 21L3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5" />', // ArrowsRightLeft
+  diagram:
+    '<path stroke-linecap="round" stroke-linejoin="round" d="M9 6.75V15m6-6v8.25m.503 3.498l4.875-2.437c.381-.19.622-.58.622-1.006V4.82c0-.836-.88-1.38-1.628-1.006l-3.869 1.934c-.317.159-.69.159-1.006 0L9.503 3.252a1.125 1.125 0 00-1.006 0L3.622 5.689C3.24 5.88 3 6.27 3 6.695V19.18c0 .836.88 1.38 1.628 1.006l3.869-1.934c.317-.159.69-.159 1.006 0l4.994 2.497c.317.158.69.158 1.006 0z" />', // Map
+  container:
+    '<path stroke-linecap="round" stroke-linejoin="round" d="M20.25 6.375c0 2.278-3.694 4.125-8.25 4.125S3.75 8.653 3.75 6.375m16.5 0c0-2.278-3.694-4.125-8.25-4.125S3.75 4.097 3.75 6.375m16.5 0v11.25c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125V6.375m16.5 0v3.75m-16.5-3.75v3.75m16.5 0v3.75C20.25 16.153 16.556 18 12 18s-8.25-1.847-8.25-4.125v-3.75m16.5 0c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125" />', // Database
+  user: '<path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z" />', // User
+  team: '<path stroke-linecap="round" stroke-linejoin="round" d="M18 18.72a9.094 9.094 0 003.741-.479 3 3 0 00-4.682-2.72m.94 3.198l.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0112 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 016 18.719m12 0a5.971 5.971 0 00-.941-3.197m0 0A5.995 5.995 0 0012 12.75a5.995 5.995 0 00-5.058 2.772m0 0a3 3 0 00-4.681 2.72 8.986 8.986 0 003.74.477m.94-3.197a5.971 5.971 0 00-.94 3.197M15 6.75a3 3 0 11-6 0 3 3 0 016 0zm6 3a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0zm-13.5 0a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0z" />', // UserGroup
+};
+
+const style = typeStyles[type] || typeStyles.entity;
+const iconPath = typeIcons[type] || typeIcons.entity;
+
+let resource: any = null;
+let href = '#';
+let hasError = false;
+let errorMessage = '';
+
+try {
+  if (!collection) {
+    throw new Error(`Unknown resource type: ${type}`);
+  }
+
+  const resourcesCollection = await getCollection(collection as any);
+  const resources = getItemsFromCollectionByIdAndSemverOrLatest(resourcesCollection, resourceId, version);
+
+  if (resources.length === 0) {
+    throw new Error(`Resource not found: ${resourceId}`);
+  }
+
+  resource = resources[0];
+  // Diagrams use /diagrams/ path, other resources use /docs/{collection}/
+  href =
+    type === 'diagram'
+      ? buildUrl(`/diagrams/${resourceId}/${resource.data.version}`)
+      : buildUrl(`/docs/${collection}/${resourceId}/${resource.data.version}`);
+} catch (error) {
+  hasError = true;
+  errorMessage = error instanceof Error ? error.message : 'Unknown error';
+}
+
+// Truncate summary if too long
+const maxSummaryLength = 120;
+const summary = resource?.data?.summary || '';
+const truncatedSummary = summary.length > maxSummaryLength ? summary.slice(0, maxSummaryLength) + '...' : summary;
+
+// Only these types have visualizers
+const hasVisualizer = ['domain', 'service', 'event', 'query', 'command', 'container'].includes(type);
+
+// Check deprecation status
+const deprecation = resource ? getDeprecatedDetails(resource) : null;
+const isDeprecated = deprecation?.isMarkedAsDeprecated || false;
+
+// Get owners (first 2)
+const owners = resource?.data?.owners?.slice(0, 2) || [];
+
+// Check if message type has a schema
+const isMessageType = ['event', 'command', 'query'].includes(type);
+const hasSchema = isMessageType && resource?.data?.schemaPath;
+
+// Check if resource has a repository URL
+const repositoryUrl = resource?.data?.repository?.url;
+
+// For services: get messages (sends/receives) with resolved versions
+const maxMessages = 3;
+const sends = resource?.data?.sends || [];
+const receives = resource?.data?.receives || [];
+const isService = type === 'service';
+
+// Helper to resolve message version and collection - use specified version or fetch from collection
+const resolveMessage = async (msg: any): Promise<{ version: string | null; collection: string | null }> => {
+  // If version is specified and not "latest", use it (assume event as default collection)
+  if (msg.version && msg.version !== 'latest') {
+    return { version: msg.version, collection: 'events' };
+  }
+
+  // Try to find the message in events, commands, or queries collections
+  const collections = ['events', 'commands', 'queries'];
+  for (const col of collections) {
+    try {
+      const items = await getCollection(col as any);
+      const found = getItemsFromCollectionByIdAndSemverOrLatest(items, msg.id);
+      if (found.length > 0 && found[0].data.version && found[0].data.version !== 'latest') {
+        return { version: found[0].data.version, collection: col };
+      }
+    } catch (e) {
+      // Collection might not exist or item not found, continue
+    }
+  }
+  return { version: null, collection: null };
+};
+
+// Resolve versions and collections for messages to show
+const sendsWithVersions = await Promise.all(
+  sends.slice(0, maxMessages).map(async (msg: any) => {
+    const resolved = await resolveMessage(msg);
+    return { ...msg, resolvedVersion: resolved.version, resolvedCollection: resolved.collection };
+  })
+);
+const receivesWithVersions = await Promise.all(
+  receives.slice(0, maxMessages).map(async (msg: any) => {
+    const resolved = await resolveMessage(msg);
+    return { ...msg, resolvedVersion: resolved.version, resolvedCollection: resolved.collection };
+  })
+);
+
+// Get specifications for services
+const specifications = isService ? getServiceSpecifications(resource?.data) : [];
+const hasSpecifications = specifications.length > 0;
+
+// Generate unique ID for this instance
+const tooltipId = `ref-tooltip-${Math.random().toString(36).slice(2, 9)}`;
+---
+
+<span class="resource-ref-wrapper inline">
+  {
+    hasError ? (
+      <span
+        class="text-[rgb(var(--ec-page-text-muted))] underline decoration-wavy decoration-red-400/50 underline-offset-2 cursor-help"
+        title={`Resource not found: ${resourceId}`}
+      >
+        {resourceId}
+      </span>
+    ) : (
+      <>
+        <a
+          href={href}
+          class:list={[
+            'resource-ref-trigger underline decoration-dotted hover:decoration-solid underline-offset-2 font-medium transition-colors',
+            isDeprecated
+              ? 'text-amber-600 decoration-amber-500/50'
+              : 'text-[rgb(var(--ec-accent))] hover:text-[rgb(var(--ec-accent-hover))]',
+          ]}
+          data-tooltip-id={tooltipId}
+        >
+          {resource?.data?.name || resourceId}
+          {isDeprecated && ' (deprecated)'}
+        </a>
+        <span
+          id={tooltipId}
+          class="resource-ref-tooltip fixed w-80 bg-[rgb(var(--ec-card-bg))] border border-[rgb(var(--ec-page-border))] border-l-[3px] rounded-r-lg rounded-l-none shadow-lg shadow-black/8 z-[9999] text-left overflow-hidden opacity-0 pointer-events-none transition-all duration-150 scale-95 origin-top-left"
+          style={`border-left-color: rgb(${style.borderColor});`}
+        >
+          {/* Deprecation banner */}
+          {isDeprecated && (
+            <span class="flex items-center gap-1.5 px-3 py-1.5 bg-[rgb(var(--ec-badge-event-bg))] text-[rgb(var(--ec-badge-event-text))] text-xs font-medium">
+              <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+                />
+              </svg>
+              Deprecated
+            </span>
+          )}
+
+          <span class="block p-3">
+            {/* Header: Name with icon top-right */}
+            <span class="flex justify-between items-start mb-2">
+              <span class="flex flex-col">
+                <span class="flex items-baseline gap-2">
+                  <span class="font-semibold text-[rgb(var(--ec-page-text))] text-[0.95rem] leading-tight">
+                    {resource?.data?.name || resourceId}
+                  </span>
+                  <span class="text-[0.65rem] text-[rgb(var(--ec-page-text-muted))] uppercase tracking-wide">{style.label}</span>
+                </span>
+                <span class="text-[0.7rem] font-mono text-[rgb(var(--ec-page-text-muted))] mt-0.5">
+                  v{resource?.data?.version}
+                </span>
+              </span>
+              <svg
+                class="w-5 h-5 flex-shrink-0"
+                style={`color: rgb(${style.borderColor});`}
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                stroke-width="1.5"
+                set:html={iconPath}
+              />
+            </span>
+
+            {/* Summary */}
+            {truncatedSummary && (
+              <span class="block text-[rgb(var(--ec-page-text-muted))] text-[0.8rem] leading-relaxed mb-3">
+                {truncatedSummary}
+              </span>
+            )}
+
+            {/* Metadata */}
+            {(isService && (sends.length > 0 || receives.length > 0)) || hasSpecifications || owners.length > 0 ? (
+              <span class="block text-[0.7rem] mb-3 space-y-1">
+                {isService && sends.length > 0 && (
+                  <span class="flex items-baseline gap-2">
+                    <span class="text-[rgb(var(--ec-page-text-muted))]">Publishes</span>
+                    <span class="font-mono text-[rgb(var(--ec-page-text))]">
+                      {sendsWithVersions.slice(0, 2).map((msg: any, idx: number) => (
+                        <>
+                          {msg.resolvedVersion && msg.resolvedCollection ? (
+                            <a
+                              href={buildUrl(`/docs/${msg.resolvedCollection}/${msg.id}/${msg.resolvedVersion}`)}
+                              class="hover:underline hover:text-[rgb(var(--ec-accent))]"
+                            >
+                              {msg.id}
+                            </a>
+                          ) : (
+                            <span class="text-[rgb(var(--ec-page-text-muted))]">{msg.id}</span>
+                          )}
+                          {idx < Math.min(sendsWithVersions.length, 2) - 1 && ', '}
+                        </>
+                      ))}
+                      {sends.length > 2 && <span class="text-[rgb(var(--ec-page-text-muted))]"> +{sends.length - 2}</span>}
+                    </span>
+                  </span>
+                )}
+                {isService && receives.length > 0 && (
+                  <span class="flex items-baseline gap-2">
+                    <span class="text-[rgb(var(--ec-page-text-muted))]">Subscribes</span>
+                    <span class="font-mono text-[rgb(var(--ec-page-text))]">
+                      {receivesWithVersions.slice(0, 2).map((msg: any, idx: number) => (
+                        <>
+                          {msg.resolvedVersion && msg.resolvedCollection ? (
+                            <a
+                              href={buildUrl(`/docs/${msg.resolvedCollection}/${msg.id}/${msg.resolvedVersion}`)}
+                              class="hover:underline hover:text-[rgb(var(--ec-accent))]"
+                            >
+                              {msg.id}
+                            </a>
+                          ) : (
+                            <span class="text-[rgb(var(--ec-page-text-muted))]">{msg.id}</span>
+                          )}
+                          {idx < Math.min(receivesWithVersions.length, 2) - 1 && ', '}
+                        </>
+                      ))}
+                      {receives.length > 2 && <span class="text-[rgb(var(--ec-page-text-muted))]"> +{receives.length - 2}</span>}
+                    </span>
+                  </span>
+                )}
+                {hasSpecifications && (
+                  <span class="flex items-baseline gap-2">
+                    <span class="text-[rgb(var(--ec-page-text-muted))]">APIs</span>
+                    <span class="font-mono text-[rgb(var(--ec-page-text))]">
+                      {specifications.map((spec: any, idx: number) => (
+                        <>
+                          <a
+                            href={getSpecUrl(spec, resourceId, resource?.data?.version)}
+                            class="hover:underline hover:text-[rgb(var(--ec-accent))]"
+                          >
+                            {getSpecLabel(spec.type)}
+                          </a>
+                          {idx < specifications.length - 1 && ', '}
+                        </>
+                      ))}
+                    </span>
+                  </span>
+                )}
+                {owners.length > 0 && (
+                  <span class="flex items-baseline gap-2">
+                    <span class="text-[rgb(var(--ec-page-text-muted))]">Owner</span>
+                    <span class="font-mono text-[rgb(var(--ec-page-text))]">
+                      {owners.map((o: any, idx: number) => {
+                        const ownerId = typeof o === 'string' ? o : o.id;
+                        return (
+                          <>
+                            <a
+                              href={buildUrl(`/docs/users/${ownerId}`)}
+                              class="hover:underline hover:text-[rgb(var(--ec-accent))]"
+                            >
+                              {ownerId}
+                            </a>
+                            {idx < owners.length - 1 && ', '}
+                          </>
+                        );
+                      })}
+                    </span>
+                  </span>
+                )}
+              </span>
+            ) : null}
+
+            {/* Actions */}
+            <span class="flex items-center justify-between pt-2 border-t border-[rgb(var(--ec-page-border))] text-[0.7rem]">
+              <span class="flex items-center gap-3">
+                {type === 'flow' && (
+                  <a
+                    href={buildUrl(`/visualiser/${collection}/${resourceId}/${resource?.data?.version}`)}
+                    class="text-[rgb(var(--ec-page-text-muted))] hover:text-[rgb(var(--ec-page-text))]"
+                  >
+                    View flow
+                  </a>
+                )}
+                {hasSchema && (
+                  <a
+                    href={buildUrl(`/schemas/${collection}/${resourceId}/${resource?.data?.version}`)}
+                    class="text-[rgb(var(--ec-page-text-muted))] hover:text-[rgb(var(--ec-page-text))]"
+                  >
+                    Schema
+                  </a>
+                )}
+                {hasVisualizer && type !== 'flow' && (
+                  <a
+                    href={buildUrl(`/visualiser/${collection}/${resourceId}/${resource?.data?.version}`)}
+                    class="text-[rgb(var(--ec-page-text-muted))] hover:text-[rgb(var(--ec-page-text))]"
+                  >
+                    Map
+                  </a>
+                )}
+                {repositoryUrl && (
+                  <a
+                    href={repositoryUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="text-[rgb(var(--ec-page-text-muted))] hover:text-[rgb(var(--ec-page-text))]"
+                  >
+                    Repo
+                  </a>
+                )}
+              </span>
+              <a href={href} class="text-[rgb(var(--ec-accent))] hover:underline font-medium">
+                {type === 'diagram' ? 'View diagram' : 'View docs'}
+              </a>
+            </span>
+          </span>
+        </span>
+      </>
+    )
+  }
+</span>
+
+<script>
+  // Initialize all resource ref tooltips
+  function initResourceRefTooltips() {
+    const triggers = document.querySelectorAll('.resource-ref-trigger');
+
+    triggers.forEach((trigger) => {
+      const tooltipId = trigger.getAttribute('data-tooltip-id');
+      if (!tooltipId) return;
+
+      const tooltip = document.getElementById(tooltipId);
+      if (!tooltip) return;
+
+      let hideTimeout: ReturnType<typeof setTimeout>;
+
+      const showTooltip = () => {
+        clearTimeout(hideTimeout);
+
+        // Get trigger position
+        const rect = trigger.getBoundingClientRect();
+        const tooltipWidth = 320; // w-80 = 20rem = 320px
+        const padding = 16;
+
+        // Calculate left position - try to align with trigger, but keep within viewport
+        let left = rect.left;
+
+        // If tooltip would overflow right edge, align to right edge of viewport
+        if (left + tooltipWidth > window.innerWidth - padding) {
+          left = window.innerWidth - tooltipWidth - padding;
+        }
+
+        // If tooltip would overflow left edge, align to left edge
+        if (left < padding) {
+          left = padding;
+        }
+
+        // Position below the trigger
+        const top = rect.bottom + 8;
+
+        tooltip.style.left = `${left}px`;
+        tooltip.style.top = `${top}px`;
+        tooltip.classList.remove('opacity-0', 'pointer-events-none', 'scale-95');
+        tooltip.classList.add('opacity-100', 'pointer-events-auto', 'scale-100');
+      };
+
+      const hideTooltip = () => {
+        hideTimeout = setTimeout(() => {
+          tooltip.classList.remove('opacity-100', 'pointer-events-auto', 'scale-100');
+          tooltip.classList.add('opacity-0', 'pointer-events-none', 'scale-95');
+        }, 100);
+      };
+
+      const keepTooltipOpen = () => {
+        clearTimeout(hideTimeout);
+      };
+
+      // Trigger events
+      trigger.addEventListener('mouseenter', showTooltip);
+      trigger.addEventListener('mouseleave', hideTooltip);
+      trigger.addEventListener('focus', showTooltip);
+      trigger.addEventListener('blur', hideTooltip);
+
+      // Tooltip events - keep open when hovering tooltip
+      tooltip.addEventListener('mouseenter', keepTooltipOpen);
+      tooltip.addEventListener('mouseleave', hideTooltip);
+    });
+  }
+
+  // Run on initial load
+  initResourceRefTooltips();
+
+  // Re-run after Astro page transitions
+  document.addEventListener('astro:page-load', initResourceRefTooltips);
+</script>

--- a/eventcatalog/src/components/MDX/components.tsx
+++ b/eventcatalog/src/components/MDX/components.tsx
@@ -20,6 +20,7 @@ import EntityPropertiesTable from '@components/MDX/EntityPropertiesTable/EntityP
 import Tabs from '@components/MDX/Tabs/Tabs.astro';
 import TabItem from '@components/MDX/Tabs/TabItem.astro';
 import ResourceLink from '@components/MDX/ResourceLink/ResourceLink.astro';
+import ResourceRef from '@components/MDX/ResourceRef/ResourceRef.astro';
 import Link from '@components/MDX/Link/Link.astro';
 import Miro from '@components/MDX/Miro/Miro.astro';
 import Lucid from '@components/MDX/Lucid/Lucid.astro';
@@ -54,6 +55,7 @@ const components = (props: any) => {
     OpenAPI,
     ResourceGroupTable: (mdxProp: any) => jsx(ResourceGroupTable, { ...props, ...mdxProp }),
     ResourceLink: (mdxProp: any) => jsx(ResourceLink, { ...props, ...mdxProp }),
+    ResourceRef: (mdxProp: any) => jsx(ResourceRef, { ...props, ...mdxProp }),
     Schema: (mdxProp: any) => jsx(Schema, { ...props, ...mdxProp }),
     SchemaViewer: (mdxProp: any) => SchemaViewerPortal({ ...props.data, ...mdxProp }),
     Step,

--- a/eventcatalog/src/remark-plugins/resource-ref.ts
+++ b/eventcatalog/src/remark-plugins/resource-ref.ts
@@ -1,0 +1,51 @@
+import { findAndReplace } from 'mdast-util-find-and-replace';
+
+/**
+ * Remark plugin that transforms [[type|Name]] or [[Name]] syntax into ResourceRef MDX components.
+ *
+ * Supported patterns:
+ * - [[entity|Order]] -> <ResourceRef type="entity">Order</ResourceRef>
+ * - [[service|OrderService@1.0.0]] -> <ResourceRef type="service" version="1.0.0">OrderService</ResourceRef>
+ * - [[diagram|target-architecture]] -> <ResourceRef type="diagram">target-architecture</ResourceRef>
+ * - [[Order]] -> <ResourceRef type="entity">Order</ResourceRef> (defaults to entity)
+ * - [[Order@0.0.1]] -> <ResourceRef type="entity" version="0.0.1">Order</ResourceRef>
+ */
+export function remarkResourceRef() {
+  return function (tree: any) {
+    // First pass: match [[type|Name]] or [[type|Name@version]] pattern
+    findAndReplace(tree, [
+      /\[\[([a-z]+)\|([\w-]+)(?:@([\d.]+))?\]\]/g,
+      // @ts-ignore: Types are complex but it works
+      function (_match: string, type: string, resourceId: string, version?: string) {
+        const attributes: any[] = [{ type: 'mdxJsxAttribute', name: 'type', value: type }];
+        if (version) {
+          attributes.push({ type: 'mdxJsxAttribute', name: 'version', value: version });
+        }
+        return {
+          type: 'mdxJsxTextElement',
+          name: 'ResourceRef',
+          attributes,
+          children: [{ type: 'text', value: resourceId }],
+        };
+      },
+    ]);
+
+    // Second pass: match [[Name]] or [[Name@version]] pattern (defaults to entity)
+    findAndReplace(tree, [
+      /\[\[([\w-]+)(?:@([\d.]+))?\]\]/g,
+      // @ts-ignore: Types are complex but it works
+      function (_match: string, resourceId: string, version?: string) {
+        const attributes: any[] = [{ type: 'mdxJsxAttribute', name: 'type', value: 'entity' }];
+        if (version) {
+          attributes.push({ type: 'mdxJsxAttribute', name: 'version', value: version });
+        }
+        return {
+          type: 'mdxJsxTextElement',
+          name: 'ResourceRef',
+          attributes,
+          children: [{ type: 'text', value: resourceId }],
+        };
+      },
+    ]);
+  };
+}

--- a/examples/default/domains/E-Commerce/index.mdx
+++ b/examples/default/domains/E-Commerce/index.mdx
@@ -77,17 +77,17 @@ The E-Commerce domain is the core business domain of FlowMart, our modern digita
 
 ## Domain Overview
 
-The E-Commerce domain encapsulates all the core business logic for the FlowMart e-commerce platform. It is built on event-driven microservices architecture.
+The E-Commerce domain encapsulates all the core business logic for the FlowMart e-commerce platform. It is built on event-driven microservices architecture with key services like [[service|OrdersService]], [[service|InventoryService]], and [[service|PaymentService]].
 
 <NodeGraph mode="full" search="false" legend="false" />
 
 FlowMart's E-Commerce domain is built on event-driven microservices architecture, enabling:
-- Real-time inventory management across multiple warehouses
-- Seamless payment processing with multiple providers
-- Smart order routing and fulfillment
-- Personalized customer notifications
-- Subscription-based shopping experiences
-- Advanced fraud detection and prevention
+- Real-time inventory management via [[service|InventoryService]] across multiple warehouses
+- Seamless payment processing with [[service|PaymentService]] and [[service|PaymentGatewayService]]
+- Smart order routing and fulfillment through [[service|OrdersService]]
+- Personalized customer notifications via [[service|NotificationService]]
+- Subscription-based shopping experiences managed by [[service|SubscriptionService]]
+- Advanced fraud detection via [[service|FraudDetectionService]]
 
 ## Core Domains for E-Commerce
 
@@ -109,9 +109,9 @@ The E-Commerce domain is built on the following sub domains:
 
 ### FlowMart E-Commerce Database Schema
 
-This diagram represents the core relational data model behind FlowMart, a fictional event-driven e-commerce platform. It captures the main business entities and their relationships, including customers, orders, products, inventory events, and payments.
+This diagram represents the core relational data model behind FlowMart. It captures the main business entities and their relationships, including the [[entity|Customer]], [[entity|Order]], [[entity|Payment]], and [[entity|Transaction]] entities.
 
-The schema is designed to support a distributed microservices architecture with event-sourced patterns, enabling services like OrderService, InventoryService, and PaymentService to operate independently while maintaining data consistency through asynchronous events.
+The schema is designed to support a distributed microservices architecture with event-sourced patterns, enabling services like [[service|OrdersService]], [[service|InventoryService]], and [[service|PaymentService]] to operate independently while maintaining data consistency through asynchronous events.
 
 ```plantuml
 @startuml
@@ -218,13 +218,15 @@ sequenceDiagram
 
 ## Key Business Flows
 
+For a visual overview of our target state, see the [[diagram|target-architecture]] diagram.
+
 ### Subscription Management
-Our subscription service powers FlowMart's popular "Subscribe & Save" feature:
+Our [[service|SubscriptionService]] powers FlowMart's popular "Subscribe & Save" feature. The [[flow|CancelSubscription]] handles subscription cancellations:
 
 <Flow id="CancelSubscription" version="latest" includeKey={false} mode="full" walkthrough={false} search={false} />
 
 ### Payment Processing
-Secure, multi-provider payment processing with fraud detection:
+Secure, multi-provider payment processing with fraud detection via [[service|FraudDetectionService]]. The [[flow|PaymentFlow]] orchestrates the complete payment journey:
 
 <Flow id="PaymentFlow" version="latest" includeKey={false} />
 

--- a/examples/default/domains/E-Commerce/subdomains/Orders/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Orders/index.mdx
@@ -33,7 +33,9 @@ import Footer from '@catalog/components/footer.astro';
 Please ensure all services are **updated** to the latest version for compatibility and performance improvements.
 :::
 
-The Orders domain handles all operations related to customer orders, from creation to fulfillment. This documentation provides an overview of the events and services involved in the Orders domain, helping developers and stakeholders understand the event-driven architecture
+The Orders domain handles all operations related to customer orders, from creation to fulfillment. This domain is part of the larger [[domain|E-Commerce]] domain and includes key services like [[service|OrdersService]], [[service|InventoryService]], and [[service|NotificationService]].
+
+Core entities include [[entity|Order]], [[entity|OrderItem]], and [[entity|Customer]]. This documentation provides an overview of the events and services involved, helping developers and stakeholders understand the event-driven architecture.
 
 <Tiles >
     <Tile icon="UserGroupIcon" href="/docs/teams/full-stack" title="Contact the team" description="Any questions? Feel free to contact the owners" />
@@ -74,12 +76,12 @@ sequenceDiagram
 ## Flows
 
 ### Cancel Subscription flow
-Documented flow when a user cancels their subscription.
+The [[flow|CancelSubscription]] documents the process when a user cancels their subscription. This flow involves the [[service|SubscriptionService]] and [[service|BillingService]].
 
 <Flow id="CancelSubscription" version="latest" includeKey={false} />
 
 ### Payment processing flow
-Documented flow when a user makes a payment within the order domain
+The [[flow|PaymentFlow]] documents the payment process within the order domain, utilizing the [[service|PaymentService]] and [[service|FraudDetectionService]].
 
 <Flow id="PaymentFlow" version="latest" includeKey={false} />
 

--- a/examples/default/domains/E-Commerce/subdomains/Orders/services/InventoryService/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Orders/services/InventoryService/index.mdx
@@ -58,7 +58,9 @@ import Footer from '@catalog/components/footer.astro';
 
 ## Overview
 
-The Inventory Service is a critical component of the system responsible for managing product stock levels, tracking inventory movements, and ensuring product availability. It interacts with other services to maintain accurate inventory records and supports operations such as order fulfillment, restocking, and inventory audits.
+The Inventory Service is a critical component of the system responsible for managing product stock levels, tracking inventory movements, and ensuring product availability. It works closely with the [[service|OrdersService]] and is part of the [[domain|Orders]] domain.
+
+The service receives events like [[event|OrderConfirmed]] and [[event|OrderAmended]], and publishes [[event|InventoryAdjusted]] and [[event|OutOfStock]] to notify other services of inventory changes.
 
 <Tiles >
     <Tile icon="DocumentIcon" href={`/docs/services/${frontmatter.id}/${frontmatter.version}/changelog`}  title="View the changelog" description="Want to know the history of this service? View the change logs" />

--- a/examples/default/domains/E-Commerce/subdomains/Orders/services/NotificationService/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Orders/services/NotificationService/index.mdx
@@ -33,7 +33,9 @@ import Footer from '@catalog/components/footer.astro';
 
 ## Overview
 
-The Notification Service is responsible for managing and delivering notifications to users and other services. It supports various notification channels such as email, SMS, push notifications, and in-app notifications. The service ensures reliable and timely delivery of messages and integrates with other services to trigger notifications based on specific events.
+The Notification Service is responsible for managing and delivering notifications to users and other services. It is part of the [[domain|Orders]] domain and listens for events from multiple services including [[service|InventoryService]] and [[service|PaymentService]].
+
+The service receives events like [[event|InventoryAdjusted]], [[event|PaymentProcessed]], and [[event|OutOfStock]] to trigger appropriate notifications. It supports various notification channels such as email, SMS, push notifications, and in-app notifications.
 
 <Tiles >
     <Tile icon="DocumentIcon" href={`/docs/services/${frontmatter.id}/${frontmatter.version}/changelog`}  title="View the changelog" description="Want to know the history of this service? View the change logs" />

--- a/examples/default/domains/E-Commerce/subdomains/Orders/services/OrdersService/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Orders/services/OrdersService/index.mdx
@@ -49,7 +49,9 @@ import Footer from '@catalog/components/footer.astro';
 
 ## Overview
 
-The Orders Service is responsible for managing customer orders within the system. It handles order creation, updating, status tracking, and interactions with other services such as Inventory, Payment, and Notification services to ensure smooth order processing and fulfillment.
+The Orders Service is responsible for managing customer orders within the system. It handles order creation, updating, status tracking, and interactions with other services such as [[service|InventoryService]], [[service|PaymentService]], and [[service|NotificationService]] to ensure smooth order processing and fulfillment.
+
+This service is part of the [[domain|Orders]] domain and works with the [[entity|Order]] entity.
 
 
 
@@ -65,9 +67,9 @@ The Orders Service is responsible for managing customer orders within the system
 | Feature | Description |
 |---------|-------------|
 | Order Management | Handles order creation, updates, and status tracking |
-| Inventory Integration | Validates and processes inventory for incoming orders |
+| Inventory Integration | Validates and processes inventory, receives [[event|InventoryAdjusted]] |
 | Payment Processing | Integrates with payment gateways to handle payment transactions |
-| Notification Integration | Sends notifications to users and other services |
+| Event Publishing | Publishes [[event|OrderAmended]], [[event|OrderCancelled]], and [[event|OrderConfirmed]] events |
 
 ## Architecture diagram 
 

--- a/examples/default/domains/E-Commerce/subdomains/Orders/services/RegistrationService/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Orders/services/RegistrationService/index.mdx
@@ -19,4 +19,12 @@ receives:
       - id: registrations-domain-eventbus
 ---
 
-This is a registration service that sends a registration event.
+## Overview
+
+The Registration Service handles user registration and authentication operations. It is part of the [[domain|Orders]] domain and works with the [[entity|Customer]] entity.
+
+The service publishes [[event|UserSignedUpEvent]] and [[event|UserForgotPasswordEvent]] events to notify other services of user registration activity. It receives [[event|DeliveryFailed]] events to handle failed email delivery scenarios.
+
+<NodeGraph />
+
+<MessageTable format="all" />

--- a/examples/default/domains/E-Commerce/subdomains/Orders/services/ShippingService/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Orders/services/ShippingService/index.mdx
@@ -38,7 +38,9 @@ import Footer from '@catalog/components/footer.astro';
 
 ## Overview
 
-The Shipping Service is responsible for managing shipping within the system. It handles order creation, updating, status tracking, and interactions with other services such as Inventory, Payment, and Notification services to ensure smooth order processing and fulfillment.
+The Shipping Service is responsible for managing shipping within the system. It is part of the [[domain|Orders]] domain and handles order fulfillment and delivery tracking.
+
+The service receives [[event|PaymentProcessed]] from the [[service|PaymentService]] and publishes shipping lifecycle events including [[event|ShipmentCreated]], [[event|ShipmentDispatched]], [[event|ShipmentInTransit]], and [[event|ShipmentDelivered]]. It interacts with the [[service|OrdersService]], [[service|InventoryService]], and [[service|NotificationService]] to ensure smooth order processing and fulfillment.
 
 <Tiles >
     <Tile icon="BoltIcon" href={`/visualiser/services/${frontmatter.id}/${frontmatter.version}`} title={`Sends ${frontmatter.sends.length} messages`} description="This service sends messages to downstream consumers" />

--- a/examples/default/domains/E-Commerce/subdomains/Payment/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Payment/index.mdx
@@ -30,26 +30,26 @@ badges:
 
 ## Overview
 
-The Payment Domain encompasses all services and components related to handling financial transactions within the system. It is responsible for managing payments, transactions, billing, fraud detection, and financial records. The domain ensures secure, reliable, and efficient processing of all payment-related activities.
+The Payment Domain encompasses all services and components related to handling financial transactions within the system. It is part of the [[domain|E-Commerce]] domain and manages entities like [[entity|Payment]], [[entity|Transaction]], and [[entity|Invoice]]. The domain ensures secure, reliable, and efficient processing of all payment-related activities.
 
 ## Services
 
 ### PaymentService
-Core payment orchestration service that coordinates payment workflows and maintains payment state.
+The [[service|PaymentService]] is the core payment orchestration service that coordinates payment workflows and maintains payment state. It publishes [[event|PaymentProcessed]] events.
 
 ### FraudDetectionService
-Analyzes transactions in real-time to detect fraudulent activity using machine learning models and rule-based systems.
+The [[service|FraudDetectionService]] analyzes transactions in real-time to detect fraudulent activity using machine learning models and rule-based systems. It publishes [[event|FraudDetected]] and [[event|FraudCheckCompleted]] events.
 
 ### PaymentGatewayService
-Manages integrations with external payment processors (Stripe, PayPal, etc.) and provides a unified interface for payment operations.
+The [[service|PaymentGatewayService]] manages integrations with external payment processors (Stripe, PayPal, etc.) and handles the [[command|ProcessPayment]] command.
 
 ## Cross-Domain Integration
 
 The Payment domain integrates with:
 
-- **Subscriptions Domain**: Processes recurring payments for subscriptions
-- **Orders Domain**: Handles payments for customer orders
-- **Inventory Domain**: Updates based on successful payments
+- **[[domain|Subscriptions]]**: Processes recurring payments for subscriptions
+- **[[domain|Orders]]**: Handles payments for customer orders via the [[flow|PaymentFlow]]
+- **Inventory**: Updates based on successful payments
 
 ## Bounded context
 

--- a/examples/default/domains/E-Commerce/subdomains/Payment/services/FraudDetectionService/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Payment/services/FraudDetectionService/index.mdx
@@ -37,7 +37,9 @@ import Footer from '@catalog/components/footer.astro'
 
 ## Overview
 
-The Fraud Detection Service is responsible for analyzing payment transactions in real-time to detect potential fraudulent activity. It uses machine learning models and rule-based systems to assess risk and prevent financial losses.
+The Fraud Detection Service is responsible for analyzing payment transactions in real-time to detect potential fraudulent activity. It is part of the [[domain|Payment]] domain and works alongside [[service|PaymentService]] and [[service|PaymentGatewayService]].
+
+The service receives [[event|PaymentInitiated]] events and publishes [[event|FraudCheckCompleted]], [[event|FraudDetected]], and [[event|RiskScoreCalculated]] events based on its analysis.
 
 <NodeGraph />
 

--- a/examples/default/domains/E-Commerce/subdomains/Payment/services/PaymentGatewayService/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Payment/services/PaymentGatewayService/index.mdx
@@ -27,7 +27,9 @@ import Footer from '@catalog/components/footer.astro'
 
 ## Overview
 
-The Payment Gateway Service acts as an abstraction layer between our payment system and external payment processors. It handles the complexity of integrating with multiple payment providers and provides a unified interface for payment operations.
+The Payment Gateway Service acts as an abstraction layer between our payment system and external payment processors. It is part of the [[domain|Payment]] domain and works alongside the [[service|PaymentService]] and [[service|FraudDetectionService]].
+
+The service receives [[command|ProcessPayment]] and [[event|FraudCheckCompleted]] events, and publishes [[event|PaymentFailed]] when transactions fail. It handles the complexity of integrating with multiple payment providers and provides a unified interface for payment operations.
 
 <NodeGraph />
 

--- a/examples/default/domains/E-Commerce/subdomains/Payment/services/PaymentService/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Payment/services/PaymentService/index.mdx
@@ -32,7 +32,9 @@ repository:
   url: 'https://github.com/event-catalog/pretend-shipping-service'
 ---
 
-The Payment Service is a crucial component of our system that handles all payment-related operations. It processes payments, manages transactions, and communicates with other services through events. Using an event-driven architecture, it ensures that all actions are asynchronous, decoupled, and scalable.
+The Payment Service is a crucial component of our system that handles all payment-related operations. It processes payments, manages the [[entity|Transaction]] and [[entity|Payment]] entities, and communicates with other services through events.
+
+This service is part of the [[domain|Payment]] domain. It receives the [[event|PaymentInitiated]] event and publishes [[event|PaymentProcessed]] when complete. Using an event-driven architecture, it ensures that all actions are asynchronous, decoupled, and scalable.
 
 ### Core features
 

--- a/examples/default/domains/E-Commerce/subdomains/Subscriptions/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Subscriptions/index.mdx
@@ -23,7 +23,9 @@ flows:
 
 ## Overview
 
-The Subscriptions Domain is responsible for managing all aspects of subscription-based services within our e-commerce platform. This includes subscription lifecycle management, recurring billing, plan management, and integration with payment systems.
+The Subscriptions Domain is responsible for managing all aspects of subscription-based services within our e-commerce platform. It is part of the [[domain|E-Commerce]] domain and manages entities like [[entity|BillingProfile]] and [[entity|SubscriptionPeriod]].
+
+This domain orchestrates the [[flow|CancelSubscription]] and [[flow|SubscriptionRenewed]] flows for subscription lifecycle management.
 
 ## Core Capabilities
 
@@ -36,15 +38,14 @@ The Subscriptions Domain is responsible for managing all aspects of subscription
 ## Services
 
 ### BillingService
-Handles billing cycle calculations, invoice generation, and payment scheduling. Coordinates with the Payment domain for processing recurring payments.
-
+The [[service|BillingService]] handles billing cycle calculations, invoice generation, and payment scheduling. It coordinates with the [[domain|Payment]] domain and [[service|PaymentService]] for processing recurring payments.
 
 ## Cross-Domain Integration
 
 The Subscriptions domain integrates closely with:
 
-- **Payment Domain**: For processing recurring payments and handling payment failures
-- **Orders Domain**: For managing subscription-based product orders
+- **[[domain|Payment]]**: For processing recurring payments via [[service|PaymentService]]
+- **[[domain|Orders]]**: For managing subscription-based product orders
 - **Customer Domain**: For customer account and profile management
 
 ## Domain Events

--- a/examples/default/domains/E-Commerce/subdomains/Subscriptions/services/BillingService/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Subscriptions/services/BillingService/index.mdx
@@ -42,7 +42,9 @@ import Footer from '@catalog/components/footer.astro'
 
 ## Overview
 
-The Billing Service is responsible for managing all billing-related operations for subscriptions. It calculates billing cycles, generates invoices, and coordinates with payment services to ensure timely payment collection.
+The Billing Service is responsible for managing all billing-related operations for subscriptions. It is part of the [[domain|Subscriptions]] domain and works with the [[entity|BillingProfile]] entity.
+
+The service receives [[event|PaymentProcessed]] and publishes [[event|InvoiceGenerated]] and [[event|SubscriptionPaymentDue]] events. It coordinates with the [[service|PaymentService]] to ensure timely payment collection and participates in the [[flow|SubscriptionRenewed]] and [[flow|CancelSubscription]] flows.
 
 ## Key Features
 

--- a/examples/default/domains/E-Commerce/subdomains/Subscriptions/services/SubscriptionService/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Subscriptions/services/SubscriptionService/index.mdx
@@ -39,7 +39,9 @@ import Footer from '@catalog/components/footer.astro';
 
 ## Overview
 
-The subscription Service is responsible for handling customer subscriptions in our system. It handles new subscriptions, cancelling subscriptions and updating them.
+The Subscription Service is responsible for handling customer subscriptions in our system. It is part of the [[domain|Subscriptions]] domain and works with the [[entity|BillingProfile]] and [[entity|SubscriptionPeriod]] entities.
+
+The service receives [[event|PaymentProcessed]] from the [[service|PaymentService]] and publishes [[event|UserSubscriptionStarted]] and [[event|UserSubscriptionCancelled]] events. It handles new subscriptions, cancelling subscriptions and updating them.
 
 <Tiles >
     <Tile icon="DocumentIcon" href={`/docs/services/${frontmatter.id}/${frontmatter.version}/changelog`}  title="View the changelog" description="Want to know the history of this service? View the change logs" />

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "lodash.merge": "4.6.2",
     "lucide-react": "^0.453.0",
     "marked": "^15.0.6",
+    "mdast-util-find-and-replace": "^3.0.2",
     "mermaid": "^11.12.1",
     "nanostores": "^1.1.0",
     "pako": "^2.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -194,6 +194,9 @@ importers:
       marked:
         specifier: ^15.0.6
         version: 15.0.12
+      mdast-util-find-and-replace:
+        specifier: ^3.0.2
+        version: 3.0.2
       mermaid:
         specifier: ^11.12.1
         version: 11.12.1
@@ -8856,7 +8859,7 @@ snapshots:
       postcss: 8.5.6
       postcss-nested: 6.2.0(postcss@8.5.6)
       unist-util-visit: 5.0.0
-      unist-util-visit-parents: 6.0.1
+      unist-util-visit-parents: 6.0.2
 
   '@expressive-code/plugin-frames@0.41.3':
     dependencies:
@@ -13699,7 +13702,7 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       parse-entities: 4.0.2
       stringify-entities: 4.0.4
-      unist-util-visit-parents: 6.0.1
+      unist-util-visit-parents: 6.0.2
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
## What This PR Does

Adds a new wiki-style syntax for creating inline references to EventCatalog resources. Authors can now use `[[type|ResourceName]]` syntax to create interactive links that display resource details in a hover tooltip. This provides a more natural writing experience compared to the existing `<ResourceLink/>` component.

<img width="885" height="447" alt="Screenshot 2026-01-14 at 15 08 32" src="https://github.com/user-attachments/assets/f8053c3e-69e9-4dfd-8149-7b5f57adb22f" />


## Changes Overview

### Key Changes
- New `ResourceRef` Astro component that renders inline links with hover tooltips
- New remark plugin (`resource-ref.ts`) that transforms wiki-style syntax to MDX components
- Supports all resource types: services, events, commands, queries, domains, flows, channels, entities, diagrams, containers, users, and teams
- Version pinning support with `[[service|OrderService@1.0.0]]` syntax
- Entity shorthand: `[[Customer]]` defaults to entity type
- Tooltips show resource summary, messages (sends/receives), API specs, and owners
- Uses CSS variables for theming and resource-type-specific colors

### Files Added
- `eventcatalog/src/components/MDX/ResourceRef/ResourceRef.astro` - Main tooltip component
- `eventcatalog/src/remark-plugins/resource-ref.ts` - Remark plugin for syntax transformation
- `.changeset/swift-ravens-dance.md` - Changeset for patch release

### Files Modified
- `eventcatalog/astro.config.mjs` - Added remark plugin to MDX config
- `eventcatalog/src/components/MDX/components.tsx` - Exported ResourceRef component
- `package.json` / `pnpm-lock.yaml` - Added `mdast-util-find-and-replace` dependency
- Example catalog files - Added usage examples with the new syntax

## How It Works

1. The remark plugin scans markdown for the pattern `[[type|Name]]` or `[[type|Name@version]]`
2. It transforms these into `<ResourceRef>` MDX components with appropriate props
3. The Astro component fetches resource data server-side using existing collection utilities
4. On hover, a tooltip appears showing resource details including summary, messages, specs, and owners
5. Clicking the link navigates to the resource documentation page

## Breaking Changes

None

## Test plan

- [ ] Run `pnpm run start:catalog` and verify inline references render correctly
- [ ] Hover over references to verify tooltips appear with correct data
- [ ] Click references to verify navigation works
- [ ] Test various resource types (services, events, commands, domains, etc.)
- [ ] Test version pinning syntax `[[service|Name@1.0.0]]`
- [ ] Test entity shorthand `[[EntityName]]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)