### PR TITLE
fix(sidebar): default to teams page when no users defined

### DIFF
--- a/.changeset/quiet-tigers-dance.md
+++ b/.changeset/quiet-tigers-dance.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Default to teams page in directory navigation when no users are defined

--- a/eventcatalog/src/layouts/VerticalSideBarLayout.astro
+++ b/eventcatalog/src/layouts/VerticalSideBarLayout.astro
@@ -52,9 +52,16 @@ import { getQueries } from '@utils/collections/queries';
 import { hasLandingPageForDocs } from '@utils/pages';
 
 import { isEventCatalogUpgradeEnabled, isEmbedEnabled, isCustomStylesEnabled } from '@utils/feature';
+import { getUsers } from '@utils/collections/users';
+import { getTeams } from '@utils/collections/teams';
 
 const catalogHasDefaultLandingPageForDocs = await hasLandingPageForDocs();
 const customDocs = await getCollection('customPages');
+
+// Get users and teams for directory navigation
+const users = await getUsers();
+const teams = await getTeams();
+const directoryDefaultUrl = users.length > 0 ? '/directory/users' : teams.length > 0 ? '/directory/teams' : '/directory/users';
 
 let events: any[] = [];
 let commands: any[] = [];
@@ -145,7 +152,7 @@ const navigationItems = [
     id: '/directory',
     label: 'Users & Teams',
     icon: Users,
-    href: buildUrl('/directory/users'),
+    href: buildUrl(directoryDefaultUrl),
     current: currentPath.includes('/directory'),
   },
 ].filter((item) => {


### PR DESCRIPTION
Fixes #1975

## What This PR Does

Updates the sidebar navigation to intelligently default to the teams page when navigating to the directory section if no users are defined in the catalog. Previously, the "Users & Teams" sidebar link always navigated to `/directory/users`, showing an empty page with "0 users" when no users existed.

## Changes Overview

### Key Changes
- Import `getUsers` and `getTeams` collection utilities in `VerticalSideBarLayout.astro`
- Add logic to determine the default directory URL based on available data
- Update the sidebar navigation href to use the dynamic URL

## How It Works

The implementation checks the users and teams collections at build time:
1. If users exist → defaults to `/directory/users`
2. If no users but teams exist → defaults to `/directory/teams`
3. Fallback → `/directory/users`

This ensures users see meaningful content when clicking the directory navigation instead of an empty users page.

## Breaking Changes

None

## Additional Notes

This is a minimal fix applied only to the sidebar navigation. The homepage quick link and other references to the directory still point to users by default.

🤖 Generated with [Claude Code](https://claude.ai/code)