### PR TITLE
fix(ci): add build step to release workflow before publish

### DIFF
--- a/.changeset/bright-waves-crash.md
+++ b/.changeset/bright-waves-crash.md
@@ -1,0 +1,6 @@
+---
+"@eventcatalog/sdk": patch
+"@eventcatalog/linter": patch
+---
+
+fix: add build step to release workflow to ensure dist/ is included in published packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Install deps
         run: pnpm i
 
+      - name: Build all packages
+        run: pnpm run build:bin
+
       - name: Create Release Pull Request or Publish to npm
         uses: changesets/action@v1
         with:


### PR DESCRIPTION
Fixes #2111

## What This PR Does

Adds a build step (`pnpm run build:bin`) to the release GitHub Actions workflow before `changeset publish` runs. Without this, packages were published without their `dist/` directory, causing `@eventcatalog/linter` v1.0.1/v1.0.2 and `@eventcatalog/sdk` versions after 2.10.0 to ship empty — breaking `npx @eventcatalog/linter` and SDK imports.

## Changes Overview

### Key Changes
- Added `pnpm run build:bin` step to `.github/workflows/release.yml` between install and publish
- Created changeset to trigger patch releases for `@eventcatalog/sdk` and `@eventcatalog/linter`

## How It Works

The release workflow uses `changesets/action` which runs `pnpm run release` (i.e., `changeset publish`). Since `dist/` is in `.gitignore` (correctly), it must be built in CI before publishing. The `verify-build.yml` workflow already does this, but the release workflow was missing the build step.

## Breaking Changes

None

## Additional Notes

After merging, the changeset will trigger new patch versions of `@eventcatalog/sdk` and `@eventcatalog/linter` — this time with `dist/` included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)