### PR TITLE
Fix AsyncAPI Dark-Mode Code Block Readability

### DIFF
--- a/.changeset/silent-rivers-glow.md
+++ b/.changeset/silent-rivers-glow.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Fix AsyncAPI documentation code blocks in dark mode so EventCatalog prose styles do not make rendered text unreadable.

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/asyncapi/[filename].astro
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/asyncapi/[filename].astro
@@ -133,7 +133,7 @@ const pagefindAttributes =
         </div>
       )
     }
-    <div id="asyncapi" class="md:pr-14" set:html={renderedComponent} />
+    <div id="asyncapi" class="not-prose md:pr-14" set:html={renderedComponent} />
   </div>
 </VerticalSideBarLayout>
 
@@ -170,5 +170,26 @@ const pagefindAttributes =
     .aui-root .z-10 {
       z-index: 8;
     }
+  }
+
+  /* Keep AsyncAPI markdown code blocks isolated from EventCatalog dark prose overrides. */
+  :root[data-theme='dark'] #asyncapi .aui-root .prose code {
+    color: #1a202c;
+    background-color: transparent;
+    border-radius: 0;
+    padding: 0;
+  }
+
+  :root[data-theme='dark'] #asyncapi .aui-root .prose pre {
+    color: #edf2f7;
+    background-color: #1a202c;
+    border: 0;
+  }
+
+  :root[data-theme='dark'] #asyncapi .aui-root .prose pre code {
+    color: inherit;
+    background-color: transparent;
+    border-radius: 0;
+    padding: 0;
   }
 </style>


### PR DESCRIPTION
Related issues: Closes #2179

## What This PR Does

This PR fixes unreadable code blocks in rendered AsyncAPI documentation when EventCatalog dark mode is enabled. It prevents EventCatalog `prose` dark-mode overrides from bleeding into AsyncAPI-rendered content. The change keeps AsyncAPI code styles consistent and readable while preserving existing page behavior.

## Changes Overview

### Key Changes
- Add `not-prose` to the AsyncAPI root container to reduce inherited typography/theme overrides.
- Add scoped dark-mode CSS overrides for `#asyncapi .aui-root .prose code` and `pre` blocks.
- Add a patch changeset for `@eventcatalog/core`.

## How It Works

The AsyncAPI page already renders content under `#asyncapi` with AsyncAPI’s own `.aui-root` styles. This update strengthens style isolation by explicitly resetting dark-mode `code` and `pre` rules only inside that scoped container. That ensures EventCatalog global dark prose CSS no longer overrides AsyncAPI syntax block colors and spacing.

## Breaking Changes

None.

## Additional Notes

- A top-level `pnpm run format` attempt failed due a Turbo crash in this environment, so formatting was completed via `pnpm --filter @eventcatalog/core run format`.