### PR TITLE
fix(sdk): preserve service subfolders when adding messages

### DIFF
--- a/packages/sdk/src/services.ts
+++ b/packages/sdk/src/services.ts
@@ -422,12 +422,15 @@ export const addMessageToService =
       throw new Error(`Cannot find service ${id} in the catalog`);
     }
 
-    // Get where the service was located, make sure it goes back there.
-    const path = existingResource.split(/[\\/]+services/)[0];
-    const pathToResource = join(path, 'services');
+    // Update the existing service in-place to avoid deleting nested folders under the service.
+    const resourcePath = existingResource.replace(directory, '').replace(/index\.(md|mdx)$/, '');
 
-    await rmServiceById(directory)(id, version);
-    await writeService(pathToResource)(service, { format: extension === '.md' ? 'md' : 'mdx' });
+    await writeResource(directory, service, {
+      path: resourcePath,
+      type: 'service',
+      override: true,
+      format: extension === '.md' ? 'md' : 'mdx',
+    });
   };
 
 /**

--- a/packages/sdk/src/test/services.test.ts
+++ b/packages/sdk/src/test/services.test.ts
@@ -2014,6 +2014,32 @@ describe('Services SDK', () => {
       const pathToService = path.join(CATALOG_PATH, 'services', 'InventoryService');
       expect(fs.existsSync(pathToService)).toEqual(true);
     });
+
+    it('preserves nested service subfolders when adding a message', async () => {
+      await writeService({
+        id: 'InventoryService',
+        name: 'Inventory Service',
+        version: '0.0.1',
+        summary: 'Service that handles the inventory',
+        markdown: '# Hello world',
+      });
+
+      await writeEvent({
+        id: 'InventoryAdjusted',
+        name: 'Inventory Adjusted',
+        version: '0.0.1',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+      });
+
+      const nestedMessagePath = path.join(CATALOG_PATH, 'services', 'InventoryService', 'messages', 'GetInventory', 'index.mdx');
+      fs.mkdirSync(path.dirname(nestedMessagePath), { recursive: true });
+      fs.writeFileSync(nestedMessagePath, '---\nid: GetInventory\nversion: 0.0.1\n---\n# Query');
+
+      await addEventToService('InventoryService', 'sends', { id: 'InventoryAdjusted', version: '0.0.1' }, '0.0.1');
+
+      expect(fs.existsSync(nestedMessagePath)).toEqual(true);
+    });
   });
 
   describe('addDataStoreToService (addDataStoreToService)', () => {


### PR DESCRIPTION
## Summary
- update `addMessageToService` to rewrite the service in-place instead of delete/recreate
- preserve nested service subfolders (for example `services/<id>/messages/...`)
- add a regression test covering nested subfolder preservation

## Testing
- `pnpm --filter @eventcatalog/sdk format`
- `pnpm --filter @eventcatalog/sdk test -- src/test/services.test.ts`

Fixes #2104
