### PR TITLE
fix(schema-viewer): add support for oneOf and anyOf JSON Schema keywords

### DIFF
--- a/.changeset/bright-schemas-render.md
+++ b/.changeset/bright-schemas-render.md
@@ -1,0 +1,13 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix(schema-viewer): add support for oneOf and anyOf JSON Schema keywords
+
+- Add handling for `anyOf` in processSchema function (was missing entirely)
+- Fix `oneOf` rendering to show selected variant's properties instead of merged properties
+- Add variant selector UI for nested `oneOf`/`anyOf` within properties
+- Add support for `oneOf`/`anyOf` in array items
+- Show variant type indicator ("anyOf" or "oneOf") in property type display
+
+Fixes #1965

--- a/examples/default/domains/E-Commerce/subdomains/Orders/services/InventoryService/commands/AddInventory/schema.json
+++ b/examples/default/domains/E-Commerce/subdomains/Orders/services/InventoryService/commands/AddInventory/schema.json
@@ -17,6 +17,213 @@
         "format": "uuid",
         "description": "The unique identifier of the warehouse where the inventory is being added."
       },
+      "source": {
+        "description": "The source of the inventory being added (tests anyOf).",
+        "anyOf": [
+          {
+            "title": "Purchase Order",
+            "type": "object",
+            "description": "Inventory received from a purchase order",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["purchase_order"]
+              },
+              "purchaseOrderId": {
+                "type": "string",
+                "format": "uuid",
+                "description": "The purchase order ID"
+              },
+              "supplierId": {
+                "type": "string",
+                "format": "uuid",
+                "description": "The supplier ID"
+              },
+              "receivedDate": {
+                "type": "string",
+                "format": "date",
+                "description": "Date the goods were received"
+              }
+            },
+            "required": ["type", "purchaseOrderId", "supplierId"]
+          },
+          {
+            "title": "Transfer",
+            "type": "object",
+            "description": "Inventory transferred from another warehouse",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["transfer"]
+              },
+              "sourceWarehouseId": {
+                "type": "string",
+                "format": "uuid",
+                "description": "The warehouse transferring the inventory"
+              },
+              "transferId": {
+                "type": "string",
+                "format": "uuid",
+                "description": "The transfer request ID"
+              }
+            },
+            "required": ["type", "sourceWarehouseId", "transferId"]
+          },
+          {
+            "title": "Return",
+            "type": "object",
+            "description": "Inventory returned by a customer",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["return"]
+              },
+              "orderId": {
+                "type": "string",
+                "format": "uuid",
+                "description": "The original order ID"
+              },
+              "returnId": {
+                "type": "string",
+                "format": "uuid",
+                "description": "The return request ID"
+              },
+              "condition": {
+                "type": "string",
+                "enum": ["new", "refurbished", "damaged"],
+                "description": "Condition of the returned item"
+              }
+            },
+            "required": ["type", "orderId", "returnId", "condition"]
+          }
+        ]
+      },
+      "priority": {
+        "description": "The priority level for processing this inventory (tests oneOf).",
+        "oneOf": [
+          {
+            "title": "Standard Priority",
+            "type": "object",
+            "description": "Normal processing priority",
+            "properties": {
+              "level": {
+                "type": "string",
+                "enum": ["standard"]
+              },
+              "expectedProcessingDays": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 7,
+                "description": "Expected days to process"
+              }
+            },
+            "required": ["level"]
+          },
+          {
+            "title": "Express Priority",
+            "type": "object",
+            "description": "Expedited processing",
+            "properties": {
+              "level": {
+                "type": "string",
+                "enum": ["express"]
+              },
+              "guaranteedByDate": {
+                "type": "string",
+                "format": "date-time",
+                "description": "Guaranteed processing completion date"
+              },
+              "rushFee": {
+                "type": "number",
+                "description": "Additional fee for rush processing"
+              }
+            },
+            "required": ["level", "guaranteedByDate"]
+          }
+        ]
+      },
+      "qualityChecks": {
+        "type": "array",
+        "description": "List of quality checks performed (tests anyOf in array items).",
+        "items": {
+          "anyOf": [
+            {
+              "title": "Visual Inspection",
+              "type": "object",
+              "description": "Manual visual inspection",
+              "properties": {
+                "checkType": {
+                  "type": "string",
+                  "enum": ["visual"]
+                },
+                "inspectorId": {
+                  "type": "string",
+                  "description": "ID of the inspector"
+                },
+                "passed": {
+                  "type": "boolean"
+                },
+                "notes": {
+                  "type": "string",
+                  "description": "Inspector notes"
+                }
+              },
+              "required": ["checkType", "inspectorId", "passed"]
+            },
+            {
+              "title": "Automated Scan",
+              "type": "object",
+              "description": "Automated barcode/QR scan",
+              "properties": {
+                "checkType": {
+                  "type": "string",
+                  "enum": ["automated_scan"]
+                },
+                "scannerId": {
+                  "type": "string",
+                  "description": "ID of the scanning device"
+                },
+                "barcodeMatch": {
+                  "type": "boolean",
+                  "description": "Whether barcode matched expected"
+                },
+                "scanTimestamp": {
+                  "type": "string",
+                  "format": "date-time"
+                }
+              },
+              "required": ["checkType", "scannerId", "barcodeMatch"]
+            },
+            {
+              "title": "Weight Check",
+              "type": "object",
+              "description": "Weight verification check",
+              "properties": {
+                "checkType": {
+                  "type": "string",
+                  "enum": ["weight"]
+                },
+                "expectedWeight": {
+                  "type": "number",
+                  "description": "Expected weight in kg"
+                },
+                "actualWeight": {
+                  "type": "number",
+                  "description": "Actual measured weight in kg"
+                },
+                "tolerancePercent": {
+                  "type": "number",
+                  "description": "Allowed tolerance percentage"
+                },
+                "withinTolerance": {
+                  "type": "boolean"
+                }
+              },
+              "required": ["checkType", "expectedWeight", "actualWeight", "withinTolerance"]
+            }
+          ]
+        }
+      },
       "timestamp": {
         "type": "string",
         "format": "date-time",
@@ -26,4 +233,3 @@
     "required": ["productId", "quantity", "warehouseId", "timestamp"],
     "additionalProperties": false
   }
