### PR TITLE
fix(core): resolve RemoteSchema env placeholders in SSR

### DIFF
--- a/.changeset/fix-remote-schema-env-fallback.md
+++ b/.changeset/fix-remote-schema-env-fallback.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix(core): resolve RemoteSchema header template variables from process.env in SSR

--- a/packages/core/eventcatalog/src/components/MDX/RemoteFile.astro
+++ b/packages/core/eventcatalog/src/components/MDX/RemoteFile.astro
@@ -3,6 +3,7 @@ import jsonpath from 'jsonpath';
 import JSONSchemaViewer from '@components/SchemaExplorer/JSONSchemaViewer';
 import { Code } from 'astro-expressive-code/components';
 import { isPrivateRemoteSchemaEnabled } from '@utils/feature';
+import { resolveTemplateVariables } from '@utils/remote-file';
 
 const {
   url,
@@ -13,18 +14,6 @@ const {
   maxHeight = '400',
   ...props
 } = Astro.props;
-
-function resolveTemplates(input: any): any {
-  if (typeof input === 'string') {
-    return input.replace(/\$\{(\w+)\}/g, (_, varName) => import.meta.env[varName] || '');
-  }
-
-  if (typeof input === 'object' && input !== null) {
-    return Object.fromEntries(Object.entries(input).map(([k, v]) => [k, resolveTemplates(v)]));
-  }
-
-  return input;
-}
 
 function isValidJSON(str: string): boolean {
   try {
@@ -69,8 +58,8 @@ function extractWithJSONPath(data: any, path: string): any {
   }
 }
 
-const resolvedUrl = resolveTemplates(url);
-const resolvedHeaders = isPrivateRemoteSchemaEnabled() ? resolveTemplates(headers) : {};
+const resolvedUrl = resolveTemplateVariables(url);
+const resolvedHeaders = isPrivateRemoteSchemaEnabled() ? resolveTemplateVariables(headers) : {};
 
 let content = '';
 let processedData: any = null;
@@ -86,8 +75,8 @@ if (Object.keys(headers).length > 0 && !isPrivateRemoteSchemaEnabled()) {
 }
 
 try {
-  const response = await fetch(resolvedUrl, {
-    headers: resolvedHeaders,
+  const response = await fetch(String(resolvedUrl), {
+    headers: resolvedHeaders as HeadersInit,
   });
 
   if (!response.ok) {

--- a/packages/core/eventcatalog/src/utils/__tests__/remote-file.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/remote-file.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { resolveTemplateVariables } from '@utils/remote-file';
+
+describe('resolveTemplateVariables', () => {
+  it('resolves placeholders from process.env fallback', () => {
+    process.env.AZURE_DEVOPS_PAT_BASE64 = 'abc123';
+
+    expect(resolveTemplateVariables('Basic ${AZURE_DEVOPS_PAT_BASE64}')).toBe('Basic abc123');
+  });
+
+  it('resolves nested object values', () => {
+    process.env.API_KEY = 'secret';
+
+    expect(resolveTemplateVariables({ headers: { Authorization: 'Bearer ${API_KEY}' } })).toEqual({
+      headers: { Authorization: 'Bearer secret' },
+    });
+  });
+
+  it('returns empty string when variable is missing', () => {
+    delete process.env.MISSING_VAR;
+
+    expect(resolveTemplateVariables('x-${MISSING_VAR}-y')).toBe('x--y');
+  });
+});

--- a/packages/core/eventcatalog/src/utils/remote-file.ts
+++ b/packages/core/eventcatalog/src/utils/remote-file.ts
@@ -1,0 +1,15 @@
+export function resolveTemplateVariables(input: unknown): unknown {
+  if (typeof input === 'string') {
+    return input.replace(/\$\{(\w+)\}/g, (_, varName) => {
+      // Vite may statically replace import.meta.env in SSR builds;
+      // process.env keeps runtime env access for dynamic keys.
+      return import.meta.env[varName] || process.env[varName] || '';
+    });
+  }
+
+  if (typeof input === 'object' && input !== null) {
+    return Object.fromEntries(Object.entries(input).map(([key, value]) => [key, resolveTemplateVariables(value)]));
+  }
+
+  return input;
+}


### PR DESCRIPTION
## Summary
- extract RemoteSchema template resolution into `@utils/remote-file`
- add `process.env` fallback for `${ENV_VAR}` placeholders to work in SSR production builds
- keep `import.meta.env` first, with runtime fallback for dynamic keys
- add focused unit tests for string/object placeholder resolution and missing vars
- add changeset for `@eventcatalog/core` patch

## Why
Fixes #2129 where `<RemoteSchema headers={...}>` placeholders resolved to empty strings in SSR production builds because dynamic `import.meta.env[varName]` access does not reliably include custom env vars at runtime.

## Verification
- `corepack pnpm exec vitest run eventcatalog/src/utils/__tests__/remote-file.spec.ts`
- `corepack pnpm --filter @eventcatalog/core format`
