### PR TITLE
fix(mcp): support AI SDK tool() helper inputSchema property

### DIFF
--- a/.changeset/gentle-clouds-float.md
+++ b/.changeset/gentle-clouds-float.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Fix MCP server to support AI SDK tool() helper inputSchema property

--- a/eventcatalog/src/enterprise/mcp/mcp-server.ts
+++ b/eventcatalog/src/enterprise/mcp/mcp-server.ts
@@ -283,7 +283,8 @@ function createMcpServer() {
     if (!toolConfig || typeof toolConfig !== 'object') continue;
 
     // Extract tool properties (Vercel AI SDK format)
-    const { description, parameters, execute } = toolConfig;
+    // The AI SDK tool() helper uses "inputSchema" for Zod schemas
+    const { description, parameters, inputSchema, execute } = toolConfig;
 
     if (!description || !execute) {
       console.warn(`[MCP] Skipping invalid extended tool: ${toolName}`);
@@ -294,7 +295,7 @@ function createMcpServer() {
       toolName,
       {
         description: description || `Custom tool: ${toolName}`,
-        inputSchema: parameters || z.object({}),
+        inputSchema: inputSchema || parameters || z.object({}),
       },
       async (params: any) => {
         try {


### PR DESCRIPTION
## What This PR Does

Fixes an issue where extended tools defined using the Vercel AI SDK `tool()` helper were not working correctly with the MCP server. The AI SDK's `tool()` helper uses `inputSchema` for Zod schemas, but the MCP server was only looking for `parameters`.

## Changes Overview

### Key Changes
- Extract `inputSchema` property from tool config in addition to `parameters`
- Use `inputSchema` as primary, falling back to `parameters` for backwards compatibility
- Add comment explaining the AI SDK tool() helper behavior

## How It Works

The Vercel AI SDK's `tool()` helper function creates tool configurations with an `inputSchema` property containing the Zod schema, rather than `parameters`. This change updates the MCP server's tool registration to check for both properties, preferring `inputSchema` when present.

## Breaking Changes

None

## Additional Notes

This is a backwards-compatible change that maintains support for tools defined with `parameters` while adding support for the AI SDK `tool()` helper format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)