### PR TITLE
fix(domains): add specifications support to domain sidebar and schema explorer

### DIFF
--- a/.changeset/gentle-specs-refactor.md
+++ b/.changeset/gentle-specs-refactor.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Extract shared specification processing utilities to reduce code duplication

--- a/eventcatalog/src/stores/sidebar-store/__tests__/sidebar-builder.spec.ts
+++ b/eventcatalog/src/stores/sidebar-store/__tests__/sidebar-builder.spec.ts
@@ -839,6 +839,85 @@ describe('getNestedSideBarData', () => {
       });
     });
 
+    describe('API & Contracts section (domain)', () => {
+      it('is not listed if the domain does not have any specifications', async () => {
+        const { writeDomain } = utils(CATALOG_FOLDER);
+        await writeDomain({
+          id: 'Shipping',
+          name: 'Shipping',
+          version: '0.0.1',
+          markdown: 'Shipping',
+        });
+
+        const navigationData = await getNestedSideBarData();
+        const domainNode = getNavigationConfigurationByKey('domain:Shipping:0.0.1', navigationData);
+        const apiContractsSection = getChildNodeByTitle('API & Contracts', domainNode.pages ?? []);
+        expect(apiContractsSection).toBeUndefined();
+      });
+
+      it('is not listed if the domain is configured not to render the section', async () => {
+        const { writeDomain } = utils(CATALOG_FOLDER);
+        // SDK update required to support specifications on domains
+        await writeDomain({
+          id: 'Shipping',
+          name: 'Shipping',
+          version: '0.0.1',
+          markdown: 'Shipping',
+          detailsPanel: {
+            specifications: {
+              visible: false,
+            },
+          } as any,
+          specifications: [{ type: 'openapi', path: 'openapi.yaml', name: 'OpenAPI' }],
+        } as any);
+
+        const navigationData = await getNestedSideBarData();
+        const domainNode = getNavigationConfigurationByKey('domain:Shipping:0.0.1', navigationData);
+        const apiContractsSection = getChildNodeByTitle('API & Contracts', domainNode.pages ?? []);
+        expect(apiContractsSection).toBeUndefined();
+      });
+
+      it('lists the specifications that the domain has if the domain has specifications', async () => {
+        const { writeDomain } = utils(CATALOG_FOLDER);
+        // SDK update required to support specifications on domains
+        await writeDomain({
+          id: 'Shipping',
+          name: 'Shipping',
+          version: '0.0.1',
+          markdown: 'Shipping',
+          specifications: [
+            { type: 'openapi', path: 'openapi.yaml', name: 'OpenAPI' },
+            { type: 'asyncapi', path: 'asyncapi.yaml', name: 'AsyncAPI' },
+            { type: 'graphql', path: 'graphql.yaml', name: 'GraphQL' },
+          ],
+        } as any);
+
+        const navigationData = await getNestedSideBarData();
+        const domainNode = getNavigationConfigurationByKey('domain:Shipping:0.0.1', navigationData);
+        const apiContractsSection = getChildNodeByTitle('API & Contracts', domainNode.pages ?? []);
+        expect(apiContractsSection.pages).toEqual([
+          {
+            type: 'item',
+            title: 'OpenAPI',
+            leftIcon: '/icons/openapi-black.svg',
+            href: '/docs/domains/Shipping/0.0.1/spec/openapi',
+          },
+          {
+            type: 'item',
+            title: 'AsyncAPI',
+            leftIcon: '/icons/asyncapi-black.svg',
+            href: '/docs/domains/Shipping/0.0.1/asyncapi/asyncapi',
+          },
+          {
+            type: 'item',
+            title: 'GraphQL',
+            leftIcon: '/icons/graphql-black.svg',
+            href: '/docs/domains/Shipping/0.0.1/graphql/graphql',
+          },
+        ]);
+      });
+    });
+
     describe('domain events section (sends)', () => {
       it('is not listed if the domain does not send any messages', async () => {
         const { writeDomain } = utils(CATALOG_FOLDER);
@@ -865,7 +944,7 @@ describe('getNestedSideBarData', () => {
           markdown: 'Order Shipped',
         });
 
-        // @ts-ignore - SDK update required to support sends/receives on domains
+        // SDK update required to support sends/receives on domains
         await writeDomain({
           id: 'Shipping',
           name: 'Shipping',
@@ -877,7 +956,7 @@ describe('getNestedSideBarData', () => {
             },
           },
           sends: [{ id: 'OrderShipped', version: '0.0.1' }],
-        });
+        } as any);
 
         const navigationData = await getNestedSideBarData();
         const domainNode = getNavigationConfigurationByKey('domain:Shipping:0.0.1', navigationData);
@@ -894,14 +973,14 @@ describe('getNestedSideBarData', () => {
           markdown: 'Order Shipped',
         });
 
-        // @ts-ignore - SDK update required to support sends/receives on domains
+        // SDK update required to support sends/receives on domains
         await writeDomain({
           id: 'Shipping',
           name: 'Shipping',
           version: '0.0.1',
           markdown: 'Shipping',
           sends: [{ id: 'OrderShipped', version: '0.0.1' }],
-        });
+        } as any);
 
         const navigationData = await getNestedSideBarData();
         const domainNode = getNavigationConfigurationByKey('domain:Shipping:0.0.1', navigationData);
