### PR TITLE
fix(core): pass auth headers when resolving AsyncAPI remote refs

### DIFF
--- a/.changeset/fix-asyncapi-remote-header-resolution.md
+++ b/.changeset/fix-asyncapi-remote-header-resolution.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix(core): pass auth headers when resolving AsyncAPI remote refs and harden env/header handling

--- a/packages/core/eventcatalog/src/content.config.ts
+++ b/packages/core/eventcatalog/src/content.config.ts
@@ -147,6 +147,7 @@ const baseSchema = z.object({
           type: z.enum(['openapi', 'asyncapi', 'graphql']),
           path: z.string(),
           name: z.string().optional(),
+          headers: z.record(z.string()).optional(),
         })
       ),
     ])

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/asyncapi/[filename].astro
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/asyncapi/[filename].astro
@@ -5,6 +5,8 @@ import { Parser } from '@asyncapi/parser';
 import { AvroSchemaParser } from '@asyncapi/avro-schema-parser';
 import fs from 'fs';
 
+import { isSameOrigin, resolveHeaders } from '@utils/remote-spec';
+
 import '@asyncapi/react-component/styles/default.min.css';
 import js from '@asyncapi/react-component/browser/standalone/without-parser.js?url';
 import { AsyncApiComponentWP, type ConfigInterface } from '@asyncapi/react-component';
@@ -19,7 +21,7 @@ export const prerender = Page.prerender;
 export const getStaticPaths = Page.getStaticPaths;
 
 // Get data
-const { collection, data, filePath, filename, path: relativeSpecPath } = await Page.getData(Astro);
+const { collection, data, filePath, filename, path: relativeSpecPath, headers = {} } = await Page.getData(Astro);
 
 const fileName = filename || 'asyncapi.yaml';
 const pathToSpec = getAbsoluteFilePathForAstroFile(filePath, fileName);
@@ -27,18 +29,62 @@ const fileExists = fs.existsSync(pathToSpec);
 const isRemote = relativeSpecPath.includes('https://');
 let content = '';
 
+const allowAnyEnvInSpecHeaders = Config?.asyncAPI?.allowAnyEnvInSpecHeaders ?? false;
+const resolvedHeaders = resolveHeaders(headers, { allowAnyEnvInHeaders: allowAnyEnvInSpecHeaders });
+
 if (fileExists && !isRemote) {
   content = fs.readFileSync(pathToSpec, 'utf8');
 }
 
 if (isRemote) {
-  // Fetch the content from the remote path
-  content = await fetch(relativeSpecPath).then((res) => res.text());
+  const response = await fetch(relativeSpecPath, { headers: resolvedHeaders });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch AsyncAPI spec: ${response.status} ${response.statusText}`);
+  }
+
+  content = await response.text();
 }
 
-// AsyncAPI parser will parser schemas for users, they can turn this off.
+// AsyncAPI parser will parse schemas for users, they can turn this off.
 const parseSchemas = Config?.asyncAPI?.renderParsedSchemas ?? true;
-const parsed = await new Parser({ schemaParsers: [AvroSchemaParser()] }).parse(content, { parseSchemas });
+const parserOptions: NonNullable<Parameters<Parser['parse']>[1]> = {
+  parseSchemas,
+  source: isRemote ? relativeSpecPath : pathToSpec,
+};
+
+if (isRemote && Object.keys(resolvedHeaders).length > 0) {
+  // NOTE: AsyncAPI parser exposes resolver wiring via __unstable.
+  // Keep this isolated so parser upgrades can adjust in one place.
+  const resolverWithHeaders = {
+    canRead: true,
+    read: async (uri: { toString: () => string }) => {
+      const targetUrl = uri.toString();
+      const shouldForwardHeaders = isSameOrigin(relativeSpecPath, targetUrl);
+
+      const response = await fetch(targetUrl, {
+        headers: shouldForwardHeaders ? resolvedHeaders : undefined,
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to fetch reference: ${response.status} ${response.statusText}`);
+      }
+
+      return response.text();
+    },
+  };
+
+  parserOptions.__unstable = {
+    resolver: {
+      resolvers: [
+        { schema: 'https', ...resolverWithHeaders },
+        { schema: 'http', ...resolverWithHeaders },
+      ],
+    },
+  };
+}
+
+const parsed = await new Parser({ schemaParsers: [AvroSchemaParser()] }).parse(content, parserOptions);
 const stringified = parsed.document?.json();
 const config: ConfigInterface = { show: { sidebar: true, errors: true } };
 

