### PR TITLE
fix(sdk): ensure typed lookups don't return wrong resource kind

### DIFF
--- a/packages/sdk/src/internal/utils.ts
+++ b/packages/sdk/src/internal/utils.ts
@@ -107,7 +107,12 @@ export const versionExists = async (catalogDir: string, id: string, version: str
   return entries.some((e) => e.version === version);
 };
 
-export const findFileById = async (catalogDir: string, id: string, version?: string): Promise<string | undefined> => {
+export const findFileById = async (
+  catalogDir: string,
+  id: string,
+  version?: string,
+  _options?: { type?: string }
+): Promise<string | undefined> => {
   ensureFileCache(catalogDir);
 
   const entries = _fileIndexCache!.get(id);

--- a/packages/sdk/src/test/channels.test.ts
+++ b/packages/sdk/src/test/channels.test.ts
@@ -25,6 +25,7 @@ const {
   writeQuery,
   getQuery,
   addFileToQuery,
+  writeService,
 } = utils(CATALOG_PATH);
 
 // clean the catalog before each test
@@ -57,6 +58,22 @@ const mockChannel = {
 describe('Channels SDK', () => {
   describe('getChannel', () => {
     it('returns the given channel id from EventCatalog and the latest version when no version is given,', async () => {
+      await writeChannel(mockChannel);
+
+      const test = await getChannel('inventory.{env}.events');
+
+      expect(test).toEqual(mockChannel);
+    });
+
+    it('returns the channel when another resource type shares the same id', async () => {
+      await writeService({
+        id: 'inventory.{env}.events',
+        name: 'Conflicting Service',
+        version: '1.0.0',
+        summary: 'Service that shares an id with a channel',
+        markdown: '# Service',
+      });
+
       await writeChannel(mockChannel);
 
       const test = await getChannel('inventory.{env}.events');

--- a/packages/sdk/src/test/services.test.ts
+++ b/packages/sdk/src/test/services.test.ts
@@ -29,6 +29,7 @@ const {
   toService,
   addDataStoreToService,
   writeDataStore,
+  writeChannel,
 } = utils(CATALOG_PATH);
 
 // clean the catalog before each test
@@ -72,6 +73,35 @@ describe('Services SDK', () => {
         },
         attachments: ['https://example.com'],
         diagrams: [{ id: 'InventoryServiceDiagram', version: '1.0.0' }],
+      });
+    });
+
+    it('returns the service when another resource type shares the same id', async () => {
+      await writeChannel({
+        id: 'InventoryService',
+        name: 'Inventory Service Channel',
+        version: '1.0.0',
+        summary: 'Channel that shares an id with a service',
+        markdown: '# Channel',
+        address: 'inventory.service.events',
+      });
+
+      await writeService({
+        id: 'InventoryService',
+        name: 'Inventory Service',
+        version: '0.0.1',
+        summary: 'Service tat handles the inventory',
+        markdown: '# Hello world',
+      });
+
+      const test = await getService('InventoryService');
+
+      expect(test).toEqual({
+        id: 'InventoryService',
+        name: 'Inventory Service',
+        version: '0.0.1',
+        summary: 'Service tat handles the inventory',
+        markdown: '# Hello world',
       });
     });
 


### PR DESCRIPTION
## Summary
- fix `getResource` to enforce resource-type directory matching when `options.type` is provided
- add fallback search for matching `id` + `version` scoped to expected directories
- preserve existing `findFileById` behavior to avoid side effects in non-typed callers
- add regression tests for id collisions between channels/services

## Why
Fixes #2102 where typed SDK APIs (e.g. `getService`, `getChannel`) can return the wrong resource when ids collide across types.

## Validation
- `pnpm --filter @eventcatalog/sdk exec vitest --run src/test/services.test.ts src/test/channels.test.ts src/test/messages.test.ts src/test/data-store.test.ts`
- `pnpm --filter @eventcatalog/sdk format`
