### PR TITLE
chore: link core, sdk, and visualiser in changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,7 +3,7 @@
   "changelog": "@changesets/cli/changelog",
   "commit": false,
   "fixed": [],
-  "linked": [],
+  "linked": [["@eventcatalog/core", "@eventcatalog/sdk", "@eventcatalog/visualiser"]],
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",


### PR DESCRIPTION
## Summary

- Link `@eventcatalog/core`, `@eventcatalog/sdk`, and `@eventcatalog/visualiser` in changeset config so they stay version-synced
- Standalone packages (linter, CLI, create-eventcatalog) remain independently versioned

🤖 Generated with [Claude Code](https://claude.com/claude-code)