--- a/packages/core/eventcatalog/src/utils/__tests__/collections/util.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/collections/util.spec.ts
@@ -1,5 +1,11 @@
 import type { CollectionTypes } from '@types';
-import { getDeprecatedDetails, isSameVersion, satisfies, sortStringVersions } from '@utils/collections/util';
+import {
+  getDeprecatedDetails,
+  isSameVersion,
+  processSpecifications,
+  satisfies,
+  sortStringVersions,
+} from '@utils/collections/util';
 import type { CollectionEntry } from 'astro:content';
 import { describe, it, expect } from 'vitest';
 
@@ -75,6 +81,33 @@ describe('Collections - utils', () => {
         message: 'This is a test message',
         deprecatedDate: 'January 1, 2021',
       });
+    });
+  });
+
+  describe('processSpecifications', () => {
+    it('preserves headers in array specification format', () => {
+      const result = processSpecifications([
+        {
+          type: 'asyncapi',
+          path: 'https://example.com/asyncapi.yaml',
+          headers: {
+            Authorization: 'Bearer ${TOKEN}',
+          },
+        },
+      ]);
+
+      expect(result).toEqual([
+        {
+          type: 'asyncapi',
+          path: 'https://example.com/asyncapi.yaml',
+          name: 'AsyncAPI',
+          filename: 'asyncapi.yaml',
+          filenameWithoutExtension: 'asyncapi',
+          headers: {
+            Authorization: 'Bearer ${TOKEN}',
+          },
+        },
+      ]);
     });
   });
 });

--- a/packages/core/eventcatalog/src/utils/__tests__/remote-spec.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/remote-spec.spec.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { isSameOrigin, resolveHeaderTemplates, resolveHeaders } from '@utils/remote-spec';
+
+describe('remote-spec utils', () => {
+  it('resolves allowed prefixed env vars by default', () => {
+    process.env.EVENTCATALOG_TOKEN = 'abc123';
+
+    expect(resolveHeaderTemplates('Bearer ${EVENTCATALOG_TOKEN}')).toBe('Bearer abc123');
+  });
+
+  it('does not resolve non-prefixed env vars by default', () => {
+    process.env.DATABASE_URL = 'secret';
+
+    expect(resolveHeaderTemplates('Leak ${DATABASE_URL}')).toBe('Leak ');
+  });
+
+  it('resolves any env var when allowAnyEnvInHeaders is enabled', () => {
+    process.env.DATABASE_URL = 'secret';
+
+    expect(resolveHeaderTemplates('Leak ${DATABASE_URL}', { allowAnyEnvInHeaders: true })).toBe('Leak secret');
+  });
+
+  it('resolves all headers in an object', () => {
+    process.env.EC_PAT = 'token';
+
+    expect(resolveHeaders({ Authorization: 'Basic ${EC_PAT}', 'X-Test': 'static' })).toEqual({
+      Authorization: 'Basic token',
+      'X-Test': 'static',
+    });
+  });
+
+  it('checks same-origin accurately', () => {
+    expect(isSameOrigin('https://api.example.com/spec.yaml', 'https://api.example.com/refs/common.yaml')).toBe(true);
+    expect(isSameOrigin('https://api.example.com/spec.yaml', 'https://attacker.example/ref.yaml')).toBe(false);
+  });
+});

