### PR TITLE
Exit beta pre-release mode

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "beta",
   "initialVersions": {
     "@eventcatalog/core": "3.12.7",


### PR DESCRIPTION
## Summary
- Exits beta pre-release mode for changesets by running `changeset pre exit`
- Changes `.changeset/pre.json` mode from `"pre"` to `"exit"`

## Impact
After this PR is merged, running `pnpm changeset version` will publish stable versions instead of beta versions.

## Next Steps
After merging this PR:
1. Run `pnpm changeset version` to bump versions to stable releases
2. Merge the resulting version PR to publish stable versions to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)