### PR TITLE
fix(deps): upgrade axios from 1.7.7 to 1.13.5

### DIFF
--- a/.changeset/gentle-waves-roll.md
+++ b/.changeset/gentle-waves-roll.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+upgrade axios from 1.7.7 to 1.13.5

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "astro-expressive-code": "^0.41.3",
     "astro-seo": "^0.8.4",
     "auth-astro": "^4.2.0",
-    "axios": "^1.7.7",
+    "axios": "^1.13.5",
     "boxen": "^8.0.1",
     "commander": "^12.1.0",
     "concurrently": "^8.2.2",


### PR DESCRIPTION
## What This PR Does

Bumps the axios dependency from version 1.7.7 to 1.13.5 to pick up bug fixes, security patches, and improvements from the latest releases.

## Changes Overview

### Key Changes
- Update `axios` version constraint in `package.json` from `^1.7.7` to `^1.13.5`

## Breaking Changes

None

## Additional Notes

Routine dependency upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)