@@ -936,7 +1015,7 @@ describe('getNestedSideBarData', () => {
           markdown: 'Payment Processed',
         });
 
-        // @ts-ignore - SDK update required to support sends/receives on domains
+        // SDK update required to support sends/receives on domains
         await writeDomain({
           id: 'Shipping',
           name: 'Shipping',
@@ -948,7 +1027,7 @@ describe('getNestedSideBarData', () => {
             },
           },
           receives: [{ id: 'PaymentProcessed', version: '0.0.1' }],
-        });
+        } as any);
 
         const navigationData = await getNestedSideBarData();
         const domainNode = getNavigationConfigurationByKey('domain:Shipping:0.0.1', navigationData);
@@ -965,14 +1044,14 @@ describe('getNestedSideBarData', () => {
           markdown: 'Payment Processed',
         });
 
-        // @ts-ignore - SDK update required to support sends/receives on domains
+        // SDK update required to support sends/receives on domains
         await writeDomain({
           id: 'Shipping',
           name: 'Shipping',
           version: '0.0.1',
           markdown: 'Shipping',
           receives: [{ id: 'PaymentProcessed', version: '0.0.1' }],
-        });
+        } as any);
 
         const navigationData = await getNestedSideBarData();
         const domainNode = getNavigationConfigurationByKey('domain:Shipping:0.0.1', navigationData);

--- a/eventcatalog/src/stores/sidebar-store/builders/domain.ts
+++ b/eventcatalog/src/stores/sidebar-store/builders/domain.ts
@@ -12,6 +12,7 @@ import {
 } from './shared';
 import { isVisualiserEnabled } from '@utils/feature';
 import { pluralizeMessageType } from '@utils/collections/messages';
