### PR TITLE
fix(language-server): remove redundant message-to-channel routes-to edges

### DIFF
--- a/.changeset/bright-foxes-dance.md
+++ b/.changeset/bright-foxes-dance.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/language-server": patch
+---
+
+Remove redundant direct message-to-channel routes-to edges when an indirect path exists through channel routing chains, and simplify user/team DSL spec by removing owns statement

--- a/packages/language-server/SPEC.md
+++ b/packages/language-server/SPEC.md
@@ -1646,21 +1646,18 @@ user_props        = "name" string_lit
                   | "role" string_lit
                   | "email" string_lit
                   | "slack" string_lit
-                  | "ms-teams" string_lit
-                  | owns_stmt
-                  | "team" identifier ;
-owns_stmt         = "owns" resource_type_kw identifier ;
-resource_type_kw  = "domain" | "service" | "event" | "command" | "query" ;
+                  | "ms-teams" string_lit ;
 
 (* Team *)
 team_decl         = "team" identifier "{" team_props "}" ;
 team_props        = "name" string_lit
+                  | "avatar" string_lit
+                  | "role" string_lit
                   | "summary" string_lit
                   | "email" string_lit
                   | "slack" string_lit
                   | "ms-teams" string_lit
-                  | "member" identifier
-                  | owns_stmt ;
+                  | "member" identifier ;
 
 (* Resource references *)
 service_ref_stmt    = "service" resource_ref ;

