### PR TITLE
Support template parameters in DSL channel names

### DIFF
--- a/.changeset/template-channel-names.md
+++ b/.changeset/template-channel-names.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/language-server": minor
+---
+
+Support template parameters in channel names (e.g. `inventory.{env}.events`) in the DSL grammar

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,6 @@
 ## @eventcatalog/cli
 
-Command-line interface for [EventCatalog](https://eventcatalog.dev). Execute catalog operations directly from your terminal to automate your EventCatalog.
+Command-line interface for [EventCatalog](https://eventcatalog.dev). Import and export catalogs using the [EventCatalog DSL](https://www.eventcatalog.dev/docs/development/dsl/introduction), run SDK functions directly from your terminal, and automate your EventCatalog workflows.
 
 ### Installation
 
@@ -11,7 +11,7 @@ npm i @eventcatalog/cli
 ### Running with npx (no installation required)
 
 ```bash
-npx @eventcatalog/cli --dir <catalog-path> <function-name> [args...]
+npx @eventcatalog/cli --dir <catalog-path> <command> [args...]
 ```
 
 ### Running after installation
@@ -19,77 +19,180 @@ npx @eventcatalog/cli --dir <catalog-path> <function-name> [args...]
 If you've installed the package, the `eventcatalog` command is available:
 
 ```bash
-eventcatalog --dir <catalog-path> <function-name> [args...]
+eventcatalog --dir <catalog-path> <command> [args...]
 ```
 
-### Common Operations
+### Global Options
 
-**List all available functions:**
+| Option             | Description                    | Default                 |
+| ------------------ | ------------------------------ | ----------------------- |
+| `-d, --dir <path>` | Path to your catalog directory | `.` (current directory) |
+
+---
+
+### Commands
+
+#### `import` — Import DSL files into your catalog
+
+Parse `.ec` (EventCatalog DSL) files and write them as catalog resources (markdown + frontmatter).
 
 ```bash
-npx @eventcatalog/cli list
+eventcatalog import [files...] [options]
 ```
 
-**Get an event:**
+**Options:**
+
+| Option      | Description                                                  |
+| ----------- | ------------------------------------------------------------ |
+| `--stdin`   | Read DSL from stdin instead of files                         |
+| `--dry-run` | Preview changes without writing to disk                      |
+| `--flat`    | Write all resources at the top level (no nested directories) |
+| `--no-init` | Skip the interactive catalog scaffolding prompt              |
+
+**Examples:**
 
 ```bash
-npx @eventcatalog/cli --dir ./my-catalog getEvent "OrderCreated"
-npx @eventcatalog/cli --dir ./my-catalog getEvent "OrderCreated" "1.0.0"
+# Import a single DSL file
+eventcatalog import architecture.ec
+
+# Import multiple files
+eventcatalog import services.ec events.ec domains.ec
+
+# Pipe DSL from another tool
+cat architecture.ec | eventcatalog import --stdin
+
+# Preview what would change
+eventcatalog import architecture.ec --dry-run
+
+# Import without nesting services inside domains
+eventcatalog import architecture.ec --flat
 ```
 
-**Get all events:**
+**Behaviors:**
+
+- If no `eventcatalog.config.js` exists, you'll be prompted to scaffold a new catalog (skip with `--no-init`).
+- Importing a newer version of an existing resource automatically versions the old one.
+- Re-importing the same version overwrites the existing resource.
+- Referenced resources that aren't defined in the DSL (e.g., `sends event OrderCreated` without an inline body) are created as stubs at version `0.0.1`.
+- Existing resource locations are preserved — updates go to where the resource already lives.
+
+---
+
+#### `export` — Export catalog resources to DSL
+
+Convert catalog resources back into EventCatalog DSL (`.ec`) format.
 
 ```bash
-npx @eventcatalog/cli --dir ./my-catalog getEvents
-npx @eventcatalog/cli --dir ./my-catalog getEvents '{"latestOnly":true}'
+eventcatalog export [options]
 ```
 
-**Write an event:**
+**Options:**
+
+| Option                | Description                                                                                  |
+| --------------------- | -------------------------------------------------------------------------------------------- |
+| `--all`               | Export the entire catalog                                                                    |
+| `--resource <type>`   | Resource type to export (`event`, `command`, `query`, `service`, `domain`, `channel`)        |
+| `--id <id>`           | Export a specific resource by ID (requires `--resource`)                                     |
+| `--version <version>` | Export a specific version (requires `--resource` and `--id`)                                 |
+| `--hydrate`           | Include referenced resources (e.g., messages referenced by a service)                        |
+| `--stdout`            | Print to stdout instead of writing a file                                                    |
+| `--playground`        | Open the exported DSL in the [EventCatalog Playground](https://playground.eventcatalog.dev/) |
+| `--output <path>`     | Custom output file path                                                                      |
+
+**Examples:**
 
 ```bash
-npx @eventcatalog/cli --dir ./my-catalog writeEvent '{"id":"OrderCreated","name":"Order Created","version":"1.0.0","markdown":"# Order Created Event"}'
+# Export a single event
+eventcatalog export --resource event --id OrderCreated --stdout
+
+# Export all services with their referenced messages
+eventcatalog export --resource service --hydrate --stdout
+
+# Export the entire catalog to a file
+eventcatalog export --all --output catalog.ec
+
+# Export and open in the playground
+eventcatalog export --all --playground
 ```
 
-**Get a service:**
+---
+
+#### `list` — List available SDK functions
+
+Display all SDK functions organized by category (Events, Commands, Queries, Services, Domains, etc.).
 
 ```bash
-npx @eventcatalog/cli --dir ./my-catalog getService "InventoryService"
+eventcatalog list
 ```
 
-**Add an event to a service:**
+---
+
+#### `<function>` — Run any SDK function
+
+Any unrecognized command is treated as an SDK function call. Output is JSON.
 
 ```bash
-npx @eventcatalog/cli --dir ./my-catalog addEventToService "InventoryService" "sends" '{"id":"OrderCreated","version":"1.0.0"}'
+eventcatalog <function-name> [args...]
 ```
 
-### Piping to Other Tools
-
-Output is JSON by default, making it easy to pipe to tools like `jq`:
+**Examples:**
 
 ```bash
-# Get all events and filter by version
-npx @eventcatalog/cli --dir ./my-catalog getEvents | jq '.[] | select(.version == "1.0.0")'
+# Get an event (latest version)
+eventcatalog --dir ./my-catalog getEvent "OrderCreated"
+
+# Get a specific version
+eventcatalog --dir ./my-catalog getEvent "OrderCreated" "1.0.0"
+
+# Get all events with options
+eventcatalog --dir ./my-catalog getEvents '{"latestOnly":true}'
+
+# Write an event
+eventcatalog --dir ./my-catalog writeEvent '{"id":"OrderCreated","name":"Order Created","version":"1.0.0","markdown":"# Order Created"}'
+
+# Get a service
+eventcatalog --dir ./my-catalog getService "InventoryService"
+
+# Add an event to a service
+eventcatalog --dir ./my-catalog addEventToService "InventoryService" "sends" '{"id":"OrderCreated","version":"1.0.0"}'
+```
+
+Run `eventcatalog list` to see all available functions.
+
+---
+
+### Piping and Composing
+
+Output from SDK functions is JSON, making it easy to pipe to tools like `jq`:
+
+```bash
+# Filter events by version
+eventcatalog --dir ./my-catalog getEvents | jq '.[] | select(.version == "1.0.0")'
 
 # Count total events
-npx @eventcatalog/cli --dir ./my-catalog getEvents | jq 'length'
+eventcatalog --dir ./my-catalog getEvents | jq 'length'
 
 # Extract event IDs
-npx @eventcatalog/cli --dir ./my-catalog getEvents | jq '.[].id'
+eventcatalog --dir ./my-catalog getEvents | jq '.[].id'
 ```
 
 ### Arguments Format
 
 Arguments are automatically parsed:
 
-- **JSON objects:** `'{"key":"value"}'` - parsed as object
-- **JSON arrays:** `'["item1","item2"]'` - parsed as array
-- **Booleans:** `true` or `false` - parsed as boolean
-- **Numbers:** `42` or `3.14` - parsed as number
-- **Strings:** anything else - kept as string
+- **JSON objects:** `'{"key":"value"}'` — parsed as object
+- **JSON arrays:** `'["item1","item2"]'` — parsed as array
+- **Booleans:** `true` or `false` — parsed as boolean
+- **Numbers:** `42` or `3.14` — parsed as number
+- **Strings:** anything else — kept as string
 
-See the [SDK docs](https://www.eventcatalog.dev/docs/sdk) for more information and examples.
+### Documentation
 
-# Enterprise support
+- [EventCatalog DSL](https://www.eventcatalog.dev/docs/development/dsl/introduction)
+- [SDK reference](https://www.eventcatalog.dev/docs/sdk)
+- [CLI documentation](https://www.eventcatalog.dev/docs/development/cli)
+
+## Enterprise support
 
 Interested in collaborating with us? Our offerings include dedicated support, priority assistance, feature development, custom integrations, and more.
 

--- a/packages/cli/src/test/import-export/channels.test.ts
+++ b/packages/cli/src/test/import-export/channels.test.ts
@@ -251,4 +251,40 @@ service OrderService {
     const channelMatches = result.match(/SharedTopic@/g);
     expect(channelMatches).toHaveLength(1);
   });
+
+  it('imports a channel with template parameters in the name', async () => {
+    const ecFile = writeEcFile(
+      'test.ec',
+      `channel inventory.{env}.events {
+  version 1.0.0
+  name "Inventory Events Channel"
+  address "inventory.{env}.events"
+  protocol "kafka"
+  summary "Central event stream for inventory events"
+}
+
+service InventoryService {
+  version 1.0.0
+  name "Inventory Service"
+  sends event InventoryAdjusted to inventory.{env}.events
+}`
+    );
+
+    const result = await importDSL({ files: [ecFile], dir: catalogPath });
+
+    expect(result).toContain('Created');
+
+    const sdk = createSDK(catalogPath);
+    const channel = await sdk.getChannel('inventory.{env}.events', '1.0.0');
+    expect(channel).toBeDefined();
+    expect(channel!.name).toBe('Inventory Events Channel');
+    expect(channel!.address).toBe('inventory.{env}.events');
+
+    const service = await sdk.getService('InventoryService', '1.0.0');
+    expect(service).toBeDefined();
+    expect(service!.sends).toBeDefined();
+    expect(service!.sends).toHaveLength(1);
+    expect((service!.sends![0] as any).to).toBeDefined();
+    expect((service!.sends![0] as any).to[0].id).toBe('inventory.{env}.events');
+  });
 });

--- a/packages/language-server/src/ec.langium
+++ b/packages/language-server/src/ec.langium
@@ -58,7 +58,7 @@ MessageBodyItem:
 
 // ─── Channel ────────────────────────────────────────────
 ChannelDef:
-  'channel' name=ID '{' (body+=ChannelBodyItem)* '}';
+  'channel' name=ChannelName '{' (body+=ChannelBodyItem)* '}';
 
 ChannelBodyItem:
   VersionStmt | NameStmt | SummaryStmt | OwnerStmt |
@@ -305,7 +305,7 @@ FromClause:
   ('delivery' deliveryMode=DeliveryMode)?;
 
 ChannelRef:
-  channelName=ID ('@' channelVersion=VERSION)?;
+  channelName=ChannelName ('@' channelVersion=VERSION)?;
 
 DeliveryMode returns string:
   'push' | 'pull' | 'push-pull';
@@ -361,7 +361,10 @@ StyleEnum returns string:
   'default' | 'post-it';
 
 ChannelRefStmt:
-  'channel' ref=ResourceRef;
+  'channel' ref=ChannelResourceRef;
+
+ChannelResourceRef:
+  name=ChannelName ('@' version=VERSION)?;
 
 FlowRefStmt:
   'flow' ref=ResourceRef;
@@ -451,6 +454,10 @@ ResourceRef:
 BoolLiteral returns boolean:
   'true' | 'false';
 
+// ─── Channel name (supports template parameters like {env}) ─
+ChannelName returns string:
+  TEMPLATE_ID | ID;
+
 // ─── Terminals ──────────────────────────────────────────
 hidden terminal WS: /\s+/;
 hidden terminal SL_COMMENT: /\/\/[^\n\r]*/;
@@ -458,4 +465,5 @@ hidden terminal ML_COMMENT: /\/\*[\s\S]*?\*\//;
 terminal VERSION: /\d+\.\d+\.\d+(-[a-zA-Z0-9_.]+)*/;
 terminal STRING: /"(?:[^"\\]|\\.)*"/;
 terminal NUMBER: /\d+/;
+terminal TEMPLATE_ID: /[a-zA-Z_][a-zA-Z0-9_.-]*\{[a-zA-Z0-9_]+\}[a-zA-Z0-9_.{}-]*/;
 terminal ID: /[a-zA-Z_][a-zA-Z0-9_.-]*/;

--- a/packages/language-server/src/generated/ast.ts
+++ b/packages/language-server/src/generated/ast.ts
@@ -13,6 +13,7 @@ export const EcTerminals = {
   VERSION: /\d+\.\d+\.\d+(-[a-zA-Z0-9_.]+)*/,
   STRING: /"(?:[^"\\]|\\.)*"/,
   NUMBER: /\d+/,
+  TEMPLATE_ID: /[a-zA-Z_][a-zA-Z0-9_.-]*\{[a-zA-Z0-9_]+\}[a-zA-Z0-9_.{}-]*/,
   ID: /[a-zA-Z_][a-zA-Z0-9_.-]*/,
 };
 