-  


### PR DESCRIPTION
Fixes #1965

## What This PR Does

This PR fixes the SchemaViewer component to properly render `oneOf` and `anyOf` JSON Schema keywords. Previously, `anyOf` was not handled at all (showing only the field name), and `oneOf` only rendered the last item in the array due to property merging issues. Now users can see all variant options via a dropdown selector and view each variant's specific properties.

## Changes Overview

### Key Changes
- Add `anyOf` handling in `processSchema` function (was completely missing)
- Fix `oneOf` processing to preserve individual variants instead of merging all properties together
- Update rendering logic to display selected variant's properties instead of merged properties
- Add `NestedVariantSelector` component for handling variants within array items
- Show variant type indicator ("anyOf" or "oneOf") in the property type display
- Add variant description display in the selector UI

## How It Works

The fix involves two main parts:

1. **Schema Processing**: The `processSchema` function now handles both `oneOf` and `anyOf` keywords by:
   - Processing each variant schema recursively
   - Storing variants in a `variants` array with their titles, descriptions, and properties
   - Tracking the variant type (`variantType: 'oneOf' | 'anyOf'`) for display purposes
   - No longer merging all variant properties together (which was causing only the last variant to show)

2. **Rendering**: The component now:
   - Detects when a property has variants and displays a dropdown selector
   - Shows the selected variant's properties (not merged properties from all variants)
   - Updates the key prop to force re-render when variant selection changes
   - Handles nested variants within array items via `NestedVariantSelector`

## Breaking Changes

None

## Additional Notes

- Added a comprehensive test schema in the default example (`AddInventory/schema.json`) that exercises all three scenarios: `anyOf` at property level, `oneOf` at property level, and `anyOf` in array items
- The test schema should be reverted before merging if not desired in the default example