### PR TITLE
Improve AvroSchemaViewer nested type resolution and enum handling

### DIFF
--- a/.changeset/dry-planes-talk.md
+++ b/.changeset/dry-planes-talk.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+feat(core): improved AvroSchemaViewer nested type resolution and enum handling


### PR DESCRIPTION
## Problem
The AvroSchemaViewer component had limited support for nested types. It could only expand fields that were direct record types at the top level. If a field was an array<record>, a map<record>, or a union containing a record (e.g., ["null", "record"]), the component:
1. Failed to show the "expand" toggle.
2. Failed to render nested fields even if they existed.
3. Failed to display enum symbols if they were wrapped in complex types.

## Solution
Refactored AvroSchemaViewer.tsx to recursively resolve nested types and correctly identify nestable structures regardless of how many levels of unions, arrays, or maps wrap them.
Key Changes:
* Recursive Nesting Detection: Refactored hasNestedFields to be recursive. It now correctly returns true if a type is a record, an array/map containing a nestable type, or a union containing any nestable type.
* Deep Type Extraction: Introduced a robust getNestedType(type, target) helper function. This replaces limited logic and can drill through any combination of array, map, and union to find a specific target type (either 'record' or 'enum').
* Enhanced AvroField Logic:
  * Uses getNestedType(field.type, 'record') to identify if there are child fields to render.
  * Uses getNestedType(field.type, 'enum') to identify if there are enum symbols to display.
  * The "Expand" button visibility is now driven by the enhanced recursive hasNestedFields.
* Recursive Prop Propagation: Updated the recursive rendering of child fields to pass down expand and showRequired props, ensuring the expanded/collapsed state and visibility settings are maintained throughout the schema hierarchy.