@@ -280,6 +281,16 @@ export const ChannelClause = "ChannelClause";
 
 export function isChannelClause(item: unknown): item is ChannelClause {
   return reflection.isInstance(item, ChannelClause);
+}
+
+export type ChannelName = string;
+
+export function isChannelName(item: unknown): item is ChannelName {
+  return (
+    typeof item === "string" &&
+    (/[a-zA-Z_][a-zA-Z0-9_.-]*\{[a-zA-Z0-9_]+\}[a-zA-Z0-9_.{}-]*/.test(item) ||
+      /[a-zA-Z_][a-zA-Z0-9_.-]*/.test(item))
+  );
 }
 
 export type ClassificationEnum =
@@ -731,7 +742,7 @@ export interface ChannelDef extends langium.AstNode {
   readonly $container: DomainDef | Program | SubdomainDef | VisualizerDef;
   readonly $type: "ChannelDef";
   body: Array<ChannelBodyItem>;
-  name: string;
+  name: ChannelName;
 }
 
 export const ChannelDef = "ChannelDef";
@@ -743,7 +754,7 @@ export function isChannelDef(item: unknown): item is ChannelDef {
 export interface ChannelRef extends langium.AstNode {
   readonly $container: FromClause | ToClause;
   readonly $type: "ChannelRef";
-  channelName: string;
+  channelName: ChannelName;
   channelVersion?: string;
 }
 
@@ -756,13 +767,28 @@ export function isChannelRef(item: unknown): item is ChannelRef {
 export interface ChannelRefStmt extends langium.AstNode {
   readonly $container: VisualizerDef;
   readonly $type: "ChannelRefStmt";
-  ref: ResourceRef;
+  ref: ChannelResourceRef;
 }
 
 export const ChannelRefStmt = "ChannelRefStmt";
 
 export function isChannelRefStmt(item: unknown): item is ChannelRefStmt {
   return reflection.isInstance(item, ChannelRefStmt);
+}
+
+export interface ChannelResourceRef extends langium.AstNode {
+  readonly $container: ChannelRefStmt;
+  readonly $type: "ChannelResourceRef";
+  name: ChannelName;
+  version?: string;
+}
+
+export const ChannelResourceRef = "ChannelResourceRef";
+
+export function isChannelResourceRef(
+  item: unknown,
+): item is ChannelResourceRef {
+  return reflection.isInstance(item, ChannelResourceRef);
 }
 
 export interface ClassificationStmt extends langium.AstNode {
@@ -1452,7 +1478,6 @@ export function isResourceAnnotationBlockItem(
 
 export interface ResourceRef extends langium.AstNode {
   readonly $container:
-    | ChannelRefStmt
     | ContainerRefStmt
     | DataProductRefStmt
     | DomainRefStmt
@@ -1986,6 +2011,7 @@ export type EcAstType = {
   ChannelDef: ChannelDef;
   ChannelRef: ChannelRef;
   ChannelRefStmt: ChannelRefStmt;
+  ChannelResourceRef: ChannelResourceRef;
   ClassificationStmt: ClassificationStmt;
   CommandDef: CommandDef;
   ContainerBodyItem: ContainerBodyItem;
@@ -2108,6 +2134,7 @@ export class EcAstReflection extends langium.AbstractAstReflection {
       ChannelDef,
       ChannelRef,
       ChannelRefStmt,
+      ChannelResourceRef,
       ClassificationStmt,
       CommandDef,
       ContainerBodyItem,
@@ -2489,6 +2516,12 @@ export class EcAstReflection extends langium.AbstractAstReflection {
         return {
           name: ChannelRefStmt,
           properties: [{ name: "ref" }],
+        };
+      }
+      case ChannelResourceRef: {
+        return {
+          name: ChannelResourceRef,
+          properties: [{ name: "name" }, { name: "version" }],
         };
       }
       case ClassificationStmt: {

--- a/packages/language-server/src/generated/grammar.ts
+++ b/packages/language-server/src/generated/grammar.ts
@@ -118,7 +118,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@133"
+                "$ref": "#/rules@135"
               },
               "arguments": []
             }
@@ -142,7 +142,7 @@ export const EcGrammar = (): Grammar =>
         "terminal": {
           "$type": "RuleCall",
           "rule": {
-            "$ref": "#/rules@135"
+            "$ref": "#/rules@138"
           },
           "arguments": []
         }
@@ -291,7 +291,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@135"
+                "$ref": "#/rules@138"
               },
               "arguments": []
             }
@@ -405,6 +405,13 @@ export const EcGrammar = (): Grammar =>
           {
             "$type": "RuleCall",
             "rule": {
+              "$ref": "#/rules@105"
+            },
+            "arguments": []
+          },
+          {
+            "$type": "RuleCall",
+            "rule": {
               "$ref": "#/rules@104"
             },
             "arguments": []
@@ -413,13 +420,6 @@ export const EcGrammar = (): Grammar =>
             "$type": "RuleCall",
             "rule": {
               "$ref": "#/rules@103"
-            },
-            "arguments": []
-          },
-          {
-            "$type": "RuleCall",
-            "rule": {
-              "$ref": "#/rules@102"
             },
             "arguments": []
           },
@@ -440,7 +440,7 @@ export const EcGrammar = (): Grammar =>
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@108"
+              "$ref": "#/rules@109"
             },
             "arguments": []
           }
@@ -470,7 +470,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@135"
+                "$ref": "#/rules@138"
               },
               "arguments": []
             }
