### PR TITLE
fix(sdk): resolve low-hanging resource lookup + link update bugs

### DIFF
--- a/packages/sdk/src/services.ts
+++ b/packages/sdk/src/services.ts
@@ -423,11 +423,13 @@ export const addMessageToService =
     }
 
     // Get where the service was located, make sure it goes back there.
-    const path = existingResource.split(/[\\/]+services/)[0];
+    const path = existingResource.split(/[\\/]+services[\\/]+/)[0];
     const pathToResource = join(path, 'services');
 
-    await rmServiceById(directory)(id, version);
-    await writeService(pathToResource)(service, { format: extension === '.md' ? 'md' : 'mdx' });
+    await writeService(pathToResource)(service, {
+      override: true,
+      format: extension === '.md' ? 'md' : 'mdx',
+    });
   };
 
 /**
@@ -539,11 +541,13 @@ export const addEntityToService =
     }
 
     // Get where the service was located, make sure it goes back there.
-    const path = existingResource.split(/[\\/]+services/)[0];
+    const path = existingResource.split(/[\\/]+services[\\/]+/)[0];
     const pathToResource = join(path, 'services');
 
-    await rmServiceById(directory)(id, version);
-    await writeService(pathToResource)(service, { format: extension === '.md' ? 'md' : 'mdx' });
+    await writeService(pathToResource)(service, {
+      override: true,
+      format: extension === '.md' ? 'md' : 'mdx',
+    });
   };
 
 /**
@@ -610,9 +614,11 @@ export const addDataStoreToService =
     }
 
     // Get where the service was located, make sure it goes back there.
-    const path = existingResource.split(/[\\/]+services/)[0];
+    const path = existingResource.split(/[\\/]+services[\\/]+/)[0];
     const pathToResource = join(path, 'services');
 
-    await rmServiceById(directory)(id, version);
-    await writeService(pathToResource)(service, { format: extension === '.md' ? 'md' : 'mdx' });
+    await writeService(pathToResource)(service, {
+      override: true,
+      format: extension === '.md' ? 'md' : 'mdx',
+    });
   };


### PR DESCRIPTION
## Summary\nThis PR tackles a low-hanging-fruit sweep in the SDK and fixes three related bugs that are safe to ship quickly:\n\n- Fix resource lookups to respect the expected type (prevents cross-type collisions)\n- Preserve nested service folders when adding messages to services\n- Remove destructive remove+rewrite flow when adding messages to channels (and keep path handling robust)\n\n## Issues\n- Closes #2102\n- Closes #2104\n- Closes #2106\n\n## What changed\n\n### 1) Type-aware resource lookup\n now filters candidate files by expected resource type folder(s) when  is provided.\nThis prevents calls like  from accidentally returning another resource type with the same id.\n\n### 2) Preserve service subfolders on message updates\n (and the shared command/query codepaths in the same file) no longer removes and recreates the service resource before write.\nIt now writes with , preserving nested folders and files under the service directory.\n\n### 3) Remove race-prone message remove+rewrite in channels\n no longer deletes message files before writing them back.\nIt now uses an in-place overwrite () and robust collection path splitting via regex.\n\n## Tests\nAdded targeted regression tests:\n- \n  - returns service when channel with same id exists\n  - preserves service subfolders when adding message to service\n- \n  - can add a channel to an older event version when a newer version exists\n\n## Validation\n- packages/core                            |  WARN  The field "pnpm.overrides" was found in /Users/thor/.openclaw/workspace/eventcatalog/packages/core/package.json. This will not take effect. You should configure "pnpm.overrides" at the root of the workspace instead.

> @eventcatalog/sdk@2.13.2 test /Users/thor/.openclaw/workspace/eventcatalog/packages/sdk
> vitest --run


 RUN  v3.2.4 /Users/thor/.openclaw/workspace/eventcatalog/packages/sdk

 ✓ src/test/data-products.test.ts (26 tests) 262ms
 ✓ src/test/commands.test.ts (49 tests) 562ms
 ✓ src/test/queries.test.ts (55 tests) 680ms
 ✓ src/test/events.test.ts (64 tests) 766ms
 ✓ src/test/domains.test.ts (71 tests) 802ms
 ✓ src/test/services.test.ts (88 tests) 1002ms
 ✓ src/test/messages.test.ts (15 tests) 315ms
 ✓ src/test/channels.test.ts (35 tests) 615ms
 ✓ src/test/data-store.test.ts (21 tests) 284ms
 ✓ src/test/entities.test.ts (14 tests) 177ms
 ✓ src/test/diagrams.test.ts (16 tests) 222ms
 ✓ src/test/teams.test.ts (9 tests) 64ms
 ✓ src/test/users.test.ts (7 tests) 23ms
 ✓ src/test/custom-docs.test.ts (9 tests) 24ms
 ✓ src/test/resources.test.ts (1 test) 14ms
 ✓ src/test/eventcatalog.test.ts (11 tests) 3222ms
   ✓ EventCatalog > dumpCatalog > the dump file should contain the catalog version, dump version and the createdAt date  571ms
   ✓ EventCatalog > dumpCatalog > should not include markdown if the includeMarkdown option is false  540ms
   ✓ EventCatalog > dumpCatalog > domains > returns a list of domains from the catalog  482ms

 Test Files  16 passed (16)
      Tests  491 passed (491)
   Start at  00:45:32
   Duration  3.83s (transform 523ms, setup 205ms, collect 2.88s, tests 9.03s, environment 2ms, prepare 1.13s)\n- packages/core                            |  WARN  The field "pnpm.overrides" was found in /Users/thor/.openclaw/workspace/eventcatalog/packages/core/package.json. This will not take effect. You should configure "pnpm.overrides" at the root of the workspace instead.

> @eventcatalog/core@3.13.0 format /Users/thor/.openclaw/workspace/eventcatalog/packages/core
> prettier --config .prettierrc --write "**/*.{js,jsx,ts,tsx,json,astro}"

