### PR TITLE
fix(core): extract isSameVersion to client-safe module to prevent node:path client bundle leak

### DIFF
--- a/.changeset/split-version-compare-client.md
+++ b/.changeset/split-version-compare-client.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Extract isSameVersion into client-safe module to prevent node:path from leaking into client bundle

--- a/packages/core/eventcatalog/src/components/Tables/Discover/DiscoverTable.tsx
+++ b/packages/core/eventcatalog/src/components/Tables/Discover/DiscoverTable.tsx
@@ -13,7 +13,7 @@ import { ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight, SearchX, X, Sea
 import { UserIcon } from '@heroicons/react/24/outline';
 import { useMemo, useState } from 'react';
 import type { TableConfiguration } from '@types';
-import { isSameVersion } from '@utils/collections/util';
+import { isSameVersion } from '@utils/collections/version-compare';
 import { FilterDropdown, CheckboxItem } from './FilterComponents';
 import DebouncedInput from '../DebouncedInput';
 import { getDiscoverColumns } from './columns';

--- a/packages/core/eventcatalog/src/components/Tables/Table.tsx
+++ b/packages/core/eventcatalog/src/components/Tables/Table.tsx
@@ -16,7 +16,7 @@ import { ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight, SearchX } from 
 import { getColumnsByCollection } from './columns';
 import { useEffect, useMemo, useState } from 'react';
 import type { CollectionMessageTypes, TableConfiguration } from '@types';
-import { isSameVersion } from '@utils/collections/util';
+import { isSameVersion } from '@utils/collections/version-compare';
 
 declare module '@tanstack/react-table' {
   // @ts-ignore

--- a/packages/core/eventcatalog/src/utils/collections/util.ts
+++ b/packages/core/eventcatalog/src/utils/collections/util.ts
@@ -1,6 +1,6 @@
 import type { CollectionTypes } from '@types';
 import type { CollectionEntry } from 'astro:content';
-import semver, { coerce, compare, eq, satisfies as satisfiesRange } from 'semver';
+import semver, { coerce, compare, satisfies as satisfiesRange } from 'semver';
 import path from 'node:path';
 
 // --- FILE PATH HELPERS ---
@@ -89,16 +89,7 @@ export const getVersions = (data: CollectionEntry<CollectionTypes>[]) => {
   return sortStringVersions(versions);
 };
 
-export function isSameVersion(v1: string | undefined, v2: string | undefined) {
-  const semverV1 = coerce(v1);
-  const semverV2 = coerce(v2);
-
-  if (semverV1 != null && semverV2 != null) {
-    return eq(semverV1, semverV2);
-  }
-
-  return v1 === v2;
-}
+export { isSameVersion } from './version-compare';
 
 /**
  * Sorts versioned items. Latest version first.

--- a/packages/core/eventcatalog/src/utils/collections/version-compare.ts
+++ b/packages/core/eventcatalog/src/utils/collections/version-compare.ts
@@ -1,0 +1,12 @@
+import { coerce, eq } from 'semver';
+
+export function isSameVersion(v1: string | undefined, v2: string | undefined) {
+  const semverV1 = coerce(v1);
+  const semverV2 = coerce(v2);
+
+  if (semverV1 != null && semverV2 != null) {
+    return eq(semverV1, semverV2);
+  }
+
+  return v1 === v2;
+}


### PR DESCRIPTION
## What This PR Does

Fixes a JavaScript heap out of memory crash during the Vite client build by preventing `node:path` from leaking into the client bundle. The `isSameVersion` function (used by client-side React table components) was imported from `util.ts`, which has a top-level `import path from 'node:path'`. This caused Vite to attempt externalizing/polyfilling Node built-ins for the browser, contributing to heap exhaustion.

## Changes Overview

### Key Changes
- Create `version-compare.ts` — a new client-safe module containing only `isSameVersion` with minimal `semver` imports (`coerce`, `eq`)
- Update `DiscoverTable.tsx` and `Table.tsx` to import `isSameVersion` from the new client-safe module
- Re-export `isSameVersion` from `util.ts` for backward compatibility with server-side consumers
- Remove unused `eq` import from `util.ts`

## How It Works

Previously, `DiscoverTable.tsx` and `Table.tsx` (both rendered with `client:only="react"` or `client:load`) imported `isSameVersion` from `@utils/collections/util`. Because `util.ts` has `import path from 'node:path'` at the top level, Vite pulled `node:path` into the client bundle graph — even though `isSameVersion` itself never uses `path`.

By extracting `isSameVersion` into its own `version-compare.ts` file that only imports `coerce` and `eq` from `semver`, the client bundle no longer includes `node:path` or any other Node built-ins.

## Breaking Changes

None — `isSameVersion` is still re-exported from `util.ts`, so all existing server-side imports continue to work.

## Test plan

- [ ] Verify `pnpm run verify-build:catalog` completes without heap OOM
- [ ] Verify the Vite warning about `node:path` externalization no longer appears during client build
- [ ] Verify discover and directory table pages render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)