@@ -522,7 +522,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@135"
+                "$ref": "#/rules@138"
               },
               "arguments": []
             }
@@ -636,14 +636,14 @@ export const EcGrammar = (): Grammar =>
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@102"
+              "$ref": "#/rules@103"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@108"
+              "$ref": "#/rules@109"
             },
             "arguments": []
           }
@@ -673,7 +673,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@135"
+                "$ref": "#/rules@138"
               },
               "arguments": []
             }
@@ -731,7 +731,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@135"
+                "$ref": "#/rules@138"
               },
               "arguments": []
             }
@@ -789,7 +789,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@135"
+                "$ref": "#/rules@138"
               },
               "arguments": []
             }
@@ -888,7 +888,7 @@ export const EcGrammar = (): Grammar =>
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@108"
+              "$ref": "#/rules@109"
             },
             "arguments": []
           }
@@ -918,7 +918,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@135"
+                "$ref": "#/rules@130"
               },
               "arguments": []
             }
@@ -1018,7 +1018,7 @@ export const EcGrammar = (): Grammar =>
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@108"
+              "$ref": "#/rules@109"
             },
             "arguments": []
           }
@@ -1048,7 +1048,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@133"
+                "$ref": "#/rules@135"
               },
               "arguments": []
             }
@@ -1079,7 +1079,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@133"
+                "$ref": "#/rules@135"
               },
               "arguments": []
             }
