### PR TITLE
fix(core): resolve type errors and add astro check script

### DIFF
--- a/.changeset/gentle-foxes-type.md
+++ b/.changeset/gentle-foxes-type.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Fix type errors in ResourceRef and SearchModal components, add type check script

--- a/eventcatalog/src/components/MDX/ResourceRef/ResourceRef.astro
+++ b/eventcatalog/src/components/MDX/ResourceRef/ResourceRef.astro
@@ -96,7 +96,7 @@ try {
     throw new Error(`Unknown resource type: ${type}`);
   }
 
-  const resourcesCollection = await getCollection(collection as any);
+  const resourcesCollection = (await getCollection(collection as any)) as { data: { id: string; version: string } }[];
   const resources = getItemsFromCollectionByIdAndSemverOrLatest(resourcesCollection, resourceId, version);
 
   if (resources.length === 0) {
@@ -153,7 +153,7 @@ const resolveMessage = async (msg: any): Promise<{ version: string | null; colle
   const collections = ['events', 'commands', 'queries'];
   for (const col of collections) {
     try {
-      const items = await getCollection(col as any);
+      const items = (await getCollection(col as any)) as { data: { id: string; version: string } }[];
       const found = getItemsFromCollectionByIdAndSemverOrLatest(items, msg.id);
       if (found.length > 0 && found[0].data.version && found[0].data.version !== 'latest') {
         return { version: found[0].data.version, collection: col };

--- a/eventcatalog/src/components/Search/SearchModal.tsx
+++ b/eventcatalog/src/components/Search/SearchModal.tsx
@@ -25,6 +25,7 @@ import {
 import { StarIcon as StarIconSolid, CircleStackIcon } from '@heroicons/react/24/solid';
 import { useStore } from '@nanostores/react';
 import { sidebarStore } from '../../stores/sidebar-store';
+import type { NavNode } from '../../stores/sidebar-store/state';
 import { favoritesStore, toggleFavorite as toggleFavoriteAction } from '../../stores/favorites-store';
 import { buildUrl } from '@utils/url-builder';
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "release": "changeset publish",
     "format": "prettier --config .prettierrc --write \"**/*.{js,jsx,ts,tsx,json,astro}\"",
     "format:diff": "prettier --config .prettierrc --list-different \"**/*.{js,jsx,ts,tsx,json,astro}\"",
-    "lint:catalog": "pnpm dlx @eventcatalog/linter examples/default"
+    "lint:catalog": "pnpm dlx @eventcatalog/linter examples/default",
+    "check": "node scripts/check-types.js"
   },
   "dependencies": {
     "@ai-sdk/react": "^3.0.17",

--- a/scripts/check-types.js
+++ b/scripts/check-types.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+
+// Run astro check with proper catalog directory setup
+import { join } from 'node:path';
+import { execSync } from 'node:child_process';
+const __dirname = import.meta.dirname;
+
+const args = process.argv.slice(2);
+const catalog = args[0] || 'default';
+
+const catalogDir = join(__dirname, '../eventcatalog/');
+const projectDIR = join(__dirname, `../examples/${catalog}`);
+
+// Type check
+execSync(`pnpm exec astro check --minimumSeverity error  --root ${catalogDir}`, {
+  stdio: 'inherit',
+  env: {
+    PATH: process.env.PATH,
+    CATALOG_DIR: catalogDir,
+    PROJECT_DIR: projectDIR,
+    NODE_OPTIONS: '--max-old-space-size=8192',
+  },
+});


### PR DESCRIPTION
## What This PR Does

Fixes TypeScript type errors in the ResourceRef and SearchModal components that were causing build failures. Also adds a new `check` npm script to run Astro type diagnostics on `.astro` files with proper environment configuration.

## Changes Overview

### Key Changes
- Fix type errors in `ResourceRef.astro` by properly casting `getCollection` return type to match expected signature
- Add missing `NavNode` type import in `SearchModal.tsx`
- Add new `scripts/check-types.js` script that runs `astro check` with correct `CATALOG_DIR` and `PROJECT_DIR` environment variables
- Add `check` npm script to package.json

## How It Works

**Type Fixes:**
- The `getCollection` function returns `unknown[]` when called with dynamic collection names. The fix casts the result to `{ data: { id: string; version: string } }[]` to satisfy the `getItemsFromCollectionByIdAndSemverOrLatest` function signature.
- The `NavNode` type was being used but not imported in SearchModal - now properly imported from the sidebar store.

**Check Script:**
- The new `check-types.js` script mirrors the approach used in `build-ci.js` by setting up the required environment variables before running `astro check`
- Defaults to using the `examples/default` catalog but accepts an optional catalog name argument

## Breaking Changes

None

## Additional Notes

Run `pnpm run check` to verify Astro file types. You can also pass a catalog name: `pnpm run check e-commerce`

🤖 Generated with [Claude Code](https://claude.ai/code)