### PR TITLE
fix(sdk): resolve getResource by requested type

### DIFF
--- a/.changeset/khaki-emus-repeat.md
+++ b/.changeset/khaki-emus-repeat.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/sdk": patch
+---
+
+Fix `getResource` type resolution to correctly return resources when multiple resource types share the same id.

--- a/packages/sdk/src/internal/resources.ts
+++ b/packages/sdk/src/internal/resources.ts
@@ -130,7 +130,7 @@ export const getResource = async (
   filePath?: string
 ): Promise<Resource | undefined> => {
   const attachSchema = options?.attachSchema || false;
-  const file = filePath || (id ? await findFileById(catalogDir, id, version) : undefined);
+  const file = filePath || (id ? await findFileById(catalogDir, id, version, options?.type) : undefined);
   if (!file || !fsSync.existsSync(file)) return;
 
   const { data, content } = cachedMatterRead(file);

--- a/packages/sdk/src/test/resources.test.ts
+++ b/packages/sdk/src/test/resources.test.ts
@@ -6,7 +6,7 @@ import fs from 'node:fs';
 
 const CATALOG_PATH = path.join(__dirname, 'catalog-resources');
 
-const { writeEvent, getResourceFolderName } = utils(CATALOG_PATH);
+const { writeEvent, writeService, writeChannel, getService, getResourceFolderName } = utils(CATALOG_PATH);
 
 // clean the catalog before each test
 beforeEach(() => {
@@ -32,6 +32,30 @@ describe('Resources SDK', () => {
       const folderName = await getResourceFolderName(CATALOG_PATH, 'OrderPlaced', '1');
 
       expect(folderName).toEqual('OrderPlaced');
+    });
+  });
+
+  describe('getResource type filtering', () => {
+    it('returns the requested resource type when multiple resources share the same id', async () => {
+      await writeChannel({
+        id: 'SharedResource',
+        name: 'SharedResource',
+        version: '1.0.0',
+        markdown: '',
+        address: 'shared.resource',
+      });
+
+      await writeService({
+        id: 'SharedResource',
+        name: 'SharedResource',
+        version: '1.0.0',
+        markdown: '',
+      });
+
+      const service = await getService('SharedResource');
+
+      expect(service?.id).toEqual('SharedResource');
+      expect(service?.address).toEqual(undefined);
     });
   });
 });


### PR DESCRIPTION
## Summary
- make SDK `findFileById` optionally type-aware using resource folder matching
- pass requested resource type from `getResource` into `findFileById`
- add regression test for duplicate id across different resource types (channel + service)
- add changeset for `@eventcatalog/sdk`

## Why
When multiple resource types share an id, `getService`/`getEvent`-style calls could resolve the wrong resource because lookup was id-only.

## Validation
- `pnpm --filter @eventcatalog/sdk exec vitest run src/test/resources.test.ts`
- `pnpm --filter @eventcatalog/sdk exec vitest run src/test/services.test.ts -t "returns the given service id from EventCatalog and the latest version when no version is given"`