@@ -1110,7 +1110,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@135"
+                "$ref": "#/rules@138"
               },
               "arguments": []
             }
@@ -1205,7 +1205,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@133"
+                "$ref": "#/rules@135"
               },
               "arguments": []
             }
@@ -1236,7 +1236,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@133"
+                "$ref": "#/rules@135"
               },
               "arguments": []
             }
@@ -1329,7 +1329,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@133"
+                "$ref": "#/rules@135"
               },
               "arguments": []
             }
@@ -1348,7 +1348,7 @@ export const EcGrammar = (): Grammar =>
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@133"
+                    "$ref": "#/rules@135"
                   },
                   "arguments": []
                 }
@@ -1386,7 +1386,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@127"
+                "$ref": "#/rules@128"
               },
               "arguments": []
             }
@@ -1417,7 +1417,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@135"
+                "$ref": "#/rules@138"
               },
               "arguments": []
             }
@@ -1552,14 +1552,14 @@ export const EcGrammar = (): Grammar =>
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@104"
+              "$ref": "#/rules@105"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@108"
+              "$ref": "#/rules@109"
             },
             "arguments": []
           }
@@ -1668,7 +1668,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@133"
+                "$ref": "#/rules@135"
               },
               "arguments": []
             }
@@ -1699,7 +1699,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@128"
+                "$ref": "#/rules@129"
               },
               "arguments": []
             }
@@ -1856,7 +1856,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@133"
+                "$ref": "#/rules@135"
               },
               "arguments": []
             }
@@ -1887,7 +1887,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@133"
+                "$ref": "#/rules@135"
               },
               "arguments": []
             }
@@ -1918,7 +1918,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@135"
+                "$ref": "#/rules@138"
               },
               "arguments": []
             }
@@ -2018,7 +2018,7 @@ export const EcGrammar = (): Grammar =>
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@108"
+              "$ref": "#/rules@109"
             },
             "arguments": []
           }
@@ -2048,7 +2048,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@126"
+                "$ref": "#/rules@127"
               },
               "arguments": []
             }
@@ -2060,7 +2060,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@127"
+                "$ref": "#/rules@128"
               },
               "arguments": []
             }
@@ -2091,7 +2091,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@126"
+                "$ref": "#/rules@127"
               },
               "arguments": []
             }
@@ -2103,7 +2103,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@135"
+                "$ref": "#/rules@138"
               },
               "arguments": []
             }
@@ -2168,7 +2168,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@133"
+                "$ref": "#/rules@135"
               },
               "arguments": []
             }
@@ -2184,7 +2184,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@133"
+                "$ref": "#/rules@135"
               },
               "arguments": []
             }
@@ -2203,7 +2203,7 @@ export const EcGrammar = (): Grammar =>
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@133"
+                    "$ref": "#/rules@135"
                   },
                   "arguments": []
                 }
@@ -2241,7 +2241,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@135"
+                "$ref": "#/rules@138"
               },
               "arguments": []
             }
@@ -2327,7 +2327,7 @@ export const EcGrammar = (): Grammar =>
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@108"
+              "$ref": "#/rules@109"
             },
             "arguments": []
           }
@@ -2537,7 +2537,7 @@ export const EcGrammar = (): Grammar =>
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@133"
+                    "$ref": "#/rules@135"
                   },
                   "arguments": []
                 }
@@ -2583,7 +2583,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@135"
+                "$ref": "#/rules@138"
               },
               "arguments": []
             }
@@ -2595,7 +2595,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@133"
+                "$ref": "#/rules@135"
               },
               "arguments": []
             },
@@ -2627,7 +2627,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@135"
+                "$ref": "#/rules@138"
               },
               "arguments": []
             }
@@ -2685,7 +2685,7 @@ export const EcGrammar = (): Grammar =>
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@108"
+              "$ref": "#/rules@109"
             },
             "arguments": []
           },
