### PR TITLE
fix(core): fix dark theme support on custom docs feature page

### DIFF
--- a/.changeset/bright-taxis-dream.md
+++ b/.changeset/bright-taxis-dream.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Fix dark theme support on custom documentation feature page by replacing hardcoded dark: variants with CSS variables

--- a/packages/core/eventcatalog/src/pages/docs/custom/feature.astro
+++ b/packages/core/eventcatalog/src/pages/docs/custom/feature.astro
@@ -10,7 +10,7 @@ import { BookOpenIcon, FileText } from 'lucide-react';
       <div class="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center mb-16">
         <div>
           <div
-            class="inline-flex items-center px-4 py-2 rounded-full bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300 font-medium text-sm mb-6"
+            class="inline-flex items-center px-4 py-2 rounded-full bg-[rgb(var(--ec-accent-subtle))] text-[rgb(var(--ec-accent))] font-medium text-sm mb-6"
           >
             <FileText className="w-4 h-4 mr-2" />
             New: Bring your documentation into EventCatalog
@@ -26,7 +26,7 @@ import { BookOpenIcon, FileText } from 'lucide-react';
             <a
               href="https://demo.eventcatalog.dev/docs/custom/guides/creating-new-microservices/01-index"
               target="_blank"
-              class="inline-flex items-center justify-center px-6 py-3 border border-transparent text-base font-medium rounded-lg text-white bg-blue-600 hover:bg-blue-700 transition-colors duration-150"
+              class="inline-flex items-center justify-center px-6 py-3 border border-transparent text-base font-medium rounded-lg text-[rgb(var(--ec-button-text))] bg-[rgb(var(--ec-button-bg))] hover:opacity-90 transition-colors duration-150"
             >
               View the demo
               <svg class="ml-2 w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
@@ -46,7 +46,7 @@ import { BookOpenIcon, FileText } from 'lucide-react';
           </div>
           <p class="text-sm text-[rgb(var(--ec-page-text-muted))]">
             Available with EventCatalog Starter or Scale plans
-            <a href="https://www.eventcatalog.dev/pricing" class="text-blue-600 dark:text-blue-400 font-medium block"
+            <a href="https://www.eventcatalog.dev/pricing" class="text-[rgb(var(--ec-accent))] font-medium block"
               >Try free for 14 days, no credit card required</a
             >
           </p>
@@ -73,8 +73,8 @@ import { BookOpenIcon, FileText } from 'lucide-react';
       {/* Features Section */}
       <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
         <div class="bg-[rgb(var(--ec-card-bg))] rounded-xl p-6 shadow-sm border border-[rgb(var(--ec-page-border))]">
-          <div class="w-12 h-12 bg-blue-100 dark:bg-blue-900/30 rounded-lg flex items-center justify-center mb-4">
-            <svg class="w-6 h-6 text-blue-600 dark:text-blue-400" viewBox="0 0 24 24" fill="currentColor">
+          <div class="w-12 h-12 bg-[rgb(var(--ec-accent-subtle))] rounded-lg flex items-center justify-center mb-4">
+            <svg class="w-6 h-6 text-[rgb(var(--ec-accent))]" viewBox="0 0 24 24" fill="currentColor">
               <path d="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zM6 20V4h7v5h5v11H6z"></path>
             </svg>
           </div>
@@ -85,8 +85,8 @@ import { BookOpenIcon, FileText } from 'lucide-react';
         </div>
 
         <div class="bg-[rgb(var(--ec-card-bg))] rounded-xl p-6 shadow-sm border border-[rgb(var(--ec-page-border))]">
-          <div class="w-12 h-12 bg-blue-100 dark:bg-blue-900/30 rounded-lg flex items-center justify-center mb-4">
-            <svg class="w-6 h-6 text-blue-600 dark:text-blue-400" viewBox="0 0 24 24" fill="currentColor">
+          <div class="w-12 h-12 bg-[rgb(var(--ec-accent-subtle))] rounded-lg flex items-center justify-center mb-4">
+            <svg class="w-6 h-6 text-[rgb(var(--ec-accent))]" viewBox="0 0 24 24" fill="currentColor">
               <path
                 d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-5 14H7v-2h7v2zm3-4H7v-2h10v2zm0-4H7V7h10v2z"
               ></path>
@@ -99,8 +99,8 @@ import { BookOpenIcon, FileText } from 'lucide-react';
         </div>
 
         <div class="bg-[rgb(var(--ec-card-bg))] rounded-xl p-6 shadow-sm border border-[rgb(var(--ec-page-border))]">
