### PR TITLE
Fix containers collection glob pattern for nested directories

### DIFF
--- a/.changeset/calm-dogs-hunt.md
+++ b/.changeset/calm-dogs-hunt.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Fix containers collection glob pattern to support nested directories

--- a/eventcatalog/src/content.config.ts
+++ b/eventcatalog/src/content.config.ts
@@ -453,7 +453,7 @@ const dataClassificationEnum = z.enum(['public', 'internal', 'confidential', 're
 
 const containers = defineCollection({
   loader: glob({
-    pattern: ['**/containers/*/index.(md|mdx)', '**/containers/*/versioned/*/index.(md|mdx)'],
+    pattern: ['**/containers/**/index.(md|mdx)', '**/containers/**/versioned/*/index.(md|mdx)'],
     base: projectDirBase,
     generateId: ({ data }) => {
       return `${data.id}-${data.version}`;


### PR DESCRIPTION
## What This PR Does

Fixes the containers collection glob pattern in the content config to support nested directory structures. Previously, the pattern used a single wildcard (`*`) which only matched immediate subdirectories. This change updates it to use a double wildcard (`**`) to match containers at any depth.

## Changes Overview

### Key Changes
- Update glob pattern from `**/containers/*/index.(md|mdx)` to `**/containers/**/index.(md|mdx)`
- Update versioned glob pattern from `**/containers/*/versioned/*/index.(md|mdx)` to `**/containers/**/versioned/*/index.(md|mdx)`

## How It Works

The glob pattern change allows the containers collection to discover container definitions that are organized in nested folder structures, not just those placed directly under the `containers/` directory. This brings the behavior in line with how other collections handle nested content.

## Breaking Changes

None

## Additional Notes

This is a non-breaking fix that enables more flexible organization of container definitions.

🤖 Generated with [Claude Code](https://claude.ai/code)