@@ -2811,14 +2811,14 @@ export const EcGrammar = (): Grammar =>
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@104"
+              "$ref": "#/rules@105"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@105"
+              "$ref": "#/rules@106"
             },
             "arguments": []
           },
@@ -2832,6 +2832,13 @@ export const EcGrammar = (): Grammar =>
           {
             "$type": "RuleCall",
             "rule": {
+              "$ref": "#/rules@104"
+            },
+            "arguments": []
+          },
+          {
+            "$type": "RuleCall",
+            "rule": {
               "$ref": "#/rules@103"
             },
             "arguments": []
@@ -2839,14 +2846,7 @@ export const EcGrammar = (): Grammar =>
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@102"
-            },
-            "arguments": []
-          },
-          {
-            "$type": "RuleCall",
-            "rule": {
-              "$ref": "#/rules@106"
+              "$ref": "#/rules@107"
             },
             "arguments": []
           }
@@ -2876,7 +2876,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@135"
+                "$ref": "#/rules@138"
               },
               "arguments": []
             }
@@ -2948,7 +2948,7 @@ export const EcGrammar = (): Grammar =>
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@108"
+              "$ref": "#/rules@109"
             },
             "arguments": []
           }
@@ -2978,7 +2978,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@135"
+                "$ref": "#/rules@138"
               },
               "arguments": []
             }
@@ -3094,7 +3094,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@133"
+                "$ref": "#/rules@135"
               },
               "arguments": []
             }
@@ -3125,7 +3125,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@133"
+                "$ref": "#/rules@135"
               },
               "arguments": []
             }
@@ -3156,7 +3156,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@133"
+                "$ref": "#/rules@135"
               },
               "arguments": []
             }
@@ -3187,7 +3187,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@133"
+                "$ref": "#/rules@135"
               },
               "arguments": []
             }
@@ -3218,7 +3218,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@133"
+                "$ref": "#/rules@135"
               },
               "arguments": []
             }
@@ -3249,7 +3249,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@133"
+                "$ref": "#/rules@135"
               },
               "arguments": []
             }
@@ -3273,7 +3273,7 @@ export const EcGrammar = (): Grammar =>
         "terminal": {
           "$type": "RuleCall",
           "rule": {
-            "$ref": "#/rules@108"
+            "$ref": "#/rules@109"
           },
           "arguments": []
         }
@@ -3302,7 +3302,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@135"
+                "$ref": "#/rules@138"
               },
               "arguments": []
             }
@@ -3432,7 +3432,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@133"
+                "$ref": "#/rules@135"
               },
               "arguments": []
             }
@@ -3463,7 +3463,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@133"
+                "$ref": "#/rules@135"
               },
               "arguments": []
             }
@@ -3494,7 +3494,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@133"
+                "$ref": "#/rules@135"
               },
               "arguments": []
             }
@@ -3525,7 +3525,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@133"
+                "$ref": "#/rules@135"
               },
               "arguments": []
             }
@@ -3556,7 +3556,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@133"
+                "$ref": "#/rules@135"
               },
               "arguments": []
             }
@@ -3587,7 +3587,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@133"
+                "$ref": "#/rules@135"
               },
               "arguments": []
             }
@@ -3618,7 +3618,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@133"
+                "$ref": "#/rules@135"
               },
               "arguments": []
             }
@@ -3649,7 +3649,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@135"
+                "$ref": "#/rules@138"
               },
               "arguments": []
             }
@@ -3673,7 +3673,7 @@ export const EcGrammar = (): Grammar =>
         "terminal": {
           "$type": "RuleCall",
           "rule": {
-            "$ref": "#/rules@108"
+            "$ref": "#/rules@109"
           },
           "arguments": []
         }
@@ -3702,7 +3702,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@135"
+                "$ref": "#/rules@138"
               },
               "arguments": []
             }
@@ -3766,7 +3766,7 @@ export const EcGrammar = (): Grammar =>
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@108"
+              "$ref": "#/rules@109"
             },
             "arguments": []
           }
@@ -3796,7 +3796,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@135"
+                "$ref": "#/rules@138"
               },
               "arguments": []
             }
@@ -3860,7 +3860,7 @@ export const EcGrammar = (): Grammar =>
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@108"
+              "$ref": "#/rules@109"
             },
             "arguments": []
           }
@@ -3890,7 +3890,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@126"
+                "$ref": "#/rules@127"
               },
               "arguments": []
             }
@@ -3902,7 +3902,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@135"
+                "$ref": "#/rules@138"
               },
               "arguments": []
             }
@@ -3921,7 +3921,7 @@ export const EcGrammar = (): Grammar =>
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@132"
+                    "$ref": "#/rules@134"
                   },
                   "arguments": []
                 }
@@ -3995,7 +3995,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@126"
+                "$ref": "#/rules@127"
               },
               "arguments": []
             }
@@ -4007,7 +4007,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@135"
+                "$ref": "#/rules@138"
               },
               "arguments": []
             }
@@ -4026,7 +4026,7 @@ export const EcGrammar = (): Grammar =>
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@132"
+                    "$ref": "#/rules@134"
                   },
                   "arguments": []
                 }
@@ -4141,7 +4141,7 @@ export const EcGrammar = (): Grammar =>
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@108"
+              "$ref": "#/rules@109"
             },
             "arguments": []
           }
@@ -4346,7 +4346,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@135"
+                "$ref": "#/rules@130"
               },
               "arguments": []
             }
@@ -4365,7 +4365,7 @@ export const EcGrammar = (): Grammar =>
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@132"
+                    "$ref": "#/rules@134"
                   },
                   "arguments": []
                 }
@@ -4431,7 +4431,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@127"
+                "$ref": "#/rules@128"
               },
               "arguments": []
             }
@@ -4466,7 +4466,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@127"
+                "$ref": "#/rules@128"
               },
               "arguments": []
             }
@@ -4497,7 +4497,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@132"
+                "$ref": "#/rules@134"
               },
               "arguments": []
             }
@@ -4528,7 +4528,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@133"
+                "$ref": "#/rules@135"
               },
               "arguments": []
             }
@@ -4559,7 +4559,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@133"
+                "$ref": "#/rules@135"
               },
               "arguments": []
             }
