### PR TITLE
spike(search): MiniSearch-backed custom docs content in header search

### DIFF
--- a/packages/core/eventcatalog/src/pages/api/search-docs-index.json.ts
+++ b/packages/core/eventcatalog/src/pages/api/search-docs-index.json.ts
@@ -1,0 +1,61 @@
+import type { APIRoute } from 'astro';
+import { getCollection } from 'astro:content';
+
+const isDev = import.meta.env.DEV;
+
+interface DocsSearchItemCompact {
+  i: string;
+  t: string;
+  u: string;
+  c: string;
+}
+
+const MAX_CONTENT_LENGTH = 5000;
+
+const stripMarkdown = (value: string) => {
+  return value
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/`[^`]*`/g, ' ')
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, ' ')
+    .replace(/\[[^\]]*\]\([^)]*\)/g, ' ')
+    .replace(/^#{1,6}\s+/gm, '')
+    .replace(/[>*_~#-]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+};
+
+const toDocsItem = (entry: any): DocsSearchItemCompact | null => {
+  const id = entry?.id as string | undefined;
+  if (!id) return null;
+
+  const body = typeof entry?.body === 'string' ? entry.body : '';
+  const content = stripMarkdown(body).slice(0, MAX_CONTENT_LENGTH);
+  if (!content) return null;
+
+  const title = (entry?.data?.title as string | undefined) || id.split('/').pop() || id;
+
+  return {
+    i: id,
+    t: title,
+    u: `/docs/${id}`,
+    c: content,
+  };
+};
+
+export const GET: APIRoute = async () => {
+  const [customPages, pages] = await Promise.all([getCollection('customPages'), getCollection('pages')]);
+
+  const items = [...customPages, ...pages].map(toDocsItem).filter((item): item is DocsSearchItemCompact => Boolean(item));
+
+  return new Response(JSON.stringify({ i: items }), {
+    headers: {
+      'Content-Type': 'application/json',
+      'Cache-Control': isDev
+        ? 'no-cache, no-store, must-revalidate'
+        : 'public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400',
+      Vary: 'Accept-Encoding',
+    },
+  });
+};
+
+export const prerender = !isDev;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -106,6 +106,7 @@
     "lucide-react": "^0.453.0",
     "marked": "^15.0.6",
     "mdast-util-find-and-replace": "^3.0.2",
+    "minisearch": "^7.1.2",
     "mermaid": "^11.12.1",
     "nanostores": "^1.1.0",
     "pako": "^2.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,6 +228,9 @@ importers:
       mermaid:
         specifier: ^11.12.1
         version: 11.12.1
+      minisearch:
+        specifier: ^7.1.2
+        version: 7.2.0
       nanostores:
         specifier: ^1.1.0
         version: 1.1.0
@@ -6325,6 +6328,9 @@ packages:
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  minisearch@7.2.0:
+    resolution: {integrity: sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==}
 
   minizlib@1.3.3:
     resolution: {integrity: sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==}
@@ -15858,6 +15864,8 @@ snapshots:
       yallist: 3.1.1
 
   minipass@7.1.2: {}
+
+  minisearch@7.2.0: {}
 
   minizlib@1.3.3:
     dependencies:


### PR DESCRIPTION
## Summary
Spike: add custom docs content search using MiniSearch while preserving existing fast header search behavior.

### What this changes
- adds a new API endpoint: `/api/search-docs-index.json`
  - indexes `customPages` + `pages` content
  - strips markdown and caps content size per entry for payload control
- keeps existing `/api/search-index.json` behavior for resource metadata search
- updates header search modal to:
  - lazy-load docs index only after user starts typing
  - run MiniSearch client-side against docs content
  - merge docs matches into existing header search results (`Doc` result type)

## UX
- Search remains in the **same header modal**.
- No extra route required; docs content results show alongside normal results.

## Perf notes
- two-index strategy (metadata + docs content)
- docs index lazy-loaded on intent (query length >= 2)
- content is pre-trimmed to avoid huge payloads

## Status
- **Spike / draft** for discussion, ranking tuning, and payload thresholds.

## Validation
- `pnpm --filter @eventcatalog/core check`
