### PR TITLE
fix(deps): downgrade react-syntax-highlighter to v15 for compatibility

### DIFF
--- a/.changeset/gentle-waves-flow.md
+++ b/.changeset/gentle-waves-flow.md
@@ -2,4 +2,4 @@
 "@eventcatalog/core": patch
 ---
 
-Downgrade react-syntax-highlighter from v16 to v15.6.6 for compatibility
+Downgrade react-syntax-highlighter to v15.6.6 for CJS/ESM compatibility and override prismjs to >=1.30.0 to fix CVE-2024-53382

--- a/package.json
+++ b/package.json
@@ -162,5 +162,10 @@
     "vite-tsconfig-paths": "^4.3.2",
     "vitest": "2.1.9"
   },
+  "pnpm": {
+    "overrides": {
+      "prismjs": ">=1.30.0"
+    }
+  },
   "packageManager": "pnpm@10.23.0+sha512.21c4e5698002ade97e4efe8b8b4a89a8de3c85a37919f957e7a0f30f38fbc5bbdd05980ffe29179b2fb6e6e691242e098d945d1601772cad0fef5fb6411e2a4b"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  prismjs: '>=1.30.0'
+
 importers:
 
   .:
@@ -6121,10 +6124,6 @@ packages:
   pretty-ms@8.0.0:
     resolution: {integrity: sha512-ASJqOugUF1bbzI35STMBUpZqdfYKlJugy6JBziGi2EE+AL5JPJGSzvpeVXojxrr0ViUYoToUjb5kjSEGf7Y83Q==}
     engines: {node: '>=14.16'}
-
-  prismjs@1.27.0:
-    resolution: {integrity: sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==}
-    engines: {node: '>=6'}
 
   prismjs@1.30.0:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
@@ -14882,8 +14881,6 @@ snapshots:
     dependencies:
       parse-ms: 3.0.0
 
-  prismjs@1.27.0: {}
-
   prismjs@1.30.0: {}
 
   prompts@2.4.2:
@@ -15117,7 +15114,7 @@ snapshots:
     dependencies:
       hastscript: 6.0.0
       parse-entities: 2.0.0
-      prismjs: 1.27.0
+      prismjs: 1.30.0
 
   regex-recursion@6.0.2:
     dependencies:


### PR DESCRIPTION
## What This PR Does

Downgrades `react-syntax-highlighter` from v16.1.0 to v15.6.6 to resolve compatibility issues. This also updates the corresponding lockfile entries including `refractor` (v5 to v3.6.0) and related dependencies.

## Changes Overview

### Key Changes
- Downgrade `react-syntax-highlighter` from `^16.1.0` to `^15.6.6` in `package.json`
- Updated `pnpm-lock.yaml` with resolved dependency tree changes (refractor v3.6.0, prismjs v1.27.0, etc.)

## How It Works

The `react-syntax-highlighter` package is used for code highlighting in the catalog. Version 15.6.6 uses `refractor@3.6.0` which has a different dependency chain than v16's `refractor@5.0.0`, providing better compatibility with the current project setup.

## Breaking Changes

None

## Additional Notes

- The `refractor` dependency shifts from v5 (with `@types/prismjs`) to v3.6.0 (with `hastscript@6`, `parse-entities@2`)
- Several transitive dependencies are added/removed accordingly in the lockfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)