@@ -4590,7 +4590,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@135"
+                "$ref": "#/rules@138"
               },
               "arguments": []
             }
@@ -4621,7 +4621,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@133"
+                "$ref": "#/rules@135"
               },
               "arguments": []
             }
@@ -4652,7 +4652,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@128"
+                "$ref": "#/rules@129"
               },
               "arguments": []
             }
@@ -4683,7 +4683,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@128"
+                "$ref": "#/rules@129"
               },
               "arguments": []
             }
@@ -4714,7 +4714,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@128"
+                "$ref": "#/rules@129"
               },
               "arguments": []
             }
@@ -4745,7 +4745,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@128"
+                "$ref": "#/rules@129"
               },
               "arguments": []
             }
@@ -4776,7 +4776,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@128"
+                "$ref": "#/rules@129"
               },
               "arguments": []
             }
@@ -4807,7 +4807,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@128"
+                "$ref": "#/rules@129"
               },
               "arguments": []
             }
@@ -4838,7 +4838,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@128"
+                "$ref": "#/rules@129"
               },
               "arguments": []
             }
@@ -4924,10 +4924,59 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@127"
+                "$ref": "#/rules@102"
               },
               "arguments": []
             }
+          }
+        ]
+      },
+      "definesHiddenTokens": false,
+      "entry": false,
+      "fragment": false,
+      "hiddenTokens": [],
+      "parameters": [],
+      "wildcard": false
+    },
+    {
+      "$type": "ParserRule",
+      "name": "ChannelResourceRef",
+      "definition": {
+        "$type": "Group",
+        "elements": [
+          {
+            "$type": "Assignment",
+            "feature": "name",
+            "operator": "=",
+            "terminal": {
+              "$type": "RuleCall",
+              "rule": {
+                "$ref": "#/rules@130"
+              },
+              "arguments": []
+            }
+          },
+          {
+            "$type": "Group",
+            "elements": [
+              {
+                "$type": "Keyword",
+                "value": "@"
+              },
+              {
+                "$type": "Assignment",
+                "feature": "version",
+                "operator": "=",
+                "terminal": {
+                  "$type": "RuleCall",
+                  "rule": {
+                    "$ref": "#/rules@134"
+                  },
+                  "arguments": []
+                }
+              }
+            ],
+            "cardinality": "?"
           }
         ]
       },
@@ -4955,7 +5004,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@127"
+                "$ref": "#/rules@128"
               },
               "arguments": []
             }
@@ -4986,7 +5035,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@127"
+                "$ref": "#/rules@128"
               },
               "arguments": []
             }
@@ -5017,7 +5066,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@127"
+                "$ref": "#/rules@128"
               },
               "arguments": []
             }
@@ -5048,7 +5097,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@127"
+                "$ref": "#/rules@128"
               },
               "arguments": []
             }
@@ -5079,7 +5128,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@127"
+                "$ref": "#/rules@128"
               },
               "arguments": []
             }
@@ -5146,7 +5195,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@109"
+                "$ref": "#/rules@110"
               },
               "arguments": []
             }
@@ -5165,7 +5214,7 @@ export const EcGrammar = (): Grammar =>
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@110"
+                    "$ref": "#/rules@111"
                   },
                   "arguments": []
                 }
@@ -5184,7 +5233,7 @@ export const EcGrammar = (): Grammar =>
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@110"
+                        "$ref": "#/rules@111"
                       },
                       "arguments": []
                     }
@@ -5213,7 +5262,7 @@ export const EcGrammar = (): Grammar =>
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@122"
+                    "$ref": "#/rules@123"
                   },
                   "arguments": []
                 },
@@ -5242,7 +5291,7 @@ export const EcGrammar = (): Grammar =>
       "definition": {
         "$type": "RuleCall",
         "rule": {
-          "$ref": "#/rules@135"
+          "$ref": "#/rules@138"
         },
         "arguments": []
       },
@@ -5262,14 +5311,14 @@ export const EcGrammar = (): Grammar =>
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@111"
+              "$ref": "#/rules@112"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@112"
+              "$ref": "#/rules@113"
             },
             "arguments": []
           }
@@ -5295,7 +5344,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@113"
+                "$ref": "#/rules@114"
               },
               "arguments": []
             }
@@ -5311,7 +5360,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@114"
+                "$ref": "#/rules@115"
               },
               "arguments": []
             }
@@ -5335,7 +5384,7 @@ export const EcGrammar = (): Grammar =>
         "terminal": {
           "$type": "RuleCall",
           "rule": {
-            "$ref": "#/rules@114"
+            "$ref": "#/rules@115"
           },
           "arguments": []
         }
@@ -5357,7 +5406,7 @@ export const EcGrammar = (): Grammar =>
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@135"
+              "$ref": "#/rules@138"
             },
             "arguments": []
           },
@@ -5443,13 +5492,6 @@ export const EcGrammar = (): Grammar =>
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@115"
-            },
-            "arguments": []
-          },
-          {
-            "$type": "RuleCall",
-            "rule": {
               "$ref": "#/rules@116"
             },
             "arguments": []
@@ -5481,6 +5523,13 @@ export const EcGrammar = (): Grammar =>
               "$ref": "#/rules@120"
             },
             "arguments": []
+          },
+          {
+            "$type": "RuleCall",
+            "rule": {
+              "$ref": "#/rules@121"
+            },
+            "arguments": []
           }
         ]
       },
