### PR TITLE
feat(analytics): add resource counting to build telemetry

### DIFF
--- a/.changeset/calm-tigers-count.md
+++ b/.changeset/calm-tigers-count.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": minor
+---
+
+Add resource counting to build telemetry (events, services, domains, etc.)

--- a/src/analytics/count-resources.js
+++ b/src/analytics/count-resources.js
@@ -1,0 +1,51 @@
+import { glob } from 'glob';
+
+const RESOURCE_PATTERNS = {
+  events: ['**/events/*/index.@(md|mdx)'],
+  commands: ['**/commands/*/index.@(md|mdx)'],
+  queries: ['**/queries/*/index.@(md|mdx)'],
+  services: ['**/services/*/index.@(md|mdx)'],
+  domains: ['domains/*/index.@(md|mdx)', 'domains/*/subdomains/*/index.@(md|mdx)'],
+  flows: ['**/flows/*/index.@(md|mdx)'],
+  channels: ['**/channels/**/index.@(md|mdx)'],
+  entities: ['**/entities/*/index.@(md|mdx)'],
+  containers: ['**/containers/**/index.@(md|mdx)'],
+  'data-products': ['**/data-products/*/index.@(md|mdx)'],
+  teams: ['teams/*.@(md|mdx)'],
+  users: ['users/*.@(md|mdx)'],
+  designs: ['**/*.ecstudio'],
+  diagrams: ['**/diagrams/**/index.@(md|mdx)'],
+  ubiquitousLanguages: ['domains/*/ubiquitous-language.@(md|mdx)', 'domains/*/subdomains/*/ubiquitous-language.@(md|mdx)'],
+};
+
+/**
+ * Count resources in the catalog directory using glob patterns
+ * @param {string} projectDir - Path to the catalog directory
+ * @returns {Promise<Record<string, number>>} - Object with resource type counts
+ */
+export async function countResources(projectDir) {
+  const counts = {};
+  for (const [type, patterns] of Object.entries(RESOURCE_PATTERNS)) {
+    let total = 0;
+    for (const pattern of patterns) {
+      const files = await glob(pattern, {
+        cwd: projectDir,
+        ignore: ['**/versioned/**', '**/dist/**', '**/node_modules/**'],
+      });
+      total += files.length;
+    }
+    counts[type] = total;
+  }
+  return counts;
+}
+
+/**
+ * Serialize resource counts to a string for telemetry
+ * @param {Record<string, number>} counts - Object with resource type counts
+ * @returns {string} - Serialized string like "events:26,commands:11,..."
+ */
+export function serializeCounts(counts) {
+  return Object.entries(counts)
+    .map(([k, v]) => `${k}:${v}`)
+    .join(',');
+}

--- a/src/analytics/log-build.js
+++ b/src/analytics/log-build.js
@@ -1,5 +1,6 @@
 import { getEventCatalogConfigFile, verifyRequiredFieldsAreInCatalogConfigFile } from '../eventcatalog-config-file-utils.js';
 import { raiseEvent } from './analytics.js';
+import { countResources, serializeCounts } from './count-resources.js';
 
 const getFeatures = async (configFile) => {
   return {
@@ -36,6 +37,7 @@ const main = async (projectDir, { isEventCatalogStarterEnabled, isEventCatalogSc
     }
 
     const features = await getFeatures(configFile);
+    const resourceCounts = await countResources(projectDir);
 
     await raiseEvent({
       command: 'build',
@@ -45,6 +47,7 @@ const main = async (projectDir, { isEventCatalogStarterEnabled, isEventCatalogSc
       features: Object.keys(features)
         .map((feature) => `${feature}:${features[feature]}`)
         .join(','),
+      resources: serializeCounts(resourceCounts),
     });
   } catch (error) {
     // Just swallow the error


### PR DESCRIPTION
## What This PR Does

Adds resource counting to build telemetry so that catalog resource counts (events, services, domains, etc.) are included in the analytics payload during builds. This provides insight into catalog composition and usage patterns.

## Changes Overview

### Key Changes
- Create new `src/analytics/count-resources.js` utility that uses glob patterns to count 15 resource types
- Modify `src/analytics/log-build.js` to include resource counts in telemetry payload
- Resource counts are serialized as a string like `"events:26,commands:11,services:15,..."`

## How It Works

The `countResources()` function uses glob patterns to count files matching each resource type in the catalog directory. Patterns are designed to match the content collection definitions in `content.config.ts`. The function excludes `versioned/`, `dist/`, and `node_modules/` directories to count only unique current resources.

Resource types counted:
- events, commands, queries, services, domains, flows, channels, entities, containers, data-products, teams, users, designs, diagrams, ubiquitousLanguages

The `serializeCounts()` function converts the counts object to a comma-separated string for the telemetry payload.

## Breaking Changes

None

## Additional Notes

The file system approach was chosen because it works within the existing `log-build.js` flow before Astro runs, avoiding the need for Astro's content collection APIs.

🤖 Generated with [Claude Code](https://claude.ai/code)