### PR TITLE
Feature/optimistic cache

### DIFF
--- a/.changeset/metal-fans-tan.md
+++ b/.changeset/metal-fans-tan.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/sdk": minor
+---
+
+Implement optimistic cache management

--- a/packages/sdk/src/internal/resources.ts
+++ b/packages/sdk/src/internal/resources.ts
@@ -20,13 +20,10 @@ export const versionResource = async (catalogDir: string, id: string) => {
     throw new Error(`No resource found with id: ${id}`);
   }
 
-  // Event that is in the route of the project
   const file = matchedFiles[0];
-  // Handle both forward and back slashes for cross-platform compatibility (Windows uses \, Unix uses /)
   const sourceDirectory = dirname(file).replace(/[/\\]versioned[/\\][^/\\]+[/\\]/, path.sep);
   const { data: { version = '0.0.1' } = {} } = matter.read(file);
   const targetDirectory = getVersionedDirectory(sourceDirectory, version);
-
   fsSync.mkdirSync(targetDirectory, { recursive: true });
 
   const ignoreListToCopy = ['events', 'commands', 'queries', 'versioned'];
@@ -72,7 +69,6 @@ export const versionResource = async (catalogDir: string, id: string) => {
   }
   // 2. Add the newly created versioned copy
   if (rootParsed) {
-    const { data: { version: ver = '0.0.1' } = {} } = rootParsed;
     const versionedIndexFile = fsSync.existsSync(join(targetDirectory, 'index.mdx'))
       ? join(targetDirectory, 'index.mdx')
       : join(targetDirectory, 'index.md');
@@ -95,13 +91,12 @@ export const writeResource = async (
 ) => {
   const path = options.path || `/${resource.id}`;
   const fullPath = join(catalogDir, path);
-  const format = options.format || 'mdx';
 
   // Create directory if it doesn't exist
   fsSync.mkdirSync(fullPath, { recursive: true });
 
   // Create or get lock file path
-  const lockPath = join(fullPath, `index.${format}`);
+  const lockPath = join(fullPath, `index.${options.format || 'mdx'}`);
 
   // Ensure the file exists before attempting to lock it
   if (!fsSync.existsSync(lockPath)) {

--- a/packages/sdk/src/internal/resources.ts
+++ b/packages/sdk/src/internal/resources.ts
@@ -1,5 +1,15 @@
 import { dirname, join } from 'path';
-import { copyDir, findFileById, getFiles, searchFilesForId, versionExists, cachedMatterRead, invalidateFileCache, upsertFileCacheEntry, removeFileCacheEntries } from './utils';
+import {
+  copyDir,
+  findFileById,
+  getFiles,
+  searchFilesForId,
+  versionExists,
+  cachedMatterRead,
+  invalidateFileCache,
+  upsertFileCacheEntry,
+  removeFileCacheEntries,
+} from './utils';
 import matter from 'gray-matter';
 import fs from 'node:fs/promises';
 import fsSync from 'node:fs';

--- a/packages/sdk/src/internal/utils.ts
+++ b/packages/sdk/src/internal/utils.ts
@@ -91,11 +91,7 @@ export function invalidateFileCache(): void {
  * Optimistically add or update a resource entry in the in-memory cache after a write.
  * If the cache is not populated this is a no-op (it will be built lazily on the next read).
  */
-export function upsertFileCacheEntry(
-  filePath: string,
-  parsed: matter.GrayMatterFile<string>,
-  isVersioned: boolean
-): void {
+export function upsertFileCacheEntry(filePath: string, parsed: matter.GrayMatterFile<string>, isVersioned: boolean): void {
   if (!_fileIndexCache || !_matterCache) return;
 
   const id = parsed.data.id;
@@ -231,10 +227,7 @@ export const getFiles = async (pattern: string, ignore: string | string[] = '') 
   if (_fileIndexCache && _matterCache && _fileIndexCatalogDir) {
     const normalizedCatalogDir = normalize(_fileIndexCatalogDir).replace(/\\/g, '/');
     const normalizedPattern = normalize(pattern).replace(/\\/g, '/');
-    if (
-      normalizedPattern.startsWith(normalizedCatalogDir) &&
-      normalizedPattern.includes('index.{md,mdx}')
-    ) {
+    if (normalizedPattern.startsWith(normalizedCatalogDir) && normalizedPattern.includes('index.{md,mdx}')) {
       const ignoreList = (Array.isArray(ignore) ? ignore : [ignore]).filter(Boolean);
       const matchRegex = globToRegex(normalizedPattern);
       const ignoreRegexes = ignoreList.map((ig) => globToRegex(ig.replace(/\\/g, '/')));


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://www.eventcatalog.dev/docs/contributing/overview

Happy contributing!

-->

## Motivation

SDK operations on big catalog keep getting slower & slower the more mdx files there is in it.

Using the recently introduced caching mechanism, this PR is an attempt to change its frequent invalidation to use instead optimistic changes related to the currently applied alteration.

First test on a big catalog show great performance improvement (down to ~5ms writeResource operations coming from up to 1500-2000ms/operation)