@@ -5494,28 +5543,6 @@ export const EcGrammar = (): Grammar =>
     {
       "$type": "ParserRule",
       "name": "StringAnnotationValue",
-      "definition": {
-        "$type": "Assignment",
-        "feature": "value",
-        "operator": "=",
-        "terminal": {
-          "$type": "RuleCall",
-          "rule": {
-            "$ref": "#/rules@133"
-          },
-          "arguments": []
-        }
-      },
-      "definesHiddenTokens": false,
-      "entry": false,
-      "fragment": false,
-      "hiddenTokens": [],
-      "parameters": [],
-      "wildcard": false
-    },
-    {
-      "$type": "ParserRule",
-      "name": "IdAnnotationValue",
       "definition": {
         "$type": "Assignment",
         "feature": "value",
@@ -5537,6 +5564,28 @@ export const EcGrammar = (): Grammar =>
     },
     {
       "$type": "ParserRule",
+      "name": "IdAnnotationValue",
+      "definition": {
+        "$type": "Assignment",
+        "feature": "value",
+        "operator": "=",
+        "terminal": {
+          "$type": "RuleCall",
+          "rule": {
+            "$ref": "#/rules@138"
+          },
+          "arguments": []
+        }
+      },
+      "definesHiddenTokens": false,
+      "entry": false,
+      "fragment": false,
+      "hiddenTokens": [],
+      "parameters": [],
+      "wildcard": false
+    },
+    {
+      "$type": "ParserRule",
       "name": "NumberAnnotationValue",
       "definition": {
         "$type": "Assignment",
@@ -5545,7 +5594,7 @@ export const EcGrammar = (): Grammar =>
         "terminal": {
           "$type": "RuleCall",
           "rule": {
-            "$ref": "#/rules@134"
+            "$ref": "#/rules@136"
           },
           "arguments": []
         }
@@ -5567,7 +5616,7 @@ export const EcGrammar = (): Grammar =>
         "terminal": {
           "$type": "RuleCall",
           "rule": {
-            "$ref": "#/rules@128"
+            "$ref": "#/rules@129"
           },
           "arguments": []
         }
@@ -5589,7 +5638,7 @@ export const EcGrammar = (): Grammar =>
         "terminal": {
           "$type": "RuleCall",
           "rule": {
-            "$ref": "#/rules@132"
+            "$ref": "#/rules@134"
           },
           "arguments": []
         }
@@ -5611,7 +5660,7 @@ export const EcGrammar = (): Grammar =>
         "terminal": {
           "$type": "RuleCall",
           "rule": {
-            "$ref": "#/rules@121"
+            "$ref": "#/rules@122"
           },
           "arguments": []
         }
@@ -5664,14 +5713,14 @@ export const EcGrammar = (): Grammar =>
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@123"
+              "$ref": "#/rules@124"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@124"
+              "$ref": "#/rules@125"
             },
             "arguments": []
           }
@@ -5697,7 +5746,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@107"
+                "$ref": "#/rules@108"
               },
               "arguments": []
             }
@@ -5709,7 +5758,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@135"
+                "$ref": "#/rules@138"
               },
               "arguments": []
             }
@@ -5728,7 +5777,7 @@ export const EcGrammar = (): Grammar =>
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@132"
+                    "$ref": "#/rules@134"
                   },
                   "arguments": []
                 }
@@ -5758,7 +5807,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@135"
+                "$ref": "#/rules@138"
               },
               "arguments": []
             }
@@ -5770,7 +5819,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@125"
+                "$ref": "#/rules@126"
               },
               "arguments": []
             }
@@ -5802,14 +5851,14 @@ export const EcGrammar = (): Grammar =>
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@135"
+              "$ref": "#/rules@138"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@132"
+              "$ref": "#/rules@134"
             },
             "arguments": []
           }
@@ -5863,7 +5912,7 @@ export const EcGrammar = (): Grammar =>
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@135"
+                "$ref": "#/rules@138"
               },
               "arguments": []
             }
@@ -5882,7 +5931,7 @@ export const EcGrammar = (): Grammar =>
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@132"
+                    "$ref": "#/rules@134"
                   },
                   "arguments": []
                 }