+import { getSpecificationsForDomain } from '@utils/collections/domains';
 
 export const buildDomainNode = (domain: CollectionEntry<'domains'>, owners: any[], context: ResourceGroupContext): NavNode => {
   const servicesInDomain = domain.data.services || [];
@@ -47,6 +48,14 @@ export const buildDomainNode = (domain: CollectionEntry<'domains'>, owners: any[
   const domainDiagrams = domain.data.diagrams || [];
   const diagramNavItems = buildDiagramNavItems(domainDiagrams, context.diagrams);
   const hasDiagrams = diagramNavItems.length > 0;
+
+  // Specifications
+  const specifications = getSpecificationsForDomain(domain);
+  const hasSpecifications = specifications.length > 0;
+  const openAPISpecifications = specifications.filter((specification) => specification.type === 'openapi');
+  const asyncAPISpecifications = specifications.filter((specification) => specification.type === 'asyncapi');
+  const graphQLSpecifications = specifications.filter((specification) => specification.type === 'graphql');
+  const renderSpecifications = hasSpecifications && shouldRenderSideBarSection(domain, 'specifications');
 
   return {
     type: 'item',
@@ -86,6 +95,37 @@ export const buildDomainNode = (domain: CollectionEntry<'domains'>, owners: any[
         title: 'Diagrams',
         icon: 'FileImage',
         pages: diagramNavItems,
+      },
+      renderSpecifications && {
+        type: 'group',
+        title: 'API & Contracts',
+        icon: 'FileCode',
+        pages: [
+          ...openAPISpecifications.map((specification) => ({
+            type: 'item',
+            title: specification.name,
+            leftIcon: '/icons/openapi-black.svg',
+            href: buildUrl(
+              `/docs/domains/${domain.data.id}/${domain.data.version}/spec/${specification.filenameWithoutExtension}`
+            ),
+          })),
+          ...asyncAPISpecifications.map((specification) => ({
+            type: 'item',
+            title: specification.name,
+            leftIcon: '/icons/asyncapi-black.svg',
+            href: buildUrl(
+              `/docs/domains/${domain.data.id}/${domain.data.version}/asyncapi/${specification.filenameWithoutExtension}`
+            ),
+          })),
+          ...graphQLSpecifications.map((specification) => ({
+            type: 'item',
+            title: specification.name,
+            leftIcon: '/icons/graphql-black.svg',
+            href: buildUrl(
+              `/docs/domains/${domain.data.id}/${domain.data.version}/graphql/${specification.filenameWithoutExtension}`
+            ),
+          })),
+        ],
       },
       renderSubDomains && {
         type: 'group',

--- a/eventcatalog/src/utils/collections/domains.ts
+++ b/eventcatalog/src/utils/collections/domains.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import type { CollectionMessageTypes } from '@types';
 import type { Service } from './types';
 import utils from '@eventcatalog/sdk';
-import { createVersionedMap, findInMap } from '@utils/collections/util';
+import { createVersionedMap, findInMap, processSpecifications } from '@utils/collections/util';
 
 const PROJECT_DIR = process.env.PROJECT_DIR || process.cwd();
 const CACHE_ENABLED = process.env.DISABLE_EVENTCATALOG_CACHE !== 'true';
@@ -382,4 +382,8 @@ export const getDomainsForService = async (service: Service): Promise<Domain[]> 
 
 export const domainHasEntities = (domain: Domain): boolean => {
   return (domain.data.entities && domain.data.entities.length > 0) || false;
+};
+
+export const getSpecificationsForDomain = (domain: Domain) => {
+  return processSpecifications(domain.data.specifications as any);
 };

--- a/eventcatalog/src/utils/collections/services.ts
+++ b/eventcatalog/src/utils/collections/services.ts
@@ -6,7 +6,7 @@ import type { CollectionMessageTypes, CollectionTypes } from '@types';
 const PROJECT_DIR = process.env.PROJECT_DIR || process.cwd();
 import utils, { type Domain } from '@eventcatalog/sdk';
 import { getDomains, getDomainsForService } from './domains';
-import { createVersionedMap, findInMap } from '@utils/collections/util';
+import { createVersionedMap, findInMap, processSpecifications } from '@utils/collections/util';
 
 export type Service = CollectionEntry<'services'>;
 
@@ -174,31 +174,7 @@ export const getConsumersOfMessage = (services: Service[], message: CollectionEn
 };
 
 export const getSpecificationsForService = (service: CollectionEntry<CollectionTypes>) => {
-  const specifications = Array.isArray(service.data.specifications) ? service.data.specifications : [];
-
-  if (service.data.specifications && !Array.isArray(service.data.specifications)) {
-    if (service.data.specifications.asyncapiPath) {
-      specifications.push({
-        type: 'asyncapi',
-        path: service.data.specifications.asyncapiPath,
-        name: 'AsyncAPI',
-      });
-    }
-    if (service.data.specifications.openapiPath) {
-      specifications.push({
-        type: 'openapi',
-        path: service.data.specifications.openapiPath,
-        name: 'OpenAPI',
-      });
-    }
-  }
-
-  return specifications.map((spec) => ({
-    ...spec,
-    name: spec.name || (spec.type === 'asyncapi' ? 'AsyncAPI' : 'OpenAPI'),
-    filename: path.basename(spec.path),
-    filenameWithoutExtension: path.basename(spec.path, path.extname(spec.path)),
-  }));
+  return processSpecifications(service.data.specifications as any);
 };
 // Get services for channel
 export const getProducersAndConsumersForChannel = async (channel: CollectionEntry<'channels'>) => {

--- a/examples/default/domains/E-Commerce/subdomains/Payment/asyncapi.yaml
+++ b/examples/default/domains/E-Commerce/subdomains/Payment/asyncapi.yaml
@@ -1,0 +1,131 @@
+asyncapi: 3.0.0
+info:
+  title: Payment Domain Events API
+  version: 0.0.1
+  description: |
+    AsyncAPI specification for the Payment Domain events.
+    This domain handles all payment-related events including payment processing,
+    fraud detection, and transaction management.
+
+channels:
+  paymentProcessed:
+    address: payment/processed
+    messages:
+      paymentProcessed:
+        $ref: '#/components/messages/PaymentProcessed'
+  paymentFailed:
+    address: payment/failed
+    messages:
+      paymentFailed:
+        $ref: '#/components/messages/PaymentFailed'
+  fraudDetected:
+    address: payment/fraud-detected
+    messages:
+      fraudDetected:
+        $ref: '#/components/messages/FraudDetected'
+
+operations:
+  onPaymentProcessed:
+    action: receive
+    channel:
+      $ref: '#/channels/paymentProcessed'
+  onPaymentFailed:
+    action: receive
+    channel:
+      $ref: '#/channels/paymentFailed'
+  onFraudDetected:
+    action: receive
+    channel:
+      $ref: '#/channels/fraudDetected'
+
+components:
+  messages:
+    PaymentProcessed:
+      name: PaymentProcessed
+      title: Payment Processed
+      summary: Event emitted when a payment has been successfully processed
+      contentType: application/json
+      payload:
+        type: object
+        properties:
+          paymentId:
+            type: string
+            format: uuid
+            description: Unique identifier for the payment
+          orderId:
+            type: string
+            format: uuid
+            description: Associated order identifier
+          amount:
+            type: number
+            format: float
+            description: Payment amount
+          currency:
+            type: string
+            description: Currency code (ISO 4217)
+          status:
+            type: string
+            enum: [completed, pending, refunded]
+          processedAt:
+            type: string
+            format: date-time
+        required:
+          - paymentId
+          - orderId
+          - amount
+          - currency
+          - status
+          - processedAt
+
+    PaymentFailed:
+      name: PaymentFailed
+      title: Payment Failed
+      summary: Event emitted when a payment has failed
+      contentType: application/json
+      payload:
+        type: object
+        properties:
+          paymentId:
+            type: string
+            format: uuid
+          orderId:
+            type: string
+            format: uuid
+          errorCode:
+            type: string
+          errorMessage:
+            type: string
+          failedAt:
+            type: string
+            format: date-time
+        required:
+          - paymentId
+          - errorCode
+          - failedAt
+
+    FraudDetected:
+      name: FraudDetected
+      title: Fraud Detected
+      summary: Event emitted when fraudulent activity is detected
+      contentType: application/json
+      payload:
+        type: object
+        properties:
+          transactionId:
+            type: string
+            format: uuid
+          riskScore:
+            type: number
+            minimum: 0
+            maximum: 100
+          riskFactors:
+            type: array
+            items:
+              type: string
+          detectedAt:
+            type: string
+            format: date-time
+        required:
+          - transactionId
+          - riskScore
+          - detectedAt

--- a/examples/default/domains/E-Commerce/subdomains/Payment/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Payment/index.mdx
@@ -6,6 +6,13 @@ summary: |
   Domain that contains payment related services and messages for processing financial transactions.
 owners:
     - dboyne
+specifications:
+  - type: asyncapi
+    path: asyncapi.yaml
+    name: Payment Events API
+  - type: openapi
+    path: openapi.yaml
+    name: Payment REST API
 services:
   - id: PaymentService
     version: 0.0.1

--- a/examples/default/domains/E-Commerce/subdomains/Payment/openapi.yaml
+++ b/examples/default/domains/E-Commerce/subdomains/Payment/openapi.yaml
@@ -1,0 +1,231 @@
+openapi: 3.0.3
+info:
+  title: Payment Domain REST API
+  version: 0.0.1
+  description: |
+    OpenAPI specification for the Payment Domain REST endpoints.
+    This API provides operations for managing payments, retrieving payment status,
+    and handling refunds.
+
+servers:
+  - url: https://api.example.com/v1
+    description: Production server
+  - url: https://staging-api.example.com/v1
+    description: Staging server
+
+paths:
+  /payments:
+    post:
+      summary: Initiate a new payment
+      operationId: createPayment
+      tags:
+        - Payments
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreatePaymentRequest'
+      responses:
+        '201':
+          description: Payment initiated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Payment'
+        '400':
+          description: Invalid request
+        '422':
+          description: Payment validation failed
+
+  /payments/{paymentId}:
+    get:
+      summary: Get payment details
+      operationId: getPayment
+      tags:
+        - Payments
+      parameters:
+        - name: paymentId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Payment details retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Payment'
+        '404':
+          description: Payment not found
+
+  /payments/{paymentId}/refund:
+    post:
+      summary: Request a refund for a payment
+      operationId: refundPayment
+      tags:
+        - Refunds
+      parameters:
+        - name: paymentId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RefundRequest'
+      responses:
+        '200':
+          description: Refund processed successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Refund'
+        '400':
+          description: Invalid refund request
+        '404':
+          description: Payment not found
+
+  /payments/{paymentId}/status:
+    get:
+      summary: Get payment status
+      operationId: getPaymentStatus
+      tags:
+        - Payments
+      parameters:
+        - name: paymentId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Payment status retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaymentStatus'
+        '404':
+          description: Payment not found
+
+components:
+  schemas:
+    CreatePaymentRequest:
+      type: object
+      required:
+        - orderId
+        - amount
+        - currency
+        - paymentMethod
+      properties:
+        orderId:
+          type: string
+          format: uuid
+          description: The order this payment is for
+        amount:
+          type: number
+          format: float
+          minimum: 0.01
+          description: Payment amount
+        currency:
+          type: string
+          pattern: '^[A-Z]{3}$'
+          description: ISO 4217 currency code
+        paymentMethod:
+          $ref: '#/components/schemas/PaymentMethod'
+
+    Payment:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        orderId:
+          type: string
+          format: uuid
+        amount:
+          type: number
+          format: float
+        currency:
+          type: string
+        status:
+          type: string
+          enum: [pending, processing, completed, failed, refunded]
+        paymentMethod:
+          $ref: '#/components/schemas/PaymentMethod'
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+
+    PaymentMethod:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum: [credit_card, debit_card, paypal, bank_transfer]
+        cardLast4:
+          type: string
+          pattern: '^\d{4}$'
+        cardBrand:
+          type: string
+          enum: [visa, mastercard, amex, discover]
+
+    PaymentStatus:
+      type: object
+      properties:
+        paymentId:
+          type: string
+          format: uuid
+        status:
+          type: string
+          enum: [pending, processing, completed, failed, refunded]
+        lastUpdated:
+          type: string
+          format: date-time
+
+    RefundRequest:
+      type: object
+      required:
+        - amount
+        - reason
+      properties:
+        amount:
+          type: number
+          format: float
+          minimum: 0.01
+        reason:
+          type: string
+          maxLength: 500
+
+    Refund:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        paymentId:
+          type: string
+          format: uuid
+        amount:
+          type: number
+          format: float
+        status:
+          type: string
+          enum: [pending, completed, failed]
+        reason:
+          type: string
+        createdAt:
+          type: string
+          format: date-time


### PR DESCRIPTION
Fixes #1826

## What This PR Does

This PR adds specifications (OpenAPI, AsyncAPI, GraphQL) support to domains, mirroring the existing functionality for services. Domain specifications now appear in the Schema Explorer and in the domain sidebar under an "API & Contracts" section. Additionally, shared specification processing utilities have been extracted to reduce code duplication.

## Changes Overview

### Key Changes
- Add domain specifications to Schema Explorer index data
- Add "API & Contracts" section to domain sidebar builder with support for OpenAPI, AsyncAPI, and GraphQL
- Extract shared specification processing utilities (`getDefaultSpecificationName`, `processSpecifications`) to `util.ts`
- Refactor `getSpecificationsForService` and `getSpecificationsForDomain` to use shared utilities
- Add comprehensive tests for domain specifications in sidebar builder
- Add example AsyncAPI and OpenAPI specifications to the Payment domain

## How It Works

1. **Schema Explorer**: The `_index.data.ts` now fetches domains alongside services and processes their specifications in parallel, adding them to the schema explorer index.

2. **Domain Sidebar**: The `domain.ts` builder now includes an "API & Contracts" section when a domain has specifications, with proper icons and URLs for each specification type.

3. **Shared Utilities**: The `util.ts` file now contains:
   - `getDefaultSpecificationName(type)` - Returns the display name for a specification type
   - `processSpecifications(specifications)` - Handles both array and legacy object formats, returning processed specifications with filename info

## Breaking Changes

None

## Additional Notes

- Example specifications added to the Payment domain demonstrate the feature in the default catalog
- Tests cover all three specification types (OpenAPI, AsyncAPI, GraphQL) and sidebar visibility configuration

🤖 Generated with [Claude Code](https://claude.ai/code)