.size-baseline.json 9ms (unchanged)
bin/eventcatalog.js 3ms (unchanged)
eventcatalog/auth.config.ts 43ms (unchanged)
eventcatalog/global.d.ts 1ms (unchanged)
eventcatalog/integrations/eventcatalog-features.ts 7ms (unchanged)
eventcatalog/src/__tests__/api/message-schemas-api.spec.ts 15ms (unchanged)
eventcatalog/src/__tests__/api/schemas.txt.spec.ts 6ms (unchanged)
eventcatalog/src/__tests__/api/schemas/test-schema.json 1ms (unchanged)
eventcatalog/src/__tests__/api/services-schemas-api.spec.ts 10ms (unchanged)
eventcatalog/src/__tests__/middleware-auth.spec.ts 6ms (unchanged)
eventcatalog/src/__tests__/node-graphs/export-mermaid.spec.ts 14ms (unchanged)
eventcatalog/src/components/ChatPanel/ChatPanel.tsx 73ms (unchanged)
eventcatalog/src/components/ChatPanel/ChatPanelButton.tsx 3ms (unchanged)
eventcatalog/src/components/Checkbox.astro 68ms (unchanged)
eventcatalog/src/components/CopyAsMarkdown.tsx 13ms (unchanged)
eventcatalog/src/components/EnvironmentDropdown.tsx 6ms (unchanged)
eventcatalog/src/components/FavoriteButton.tsx 2ms (unchanged)
eventcatalog/src/components/Grids/components.tsx 9ms (unchanged)
eventcatalog/src/components/Grids/DomainGrid.tsx 37ms (unchanged)
eventcatalog/src/components/Grids/MessageGrid.tsx 17ms (unchanged)
eventcatalog/src/components/Grids/specification-utils.ts 6ms (unchanged)
eventcatalog/src/components/Grids/utils.tsx 4ms (unchanged)
eventcatalog/src/components/Header.astro 64ms (unchanged)
eventcatalog/src/components/Lists/OwnersList.tsx 2ms (unchanged)
eventcatalog/src/components/Lists/PillList.tsx 2ms (unchanged)
eventcatalog/src/components/Lists/PillListFlat.tsx 6ms (unchanged)
eventcatalog/src/components/Lists/VersionList.astro 12ms (unchanged)
eventcatalog/src/components/MDX/Accordion/Accordion.astro 3ms (unchanged)
eventcatalog/src/components/MDX/Accordion/Accordion.tsx 3ms (unchanged)
eventcatalog/src/components/MDX/Accordion/AccordionGroup.astro 2ms (unchanged)
eventcatalog/src/components/MDX/Admonition.tsx 3ms (unchanged)
eventcatalog/src/components/MDX/AsyncAPI/AsyncAPI.astro 3ms (unchanged)
eventcatalog/src/components/MDX/Attachments.astro 28ms (unchanged)
eventcatalog/src/components/MDX/ChannelInformation/ChannelInformation.tsx 5ms (unchanged)
eventcatalog/src/components/MDX/components.tsx 4ms (unchanged)
eventcatalog/src/components/MDX/Design/Design.astro 16ms (unchanged)
eventcatalog/src/components/MDX/DrawIO/DrawIO.astro 6ms (unchanged)
eventcatalog/src/components/MDX/EntityMap/EntityMap.astro 10ms (unchanged)
eventcatalog/src/components/MDX/EntityPropertiesTable/EntityPropertiesTable.astro 22ms (unchanged)
eventcatalog/src/components/MDX/FigJam/FigJam.astro 6ms (unchanged)
eventcatalog/src/components/MDX/File.tsx 2ms (unchanged)
eventcatalog/src/components/MDX/Flow/Flow.astro 10ms (unchanged)
eventcatalog/src/components/MDX/IcePanel/IcePanel.astro 11ms (unchanged)
eventcatalog/src/components/MDX/Link/Link.astro 1ms (unchanged)
eventcatalog/src/components/MDX/Lucid/Lucid.astro 5ms (unchanged)
eventcatalog/src/components/MDX/MermaidFileLoader/MermaidFileLoader.astro 7ms (unchanged)
eventcatalog/src/components/MDX/MessageTable/MessageTable.astro 7ms (unchanged)
eventcatalog/src/components/MDX/MessageTable/MessageTable.client.tsx 14ms (unchanged)
eventcatalog/src/components/MDX/Miro/Miro.astro 8ms (unchanged)
eventcatalog/src/components/MDX/NodeGraph/AstroNodeGraph.tsx 4ms (unchanged)
eventcatalog/src/components/MDX/NodeGraph/NodeGraph.astro 14ms (unchanged)
eventcatalog/src/components/MDX/NodeGraph/NodeGraphPortal.tsx 1ms (unchanged)
eventcatalog/src/components/MDX/OpenAPI/OpenAPI.astro 2ms (unchanged)
eventcatalog/src/components/MDX/page-components.tsx 1ms (unchanged)
eventcatalog/src/components/MDX/RemoteFile.astro 13ms (unchanged)
eventcatalog/src/components/MDX/RemoteSchema.astro 4ms (unchanged)
eventcatalog/src/components/MDX/ResourceGroupTable/ResourceGroupTable.astro 8ms (unchanged)
eventcatalog/src/components/MDX/ResourceGroupTable/ResourceGroupTable.client.tsx 14ms (unchanged)
eventcatalog/src/components/MDX/ResourceLink/ResourceLink.astro 4ms (unchanged)
eventcatalog/src/components/MDX/ResourceRef/ResourceRef.astro 60ms (unchanged)
eventcatalog/src/components/MDX/Schema.astro 4ms (unchanged)
eventcatalog/src/components/MDX/SchemaViewer/SchemaViewerPortal.tsx 1ms (unchanged)
eventcatalog/src/components/MDX/SchemaViewer/SchemaViewerRoot.astro 15ms (unchanged)
eventcatalog/src/components/MDX/Steps/Step.astro 4ms (unchanged)
eventcatalog/src/components/MDX/Steps/Steps.astro 4ms (unchanged)
eventcatalog/src/components/MDX/Tabs/TabItem.astro 1ms (unchanged)
eventcatalog/src/components/MDX/Tabs/Tabs.astro 10ms (unchanged)
eventcatalog/src/components/MDX/Tiles/Tile.astro 6ms (unchanged)
eventcatalog/src/components/MDX/Tiles/Tiles.astro 2ms (unchanged)
eventcatalog/src/components/SchemaExplorer/ApiAccessSection.tsx 4ms (unchanged)
eventcatalog/src/components/SchemaExplorer/ApiContentViewer.tsx 4ms (unchanged)
eventcatalog/src/components/SchemaExplorer/AvroSchemaViewer.tsx 13ms (unchanged)
eventcatalog/src/components/SchemaExplorer/DiffViewer.tsx 3ms (unchanged)
eventcatalog/src/components/SchemaExplorer/JSONSchemaViewer.tsx 29ms (unchanged)
eventcatalog/src/components/SchemaExplorer/OwnersSection.tsx 2ms (unchanged)
eventcatalog/src/components/SchemaExplorer/Pagination.tsx 3ms (unchanged)
eventcatalog/src/components/SchemaExplorer/ProducersConsumersSection.tsx 5ms (unchanged)
eventcatalog/src/components/SchemaExplorer/SchemaCodeModal.tsx 3ms (unchanged)
eventcatalog/src/components/SchemaExplorer/SchemaContentViewer.tsx 4ms (unchanged)
eventcatalog/src/components/SchemaExplorer/SchemaDetailsHeader.tsx 5ms (unchanged)
eventcatalog/src/components/SchemaExplorer/SchemaDetailsPanel.tsx 7ms (unchanged)
eventcatalog/src/components/SchemaExplorer/SchemaExplorer.tsx 21ms (unchanged)
eventcatalog/src/components/SchemaExplorer/SchemaFilters.tsx 3ms (unchanged)
eventcatalog/src/components/SchemaExplorer/SchemaListItem.tsx 2ms (unchanged)
eventcatalog/src/components/SchemaExplorer/SchemaPageViewer.tsx 1ms (unchanged)
eventcatalog/src/components/SchemaExplorer/SchemaViewerModal.tsx 2ms (unchanged)
eventcatalog/src/components/SchemaExplorer/types.ts 1ms (unchanged)
eventcatalog/src/components/SchemaExplorer/utils.ts 2ms (unchanged)
eventcatalog/src/components/SchemaExplorer/VersionHistoryModal.tsx 2ms (unchanged)
eventcatalog/src/components/Search/Search.astro 6ms (unchanged)
eventcatalog/src/components/Search/SearchDataLoader.astro 2ms (unchanged)
eventcatalog/src/components/Search/SearchModal.tsx 11ms (unchanged)
eventcatalog/src/components/Seo.astro 6ms (unchanged)
eventcatalog/src/components/SideNav/CustomDocsNav.astro 2ms (unchanged)
eventcatalog/src/components/SideNav/NestedSideBar/index.tsx 32ms (unchanged)
eventcatalog/src/components/SideNav/NestedSideBar/SearchBar.tsx 14ms (unchanged)
eventcatalog/src/components/SideNav/NestedSideBar/storage.ts 6ms (unchanged)
eventcatalog/src/components/SideNav/NestedSideBar/utils.ts 2ms (unchanged)
eventcatalog/src/components/SideNav/SideNav.astro 2ms (unchanged)
eventcatalog/src/components/Studio/StudioPageModal.tsx 5ms (unchanged)
eventcatalog/src/components/Tables/columns/ContainersTableColumns.tsx 9ms (unchanged)
eventcatalog/src/components/Tables/columns/DomainTableColumns.tsx 5ms (unchanged)
eventcatalog/src/components/Tables/columns/FlowTableColumns.tsx 3ms (unchanged)
eventcatalog/src/components/Tables/columns/index.tsx 1ms (unchanged)
eventcatalog/src/components/Tables/columns/MessageTableColumns.tsx 6ms (unchanged)
eventcatalog/src/components/Tables/columns/ServiceTableColumns.tsx 6ms (unchanged)
eventcatalog/src/components/Tables/columns/SharedColumns.tsx 2ms (unchanged)
eventcatalog/src/components/Tables/columns/TeamsTableColumns.tsx 5ms (unchanged)
eventcatalog/src/components/Tables/columns/UserTableColumns.tsx 7ms (unchanged)
eventcatalog/src/components/Tables/DebouncedInput.tsx 1ms (unchanged)
eventcatalog/src/components/Tables/Discover/columns.tsx 23ms (unchanged)
eventcatalog/src/components/Tables/Discover/DiscoverTable.tsx 26ms (unchanged)
eventcatalog/src/components/Tables/Discover/FilterComponents.tsx 4ms (unchanged)
eventcatalog/src/components/Tables/Discover/index.ts 1ms (unchanged)
eventcatalog/src/components/Tables/filters/custom-filters.ts 2ms (unchanged)
eventcatalog/src/components/Tables/Table.tsx 15ms (unchanged)
eventcatalog/src/components/ThemeToggle.tsx 1ms (unchanged)
eventcatalog/src/content.config-shared-collections.ts 1ms (unchanged)
eventcatalog/src/content.config.ts 31ms (unchanged)
eventcatalog/src/enterprise/ai/chat-api.ts 9ms (unchanged)
eventcatalog/src/enterprise/auth/[...auth].ts 1ms (unchanged)
eventcatalog/src/enterprise/auth/error.astro 7ms (unchanged)
eventcatalog/src/enterprise/auth/login.astro 45ms (unchanged)
eventcatalog/src/enterprise/auth/middleware/middleware-auth.ts 8ms (unchanged)
eventcatalog/src/enterprise/auth/middleware/middleware.ts 2ms (unchanged)
eventcatalog/src/enterprise/auth/unauthorized.astro 8ms (unchanged)
eventcatalog/src/enterprise/collections/custom-pages.ts 1ms (unchanged)
eventcatalog/src/enterprise/collections/index.ts 0ms (unchanged)
eventcatalog/src/enterprise/custom-documentation/__tests__/custom-docs/adjacent-pages.spec.ts 3ms (unchanged)
eventcatalog/src/enterprise/custom-documentation/__tests__/custom-docs/custom-docs.spec.ts 9ms (unchanged)
eventcatalog/src/enterprise/custom-documentation/__tests__/custom-docs/mocks.ts 1ms (unchanged)
eventcatalog/src/enterprise/custom-documentation/collection.ts 1ms (unchanged)
eventcatalog/src/enterprise/custom-documentation/components/CustomDocsNav/components/NestedItem.tsx 5ms (unchanged)
eventcatalog/src/enterprise/custom-documentation/components/CustomDocsNav/components/NoResultsFound.tsx 1ms (unchanged)
eventcatalog/src/enterprise/custom-documentation/components/CustomDocsNav/CustomDocsNav.astro 2ms (unchanged)
eventcatalog/src/enterprise/custom-documentation/components/CustomDocsNav/CustomDocsNavWrapper.tsx 1ms (unchanged)
eventcatalog/src/enterprise/custom-documentation/components/CustomDocsNav/index.tsx 10ms (unchanged)
eventcatalog/src/enterprise/custom-documentation/components/CustomDocsNav/types.ts 1ms (unchanged)
eventcatalog/src/enterprise/custom-documentation/pages/docs/custom/index.astro 36ms (unchanged)
eventcatalog/src/enterprise/custom-documentation/utils/custom-docs.ts 6ms (unchanged)
eventcatalog/src/enterprise/mcp/__tests__/mcp-server.spec.ts 8ms (unchanged)
eventcatalog/src/enterprise/mcp/mcp-server.ts 12ms (unchanged)
eventcatalog/src/enterprise/plans/index.astro 33ms (unchanged)
eventcatalog/src/enterprise/tools/__tests__/catalog-tools.mocks.ts 8ms (unchanged)
eventcatalog/src/enterprise/tools/__tests__/catalog-tools.spec.ts 31ms (unchanged)
eventcatalog/src/enterprise/tools/catalog-tools.ts 24ms (unchanged)
eventcatalog/src/enterprise/tools/index.ts 0ms (unchanged)
eventcatalog/src/enterprise/visualizer-layout/reset.ts 2ms (unchanged)
eventcatalog/src/enterprise/visualizer-layout/save.ts 2ms (unchanged)
eventcatalog/src/env.d.ts 1ms (unchanged)
eventcatalog/src/hooks/eventcatalog-visualizer.ts 4ms (unchanged)
eventcatalog/src/icons/protocols/index.ts 1ms (unchanged)
eventcatalog/src/layouts/DirectoryLayout.astro 11ms (unchanged)
eventcatalog/src/layouts/DiscoverLayout.astro 16ms (unchanged)
eventcatalog/src/layouts/Footer.astro 6ms (unchanged)
eventcatalog/src/layouts/VerticalSideBarLayout.astro 35ms (unchanged)
eventcatalog/src/layouts/VisualiserLayout.astro 8ms (unchanged)
eventcatalog/src/pages/_index.astro 26ms (unchanged)
eventcatalog/src/pages/api/catalog.ts 1ms (unchanged)
eventcatalog/src/pages/api/schemas/[collection]/[id]/[version]/index.ts 3ms (unchanged)
eventcatalog/src/pages/api/schemas/services/[id]/[version]/[specification]/index.ts 2ms (unchanged)
eventcatalog/src/pages/api/sidebar-data.json.ts 1ms (unchanged)
eventcatalog/src/pages/architecture/[type]/[id]/[version]/_index.data.ts 3ms (unchanged)
eventcatalog/src/pages/architecture/[type]/[id]/[version]/index.astro 4ms (unchanged)
eventcatalog/src/pages/diagrams/[id]/[version].mdx.ts 2ms (unchanged)
eventcatalog/src/pages/diagrams/[id]/[version]/_index.data.ts 2ms (unchanged)
eventcatalog/src/pages/diagrams/[id]/[version]/embed.astro 26ms (unchanged)
eventcatalog/src/pages/diagrams/[id]/[version]/index.astro 30ms (unchanged)
eventcatalog/src/pages/directory/[type]/_index.data.ts 2ms (unchanged)
eventcatalog/src/pages/directory/[type]/index.astro 3ms (unchanged)
eventcatalog/src/pages/discover/[type]/_index.data.ts 2ms (unchanged)
eventcatalog/src/pages/discover/[type]/index.astro 22ms (unchanged)
eventcatalog/src/pages/docs/[type]/[id]/[version].md.ts 2ms (unchanged)
eventcatalog/src/pages/docs/[type]/[id]/[version].mdx.ts 3ms (unchanged)
eventcatalog/src/pages/docs/[type]/[id]/[version]/_index.data.ts 2ms (unchanged)
eventcatalog/src/pages/docs/[type]/[id]/[version]/asyncapi/_[filename].data.ts 3ms (unchanged)
eventcatalog/src/pages/docs/[type]/[id]/[version]/asyncapi/[filename].astro 11ms (unchanged)
eventcatalog/src/pages/docs/[type]/[id]/[version]/changelog/_index.data.ts 4ms (unchanged)
eventcatalog/src/pages/docs/[type]/[id]/[version]/changelog/index.astro 24ms (unchanged)
eventcatalog/src/pages/docs/[type]/[id]/[version]/graphql/_[filename].data.ts 4ms (unchanged)
eventcatalog/src/pages/docs/[type]/[id]/[version]/graphql/[filename].astro 21ms (unchanged)
eventcatalog/src/pages/docs/[type]/[id]/[version]/index.astro 59ms (unchanged)
eventcatalog/src/pages/docs/[type]/[id]/[version]/spec/_[filename].data.ts 3ms (unchanged)
eventcatalog/src/pages/docs/[type]/[id]/[version]/spec/_OpenAPI.tsx 2ms (unchanged)
eventcatalog/src/pages/docs/[type]/[id]/[version]/spec/[filename].astro 9ms (unchanged)
eventcatalog/src/pages/docs/[type]/[id]/index.astro 4ms (unchanged)
eventcatalog/src/pages/docs/[type]/[id]/language.mdx.ts 2ms (unchanged)
eventcatalog/src/pages/docs/[type]/[id]/language/_index.data.ts 1ms (unchanged)
eventcatalog/src/pages/docs/[type]/[id]/language/[dictionaryId]/_index.data.ts 2ms (unchanged)
eventcatalog/src/pages/docs/[type]/[id]/language/[dictionaryId]/index.astro 19ms (unchanged)
eventcatalog/src/pages/docs/[type]/[id]/language/index.astro 57ms (unchanged)
eventcatalog/src/pages/docs/custom/[...path].mdx.ts 2ms (unchanged)
eventcatalog/src/pages/docs/custom/[...path]/_index.data.ts 2ms (unchanged)
eventcatalog/src/pages/docs/custom/[...path]/index.astro 1ms (unchanged)
eventcatalog/src/pages/docs/custom/feature.astro 17ms (unchanged)
eventcatalog/src/pages/docs/custom/index.astro 14ms (unchanged)
eventcatalog/src/pages/docs/llm/llms-full.txt.ts 2ms (unchanged)
eventcatalog/src/pages/docs/llm/llms-services.txt.ts 3ms (unchanged)
eventcatalog/src/pages/docs/llm/llms.txt.ts 6ms (unchanged)
eventcatalog/src/pages/docs/llm/schemas.txt.ts 3ms (unchanged)
eventcatalog/src/pages/docs/teams/[id].md.ts 1ms (unchanged)
eventcatalog/src/pages/docs/teams/[id].mdx.ts 1ms (unchanged)
eventcatalog/src/pages/docs/teams/[id]/_index.data.ts 1ms (unchanged)
eventcatalog/src/pages/docs/teams/[id]/index.astro 24ms (unchanged)
eventcatalog/src/pages/docs/users/[id].md.ts 2ms (unchanged)
eventcatalog/src/pages/docs/users/[id].mdx.ts 1ms (unchanged)
eventcatalog/src/pages/docs/users/[id]/_index.data.ts 2ms (unchanged)
eventcatalog/src/pages/docs/users/[id]/index.astro 23ms (unchanged)
eventcatalog/src/pages/icepanel/index.astro 4ms (unchanged)
eventcatalog/src/pages/index.astro 8ms (unchanged)
eventcatalog/src/pages/miro/index.astro 5ms (unchanged)
eventcatalog/src/pages/rss/[resource]/rss.xml.js 3ms (unchanged)
eventcatalog/src/pages/schemas/[type]/[id]/[version]/_index.data.ts 3ms (unchanged)
eventcatalog/src/pages/schemas/[type]/[id]/[version]/index.astro 8ms (unchanged)
eventcatalog/src/pages/schemas/explorer/_index.data.ts 7ms (unchanged)
eventcatalog/src/pages/schemas/explorer/index.astro 3ms (unchanged)
eventcatalog/src/pages/studio.astro 30ms (unchanged)
eventcatalog/src/pages/visualiser/[type]/[id]/[version].mermaid.ts 3ms (unchanged)
eventcatalog/src/pages/visualiser/[type]/[id]/[version]/_index.data.ts 3ms (unchanged)
eventcatalog/src/pages/visualiser/[type]/[id]/[version]/data/_index.data.ts 2ms (unchanged)
eventcatalog/src/pages/visualiser/[type]/[id]/[version]/data/index.astro 6ms (unchanged)
eventcatalog/src/pages/visualiser/[type]/[id]/[version]/index.astro 6ms (unchanged)
eventcatalog/src/pages/visualiser/[type]/[id]/index.astro 4ms (unchanged)
eventcatalog/src/pages/visualiser/context-map/index.astro 2ms (unchanged)
eventcatalog/src/pages/visualiser/designs/[id]/_index.data.ts 2ms (unchanged)
eventcatalog/src/pages/visualiser/designs/[id]/index.astro 3ms (unchanged)
eventcatalog/src/pages/visualiser/domain-integrations/index.astro 3ms (unchanged)
eventcatalog/src/pages/visualiser/domains/[id]/[version]/entity-map/_index.data.ts 2ms (unchanged)
eventcatalog/src/pages/visualiser/domains/[id]/[version]/entity-map/index.astro 7ms (unchanged)
eventcatalog/src/remark-plugins/directives.ts 3ms (unchanged)
eventcatalog/src/remark-plugins/mermaid.ts 1ms (unchanged)
eventcatalog/src/remark-plugins/plantuml.ts 2ms (unchanged)
eventcatalog/src/remark-plugins/resource-ref.ts 2ms (unchanged)
eventcatalog/src/stores/favorites-store.ts 2ms (unchanged)
eventcatalog/src/stores/sidebar-store/__tests__/data-product-builder.spec.ts 14ms (unchanged)
eventcatalog/src/stores/sidebar-store/__tests__/sidebar-builder.spec.ts 67ms (unchanged)
eventcatalog/src/stores/sidebar-store/builders/container.ts 4ms (unchanged)
eventcatalog/src/stores/sidebar-store/builders/data-product.ts 4ms (unchanged)
eventcatalog/src/stores/sidebar-store/builders/domain.ts 6ms (unchanged)
eventcatalog/src/stores/sidebar-store/builders/flow.ts 1ms (unchanged)
eventcatalog/src/stores/sidebar-store/builders/message.ts 4ms (unchanged)
eventcatalog/src/stores/sidebar-store/builders/service.ts 5ms (unchanged)
eventcatalog/src/stores/sidebar-store/builders/shared.ts 5ms (unchanged)
eventcatalog/src/stores/sidebar-store/index.ts 1ms (unchanged)
eventcatalog/src/stores/sidebar-store/state.ts 14ms (unchanged)
eventcatalog/src/stores/theme-store.ts 2ms (unchanged)
eventcatalog/src/types/index.ts 1ms (unchanged)
eventcatalog/src/types/mcp-modules.d.ts 3ms (unchanged)
eventcatalog/src/types/react-syntax-highlighter.d.ts 0ms (unchanged)
eventcatalog/src/utils/__tests__/channels/channels.spec.ts 4ms (unchanged)
eventcatalog/src/utils/__tests__/channels/mocks.ts 1ms (unchanged)
eventcatalog/src/utils/__tests__/collections/fake-catalog/events/OrderAmended/schema-unchanged.json 1ms (unchanged)
eventcatalog/src/utils/__tests__/collections/fake-catalog/events/OrderAmended/schema.json 1ms (unchanged)
eventcatalog/src/utils/__tests__/collections/fake-catalog/events/OrderAmended/versioned/0.0.1/schema-unchanged.json 1ms (unchanged)
eventcatalog/src/utils/__tests__/collections/fake-catalog/events/OrderAmended/versioned/0.0.1/schema.json 0ms (unchanged)
eventcatalog/src/utils/__tests__/collections/file-diffs.spec.ts 2ms (unchanged)
eventcatalog/src/utils/__tests__/collections/util.spec.ts 4ms (unchanged)
eventcatalog/src/utils/__tests__/commands/commands.spec.ts 3ms (unchanged)
eventcatalog/src/utils/__tests__/commands/mocks.ts 2ms (unchanged)
eventcatalog/src/utils/__tests__/commands/node-graph.spec.ts 8ms (unchanged)
eventcatalog/src/utils/__tests__/containers/mocks.ts 3ms (unchanged)
eventcatalog/src/utils/__tests__/containers/node-graph.spec.ts 5ms (unchanged)
eventcatalog/src/utils/__tests__/data-products/mocks.ts 3ms (unchanged)
eventcatalog/src/utils/__tests__/data-products/node-graph.spec.ts 27ms (unchanged)
eventcatalog/src/utils/__tests__/domains/domain-entity-map.spec.ts 11ms (unchanged)
eventcatalog/src/utils/__tests__/domains/domains-canvas.spec.ts 6ms (unchanged)
eventcatalog/src/utils/__tests__/domains/domains.spec.ts 11ms (unchanged)
eventcatalog/src/utils/__tests__/domains/mocks.ts 4ms (unchanged)
eventcatalog/src/utils/__tests__/domains/node-graph.spec.ts 6ms (unchanged)
eventcatalog/src/utils/__tests__/entities/entities.spec.ts 2ms (unchanged)
eventcatalog/src/utils/__tests__/entities/mocks.ts 1ms (unchanged)
eventcatalog/src/utils/__tests__/events/events.spec.ts 2ms (unchanged)
eventcatalog/src/utils/__tests__/events/mocks.ts 2ms (unchanged)
eventcatalog/src/utils/__tests__/events/node-graph.spec.ts 12ms (unchanged)
eventcatalog/src/utils/__tests__/features.spec.ts 6ms (unchanged)
eventcatalog/src/utils/__tests__/flows/mocks.ts 2ms (unchanged)
eventcatalog/src/utils/__tests__/flows/node-graph.spec.ts 5ms (unchanged)
eventcatalog/src/utils/__tests__/markdown.spec.ts 2ms (unchanged)
eventcatalog/src/utils/__tests__/messages/messages.spec.ts 8ms (unchanged)
eventcatalog/src/utils/__tests__/messages/mocks.ts 3ms (unchanged)
eventcatalog/src/utils/__tests__/messages/node-graph.spec.ts 28ms (unchanged)
eventcatalog/src/utils/__tests__/queries/mocks.ts 2ms (unchanged)
eventcatalog/src/utils/__tests__/queries/node-graph.spec.ts 8ms (unchanged)
eventcatalog/src/utils/__tests__/queries/queries.spec.ts 2ms (unchanged)
eventcatalog/src/utils/__tests__/remote-file.spec.ts 1ms (unchanged)
eventcatalog/src/utils/__tests__/remote-spec.spec.ts 1ms (unchanged)
eventcatalog/src/utils/__tests__/schemas/schemas.spec.ts 2ms (unchanged)
eventcatalog/src/utils/__tests__/services/mocks.ts 2ms (unchanged)
eventcatalog/src/utils/__tests__/services/node-graph.spec.ts 7ms (unchanged)
eventcatalog/src/utils/__tests__/services/services.spec.ts 7ms (unchanged)
eventcatalog/src/utils/__tests__/url-builder.spec.ts 3ms (unchanged)
eventcatalog/src/utils/badges.tsx 1ms (unchanged)
eventcatalog/src/utils/clipboard.ts 1ms (unchanged)
eventcatalog/src/utils/collections/changelogs.ts 2ms (unchanged)
eventcatalog/src/utils/collections/channels.ts 5ms (unchanged)
eventcatalog/src/utils/collections/commands.ts 3ms (unchanged)
eventcatalog/src/utils/collections/containers.ts 3ms (unchanged)
eventcatalog/src/utils/collections/data-products.ts 2ms (unchanged)
eventcatalog/src/utils/collections/designs.ts 1ms (unchanged)
eventcatalog/src/utils/collections/diagrams.ts 2ms (unchanged)
eventcatalog/src/utils/collections/domains.ts 12ms (unchanged)
eventcatalog/src/utils/collections/entities.ts 3ms (unchanged)
eventcatalog/src/utils/collections/events.ts 3ms (unchanged)
eventcatalog/src/utils/collections/flows.ts 3ms (unchanged)
eventcatalog/src/utils/collections/icons.ts 1ms (unchanged)
eventcatalog/src/utils/collections/messages.ts 7ms (unchanged)
eventcatalog/src/utils/collections/owners.ts 2ms (unchanged)
eventcatalog/src/utils/collections/queries.ts 3ms (unchanged)
eventcatalog/src/utils/collections/schemas.ts 3ms (unchanged)
eventcatalog/src/utils/collections/services.ts 8ms (unchanged)
eventcatalog/src/utils/collections/teams.ts 3ms (unchanged)
eventcatalog/src/utils/collections/types.ts 1ms (unchanged)
eventcatalog/src/utils/collections/users.ts 3ms (unchanged)
eventcatalog/src/utils/collections/util.ts 12ms (unchanged)
eventcatalog/src/utils/collections/versions.ts 2ms (unchanged)
eventcatalog/src/utils/colors.ts 1ms (unchanged)
eventcatalog/src/utils/eventcatalog-config/catalog.ts 1ms (unchanged)
eventcatalog/src/utils/feature.ts 3ms (unchanged)
eventcatalog/src/utils/file-diffs.ts 4ms (unchanged)
eventcatalog/src/utils/files.ts 2ms (unchanged)
eventcatalog/src/utils/git.ts 2ms (unchanged)
eventcatalog/src/utils/llms.ts 2ms (unchanged)
eventcatalog/src/utils/markdown.ts 1ms (unchanged)
eventcatalog/src/utils/mermaid-zoom.ts 18ms (unchanged)
eventcatalog/src/utils/node-graphs/channel-node-graph.ts 2ms (unchanged)
eventcatalog/src/utils/node-graphs/container-node-graph.ts 6ms (unchanged)
eventcatalog/src/utils/node-graphs/data-products-node-graph.ts 6ms (unchanged)
eventcatalog/src/utils/node-graphs/domain-entity-map.ts 7ms (unchanged)
eventcatalog/src/utils/node-graphs/domains-canvas.ts 9ms (unchanged)
eventcatalog/src/utils/node-graphs/domains-node-graph.ts 9ms (unchanged)
eventcatalog/src/utils/node-graphs/export-mermaid.ts 7ms (unchanged)
eventcatalog/src/utils/node-graphs/export-node-graph.ts 2ms (unchanged)
eventcatalog/src/utils/node-graphs/flows-node-graph.ts 5ms (unchanged)
eventcatalog/src/utils/node-graphs/layout-persistence.ts 3ms (unchanged)
eventcatalog/src/utils/node-graphs/message-node-graph.ts 27ms (unchanged)
eventcatalog/src/utils/node-graphs/services-node-graph.ts 8ms (unchanged)
eventcatalog/src/utils/node-graphs/utils/utils.ts 6ms (unchanged)
eventcatalog/src/utils/page-loaders/hybrid-page.ts 2ms (unchanged)
eventcatalog/src/utils/page-loaders/page-data-loader.ts 1ms (unchanged)
eventcatalog/src/utils/pages.ts 1ms (unchanged)
eventcatalog/src/utils/protocols.tsx 1ms (unchanged)
eventcatalog/src/utils/remote-file.ts 1ms (unchanged)
eventcatalog/src/utils/remote-spec.ts 2ms (unchanged)
eventcatalog/src/utils/resource-files.ts 2ms (unchanged)
eventcatalog/src/utils/url-builder.ts 2ms (unchanged)
eventcatalog/tsconfig.json 1ms (unchanged)
package.json 1ms (unchanged)
playwright.config.ts 1ms (unchanged)
scripts/build-ci.js 2ms (unchanged)
scripts/check-build-size.js 3ms (unchanged)
scripts/check-types.js 1ms (unchanged)
scripts/ci/test.js 1ms (unchanged)
scripts/generate-catalog-locally.js 1ms (unchanged)
scripts/notify-discord-release.js 6ms (unchanged)
scripts/preview-catalog-locally.js 1ms (unchanged)
scripts/start-catalog-locally.js 1ms (unchanged)
scripts/start-server-locally.js 1ms (unchanged)
scripts/update-size-baseline.js 2ms (unchanged)
src/__mocks__/astro-content.ts 1ms (unchanged)
src/__tests__/catalog-to-astro-content-directory.spec.ts 2ms (unchanged)
src/__tests__/eventcatalog-config-file-utils.spec.ts 3ms (unchanged)
src/__tests__/example-catalog-dependencies/package.json 0ms (unchanged)
src/__tests__/example-catalog/commands/AddInventory/schema.json 0ms (unchanged)
src/__tests__/example-catalog/commands/AddInventory/versioned/0.0.1/schema.json 0ms (unchanged)
src/__tests__/example-catalog/domains/Payment/events/PaymentDomainTestEvent1/schema.json 1ms (unchanged)
src/__tests__/example-catalog/eventcatalog.config.defaults.js 1ms (unchanged)
src/__tests__/example-catalog/events/InventoryAdjusted/schema.json 2ms (unchanged)
src/__tests__/example-catalog/events/OrderAmended/schema.json 1ms (unchanged)
src/__tests__/example-catalog/events/OrderCancelled/schema.json 1ms (unchanged)
src/__tests__/example-catalog/events/OrderConfirmed/schema.json 1ms (unchanged)
src/__tests__/example-catalog/package.json 0ms (unchanged)
src/__tests__/example-catalog/services/PaymentService/events/PaymentAccepted/schema.json 1ms (unchanged)
src/__tests__/migrations/message-channels-to-service-channels.spec.ts 3ms (unchanged)
src/__tests__/resolve-catalog-dependencies.spec.ts 3ms (unchanged)
src/analytics/analytics.js 1ms (unchanged)
src/analytics/count-resources.js 1ms (unchanged)
src/analytics/log-build.js 1ms (unchanged)
src/catalog-to-astro-content-directory.js 1ms (unchanged)
src/constants.ts 0ms (unchanged)
src/eventcatalog-config-file-utils.js 3ms (unchanged)
src/eventcatalog.auth.ts 1ms (unchanged)
src/eventcatalog.config.ts 2ms (unchanged)
src/eventcatalog.ts 10ms (unchanged)
src/features.ts 1ms (unchanged)
src/generate.js 2ms (unchanged)
src/map-catalog-to-astro.js 3ms (unchanged)
src/migrations/index.ts 1ms (unchanged)
src/migrations/message-channels-to-service-channels.ts 4ms (unchanged)
src/resolve-catalog-dependencies.js 2ms (unchanged)
src/utils/cli-logger.ts 2ms (unchanged)
src/watcher.js 2ms (unchanged)
tsconfig.json 0ms (unchanged)
tsup.config.js 0ms (unchanged)
vitest.config.js 1ms (unchanged)\n- packages/core                            |  WARN  The field "pnpm.overrides" was found in /Users/thor/.openclaw/workspace/eventcatalog/packages/core/package.json. This will not take effect. You should configure "pnpm.overrides" at the root of the workspace instead.

