### PR TITLE
feat(mermaid): add configurable maxTextSize for larger diagrams

### DIFF
--- a/.changeset/brave-mermaid-shine.md
+++ b/.changeset/brave-mermaid-shine.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Add configurable maxTextSize for mermaid diagrams to allow rendering larger diagrams

--- a/eventcatalog/src/components/MDX/NodeGraph/MermaidView.tsx
+++ b/eventcatalog/src/components/MDX/NodeGraph/MermaidView.tsx
@@ -7,9 +7,10 @@ import { copyToClipboard } from '@utils/clipboard';
 interface MermaidViewProps {
   nodes: Node[];
   edges: Edge[];
+  maxTextSize?: number;
 }
 
-const MermaidView = ({ nodes, edges }: MermaidViewProps) => {
+const MermaidView = ({ nodes, edges, maxTextSize = 100000 }: MermaidViewProps) => {
   const [copySuccess, setCopySuccess] = useState(false);
   const [mermaidCode, setMermaidCode] = useState('');
   const [previewSvg, setPreviewSvg] = useState<string | null>(null);
@@ -42,6 +43,7 @@ const MermaidView = ({ nodes, edges }: MermaidViewProps) => {
         const currentTheme = isDarkMode ? 'dark' : 'default';
 
         mermaid.initialize({
+          maxTextSize: maxTextSize,
           startOnLoad: false,
           theme: currentTheme,
           flowchart: {

--- a/eventcatalog/src/components/MDX/NodeGraph/NodeGraph.astro
+++ b/eventcatalog/src/components/MDX/NodeGraph/NodeGraph.astro
@@ -158,6 +158,7 @@ if (collection === 'services-containers') {
     includeKey={showLegend}
     zoomOnScroll={zoomOnScroll}
     isChatEnabled={isChatEnabled}
+    maxTextSize={config.mermaid?.maxTextSize}
   />
 </div>
 

--- a/eventcatalog/src/components/MDX/NodeGraph/NodeGraph.tsx
+++ b/eventcatalog/src/components/MDX/NodeGraph/NodeGraph.tsx
@@ -18,23 +18,7 @@ import {
   type NodeTypes,
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
-import {
-  ExternalLink,
-  HistoryIcon,
-  CheckIcon,
-  ClipboardIcon,
-  ChevronDownIcon,
-  MoreVertical,
-  Zap,
-  EyeOff,
-  Code,
-  Share2,
-  Search,
-  Grid3x3,
-  Maximize2,
-  Map,
-  Sparkles,
-} from 'lucide-react';
+import { ExternalLink, HistoryIcon, CheckIcon, ClipboardIcon, MoreVertical } from 'lucide-react';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import { toPng } from 'html-to-image';
 import { DocumentArrowDownIcon, PresentationChartLineIcon } from '@heroicons/react/24/outline';
@@ -93,6 +77,7 @@ interface Props {
   isStudioModalOpen?: boolean;
   setIsStudioModalOpen?: (isOpen: boolean) => void;
   isChatEnabled?: boolean;
+  maxTextSize?: number;
 }
 
 const getVisualiserUrlForCollection = (collectionItem: CollectionEntry<CollectionTypes>) => {
@@ -115,6 +100,7 @@ const NodeGraphBuilder = ({
   isStudioModalOpen,
   setIsStudioModalOpen = () => {},
   isChatEnabled = false,
+  maxTextSize,
 }: Props) => {
   const nodeTypes = useMemo(
     () =>
@@ -723,7 +709,7 @@ const NodeGraphBuilder = ({
           </div>
           {/* Mermaid View */}
           <div className="flex-1 overflow-hidden">
-            <MermaidView nodes={nodes} edges={edges} />
+            <MermaidView nodes={nodes} edges={edges} maxTextSize={maxTextSize} />
           </div>
         </>
       ) : (
@@ -965,6 +951,7 @@ interface NodeGraphProps {
   zoomOnScroll?: boolean;
   designId?: string;
   isChatEnabled?: boolean;
+  maxTextSize?: number;
 }
 
 const NodeGraph = ({
@@ -986,6 +973,7 @@ const NodeGraph = ({
   zoomOnScroll = false,
   designId,
   isChatEnabled = false,
+  maxTextSize,
 }: NodeGraphProps) => {
   const [elem, setElem] = useState(null);
   const [showFooter, setShowFooter] = useState(true);
@@ -1032,6 +1020,7 @@ const NodeGraph = ({
             isStudioModalOpen={isStudioModalOpen}
             setIsStudioModalOpen={setIsStudioModalOpen}
             isChatEnabled={isChatEnabled}
+            maxTextSize={maxTextSize}
           />
 
           {showFooter && (

--- a/eventcatalog/src/pages/diagrams/[id]/[version]/embed.astro
+++ b/eventcatalog/src/pages/diagrams/[id]/[version]/embed.astro
@@ -570,6 +570,7 @@ const diagramId = props.data.id;
         const isDarkMode = document.documentElement.getAttribute('data-theme') === 'dark';
 
         mermaid.initialize({
+          maxTextSize: window.eventcatalog?.mermaid?.maxTextSize || 100000,
           startOnLoad: false,
           theme: isDarkMode ? 'dark' : 'default',
           fontFamily: 'system-ui, -apple-system, sans-serif',

--- a/eventcatalog/src/utils/mermaid-zoom.ts
+++ b/eventcatalog/src/utils/mermaid-zoom.ts
@@ -600,6 +600,7 @@ export async function renderMermaidWithZoom(graphs: HTMLCollectionOf<Element>, m
   };
 
   mermaid.initialize({
+    maxTextSize: mermaidConfig?.maxTextSize || 100000,
     flowchart: {
       curve: 'linear',
       rankSpacing: 0,

--- a/src/eventcatalog.config.ts
+++ b/src/eventcatalog.config.ts
@@ -110,6 +110,7 @@ export interface Config {
     domains?: ResourceDependency[];
   };
   mermaid?: {
+    maxTextSize?: number;
     iconPacks?: string[];
   };
   chat?: {


### PR DESCRIPTION
## What This PR Does

Adds a new `mermaid.maxTextSize` configuration option that allows users to increase the maximum text size for Mermaid diagram rendering. This enables larger diagrams to render in the browser without hitting the default size limit.

## Changes Overview

### Key Changes
- Add `maxTextSize` property to the mermaid config type in `eventcatalog.config.ts`
- Pass `maxTextSize` through the component chain: NodeGraph.astro → NodeGraph.tsx → MermaidView.tsx
- Use config value in `mermaid-zoom.ts` via the existing `window.eventcatalog.mermaid` pattern
- Fix `embed.astro` to use `window.eventcatalog.mermaid.maxTextSize` instead of server-side config

## How It Works

The configuration flows through two paths:
1. **Server → React components**: Config is read in Astro files and passed as props to React components
2. **Server → Client scripts**: Config is serialized to `window.eventcatalog.mermaid` for client-side scripts

Default value is `100000`. Users can override in their eventcatalog config:

```js
mermaid: {
  maxTextSize: 200000
}
```

## Breaking Changes

None

## Additional Notes

Removes unused lucide-react icon imports from NodeGraph.tsx.

🤖 Generated with [Claude Code](https://claude.ai/code)