--- a/packages/language-server/test/__snapshots__/examples-snapshot.test.ts.snap
+++ b/packages/language-server/test/__snapshots__/examples-snapshot.test.ts.snap
@@ -129,13 +129,6 @@ exports[`playground examples snapshot tests > AWS Event Pipeline > AWS Event Pip
     "type": "contains",
   },
   {
-    "id": "event:OrderCreated@1.0.0-routes-to-channel:PickingQueue@1.0.0",
-    "label": undefined,
-    "source": "event:OrderCreated@1.0.0",
-    "target": "channel:PickingQueue@1.0.0",
-    "type": "routes-to",
-  },
-  {
     "id": "channel:PickingQueue@1.0.0-receives-service:WarehouseService@1.0.0",
     "label": undefined,
     "source": "channel:PickingQueue@1.0.0",
@@ -150,13 +143,6 @@ exports[`playground examples snapshot tests > AWS Event Pipeline > AWS Event Pip
     "type": "contains",
   },
   {
-    "id": "event:OrderCancelled@1.0.0-routes-to-channel:PickingQueue@1.0.0",
-    "label": undefined,
-    "source": "event:OrderCancelled@1.0.0",
-    "target": "channel:PickingQueue@1.0.0",
-    "type": "routes-to",
-  },
-  {
     "id": "domain:Fulfillment@1.0.0-contains-service:ShippingService@1.0.0",
     "label": undefined,
     "source": "domain:Fulfillment@1.0.0",
@@ -169,13 +155,6 @@ exports[`playground examples snapshot tests > AWS Event Pipeline > AWS Event Pip
     "source": "domain:Fulfillment@1.0.0",
     "target": "channel:ShippingQueue@1.0.0",
     "type": "contains",
-  },
-  {
-    "id": "event:OrderCreated@1.0.0-routes-to-channel:ShippingQueue@1.0.0",
-    "label": undefined,
-    "source": "event:OrderCreated@1.0.0",
-    "target": "channel:ShippingQueue@1.0.0",
-    "type": "routes-to",
   },
   {
     "id": "channel:ShippingQueue@1.0.0-receives-service:ShippingService@1.0.0",
@@ -227,13 +206,6 @@ exports[`playground examples snapshot tests > AWS Event Pipeline > AWS Event Pip
     "type": "contains",
   },
   {
-    "id": "event:OrderCreated@1.0.0-routes-to-channel:EmailQueue@1.0.0",
-    "label": undefined,
-    "source": "event:OrderCreated@1.0.0",
-    "target": "channel:EmailQueue@1.0.0",
-    "type": "routes-to",
-  },
-  {
     "id": "channel:EmailQueue@1.0.0-receives-service:EmailService@1.0.0",
     "label": undefined,
     "source": "channel:EmailQueue@1.0.0",
@@ -248,25 +220,11 @@ exports[`playground examples snapshot tests > AWS Event Pipeline > AWS Event Pip
     "type": "contains",
   },
   {
-    "id": "event:OrderShipped@1.0.0-routes-to-channel:EmailQueue@1.0.0",
-    "label": undefined,
-    "source": "event:OrderShipped@1.0.0",
-    "target": "channel:EmailQueue@1.0.0",
-    "type": "routes-to",
-  },
-  {
     "id": "domain:Notifications@1.0.0-contains-event:OrderCancelled@1.0.0",
     "label": undefined,
     "source": "domain:Notifications@1.0.0",
     "target": "event:OrderCancelled@1.0.0",
     "type": "contains",
-  },
-  {
-    "id": "event:OrderCancelled@1.0.0-routes-to-channel:EmailQueue@1.0.0",
-    "label": undefined,
-    "source": "event:OrderCancelled@1.0.0",
-    "target": "channel:EmailQueue@1.0.0",
-    "type": "routes-to",
   },
   {
     "id": "domain:Notifications@1.0.0-contains-service:PushNotificationService@1.0.0",
@@ -283,25 +241,11 @@ exports[`playground examples snapshot tests > AWS Event Pipeline > AWS Event Pip
     "type": "contains",
   },
   {
-    "id": "event:OrderShipped@1.0.0-routes-to-channel:PushQueue@1.0.0",
-    "label": undefined,
-    "source": "event:OrderShipped@1.0.0",
-    "target": "channel:PushQueue@1.0.0",
-    "type": "routes-to",
-  },
-  {
     "id": "channel:PushQueue@1.0.0-receives-service:PushNotificationService@1.0.0",
     "label": undefined,
     "source": "channel:PushQueue@1.0.0",
     "target": "service:PushNotificationService@1.0.0",
     "type": "receives",
-  },
-  {
-    "id": "event:OrderCancelled@1.0.0-routes-to-channel:PushQueue@1.0.0",
-    "label": undefined,
-    "source": "event:OrderCancelled@1.0.0",
-    "target": "channel:PushQueue@1.0.0",
-    "type": "routes-to",
   },
   {
     "id": "domain:Notifications@1.0.0-contains-service:SmsService@1.0.0",
@@ -316,13 +260,6 @@ exports[`playground examples snapshot tests > AWS Event Pipeline > AWS Event Pip
     "source": "domain:Notifications@1.0.0",
     "target": "channel:SmsQueue@1.0.0",
     "type": "contains",
-  },
-  {
-    "id": "event:OrderShipped@1.0.0-routes-to-channel:SmsQueue@1.0.0",
-    "label": undefined,
-    "source": "event:OrderShipped@1.0.0",
-    "target": "channel:SmsQueue@1.0.0",
-    "type": "routes-to",
   },
   {
     "id": "channel:SmsQueue@1.0.0-receives-service:SmsService@1.0.0",
@@ -381,13 +318,6 @@ exports[`playground examples snapshot tests > AWS Event Pipeline > AWS Event Pip
     "type": "contains",
   },
   {
-    "id": "event:OrderCreated@1.0.0-routes-to-channel:MetricsQueue@1.0.0",
-    "label": undefined,
-    "source": "event:OrderCreated@1.0.0",
-    "target": "channel:MetricsQueue@1.0.0",
-    "type": "routes-to",
-  },
-  {
     "id": "channel:MetricsQueue@1.0.0-receives-service:MetricsService@1.0.0",
     "label": undefined,
     "source": "channel:MetricsQueue@1.0.0",
@@ -402,25 +332,11 @@ exports[`playground examples snapshot tests > AWS Event Pipeline > AWS Event Pip
     "type": "contains",
   },
   {
-    "id": "event:OrderShipped@1.0.0-routes-to-channel:MetricsQueue@1.0.0",
-    "label": undefined,
-    "source": "event:OrderShipped@1.0.0",
-    "target": "channel:MetricsQueue@1.0.0",
-    "type": "routes-to",
-  },
-  {
     "id": "domain:Analytics@1.0.0-contains-event:OrderCancelled@1.0.0",
     "label": undefined,
     "source": "domain:Analytics@1.0.0",
     "target": "event:OrderCancelled@1.0.0",
     "type": "contains",
-  },
-  {
-    "id": "event:OrderCancelled@1.0.0-routes-to-channel:MetricsQueue@1.0.0",
-    "label": undefined,
-    "source": "event:OrderCancelled@1.0.0",
-    "target": "channel:MetricsQueue@1.0.0",
-    "type": "routes-to",
   },
   {
     "id": "domain:Analytics@1.0.0-contains-service:SearchService@1.0.0",
@@ -437,25 +353,11 @@ exports[`playground examples snapshot tests > AWS Event Pipeline > AWS Event Pip
     "type": "contains",
   },
   {
-    "id": "event:OrderCreated@1.0.0-routes-to-channel:SearchIndexQueue@1.0.0",
-    "label": undefined,
-    "source": "event:OrderCreated@1.0.0",
-    "target": "channel:SearchIndexQueue@1.0.0",
-    "type": "routes-to",
-  },
-  {
     "id": "channel:SearchIndexQueue@1.0.0-receives-service:SearchService@1.0.0",
     "label": undefined,
     "source": "channel:SearchIndexQueue@1.0.0",
     "target": "service:SearchService@1.0.0",
     "type": "receives",
-  },
-  {
-    "id": "event:OrderShipped@1.0.0-routes-to-channel:SearchIndexQueue@1.0.0",
-    "label": undefined,
-    "source": "event:OrderShipped@1.0.0",
-    "target": "channel:SearchIndexQueue@1.0.0",
-    "type": "routes-to",
   },
   {
     "id": "domain:Analytics@1.0.0-contains-channel:AnalyticsEventBus@1.0.0",
@@ -1750,13 +1652,6 @@ exports[`playground examples snapshot tests > Channel Routing > Channel Routing 
     "source": "service:FilterService@1.0.0",
     "target": "event:SensorReading@1.0.0",
     "type": "sends",
-  },
-  {
-    "id": "event:SensorReading@1.0.0-routes-to-channel:SensorFiltered@1.0.0",
-    "label": undefined,
-    "source": "event:SensorReading@1.0.0",
-    "target": "channel:SensorFiltered@1.0.0",
-    "type": "routes-to",
   },
   {
     "id": "service:FilterService@1.0.0-sends-event:DeviceAlert@1.0.0",


### PR DESCRIPTION
## What This PR Does

Fixes the DSL graph builder to eliminate redundant direct message-to-channel `routes-to` edges when an indirect path already exists through channel routing chains. Also simplifies the user/team DSL spec by removing the `owns` statement.

## Changes Overview

### Key Changes
- Add BFS-based `canReachViaRoutes` helper to detect indirect paths between nodes
- Post-processing step in `astToGraph` removes redundant direct message → channel edges
- Simplify user declaration (remove `owns` and `team` properties)
- Simplify team declaration (remove `owns`, add `avatar` and `role` properties)
- Add test for cross-domain channel routing edge deduplication
- Update existing test expectations and snapshot

## How It Works

After all edges are built, a post-processing pass iterates over `routes-to` edges. For each edge from a non-channel node to a channel node, it checks (via BFS) whether an alternative path exists through the routing chain. If so, the direct edge is removed as redundant. This prevents visual clutter in graphs with multi-hop channel routing (e.g., OrderEventBus → MainEventBus → NotificationsEventBus → EmailQueue).

## Breaking Changes

None

## Additional Notes

The snapshot removals reflect the corrected behavior — those edges were redundant duplicates of paths already expressed through channel chains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)