### PR TITLE
fix(core): replace concurrently with native spawn for dev server

### DIFF
--- a/.changeset/teal-lions-dance.md
+++ b/.changeset/teal-lions-dance.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Replace `concurrently` with native `spawn` for dev server process management, improving output filtering and replacing astro version line with eventcatalog version

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.5",
+    "prettier-plugin-astro": "^0.14.1",
     "turbo": "^2.8.4"
   },
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@changesets/cli':
         specifier: ^2.27.5
         version: 2.29.7(@types/node@22.13.14)
+      prettier-plugin-astro:
+        specifier: ^0.14.1
+        version: 0.14.1
       turbo:
         specifier: ^2.8.4
         version: 2.8.4


### PR DESCRIPTION
## What This PR Does

Removes the `concurrently` dependency from the dev server startup and replaces it with the existing `runCommandWithFilteredOutput` helper which uses native Node.js `spawn`. This improves output filtering capabilities and adds a line transformer that replaces the Astro version line in the terminal output with the EventCatalog version.

## Changes Overview

### Key Changes
- Remove `concurrently` import from `eventcatalog.ts` — dev command now uses `runCommandWithFilteredOutput`
- Add `createAstroDevLineFilter()` to filter `[router]` lines in addition to existing glob-loader/collection noise
- Add `replaceAstroReadyVersionLine()` to swap `astro vX.Y.Z  ready ...` with `eventcatalog vX.Y.Z  ready ...`
- Add optional `transformLine` parameter to `runCommandWithFilteredOutput` for per-line output transformation
- Add `prettier-plugin-astro` dev dependency to root `package.json`

## How It Works

Previously the dev server was launched via `concurrently` which used platform-specific shell pipes (`grep` on Unix, `findstr` on Windows) for filtering output. This was replaced by passing the `npx astro dev` command directly to `runCommandWithFilteredOutput`, which reads stdout line-by-line using the existing cross-platform approach. A new `transformLine` option allows mutating individual lines before writing them, used here to display the EventCatalog version instead of the Astro version in the "ready" banner.

## Breaking Changes

None

## Additional Notes

- The `concurrently` package can be removed from `packages/core` dependencies as a follow-up if it is no longer used elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)