### PR TITLE
fix(core): avoid 404 from domain integrations View Documentation CTA

### DIFF
--- a/packages/core/eventcatalog/src/pages/visualiser/domain-integrations/index.astro
+++ b/packages/core/eventcatalog/src/pages/visualiser/domain-integrations/index.astro
@@ -2,7 +2,14 @@
 import NodeGraph from '@components/MDX/NodeGraph/NodeGraph.astro';
 import VisualiserLayout from '@layouts/VisualiserLayout.astro';
 import { buildUrl } from '@utils/url-builder';
+import { getDomains } from '@utils/collections/domains';
 import { ClientRouter } from 'astro:transitions';
+
+const domains = await getDomains({ getAllVersions: false });
+const docsUrl =
+  domains.length > 0
+    ? buildUrl(`/docs/domains/${domains[0].data.id}/${domains[0].data.latestVersion}`)
+    : buildUrl('/discover/domains');
 ---
 
 <VisualiserLayout title={`Visualiser | Domain Architecture`} description="High-level view of all domains and their relationships">
@@ -23,7 +30,7 @@ import { ClientRouter } from 'astro:transitions';
       linksToVisualiser={false}
       href={{
         label: 'View Documentation',
-        url: buildUrl('/docs'),
+        url: docsUrl,
       }}
     />
   </div>


### PR DESCRIPTION
## Summary
- fixes the Domain Integrations visualiser CTA that currently links to /docs (404 in many catalogs)
- resolves the CTA to a meaningful docs destination:
  - first domain docs page when domains exist
  - /discover/domains fallback when the catalog has no domains yet

## Why
Issue #2178 reports that "View Documentation" on /visualiser/domain-integrations navigates to a dead route. This keeps the CTA useful across both populated and empty catalogs.

## Validation
- pnpm --filter @eventcatalog/core format
- pnpm --filter @eventcatalog/core test (43 files, 588 tests passing)

Closes #2178