-          <div class="w-12 h-12 bg-blue-100 dark:bg-blue-900/30 rounded-lg flex items-center justify-center mb-4">
-            <svg class="w-6 h-6 text-blue-600 dark:text-blue-400" viewBox="0 0 24 24" fill="currentColor">
+          <div class="w-12 h-12 bg-[rgb(var(--ec-accent-subtle))] rounded-lg flex items-center justify-center mb-4">
+            <svg class="w-6 h-6 text-[rgb(var(--ec-accent))]" viewBox="0 0 24 24" fill="currentColor">
               <path d="M18 2H6c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zM6 4h5v8l-2.5-1.5L6 12V4z"
               ></path>
             </svg>
@@ -112,8 +112,8 @@ import { BookOpenIcon, FileText } from 'lucide-react';
         </div>
 
         <div class="bg-[rgb(var(--ec-card-bg))] rounded-xl p-6 shadow-sm border border-[rgb(var(--ec-page-border))]">
-          <div class="w-12 h-12 bg-blue-100 dark:bg-blue-900/30 rounded-lg flex items-center justify-center mb-4">
-            <svg class="w-6 h-6 text-blue-600 dark:text-blue-400" viewBox="0 0 24 24" fill="currentColor">
+          <div class="w-12 h-12 bg-[rgb(var(--ec-accent-subtle))] rounded-lg flex items-center justify-center mb-4">
+            <svg class="w-6 h-6 text-[rgb(var(--ec-accent))]" viewBox="0 0 24 24" fill="currentColor">
               <path
                 d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"
               ></path>
@@ -126,8 +126,8 @@ import { BookOpenIcon, FileText } from 'lucide-react';
         </div>
 
         <div class="bg-[rgb(var(--ec-card-bg))] rounded-xl p-6 shadow-sm border border-[rgb(var(--ec-page-border))]">
-          <div class="w-12 h-12 bg-blue-100 dark:bg-blue-900/30 rounded-lg flex items-center justify-center mb-4">
-            <svg class="w-6 h-6 text-blue-600 dark:text-blue-400" viewBox="0 0 24 24" fill="currentColor">
+          <div class="w-12 h-12 bg-[rgb(var(--ec-accent-subtle))] rounded-lg flex items-center justify-center mb-4">
+            <svg class="w-6 h-6 text-[rgb(var(--ec-accent))]" viewBox="0 0 24 24" fill="currentColor">
               <path d="M3 9h14V7H3v2zm0 4h14v-2H3v2zm0 4h14v-2H3v2zm16 0h2v-2h-2v2zm0-10v2h2V7h-2zm0 6h2v-2h-2v2z"></path>
             </svg>
           </div>
@@ -138,8 +138,8 @@ import { BookOpenIcon, FileText } from 'lucide-react';
         </div>
 
         <div class="bg-[rgb(var(--ec-card-bg))] rounded-xl p-6 shadow-sm border border-[rgb(var(--ec-page-border))]">
-          <div class="w-12 h-12 bg-blue-100 dark:bg-blue-900/30 rounded-lg flex items-center justify-center mb-4">
-            <svg class="w-6 h-6 text-blue-600 dark:text-blue-400" viewBox="0 0 24 24" fill="currentColor">
+          <div class="w-12 h-12 bg-[rgb(var(--ec-accent-subtle))] rounded-lg flex items-center justify-center mb-4">
+            <svg class="w-6 h-6 text-[rgb(var(--ec-accent))]" viewBox="0 0 24 24" fill="currentColor">
               <path d="M20 2H4c-1.1 0-2 .9-2 2v18l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm0 14H6l-2 2V4h16v12z"></path>
             </svg>
           </div>


### PR DESCRIPTION
## What This PR Does

The custom documentation feature page (`/docs/custom/feature`) used hardcoded `dark:` Tailwind variants and static blue color classes that don't respond to EventCatalog's CSS variable-based theming system. This PR replaces all instances with the appropriate CSS variables so the page renders correctly in dark mode.

## Changes Overview

### Key Changes
- Replace `dark:bg-blue-900/30` / `bg-blue-100` with `bg-[rgb(var(--ec-accent-subtle))]`
- Replace `dark:text-blue-300` / `text-blue-700` / `text-blue-600` / `dark:text-blue-400` with `text-[rgb(var(--ec-accent))]`
- Replace `text-white bg-blue-600 hover:bg-blue-700` on CTA button with `text-[rgb(var(--ec-button-text))] bg-[rgb(var(--ec-button-bg))]`

## How It Works

EventCatalog uses CSS variables (`--ec-*`) that automatically adapt to the active theme via the `data-theme` attribute. The `dark:` Tailwind variants only work with Tailwind's built-in dark mode detection, which doesn't align with EventCatalog's theming. By switching to CSS variables, the page now correctly follows whatever theme is active.

## Breaking Changes

None

## Test plan

- [ ] Verify custom docs feature page renders correctly in light theme
- [ ] Verify custom docs feature page renders correctly in dark theme
- [ ] Verify badge pill, CTA button, pricing link, and feature card icons all use correct theme colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)