### PR TITLE
fix(core): verify required config fields before copying core to prevent vite restart race

### DIFF
--- a/.changeset/gentle-clouds-drift.md
+++ b/.changeset/gentle-clouds-drift.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+verify required config fields before copying core to prevent Vite restart race conditions


### PR DESCRIPTION
## What This PR Does

Moves the `verifyRequiredFieldsAreInCatalogConfigFile()` call to run **before** `copyCore()` in both the `dev` and `build` commands. This prevents a race condition where writing config fields (like `cId`) after the Vite dev server starts triggers a config dependency change restart, which conflicts with the initial dependency scan and floods the terminal with errors.

## Changes Overview

### Key Changes
- Call `verifyRequiredFieldsAreInCatalogConfigFile(dir)` before `copyCore()` in the `dev` command
- Call `verifyRequiredFieldsAreInCatalogConfigFile(dir)` before `copyCore()` in the `build` command
- Add import for `verifyRequiredFieldsAreInCatalogConfigFile` from `eventcatalog-config-file-utils`

## How It Works

The `verifyRequiredFieldsAreInCatalogConfigFile` utility checks that required fields (e.g., `cId`) exist in the catalog config file, writing them if missing. Previously this could happen after the Vite server started, causing the server to detect a config change and restart mid-initialization. By running verification before `copyCore()`, the config is stable when Astro/Vite starts, avoiding the restart race.

## Breaking Changes

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)