@@ -5913,6 +5962,36 @@ export const EcGrammar = (): Grammar =>
           {
             "$type": "Keyword",
             "value": "false"
+          }
+        ]
+      },
+      "definesHiddenTokens": false,
+      "entry": false,
+      "fragment": false,
+      "hiddenTokens": [],
+      "parameters": [],
+      "wildcard": false
+    },
+    {
+      "$type": "ParserRule",
+      "name": "ChannelName",
+      "dataType": "string",
+      "definition": {
+        "$type": "Alternatives",
+        "elements": [
+          {
+            "$type": "RuleCall",
+            "rule": {
+              "$ref": "#/rules@137"
+            },
+            "arguments": []
+          },
+          {
+            "$type": "RuleCall",
+            "rule": {
+              "$ref": "#/rules@138"
+            },
+            "arguments": []
           }
         ]
       },
@@ -5979,6 +6058,16 @@ export const EcGrammar = (): Grammar =>
       "definition": {
         "$type": "RegexToken",
         "regex": "/\\\\d+/"
+      },
+      "fragment": false,
+      "hidden": false
+    },
+    {
+      "$type": "TerminalRule",
+      "name": "TEMPLATE_ID",
+      "definition": {
+        "$type": "RegexToken",
+        "regex": "/[a-zA-Z_][a-zA-Z0-9_.-]*\\\\{[a-zA-Z0-9_]+\\\\}[a-zA-Z0-9_.{}-]*/"
       },
       "fragment": false,
       "hidden": false

--- a/packages/language-server/test/parsing.test.ts
+++ b/packages/language-server/test/parsing.test.ts
@@ -176,6 +176,93 @@ describe("Channel routing", () => {
 });
 
 // ---------------------------------------------------------------------------
+// 4b. Template channel names (e.g. inventory.{env}.events)
+// ---------------------------------------------------------------------------
+describe("Template channel names", () => {
+  it("parses a channel definition with template parameters in the name", async () => {
+    const doc = await parseProgram(`
+      channel inventory.{env}.events {
+        version 1.0.0
+        name "Inventory Events Channel"
+        address "inventory.{env}.events"
+        protocol "kafka"
+        summary "Central event stream for inventory events"
+      }
+    `);
+    const errors = doc.parseResult.parserErrors;
+    expect(errors).toHaveLength(0);
+
+    const ch = doc.parseResult.value.definitions[0];
+    if (isChannelDef(ch)) {
+      expect(ch.name).toBe("inventory.{env}.events");
+    }
+  });
+
+  it("parses sends to a template channel name", async () => {
+    const doc = await parseProgram(`
+      service InventoryService {
+        version 1.0.0
+        sends event InventoryAdjusted to inventory.{env}.events
+      }
+    `);
+    const errors = doc.parseResult.parserErrors;
+    expect(errors).toHaveLength(0);
+
+    const svc = doc.parseResult.value.definitions[0];
+    if (isServiceDef(svc)) {
+      const sends = utils.getSends(svc.body);
+      expect(sends).toHaveLength(1);
+      if (isToClause(sends[0].channelClause)) {
+        expect(sends[0].channelClause.channels[0].channelName).toBe(
+          "inventory.{env}.events",
+        );
+      }
+    }
+  });
+
+  it("parses receives from a template channel name with version", async () => {
+    const doc = await parseProgram(`
+      service InventoryService {
+        version 1.0.0
+        receives command UpdateInventory from inventory.{env}.events@1.0.0
+      }
+    `);
+    const errors = doc.parseResult.parserErrors;
+    expect(errors).toHaveLength(0);
+
+    const svc = doc.parseResult.value.definitions[0];
+    if (isServiceDef(svc)) {
+      const receives = utils.getReceives(svc.body);
+      expect(receives).toHaveLength(1);
+      if (isFromClause(receives[0].channelClause)) {
+        expect(receives[0].channelClause.channels[0].channelName).toBe(
+          "inventory.{env}.events",
+        );
+        expect(receives[0].channelClause.channels[0].channelVersion).toBe(
+          "1.0.0",
+        );
+      }
+    }
+  });
+
+  it("parses a template channel name with multiple template segments", async () => {
+    const doc = await parseProgram(`
+      channel topic.{region}.{env}.orders {
+        version 1.0.0
+        summary "Multi-region orders topic"
+      }
+    `);
+    const errors = doc.parseResult.parserErrors;
+    expect(errors).toHaveLength(0);
+
+    const ch = doc.parseResult.value.definitions[0];
+    if (isChannelDef(ch)) {
+      expect(ch.name).toBe("topic.{region}.{env}.orders");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
 // 5. Sends to channel with inline body
 // ---------------------------------------------------------------------------
 describe("Sends to channel with inline body", () => {

--- a/packages/playground/src/monaco/ec-completion.ts
+++ b/packages/playground/src/monaco/ec-completion.ts
@@ -132,7 +132,7 @@ const contextSuggestions: Record<string, Suggestion[]> = {
 
 function findEnclosingResource(text: string): string | null {
   const stack: string[] = [];
-  const tokenRegex = /\b(domain|service|event|command|query|channel|user|team|flow|container|data-product|subdomain|visualizer|actor|external-system)\b[^{}]*\{|\{|\}/g;
+  const tokenRegex = /\b(domain|service|event|command|query|channel|user|team|flow|container|data-product|subdomain|visualizer|actor|external-system)\b(?:[^{}]|\{[a-zA-Z0-9_]+\})*\{|\{|\}/g;
   let match;
 
   while ((match = tokenRegex.exec(text)) !== null) {
@@ -161,7 +161,7 @@ function extractResourceVersions(text: string): Map<string, string[]> {
 
   for (const type of resourceTypes) {
     const defRegex = new RegExp(
-      `\\b${type}\\s+([a-zA-Z_][a-zA-Z0-9_.\\-]*)\\s*\\{[^}]*?version\\s+(\\d+\\.\\d+\\.\\d+(?:-[a-zA-Z0-9_.]+)*)`,
+      `\\b${type}\\s+([a-zA-Z_][a-zA-Z0-9_.{}\\-]*)\\s*\\{[^}]*?version\\s+(\\d+\\.\\d+\\.\\d+(?:-[a-zA-Z0-9_.]+)*)`,
       'g'
     );
     let match;

--- a/packages/playground/src/monaco/ec-language.ts
+++ b/packages/playground/src/monaco/ec-language.ts
@@ -33,6 +33,7 @@ export function registerEcLanguage(monaco: Monaco) {
         [/"[^"]*"/, 'string'],
         [/@[a-zA-Z][\w-]*/, 'annotation'],
         [/\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?/, 'number.version'],
+        [/[a-zA-Z_][\w.-]*(\{[a-zA-Z0-9_]+\}[\w.-]*)+/, 'identifier'],
         [/[a-zA-Z_][\w-]*/, {
           cases: {
             '@keywords': 'keyword',


### PR DESCRIPTION
## What This PR Does

Adds support for template parameters (e.g. `{env}`, `{region}`) in channel names within the EventCatalog DSL. Channel names like `inventory.{env}.events` are common in messaging systems (Kafka, NATS) but were previously rejected by the parser because `{` and `}` weren't valid identifier characters.

## Changes Overview

### Key Changes
- Add `TEMPLATE_ID` terminal to the Langium grammar that matches identifiers containing `{param}` template segments
- Add `ChannelName` parser rule (returns `string`) that accepts either `TEMPLATE_ID` or `ID`
- Update `ChannelDef`, `ChannelRef`, and `ChannelRefStmt` grammar rules to use `ChannelName`
- Add `ChannelResourceRef` rule for channel references in visualizer blocks
- Update Monaco tokenizer to highlight template channel names as identifiers
- Update Monaco completion context detection to handle `{param}` segments in names
- Update CLI README with comprehensive documentation for import/export commands

## How It Works

A new `TEMPLATE_ID` terminal (`/[a-zA-Z_][a-zA-Z0-9_.-]*\{[a-zA-Z0-9_]+\}[a-zA-Z0-9_.{}-]*/`) is added before the `ID` terminal. It requires at least one `{param}` segment, so it won't match plain identifiers. The `ChannelName` parser rule is used only in channel-specific grammar positions (channel definitions, channel references in `to`/`from` clauses, and visualizer channel refs), avoiding any ambiguity with block-opening braces in other resource types.

Since `ChannelName returns string`, all downstream code (compiler, graph builder, CLI import/export) continues to work without changes -- the AST properties remain typed as `string`.

## Breaking Changes

None

## Test plan

- [x] All 191 language-server tests pass (4 new parsing tests)
- [x] All 155 CLI tests pass (1 new import test)
- [ ] Manual test in playground with template channel names

🤖 Generated with [Claude Code](https://claude.com/claude-code)