### PR TITLE
feat(core): add doc resource reference type for custom documentation pages

### DIFF
--- a/.changeset/clever-foxes-dance.md
+++ b/.changeset/clever-foxes-dance.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Add `doc` resource reference type support for custom documentation pages, extract badge styling into shared utility, and fix theming to use CSS variables

--- a/examples/default/docs/guides/event-storming/01-index.mdx
+++ b/examples/default/docs/guides/event-storming/01-index.mdx
@@ -101,5 +101,5 @@ To conduct an effective Event Storming session, you'll need:
 ## Next Steps
 
 Continue reading to learn:
-- [How to Facilitate an Event Storming Session](/docs/guides/event-storming/02-facilitation)
-- [From Event Storming to Implementation](/docs/guides/event-storming/03-implementation) 
+- [[doc|guides/event-storming/02-facilitation]]
+- [[doc|guides/event-storming/03-implementation]]

--- a/examples/default/docs/operations-and-support/runbooks/index.mdx
+++ b/examples/default/docs/operations-and-support/runbooks/index.mdx
@@ -16,6 +16,15 @@ Browse the runbooks in this section to find procedures for:
 - **Payment Service** - Payment gateway and transaction failures
 - **Shipping Service** - Shipping provider integrations and tracking
 
+## Quick Links
+
+Use inline custom doc references to jump directly to each runbook:
+
+- [[doc|operations-and-support/runbooks/inventory-service-runbook]]
+- [[doc|operations-and-support/runbooks/orders-service-runbook]]
+- [[doc|operations-and-support/runbooks/payment-service-runbook]]
+- [[doc|operations-and-support/runbooks/shipping-service-runbook]]
+
 ## Using Runbooks
 
 1. Identify the affected service

--- a/packages/core/eventcatalog/src/components/MDX/ResourceRef/ResourceRef.astro
+++ b/packages/core/eventcatalog/src/components/MDX/ResourceRef/ResourceRef.astro
@@ -28,7 +28,8 @@ interface Props {
     | 'diagram'
     | 'container'
     | 'user'
-    | 'team';
+    | 'team'
+    | 'doc';
   version?: string;
 }
 
@@ -37,6 +38,20 @@ const { type = 'entity', version } = Astro.props;
 // Get resource ID from slot content
 const slotContent = await Astro.slots.render('default');
 const resourceId = slotContent.trim();
