### PR TITLE
chore(core): upgrade jsonpath dependency to v1.2.1

### DIFF
--- a/.changeset/gentle-foxes-leap.md
+++ b/.changeset/gentle-foxes-leap.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+upgrade jsonpath dependency from v1.2.0 to v1.2.1

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -97,7 +97,7 @@
     "hono": "^4.11.7",
     "html-to-image": "^1.11.11",
     "js-yaml": "^4.1.1",
-    "jsonpath": "^1.2.0",
+    "jsonpath": "^1.2.1",
     "jsonwebtoken": "^9.0.2",
     "lodash.debounce": "^4.0.8",
     "lodash.merge": "4.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,7 +220,7 @@ importers:
         specifier: ^4.1.1
         version: 4.1.1
       jsonpath:
-        specifier: ^1.2.0
+        specifier: ^1.2.1
         version: 1.2.1
       jsonwebtoken:
         specifier: ^9.0.2


### PR DESCRIPTION
## What This PR Does

Upgrades the `jsonpath` dependency in `@eventcatalog/core` from `^1.2.0` to `^1.2.1` to pick up the latest patch release with bug fixes.

## Changes Overview

### Key Changes
- Updated `jsonpath` version in `packages/core/package.json` from `^1.2.0` to `^1.2.1`
- Updated `pnpm-lock.yaml` with the resolved version

## Breaking Changes

None

## Additional Notes

Patch-level dependency bump only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)