### PR TITLE
fix(core): prevent first-run dep-scan restart race in dev

### DIFF
--- a/.changeset/fair-poems-burn.md
+++ b/.changeset/fair-poems-burn.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Fix first-run dev startup race by loading non-module `eventcatalog.config.js` from a temp directory outside the project, avoiding watcher-triggered restarts during Vite dependency scanning.

--- a/packages/core/src/__tests__/eventcatalog-config-file-utils.spec.ts
+++ b/packages/core/src/__tests__/eventcatalog-config-file-utils.spec.ts
@@ -11,7 +11,6 @@ import {
   verifyRequiredFieldsAreInCatalogConfigFile,
   writeEventCatalogConfigFile,
 } from '../eventcatalog-config-file-utils';
-import { tmpdir } from 'os';
 
 describe('catalog-to-astro-content-directory', () => {
   afterEach(async () => {
@@ -103,10 +102,10 @@ describe('catalog-to-astro-content-directory', () => {
         })
       );
     });
-    it('removes eventcatalog config from the tmpdir', async () => {
+    it('does not create eventcatalog.config.mjs in the project directory', async () => {
       await getEventCatalogConfigFile(CATALOG_DIR);
 
-      const configFile = path.join(tmpdir(), 'eventcatalog.config.mjs');
+      const configFile = path.join(CATALOG_DIR, 'eventcatalog.config.mjs');
       expect(existsSync(configFile)).toBe(false);
     });
   });


### PR DESCRIPTION
## Summary
Fixes the first-run dev startup race that causes `vite:dep-scan` to fail with `Request is outdated` for fresh users.

### Root cause
When `package.json` is not `type: module`, `getEventCatalogConfigFile` copied `eventcatalog.config.js` to `eventcatalog.config.mjs` **inside the project directory** and then deleted it. That write/delete operation is picked up by Astro/Vite file watchers and triggers `Configuration file updated. Restarting...` during initial dependency scanning.

### Fix
- Load non-module config via a temp `.mjs` file in OS temp dir (outside project)
- Keep cleanup for legacy in-project temp files
- Add cache-busting query param to dynamic import

## Validation
- `pnpm --filter @eventcatalog/core exec vitest --run src/__tests__/eventcatalog-config-file-utils.spec.ts`
- Manual repro path verified before/after in fresh setup flow (`create-eventcatalog` + first `npm run dev`)

## Changeset
- patch release for `@eventcatalog/core`