+
+const normalizeCustomDocPath = (value: string): string => {
+  const normalized = value
+    .trim()
+    .replace(/^https?:\/\/[^/]+/i, '')
+    .replace(/\\/g, '/');
+  return normalized
+    .replace(/^\/+/, '')
+    .replace(/^docs\/custom\//i, '')
+    .replace(/^docs\//i, '')
+    .replace(/\/+$/, '');
+};
+
+const normalizedResourceId = normalizeCustomDocPath(resourceId).toLowerCase();
 
 // Map type to collection name
 const collection = resourceToCollectionMap[type as keyof typeof resourceToCollectionMap];
@@ -56,6 +71,7 @@ const typeStyles: Record<string, { borderColor: string; label: string }> = {
   container: { borderColor: 'var(--ec-badge-default-text)', label: 'Container' }, // gray
   user: { borderColor: 'var(--ec-badge-default-text)', label: 'User' }, // gray
   team: { borderColor: 'var(--ec-badge-default-text)', label: 'Team' }, // gray
+  doc: { borderColor: 'var(--ec-badge-default-text)', label: 'Doc' }, // gray
 };
 
 // SVG icons for each type (from heroicons outline)
@@ -81,6 +97,7 @@ const typeIcons: Record<string, string> = {
     '<path stroke-linecap="round" stroke-linejoin="round" d="M20.25 6.375c0 2.278-3.694 4.125-8.25 4.125S3.75 8.653 3.75 6.375m16.5 0c0-2.278-3.694-4.125-8.25-4.125S3.75 4.097 3.75 6.375m16.5 0v11.25c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125V6.375m16.5 0v3.75m-16.5-3.75v3.75m16.5 0v3.75C20.25 16.153 16.556 18 12 18s-8.25-1.847-8.25-4.125v-3.75m16.5 0c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125" />', // Database
   user: '<path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z" />', // User
   team: '<path stroke-linecap="round" stroke-linejoin="round" d="M18 18.72a9.094 9.094 0 003.741-.479 3 3 0 00-4.682-2.72m.94 3.198l.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0112 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 016 18.719m12 0a5.971 5.971 0 00-.941-3.197m0 0A5.995 5.995 0 0012 12.75a5.995 5.995 0 00-5.058 2.772m0 0a3 3 0 00-4.681 2.72 8.986 8.986 0 003.74.477m.94-3.197a5.971 5.971 0 00-.94 3.197M15 6.75a3 3 0 11-6 0 3 3 0 016 0zm6 3a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0zm-13.5 0a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0z" />', // UserGroup
+  doc: '<path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-8.25a2.25 2.25 0 00-2.25-2.25h-10.5A2.25 2.25 0 004.5 6v12a2.25 2.25 0 002.25 2.25h5.25M16.5 18.75h6m-3-3v6" />', // Document with plus
 };
 
 const style = typeStyles[type] || typeStyles.entity;
@@ -92,23 +109,51 @@ let hasError = false;
 let errorMessage = '';
 
 try {
-  if (!collection) {
-    throw new Error(`Unknown resource type: ${type}`);
+  if (type === 'doc') {
+    const docs = (await getCollection('customPages')) as {
+      id: string;
+      data: { title?: string; summary?: string; slug?: string; owners?: any[] };
+    }[];
+
+    const doc = docs.find((entry) => {
+      const normalizedId = normalizeCustomDocPath(entry.id).toLowerCase();
+      const normalizedSlug = normalizeCustomDocPath(entry.data.slug || '').toLowerCase();
+
+      return normalizedId === normalizedResourceId || normalizedSlug === normalizedResourceId;
+    });
+
+    if (!doc) {
+      throw new Error(`Document not found: ${resourceId}`);
+    }
+
+    const docSlug = normalizeCustomDocPath(doc.data.slug || doc.id);
+    href = buildUrl(`/docs/custom/${docSlug}`);
+    resource = {
+      ...doc,
+      data: {
+        ...doc.data,
+        name: doc.data.title || docSlug,
+      },
+    };
+  } else {
+    if (!collection) {
+      throw new Error(`Unknown resource type: ${type}`);
+    }
+
+    const resourcesCollection = (await getCollection(collection as any)) as { data: { id: string; version: string } }[];
+    const resources = getItemsFromCollectionByIdAndSemverOrLatest(resourcesCollection, resourceId, version);
+
+    if (resources.length === 0) {
+      throw new Error(`Resource not found: ${resourceId}`);
+    }
+
+    resource = resources[0];
+    // Diagrams use /diagrams/ path, other resources use /docs/{collection}/
+    href =
+      type === 'diagram'
+        ? buildUrl(`/diagrams/${resourceId}/${resource.data.version}`)
+        : buildUrl(`/docs/${collection}/${resourceId}/${resource.data.version}`);
   }
-
-  const resourcesCollection = (await getCollection(collection as any)) as { data: { id: string; version: string } }[];
-  const resources = getItemsFromCollectionByIdAndSemverOrLatest(resourcesCollection, resourceId, version);
-
-  if (resources.length === 0) {
-    throw new Error(`Resource not found: ${resourceId}`);
-  }
-
-  resource = resources[0];
-  // Diagrams use /diagrams/ path, other resources use /docs/{collection}/
-  href =
-    type === 'diagram'
-      ? buildUrl(`/diagrams/${resourceId}/${resource.data.version}`)
-      : buildUrl(`/docs/${collection}/${resourceId}/${resource.data.version}`);
 } catch (error) {
   hasError = true;
   errorMessage = error instanceof Error ? error.message : 'Unknown error';
@@ -118,6 +163,8 @@ try {
 const maxSummaryLength = 120;
 const summary = resource?.data?.summary || '';
 const truncatedSummary = summary.length > maxSummaryLength ? summary.slice(0, maxSummaryLength) + '...' : summary;
+
+const isVersionedResource = type !== 'doc';
 
 // Only these types have visualizers
 const hasVisualizer = ['domain', 'service', 'event', 'query', 'command', 'container'].includes(type);
@@ -192,7 +239,7 @@ const tooltipId = `ref-tooltip-${Math.random().toString(36).slice(2, 9)}`;
     hasError ? (
       <span
         class="text-[rgb(var(--ec-page-text-muted))] underline decoration-wavy decoration-red-400/50 underline-offset-2 cursor-help"
-        title={`Resource not found: ${resourceId}`}
+        title={`Reference not found: ${resourceId}`}
       >
         {resourceId}
       </span>
@@ -240,9 +287,11 @@ const tooltipId = `ref-tooltip-${Math.random().toString(36).slice(2, 9)}`;
                   </span>
                   <span class="text-[0.65rem] text-[rgb(var(--ec-page-text-muted))] uppercase tracking-wide">{style.label}</span>
                 </span>
-                <span class="text-[0.7rem] font-mono text-[rgb(var(--ec-page-text-muted))] mt-0.5">
-                  v{resource?.data?.version}
-                </span>
+                {isVersionedResource && (
+                  <span class="text-[0.7rem] font-mono text-[rgb(var(--ec-page-text-muted))] mt-0.5">
+                    v{resource?.data?.version}
+                  </span>
+                )}
               </span>
               <svg
                 class="w-5 h-5 flex-shrink-0"
@@ -392,7 +441,7 @@ const tooltipId = `ref-tooltip-${Math.random().toString(36).slice(2, 9)}`;
                 )}
               </span>
               <a href={href} class="text-[rgb(var(--ec-accent))] hover:underline font-medium">
-                {type === 'diagram' ? 'View diagram' : 'View docs'}
+                {type === 'diagram' ? 'View diagram' : type === 'doc' ? 'View doc' : 'View docs'}
               </a>
             </span>
           </span>

--- a/packages/core/eventcatalog/src/enterprise/custom-documentation/components/CustomDocsNav/components/NestedItem.tsx
+++ b/packages/core/eventcatalog/src/enterprise/custom-documentation/components/CustomDocsNav/components/NestedItem.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { buildUrl } from '@utils/url-builder';
 import type { SidebarItem } from '../types';
 import { ExternalLinkIcon } from 'lucide-react';
+import { getCustomDocsSidebarBadgeClasses } from '@enterprise/custom-documentation/utils/badge-styles';
 
 interface NestedItemProps {
   item: SidebarItem;
@@ -28,6 +29,8 @@ const NestedItem: React.FC<NestedItemProps> = ({
     const folderHasLink = !!item.slug;
     const folderPath = folderHasLink ? buildUrl(`/docs/custom/${item.slug}`) : undefined;
     const isFolderActive = folderPath && (currentPath === folderPath || currentPath.endsWith(`/${item.slug}`));
+
+    const badgeClassName = getCustomDocsSidebarBadgeClasses(item.badge?.color);
 
     return (
       <div className="py-1">
@@ -66,17 +69,7 @@ const NestedItem: React.FC<NestedItemProps> = ({
               data-active={isFolderActive}
             >
               <span className="truncate">{item.label}</span>
-              {item.badge && item?.badge?.text && (
-                <span
-                  className={
-                    item.badge.color
-                      ? `text-${item.badge.color}-600 dark:text-${item.badge.color}-400 ml-2 text-[10px] font-medium bg-${item.badge.color}-50 dark:bg-${item.badge.color}-500/20 px-2 py-0.5 rounded uppercase`
-                      : `text-[rgb(var(--ec-accent))] ml-2 text-[10px] font-medium bg-[rgb(var(--ec-accent-subtle))] px-2 py-0.5 rounded uppercase`
-                  }
-                >
-                  {item.badge.text}
-                </span>
-              )}
+              {item.badge && item?.badge?.text && <span className={badgeClassName}>{item.badge.text}</span>}
             </a>
           ) : (
             // Folder without index file - render as toggle button
@@ -88,17 +81,7 @@ const NestedItem: React.FC<NestedItemProps> = ({
               }}
             >
               <span className="truncate">{item.label}</span>
-              {item.badge && item?.badge?.text && (
-                <span
-                  className={
-                    item.badge.color
-                      ? `text-${item.badge.color}-600 dark:text-${item.badge.color}-400 ml-2 text-[10px] font-medium bg-${item.badge.color}-50 dark:bg-${item.badge.color}-500/20 px-2 py-0.5 rounded uppercase`
-                      : `text-[rgb(var(--ec-accent))] ml-2 text-[10px] font-medium bg-[rgb(var(--ec-accent-subtle))] px-2 py-0.5 rounded uppercase`
-                  }
-                >
-                  {item.badge.text}
-                </span>
-              )}
+              {item.badge && item?.badge?.text && <span className={badgeClassName}>{item.badge.text}</span>}
             </button>
           )}
         </div>
@@ -153,6 +136,8 @@ const NestedItem: React.FC<NestedItemProps> = ({
     itemPath = item.slug;
   }
 
+  const badgeClassName = getCustomDocsSidebarBadgeClasses(item.badge?.color);
+
   return (
     <a
       href={itemPath}
@@ -165,17 +150,7 @@ const NestedItem: React.FC<NestedItemProps> = ({
         {item.label}
         {isExternalLink && <ExternalLinkIcon className="w-3 -mt-0.5 h-3" />}
       </span>
-      {item.badge && item?.badge?.text && (
-        <span
-          className={
-            item.badge.color
-              ? `text-${item.badge.color}-600 dark:text-${item.badge.color}-400 ml-2 text-[10px] font-medium bg-${item.badge.color}-50 dark:bg-${item.badge.color}-500/20 px-2 py-0.5 rounded uppercase`
-              : `text-[rgb(var(--ec-accent))] ml-2 text-[10px] font-medium bg-[rgb(var(--ec-accent-subtle))] px-2 py-0.5 rounded uppercase`
-          }
-        >
-          {item.badge.text}
-        </span>
-      )}
+      {item.badge && item?.badge?.text && <span className={badgeClassName}>{item.badge.text}</span>}
     </a>
   );
 };

--- a/packages/core/eventcatalog/src/enterprise/custom-documentation/components/CustomDocsNav/index.tsx
+++ b/packages/core/eventcatalog/src/enterprise/custom-documentation/components/CustomDocsNav/index.tsx
@@ -4,6 +4,7 @@ import { buildUrl } from '@utils/url-builder';
 import type { CustomDocsNavProps, SidebarSection, SidebarItem } from './types';
 import NestedItem from './components/NestedItem';
 import NoResultsFound from './components/NoResultsFound';
+import { getCustomDocsSidebarBadgeClasses } from '@enterprise/custom-documentation/utils/badge-styles';
 
 const STORAGE_KEY = 'EventCatalog:customDocsSidebarCollapsedGroups';
 const DEBOUNCE_DELAY = 300; // 300ms debounce delay
@@ -225,105 +226,98 @@ const CustomDocsNav: React.FC<CustomDocsNavProps> = ({ sidebarItems }) => {
         {hasNoResults ? (
           <NoResultsFound searchTerm={debouncedSearchTerm} />
         ) : (
-          filteredSidebarItems.map((section: SidebarSection, index: number) => (
-            <div className="pt-2 pb-2 px-3" key={`section-${index}`}>
-              <div className="space-y-0" data-section={`section-${index}`}>
-                {section.items ? (
-                  <div className="flex items-center">
-                    <button
-                      className="p-1 hover:bg-[rgb(var(--ec-content-hover))] rounded-md flex-shrink-0"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        toggleGroupCollapse(`section-${index}`);
-                      }}
-                    >
-                      <div
-                        className={`transition-transform duration-150 ${collapsedGroups[`section-${index}`] ? '' : 'rotate-180'}`}
+          filteredSidebarItems.map((section: SidebarSection, index: number) => {
+            const sectionBadgeClassName = getCustomDocsSidebarBadgeClasses(section.badge?.color);
+            return (
+              <div className="pt-2 pb-2 px-3" key={`section-${index}`}>
+                <div className="space-y-0" data-section={`section-${index}`}>
+                  {section.items ? (
+                    <div className="flex items-center">
+                      <button
+                        className="p-1 hover:bg-[rgb(var(--ec-content-hover))] rounded-md flex-shrink-0"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          toggleGroupCollapse(`section-${index}`);
+                        }}
                       >
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          strokeWidth="1.5"
-                          stroke="currentColor"
-                          aria-hidden="true"
-                          data-slot="icon"
-                          className="h-3 w-3 text-[rgb(var(--ec-icon-color))]"
+                        <div
+                          className={`transition-transform duration-150 ${collapsedGroups[`section-${index}`] ? '' : 'rotate-180'}`}
                         >
-                          <path strokeLinecap="round" strokeLinejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"></path>
-                        </svg>
+                          <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            strokeWidth="1.5"
+                            stroke="currentColor"
+                            aria-hidden="true"
+                            data-slot="icon"
+                            className="h-3 w-3 text-[rgb(var(--ec-icon-color))]"
+                          >
+                            <path strokeLinecap="round" strokeLinejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"></path>
+                          </svg>
+                        </div>
+                      </button>
+                      <button
+                        className="flex items-center justify-between px-2 py-0.5 text-xs font-bold rounded-md hover:bg-[rgb(var(--ec-content-hover))] min-w-0 flex-1"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          toggleGroupCollapse(`section-${index}`);
+                        }}
+                      >
+                        <span className="truncate">{section.label}</span>
+                        {section.badge && section?.badge?.text && (
+                          <span className={sectionBadgeClassName}>{section.badge.text}</span>
+                        )}
+                      </button>
+                    </div>
+                  ) : (
+                    <div className="flex items-center">
+                      <span className="flex-grow flex items-center justify-between px-2 py-0.5 text-xs font-bold rounded-md">
+                        <span className="truncate">{section.label}</span>
+                        <span className={sectionBadgeClassName}>Section</span>
+                      </span>
+                    </div>
+                  )}
+
+                  {section.items && (
+                    <div
+                      className={`overflow-hidden transition-[height] duration-150 ease-out ${
+                        collapsedGroups[`section-${index}`] ? 'h-0' : 'h-auto'
+                      }`}
+                    >
+                      <div className="space-y-0.5 border-[rgb(var(--ec-page-border))] border-l pl-4 ml-[9px] mt-1">
+                        {section.items.map((item: SidebarItem, itemIndex: number) => (
+                          <NestedItem
+                            key={`item-${index}-${itemIndex}`}
+                            item={item}
+                            currentPath={currentPath}
+                            parentId={`${index}`}
+                            itemIndex={itemIndex}
+                            collapsedGroups={collapsedGroups}
+                            toggleGroupCollapse={toggleGroupCollapse}
+                          />
+                        ))}
                       </div>
-                    </button>
-                    <button
-                      className="flex items-center justify-between px-2 py-0.5 text-xs font-bold rounded-md hover:bg-[rgb(var(--ec-content-hover))] min-w-0 flex-1"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        toggleGroupCollapse(`section-${index}`);
-                      }}
+                    </div>
+                  )}
+
+                  {section.slug && !section.items && (
+                    <a
+                      href={buildUrl(`/docs/custom/${section.slug}`)}
+                      className={`flex items-center px-2 py-1.5 text-xs ${
+                        currentPath.endsWith(`/${section.slug}`)
+                          ? 'bg-[rgb(var(--ec-accent-subtle))] text-[rgb(var(--ec-page-text))] font-semibold'
+                          : 'text-[rgb(var(--ec-page-text-muted))] hover:bg-[rgb(var(--ec-content-hover))]'
+                      } rounded-md ml-6`}
+                      data-active={currentPath.endsWith(`/${section.slug}`)}
                     >
                       <span className="truncate">{section.label}</span>
-                      {section.badge && section?.badge?.text && (
-                        <span
-                          className={
-                            section.badge.color
-                              ? `text-${section.badge.color}-600 dark:text-${section.badge.color}-400 ml-2 text-[10px] font-medium bg-${section.badge.color}-50 dark:bg-${section.badge.color}-500/20 px-2 py-0.5 rounded uppercase`
-                              : `text-[rgb(var(--ec-accent))] ml-2 text-[10px] font-medium bg-[rgb(var(--ec-accent-subtle))] px-2 py-0.5 rounded uppercase`
-                          }
-                        >
-                          {section.badge.text}
-                        </span>
-                      )}
-                    </button>
-                  </div>
-                ) : (
-                  <div className="flex items-center">
-                    <span className="flex-grow flex items-center justify-between px-2 py-0.5 text-xs font-bold rounded-md">
-                      <span className="truncate">{section.label}</span>
-                      <span className="text-[rgb(var(--ec-accent))] ml-2 text-[10px] font-medium bg-[rgb(var(--ec-accent-subtle))] px-2 py-0.5 rounded uppercase">
-                        Section
-                      </span>
-                    </span>
-                  </div>
-                )}
-
-                {section.items && (
-                  <div
-                    className={`overflow-hidden transition-[height] duration-150 ease-out ${
-                      collapsedGroups[`section-${index}`] ? 'h-0' : 'h-auto'
-                    }`}
-                  >
-                    <div className="space-y-0.5 border-[rgb(var(--ec-page-border))] border-l pl-4 ml-[9px] mt-1">
-                      {section.items.map((item: SidebarItem, itemIndex: number) => (
-                        <NestedItem
-                          key={`item-${index}-${itemIndex}`}
-                          item={item}
-                          currentPath={currentPath}
-                          parentId={`${index}`}
-                          itemIndex={itemIndex}
-                          collapsedGroups={collapsedGroups}
-                          toggleGroupCollapse={toggleGroupCollapse}
-                        />
-                      ))}
-                    </div>
-                  </div>
-                )}
-
-                {section.slug && !section.items && (
-                  <a
-                    href={buildUrl(`/docs/custom/${section.slug}`)}
-                    className={`flex items-center px-2 py-1.5 text-xs ${
-                      currentPath.endsWith(`/${section.slug}`)
-                        ? 'bg-[rgb(var(--ec-accent-subtle))] text-[rgb(var(--ec-page-text))] font-semibold'
-                        : 'text-[rgb(var(--ec-page-text-muted))] hover:bg-[rgb(var(--ec-content-hover))]'
-                    } rounded-md ml-6`}
-                    data-active={currentPath.endsWith(`/${section.slug}`)}
-                  >
-                    <span className="truncate">{section.label}</span>
-                  </a>
-                )}
+                    </a>
+                  )}
+                </div>
               </div>
-            </div>
-          ))
+            );
+          })
         )}
       </div>
     </nav>

--- a/packages/core/eventcatalog/src/enterprise/custom-documentation/pages/docs/custom/index.astro
+++ b/packages/core/eventcatalog/src/enterprise/custom-documentation/pages/docs/custom/index.astro
@@ -12,6 +12,7 @@ import { buildUrl } from '@utils/url-builder';
 import { resourceToCollectionMap } from '@utils/collections/util';
 import { getMDXComponentsByName } from '@utils/markdown';
 import { getAdjacentPages } from '@enterprise/custom-documentation/utils/custom-docs';
+import { getCustomDocsContentBadgeClasses } from '@enterprise/custom-documentation/utils/badge-styles';
 
 import CustomDocsNav from '@enterprise/custom-documentation/components/CustomDocsNav/CustomDocsNav.astro';
 import NodeGraph from '@components/MDX/NodeGraph/NodeGraph.astro';
@@ -78,6 +79,11 @@ const ownersList = filteredOwners.map((o) => ({
 }));
 
 const badges = doc?.badges || [];
+
+const getCustomDocBadgeClasses = (badge: any) => {
+  const color = badge?.backgroundColor || badge?.textColor;
+  return `${getCustomDocsContentBadgeClasses(color)} ${badge?.class ? badge.class : ''}`;
+};
 ---
 
 <VerticalSideBarLayout title={doc.title || 'Documentation'} showNestedSideBar={false}>
@@ -104,12 +110,9 @@ const badges = doc?.badges || [];
                   {badges.map((badge: any) => {
                     return (
                       <a href={badge.url || '#'} class="pb-2">
-                        <span
-                          id={badge.id || ''}
-                          class={`text-sm font-light text-gray-500 px-2 py-1 rounded-md mr-2  bg-gradient-to-b  from-${badge.backgroundColor}-100 to-${badge.backgroundColor}-200 space-x-1 border border-${badge.backgroundColor}-200 text-${badge.textColor}-800 flex items-center ${badge.class ? badge.class : ''} `}
-                        >
-                          {badge.icon && <badge.icon className="w-4 h-4 inline-block mr-1 " />}
-                          {badge.iconURL && <img src={badge.iconURL} class="w-5 h-5 inline-block " />}
+                        <span id={badge.id || ''} class={`${getCustomDocBadgeClasses(badge)} mr-2`}>
+                          {badge.icon && <badge.icon className="w-4 h-4 flex-shrink-0 text-[rgb(var(--ec-icon-color))]" />}
+                          {badge.iconURL && <img src={badge.iconURL} class="w-4 h-4 flex-shrink-0 opacity-80" alt="" />}
                           <span>{badge.content}</span>
                         </span>
                       </a>

--- a/packages/core/eventcatalog/src/enterprise/custom-documentation/utils/badge-styles.ts
+++ b/packages/core/eventcatalog/src/enterprise/custom-documentation/utils/badge-styles.ts
@@ -1,0 +1,51 @@
+type ThemeBadgeType = 'domain' | 'service' | 'event' | 'command' | 'query' | 'design' | 'channel' | 'default';
+
+const THEME_BADGE_CLASSES: Record<ThemeBadgeType, string> = {
+  domain: 'bg-[rgb(var(--ec-badge-domain-bg))] text-[rgb(var(--ec-badge-domain-text))]',
+  service: 'bg-[rgb(var(--ec-badge-service-bg))] text-[rgb(var(--ec-badge-service-text))]',
+  event: 'bg-[rgb(var(--ec-badge-event-bg))] text-[rgb(var(--ec-badge-event-text))]',
+  command: 'bg-[rgb(var(--ec-badge-command-bg))] text-[rgb(var(--ec-badge-command-text))]',
+  query: 'bg-[rgb(var(--ec-badge-query-bg))] text-[rgb(var(--ec-badge-query-text))]',
+  design: 'bg-[rgb(var(--ec-badge-design-bg))] text-[rgb(var(--ec-badge-design-text))]',
+  channel: 'bg-[rgb(var(--ec-badge-channel-bg))] text-[rgb(var(--ec-badge-channel-text))]',
+  default: 'bg-[rgb(var(--ec-badge-default-bg))] text-[rgb(var(--ec-badge-default-text))]',
+};
+
+const COLOR_TO_THEME_BADGE: Record<string, ThemeBadgeType> = {
+  yellow: 'domain',
+  amber: 'event',
+  orange: 'event',
+  red: 'event',
+  rose: 'event',
+  pink: 'service',
+  fuchsia: 'service',
+  blue: 'command',
+  sky: 'command',
+  purple: 'query',
+  violet: 'query',
+  cyan: 'query',
+  teal: 'design',
+  green: 'design',
+  emerald: 'design',
+  lime: 'design',
+  indigo: 'channel',
+  slate: 'default',
+  gray: 'default',
+  zinc: 'default',
+  neutral: 'default',
+  stone: 'default',
+};
+
+const getThemeBadgeClasses = (color?: string) => {
+  if (!color) return THEME_BADGE_CLASSES.default;
+  const key = color.trim().toLowerCase();
+  return THEME_BADGE_CLASSES[COLOR_TO_THEME_BADGE[key] || 'default'];
+};
+
+export const getCustomDocsSidebarBadgeClasses = (color?: string) => {
+  return `ml-2 text-[10px] font-medium px-2 py-0.5 rounded uppercase border border-[rgb(var(--ec-page-border))] ${getThemeBadgeClasses(color)}`;
+};
+
+export const getCustomDocsContentBadgeClasses = (color?: string) => {
+  return `inline-flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm font-medium border border-[rgb(var(--ec-page-border))] ${getThemeBadgeClasses(color)}`;
+};

--- a/packages/core/eventcatalog/src/layouts/VerticalSideBarLayout.astro
+++ b/packages/core/eventcatalog/src/layouts/VerticalSideBarLayout.astro
@@ -225,6 +225,22 @@ const canPageBeEmbedded = isEmbedEnabled();
     </script>
     <SEO title={`EventCatalog | ${title}`} description={description} ogTitle={title} />
     <style is:global>
+      html,
+      body {
+        background-color: rgb(var(--ec-page-bg));
+      }
+
+      body {
+        min-height: 100vh;
+        min-height: 100dvh;
+      }
+
+      #eventcatalog-application {
+        min-height: 100vh;
+        min-height: 100dvh;
+        background-color: rgb(var(--ec-page-bg));
+      }
+
       .sidebar-transition {
         transition-property: width, transform;
         transition-duration: 300ms;

--- a/packages/core/eventcatalog/src/remark-plugins/__tests__/resource-ref.spec.ts
+++ b/packages/core/eventcatalog/src/remark-plugins/__tests__/resource-ref.spec.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { remarkResourceRef } from '../resource-ref';
+
+type MdxElement = {
+  type: 'mdxJsxTextElement';
+  name: string;
+  attributes: Array<{ type: string; name: string; value: string }>;
+  children: Array<{ type: string; value: string }>;
+};
+
+const createTree = (value: string) => ({
+  type: 'root',
+  children: [
+    {
+      type: 'paragraph',
+      children: [{ type: 'text', value }],
+    },
+  ],
+});
+
+const getResourceRefs = (node: any, refs: MdxElement[] = []): MdxElement[] => {
+  if (node?.type === 'mdxJsxTextElement' && node?.name === 'ResourceRef') {
+    refs.push(node as MdxElement);
+  }
+
+  if (Array.isArray(node?.children)) {
+    node.children.forEach((child: any) => getResourceRefs(child, refs));
+  }
+
+  return refs;
+};
+
+const getAttributeValue = (node: MdxElement, name: string) => {
+  return node.attributes.find((attr) => attr.name === name)?.value;
+};
+
+describe('remarkResourceRef', () => {
+  it('transforms custom doc references with nested paths', () => {
+    const tree = createTree('See [[doc|runbooks/oncall/intro]].');
+
+    remarkResourceRef()(tree);
+
+    const refs = getResourceRefs(tree);
+
+    expect(refs).toHaveLength(1);
+    expect(getAttributeValue(refs[0], 'type')).toBe('doc');
+    expect(getAttributeValue(refs[0], 'version')).toBeUndefined();
+    expect(refs[0].children[0].value).toBe('runbooks/oncall/intro');
+  });
+
+  it('preserves @ characters in doc references', () => {
+    const tree = createTree('See [[doc|runbooks/oncall@v2]].');
+
+    remarkResourceRef()(tree);
+
+    const refs = getResourceRefs(tree);
+
+    expect(refs).toHaveLength(1);
+    expect(getAttributeValue(refs[0], 'type')).toBe('doc');
+    expect(getAttributeValue(refs[0], 'version')).toBeUndefined();
+    expect(refs[0].children[0].value).toBe('runbooks/oncall@v2');
+  });
+
+  it('keeps version parsing for existing resource references', () => {
+    const tree = createTree('See [[service|OrdersService@1.2.3]].');
+
+    remarkResourceRef()(tree);
+
+    const refs = getResourceRefs(tree);
+
+    expect(refs).toHaveLength(1);
+    expect(getAttributeValue(refs[0], 'type')).toBe('service');
+    expect(getAttributeValue(refs[0], 'version')).toBe('1.2.3');
+    expect(refs[0].children[0].value).toBe('OrdersService');
+  });
+});

--- a/packages/core/eventcatalog/src/remark-plugins/resource-ref.ts
+++ b/packages/core/eventcatalog/src/remark-plugins/resource-ref.ts
@@ -7,17 +7,31 @@ import { findAndReplace } from 'mdast-util-find-and-replace';
  * - [[entity|Order]] -> <ResourceRef type="entity">Order</ResourceRef>
  * - [[service|OrderService@1.0.0]] -> <ResourceRef type="service" version="1.0.0">OrderService</ResourceRef>
  * - [[diagram|target-architecture]] -> <ResourceRef type="diagram">target-architecture</ResourceRef>
+ * - [[doc|runbooks/oncall]] -> <ResourceRef type="doc">runbooks/oncall</ResourceRef>
  * - [[Order]] -> <ResourceRef type="entity">Order</ResourceRef> (defaults to entity)
  * - [[Order@0.0.1]] -> <ResourceRef type="entity" version="0.0.1">Order</ResourceRef>
  */
 export function remarkResourceRef() {
   return function (tree: any) {
-    // First pass: match [[type|Name]] or [[type|Name@version]] pattern
+    // First pass: match [[type|Name]], [[type|Name@version]], or nested ids like [[doc|guides/getting-started]]
     findAndReplace(tree, [
-      /\[\[([a-z]+)\|([\w-]+)(?:@([\d.]+))?\]\]/g,
+      /\[\[([a-z-]+)\|([^[\]]+?)\]\]/g,
       // @ts-ignore: Types are complex but it works
-      function (_match: string, type: string, resourceId: string, version?: string) {
-        const attributes: any[] = [{ type: 'mdxJsxAttribute', name: 'type', value: type }];
+      function (_match: string, type: string, target: string) {
+        const normalizedType = type.trim().toLowerCase();
+        let resourceId = target.trim();
+        let version: string | undefined;
+
+        // Preserve existing @version behavior for resource refs, but keep doc targets as-is.
+        if (normalizedType !== 'doc') {
+          const versionMatch = resourceId.match(/^(.*)@([\d.]+)$/);
+          if (versionMatch) {
+            resourceId = versionMatch[1].trim();
+            version = versionMatch[2];
+          }
+        }
+
+        const attributes: any[] = [{ type: 'mdxJsxAttribute', name: 'type', value: normalizedType }];
         if (version) {
           attributes.push({ type: 'mdxJsxAttribute', name: 'version', value: version });
         }


### PR DESCRIPTION
## What This PR Does

Adds a new `[[doc|path/to/doc]]` wiki-link syntax for referencing custom documentation pages inline within MDX content. This allows authors to create rich inline links to custom docs pages with tooltips, similar to how events, services, and other resources are referenced. Also extracts badge styling into a shared utility and fixes theming to use CSS variables throughout the custom docs sidebar.

## Changes Overview

### Key Changes
- **New `doc` resource type** — `ResourceRef.astro` now handles `type === 'doc'` by looking up entries in the `customPages` collection and rendering a tooltip with title and summary
- **Remark plugin update** — `resource-ref.ts` regex updated to support forward-slash paths in the target (e.g. `[[doc|guides/event-storming/02-facilitation]]`), replacing the stricter `[\w-]+` pattern
- **`normalizeCustomDocPath` helper** — strips URL prefixes and normalizes paths to match `customPages` collection IDs
- **Badge styles utility** — new `badge-styles.ts` extracts repeated badge className logic from `NestedItem.tsx` and `CustomDocsNav/index.tsx` into a single shared function with CSS variable-based theming
- **Theming fixes** — `index.astro` and `VerticalSideBarLayout.astro` migrated from hardcoded Tailwind colors / `dark:` variants to `--ec-*` CSS variables
- **Tests** — new test file `resource-ref.spec.ts` covering the remark plugin for doc paths, `@`-versioned paths, and versioned service refs
- **Example catalog** — updated guide and runbook MDX files to demonstrate the new `[[doc|...]]` syntax

## How It Works

The `[[doc|path/to/doc]]` syntax is parsed by the remark plugin which emits a `resourceRef` MDX component call with `type="doc"`. `ResourceRef.astro` detects this type, fetches the matching `customPages` entry by normalizing the path (stripping `docs/custom/` prefixes), and renders an inline link with a hover tooltip showing the page title and summary. If the doc is not found, it renders a broken-link styled fallback.

## Breaking Changes

None

## Additional Notes

- The regex change in `resource-ref.ts` is intentionally permissive for path characters — callers should ensure only valid paths are passed
- The `doc` type intentionally bypasses `resourceToCollectionMap` since custom pages use a separate lookup pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)