### PR TITLE
Fix slow asset loading during View Transitions navigation

### DIFF
--- a/.changeset/swift-tigers-dance.md
+++ b/.changeset/swift-tigers-dance.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Add transition:persist to Header and Footer to prevent asset re-requests during View Transitions navigation

--- a/eventcatalog/src/layouts/Footer.astro
+++ b/eventcatalog/src/layouts/Footer.astro
@@ -4,7 +4,10 @@ import { showEventCatalogBranding } from '@utils/feature';
 const { className } = Astro.props;
 ---
 
-<footer class={`relative py-4 space-y-8 border-t border-[rgb(var(--ec-page-border))] ${className}`}>
+<footer
+  transition:persist="site-footer"
+  class={`relative py-4 space-y-8 border-t border-[rgb(var(--ec-page-border))] ${className}`}
+>
   {
     showEventCatalogBranding() && (
       <div class="flex justify-between items-center py-8 text-[rgb(var(--ec-page-text-muted))] text-sm font-light">

--- a/eventcatalog/src/layouts/VerticalSideBarLayout.astro
+++ b/eventcatalog/src/layouts/VerticalSideBarLayout.astro
@@ -277,7 +277,9 @@ const canPageBeEmbedded = isEmbedEnabled();
     {/* Load search data even when sidebar is hidden */}
     <SearchDataLoader />
     <main id="eventcatalog-application" class="relative">
-      <Header />
+      <div transition:persist="site-header">
+        <Header />
+      </div>
       <div class="flex">
         <aside class="flex" id="eventcatalog-vertical-nav">
           <div


### PR DESCRIPTION
## What This PR Does

Adds `transition:persist` directive to the Header and Footer components to prevent them from being re-rendered during Astro View Transitions navigation. This fixes a performance issue where assets like `logo.png` and `github.svg` were being re-requested on every client-side navigation, causing 8+ second delays in Docker/SSR production environments.

## Changes Overview

### Key Changes
- Wrap `<Header />` component with `transition:persist="site-header"` in `VerticalSideBarLayout.astro`
- Add `transition:persist="site-footer"` directly to the `<footer>` element in `Footer.astro`

## How It Works

When using Astro's View Transitions (ClientRouter), navigating between pages normally triggers a full re-render of all components, causing the browser to re-request assets referenced in those components. By adding `transition:persist`, we tell Astro to keep these DOM nodes in place during navigation instead of replacing them. This means:

1. The Header and Footer stay in the DOM across page transitions
2. Assets within these components (logo.png, github.svg, social icons) don't get re-requested
3. Navigation feels instant since the browser doesn't need to fetch these assets again

## Breaking Changes

None

## Additional Notes

If users still experience slow asset loading after this fix, they may need to:
- Configure nginx/CDN to serve static assets instead of going through Node.js
- Add Astro prefetch configuration for additional optimization
- Consider inlining Footer SVGs to eliminate mask-image CSS requests entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)