--- a/packages/core/eventcatalog/src/utils/collections/util.ts
+++ b/packages/core/eventcatalog/src/utils/collections/util.ts
@@ -21,6 +21,7 @@ export interface SpecificationInput {
   type: SpecificationType;
   path: string;
   name?: string;
+  headers?: Record<string, string>;
 }
 
 export interface ProcessedSpecification {
@@ -29,6 +30,7 @@ export interface ProcessedSpecification {
   name: string;
   filename: string;
   filenameWithoutExtension: string;
+  headers?: Record<string, string>;
 }
 
 export const getDefaultSpecificationName = (type: string): string => {

--- a/packages/core/eventcatalog/src/utils/eventcatalog-config/catalog.ts
+++ b/packages/core/eventcatalog/src/utils/eventcatalog-config/catalog.ts
@@ -16,6 +16,10 @@ export type CatalogConfig = {
       users?: SideBarItemConfig;
     };
   };
+  asyncAPI?: {
+    renderParsedSchemas?: boolean;
+    allowAnyEnvInSpecHeaders?: boolean;
+  };
 };
 
 const getConfigValue = (obj: any, key: string, defaultValue: any) => {
@@ -44,4 +48,4 @@ export const isCollectionVisibleInCatalog = (collection: string) => {
   return getConfigValue(collectionConfig, 'visible', true);
 };
 
-export default config.default;
+export default config.default as CatalogConfig;

--- a/packages/core/eventcatalog/src/utils/remote-spec.ts
+++ b/packages/core/eventcatalog/src/utils/remote-spec.ts
@@ -1,0 +1,45 @@
+export const SAFE_ENV_PREFIXES = ['EVENTCATALOG_', 'EC_'];
+
+const isAllowedEnvVariable = (varName: string, allowAnyEnvInHeaders: boolean): boolean => {
+  if (allowAnyEnvInHeaders) return true;
+  return SAFE_ENV_PREFIXES.some((prefix) => varName.startsWith(prefix));
+};
+
+export const resolveHeaderTemplates = (
+  value: string,
+  {
+    allowAnyEnvInHeaders = false,
+  }: {
+    allowAnyEnvInHeaders?: boolean;
+  } = {}
+): string => {
+  return value.replace(/\$\{(\w+)\}/g, (_, varName) => {
+    if (!isAllowedEnvVariable(varName, allowAnyEnvInHeaders)) {
+      return '';
+    }
+
+    // import.meta.env works in Vite contexts, process.env is the runtime fallback for SSR.
+    return import.meta.env[varName] || process.env[varName] || '';
+  });
+};
+
+export const resolveHeaders = (
+  headers: Record<string, string>,
+  {
+    allowAnyEnvInHeaders = false,
+  }: {
+    allowAnyEnvInHeaders?: boolean;
+  } = {}
+): Record<string, string> => {
+  return Object.fromEntries(
+    Object.entries(headers).map(([key, value]) => [key, resolveHeaderTemplates(String(value), { allowAnyEnvInHeaders })])
+  );
+};
+
+export const isSameOrigin = (sourceUrl: string, targetUrl: string): boolean => {
+  try {
+    return new URL(sourceUrl).origin === new URL(targetUrl).origin;
+  } catch {
+    return false;
+  }
+};


### PR DESCRIPTION
## Summary
- add optional `headers` support to specification entries in content schema
- preserve specification headers in processed specification metadata
- pass resolved headers when fetching remote AsyncAPI specs
- configure AsyncAPI parser resolver to reuse the same headers for HTTP/HTTPS `$ref` fetches
- set parser `source` so remote relative refs resolve correctly

## Why
Fixes #2130 where private AsyncAPI specs can be fetched but nested remote `$ref` resources fail auth because request headers were not reused.

## Verification
- `corepack pnpm exec vitest run eventcatalog/src/utils/__tests__/collections/util.spec.ts eventcatalog/src/utils/__tests__/services/services.spec.ts`

## Notes
- `astro check` could not be run in this local clone because `packages/core/eventcatalog/astro.config.mjs` expects a local `eventcatalog.config` file that is not present in this environment.