> @eventcatalog/sdk@2.13.2 format /Users/thor/.openclaw/workspace/eventcatalog/packages/sdk
> prettier --write .

.prettierrc 17ms (unchanged)
CHANGELOG.md 55ms (unchanged)
package.json 2ms (unchanged)
README.md 24ms (unchanged)
src/channels.ts 20ms (unchanged)
src/commands.ts 12ms (unchanged)
src/containers.ts 7ms (unchanged)
src/custom-docs.ts 6ms (unchanged)
src/data-products.ts 5ms (unchanged)
src/data-stores.ts 3ms (unchanged)
src/diagrams.ts 4ms (unchanged)
src/docs.ts 2ms (unchanged)
src/domains.ts 19ms (unchanged)
src/entities.ts 3ms (unchanged)
src/eventcatalog.ts 6ms (unchanged)
src/events.ts 5ms (unchanged)
src/index.ts 13ms (unchanged)
src/internal/resources.ts 22ms (unchanged)
src/internal/utils.ts 7ms (unchanged)
src/messages.ts 6ms (unchanged)
src/queries.ts 5ms (unchanged)
src/services.ts 12ms (unchanged)
src/teams.ts 4ms (unchanged)
src/test/catalog-eventcatalog/channels/inventory.{env}.events/index.mdx 8ms (unchanged)
src/test/catalog-eventcatalog/channels/orders.{env}.events/index.mdx 4ms (unchanged)
src/test/catalog-eventcatalog/channels/payment.{env}.events/index.mdx 3ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/changelog.mdx 1ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/index.mdx 11ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/InventoryService/changelog.mdx 1ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/InventoryService/commands/AddInventory/index.mdx 5ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/InventoryService/commands/AddInventory/schema.json 1ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/InventoryService/commands/DeleteInventory/index.mdx 4ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/InventoryService/commands/UpdateInventory/index.mdx 5ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/InventoryService/commands/UpdateInventory/schema.json 1ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/InventoryService/events/InventoryAdjusted/changelog.mdx 4ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/InventoryService/events/InventoryAdjusted/index.mdx 8ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/InventoryService/events/InventoryAdjusted/schema.json 1ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/InventoryService/events/InventoryAdjusted/schema.yml 1ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/InventoryService/events/InventoryAdjusted/versioned/0.0.1/changelog.mdx 1ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/InventoryService/events/InventoryAdjusted/versioned/0.0.1/index.mdx 2ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/InventoryService/events/InventoryAdjusted/versioned/1.0.0/changelog.mdx 2ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/InventoryService/events/InventoryAdjusted/versioned/1.0.0/index.mdx 4ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/InventoryService/events/OutOfStock/index.mdx 4ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/InventoryService/events/OutOfStock/versioned/0.0.1/index.mdx 4ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/InventoryService/index.mdx 11ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/InventoryService/queries/GetInventoryList/index.mdx 3ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/InventoryService/queries/GetInventoryList/schema.json 1ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/InventoryService/queries/GetInventoryStatus/index.mdx 3ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/InventoryService/queries/GetInventoryStatus/schema.json 1ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/InventoryService/versioned/0.0.1/index.mdx 3ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/NotificationService/index.mdx 6ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/NotificationService/queries/GetNotificationDetails/index.mdx 3ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/NotificationService/queries/GetNotificationDetails/schema.json 1ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/NotificationService/queries/GetUserNotifications/index.mdx 4ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/NotificationService/queries/GetUserNotifications/schema.json 1ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/OrdersService/changelog.mdx 1ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/OrdersService/commands/PlaceOrder/index.mdx 3ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/OrdersService/commands/PlaceOrder/schema.json 2ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/OrdersService/events/OrderAmended/index.mdx 4ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/OrdersService/events/OrderAmended/schema.json 1ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/OrdersService/events/OrderCancelled/index.mdx 4ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/OrdersService/events/OrderCancelled/schema.json 1ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/OrdersService/events/OrderConfirmed/index.mdx 3ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/OrdersService/events/OrderConfirmed/schema.json 1ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/OrdersService/index.mdx 5ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/OrdersService/openapi.yml 10ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/OrdersService/order-service-asyncapi.yaml 5ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/OrdersService/queries/GetOrder/index.mdx 3ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/OrdersService/queries/GetOrder/schema.json 0ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/OrdersService/versioned/0.0.2/changelog.mdx 1ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/OrdersService/versioned/0.0.2/index.mdx 2ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/OrdersService/versioned/0.0.2/openapi.yml 3ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/OrdersService/versioned/0.0.2/order-service-asyncapi.yaml 4ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/ShippingService/commands/CancelShipment/index.mdx 3ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/ShippingService/commands/CancelShipment/schema.json 0ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/ShippingService/commands/CreateReturnLabel/index.mdx 2ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/ShippingService/commands/CreateReturnLabel/schema.json 0ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/ShippingService/commands/CreateShipment/index.mdx 2ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/ShippingService/commands/CreateShipment/schema.json 1ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/ShippingService/commands/UpdateShipmentStatus/index.mdx 2ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/ShippingService/commands/UpdateShipmentStatus/schema.json 1ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/ShippingService/events/DeliveryFailed/index.mdx 2ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/ShippingService/events/DeliveryFailed/schema.json 0ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/ShippingService/events/ReturnInitiated/index.mdx 2ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/ShippingService/events/ReturnInitiated/schema.json 0ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/ShippingService/events/ShipmentCreated/index.mdx 2ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/ShippingService/events/ShipmentCreated/schema.json 1ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/ShippingService/events/ShipmentDelivered/index.mdx 2ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/ShippingService/events/ShipmentDelivered/schema.json 0ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/ShippingService/events/ShipmentDispatched/index.mdx 2ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/ShippingService/events/ShipmentDispatched/schema.json 0ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/ShippingService/events/ShipmentInTransit/index.mdx 2ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/ShippingService/events/ShipmentInTransit/schema.json 0ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/services/ShippingService/index.mdx 3ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/ubiquitous-language.mdx 2ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/versioned/0.0.1/index.mdx 1ms (unchanged)
src/test/catalog-eventcatalog/domains/Orders/versioned/0.0.2/index.mdx 2ms (unchanged)
src/test/catalog-eventcatalog/eventcatalog.config.js 3ms (unchanged)
src/test/catalog-eventcatalog/package.json 0ms (unchanged)
src/test/catalog-eventcatalog/teams/full-stack.mdx 3ms (unchanged)
src/test/catalog-eventcatalog/teams/mobile-devs.mdx 3ms (unchanged)
src/test/catalog-eventcatalog/teams/order-management.mdx 2ms (unchanged)
src/test/catalog-eventcatalog/teams/subscriptions-management.mdx 2ms (unchanged)
src/test/catalog-eventcatalog/users/alee.mdx 1ms (unchanged)
src/test/catalog-eventcatalog/users/aSmith.mdx 4ms (unchanged)
src/test/catalog-eventcatalog/users/azhang.mdx 1ms (unchanged)
src/test/catalog-eventcatalog/users/dboyne.mdx 3ms (unchanged)
src/test/catalog-eventcatalog/users/dkim.mdx 1ms (unchanged)
src/test/catalog-eventcatalog/users/jbrown.mdx 1ms (unchanged)
src/test/catalog-eventcatalog/users/jchen.mdx 1ms (unchanged)
src/test/catalog-eventcatalog/users/jmiller.mdx 1ms (unchanged)
src/test/catalog-eventcatalog/users/kpatel.mdx 1ms (unchanged)
src/test/catalog-eventcatalog/users/lkim.mdx 1ms (unchanged)
src/test/catalog-eventcatalog/users/lnguyen.mdx 1ms (unchanged)
src/test/catalog-eventcatalog/users/mchen.mdx 1ms (unchanged)
src/test/catalog-eventcatalog/users/mSmith.mdx 1ms (unchanged)
src/test/catalog-eventcatalog/users/mwang.mdx 1ms (unchanged)
src/test/catalog-eventcatalog/users/mwilson.mdx 1ms (unchanged)
src/test/catalog-eventcatalog/users/nshah.mdx 1ms (unchanged)
src/test/catalog-eventcatalog/users/rjohnson.mdx 1ms (unchanged)
src/test/catalog-eventcatalog/users/rjones.mdx 1ms (unchanged)
src/test/catalog-eventcatalog/users/rsingh.mdx 1ms (unchanged)
src/test/catalog-eventcatalog/users/rthomas.mdx 2ms (unchanged)
src/test/catalog-eventcatalog/users/slee.mdx 1ms (unchanged)
src/test/catalog-eventcatalog/users/spatel.mdx 1ms (unchanged)
src/test/catalog-eventcatalog/users/tgarcia.mdx 1ms (unchanged)
src/test/channels.test.ts 23ms (unchanged)
src/test/commands.test.ts 34ms (unchanged)
src/test/custom-docs.test.ts 6ms (unchanged)
src/test/data-products.test.ts 16ms (unchanged)
src/test/data-store.test.ts 11ms (unchanged)
src/test/diagrams.test.ts 6ms (unchanged)
src/test/domains.test.ts 31ms (unchanged)
src/test/entities.test.ts 6ms (unchanged)
src/test/eventcatalog.test.ts 5ms (unchanged)
src/test/events.test.ts 31ms (unchanged)
src/test/messages.test.ts 8ms (unchanged)
src/test/queries.test.ts 23ms (unchanged)
src/test/resources.test.ts 1ms (unchanged)
src/test/services.test.ts 41ms (unchanged)
src/test/teams.test.ts 4ms (unchanged)
src/test/users.test.ts 3ms (unchanged)
src/types.d.ts 6ms (unchanged)
src/users.ts 4ms (unchanged)
tsconfig.json 1ms (unchanged)
tsup.config.ts 1ms (unchanged)
vitest.config.ts 1ms (unchanged)
vitest.setup.ts 3ms (unchanged)