### PR TITLE
fix(sdk): respect resource type in getResource lookup

### DIFF
--- a/packages/sdk/src/internal/resources.ts
+++ b/packages/sdk/src/internal/resources.ts
@@ -127,7 +127,7 @@ export const getResource = async (
   filePath?: string
 ): Promise<Resource | undefined> => {
   const attachSchema = options?.attachSchema || false;
-  const file = filePath || (id ? await findFileById(catalogDir, id, version) : undefined);
+  const file = filePath || (id ? await findFileById(catalogDir, id, version, { type: options?.type }) : undefined);
   if (!file || !fsSync.existsSync(file)) return;
 
   const { data, content } = matter.read(file);

--- a/packages/sdk/src/test/services.test.ts
+++ b/packages/sdk/src/test/services.test.ts
@@ -29,6 +29,7 @@ const {
   toService,
   addDataStoreToService,
   writeDataStore,
+  writeChannel,
 } = utils(CATALOG_PATH);
 
 // clean the catalog before each test
@@ -152,6 +153,36 @@ describe('Services SDK', () => {
         version: '1.0.0',
         summary: 'Service tat handles the inventory',
         markdown: '# Hello world',
+      });
+    });
+
+    it('returns the service when a channel with the same id exists', async () => {
+      await writeChannel({
+        id: 'InventoryResource',
+        name: 'Inventory Channel',
+        version: '1.0.0',
+        summary: 'A channel with the same id as a service',
+        markdown: '# Channel',
+        address: 'inventory.resource',
+        protocols: ['kafka'],
+      });
+
+      await writeService({
+        id: 'InventoryResource',
+        name: 'Inventory Service',
+        version: '1.0.0',
+        summary: 'A service with the same id as a channel',
+        markdown: '# Service',
+      });
+
+      const test = await getService('InventoryResource');
+
+      expect(test).toEqual({
+        id: 'InventoryResource',
+        name: 'Inventory Service',
+        version: '1.0.0',
+        summary: 'A service with the same id as a channel',
+        markdown: '# Service',
       });
     });
 


### PR DESCRIPTION
## Summary
- update SDK findFileById to optionally filter matches by resource type path (service/channel/domain/etc.)
- pass the requested resource type from getResource into findFileById
- add a regression test proving getService still returns a service when a channel exists with the same id

## Why
getResource previously resolved by id only, so collisions across resource types (e.g. service + channel with same id) could return the wrong file.

## Verification
- pnpm --filter @eventcatalog/sdk run format
- pnpm --filter @eventcatalog/sdk test -- src/test/services.test.ts

Closes #2102