### PR TITLE
perf(core): route-split heavy OpenAPI and graph viewers

### DIFF
--- a/packages/core/eventcatalog/src/components/MDX/NodeGraph/AstroNodeGraph.tsx
+++ b/packages/core/eventcatalog/src/components/MDX/NodeGraph/AstroNodeGraph.tsx
@@ -8,10 +8,11 @@
  * - URL building with Astro's URL utilities
  */
 
-import { useCallback } from 'react';
-import { NodeGraph } from '@eventcatalog/visualiser';
+import { useCallback, lazy, Suspense } from 'react';
 import '@eventcatalog/visualiser/styles.css';
 import type { Node, Edge } from '@xyflow/react';
+
+const NodeGraph = lazy(() => import('@eventcatalog/visualiser').then((module) => ({ default: module.NodeGraph })));
 
 interface AstroNodeGraphProps {
   id: string;
@@ -89,15 +90,17 @@ const AstroNodeGraph = ({ isDevMode = false, resourceKey, ...otherProps }: Astro
   }, []);
 
   return (
-    <NodeGraph
-      {...otherProps}
-      resourceKey={resourceKey}
-      isDevMode={isDevMode}
-      onNavigate={handleNavigate}
-      onBuildUrl={handleBuildUrl}
-      onSaveLayout={handleSaveLayout}
-      onResetLayout={handleResetLayout}
-    />
+    <Suspense fallback={<div>Loading graph...</div>}>
+      <NodeGraph
+        {...otherProps}
+        resourceKey={resourceKey}
+        isDevMode={isDevMode}
+        onNavigate={handleNavigate}
+        onBuildUrl={handleBuildUrl}
+        onSaveLayout={handleSaveLayout}
+        onResetLayout={handleResetLayout}
+      />
+    </Suspense>
   );
 };
 

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/spec/_OpenAPI.tsx
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/spec/_OpenAPI.tsx
@@ -1,7 +1,10 @@
-import { useState, useEffect } from 'react';
-import { ApiReferenceReact } from '@scalar/api-reference-react';
+import { useState, useEffect, lazy, Suspense } from 'react';
 import '@scalar/api-reference-react/style.css';
 import './_styles.css';
+
+const ApiReferenceReact = lazy(() =>
+  import('@scalar/api-reference-react').then((module) => ({ default: module.ApiReferenceReact }))
+);
 
 const OpenAPISpec = ({ spec }: { spec: string }) => {
   const [loaded, setLoaded] = useState(false);
@@ -31,25 +34,27 @@ const OpenAPISpec = ({ spec }: { spec: string }) => {
   return (
     <div>
       {!loaded && <div>Loading...</div>}
-      <ApiReferenceReact
-        key={isDarkMode ? 'dark' : 'light'}
-        configuration={{
-          spec: {
-            content: spec,
-          },
-          theme: 'fastify',
-          hideClientButton: true,
-          onLoaded: () => {
-            setLoaded(true);
-          },
-          forceDarkModeState: isDarkMode ? 'dark' : 'light',
-          darkMode: isDarkMode,
-          defaultOpenAllTags: true,
-          hideDarkModeToggle: true,
-          searchHotKey: 'p',
-          showSidebar: true,
-        }}
-      />
+      <Suspense fallback={<div>Loading OpenAPI reference...</div>}>
+        <ApiReferenceReact
+          key={isDarkMode ? 'dark' : 'light'}
+          configuration={{
+            spec: {
+              content: spec,
+            },
+            theme: 'fastify',
+            hideClientButton: true,
+            onLoaded: () => {
+              setLoaded(true);
+            },
+            forceDarkModeState: isDarkMode ? 'dark' : 'light',
+            darkMode: isDarkMode,
+            defaultOpenAllTags: true,
+            hideDarkModeToggle: true,
+            searchHotKey: 'p',
+            showSidebar: true,
+          }}
+        />
+      </Suspense>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
This is PR #3 from the perf deep-dive plan: route-level splitting for heavy viewers.

Changes:
- lazy-load `@scalar/api-reference-react` in OpenAPI spec viewer (`_OpenAPI.tsx`) via `React.lazy` + `Suspense`
- lazy-load `NodeGraph` from `@eventcatalog/visualiser` in `AstroNodeGraph.tsx` via `React.lazy` + `Suspense`

## Why
Both OpenAPI rendering and node-graph rendering pull in large dependencies. Deferring module evaluation until these components are actually needed helps reduce initial JS pressure and keeps route bundles more focused.

## Notes
- CSS imports remain unchanged, so visual styling behavior is preserved.
- Formatter run: `corepack pnpm --filter @eventcatalog/core format`
- Full test suite was not re-run here because current local baseline has unrelated pre-existing failures in this environment.
