### PR TITLE
fix(core): support nested directory structures in resource docs glob patterns

### DIFF
--- a/.changeset/bright-waves-glow.md
+++ b/.changeset/bright-waves-glow.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Fix resource docs glob patterns to support nested directory structures using double-star wildcards

--- a/packages/core/eventcatalog/src/content.config.ts
+++ b/packages/core/eventcatalog/src/content.config.ts
@@ -523,12 +523,12 @@ const resourceDocs = defineCollection({
     // Resource-level docs are restricted to known resource paths.
     // This avoids scanning external docs such as node_modules/**/docs.
     pattern: withIgnoredBuildArtifacts([
-      '{events,commands,queries,services,flows,containers,channels,entities,data-products}/*/docs/**/*.@(md|mdx)',
-      '{events,commands,queries,services,flows,containers,channels,entities,data-products}/*/versioned/*/docs/**/*.@(md|mdx)',
-      'domains/*/docs/**/*.@(md|mdx)',
-      'domains/*/versioned/*/docs/**/*.@(md|mdx)',
-      'domains/*/subdomains/*/docs/**/*.@(md|mdx)',
-      'domains/*/subdomains/*/versioned/*/docs/**/*.@(md|mdx)',
+      '{events,commands,queries,services,flows,containers,channels,entities,data-products}/**/docs/**/*.@(md|mdx)',
+      '{events,commands,queries,services,flows,containers,channels,entities,data-products}/**/docs/*.@(md|mdx)',
+      '{events,commands,queries,services,flows,containers,channels,entities,data-products}/**/versioned/*/docs/**/*.@(md|mdx)',
+      '{events,commands,queries,services,flows,containers,channels,entities,data-products}/**/versioned/*/docs/*.@(md|mdx)',
+      'domains/**/docs/**/*.@(md|mdx)',
+      'domains/**/docs/*.@(md|mdx)',
     ]),
     base: projectDirBase,
   }),


### PR DESCRIPTION
## What This PR Does

Updates the resource docs content collection glob patterns in `content.config.ts` to use double-star (`**`) wildcards instead of single-star (`*`). This allows resource documentation files to be discovered in nested directory structures, not just at the immediate child level.

## Changes Overview

### Key Changes
- Replace `*/docs/` with `**/docs/` for all resource types (events, commands, queries, services, flows, containers, channels, entities, data-products)
- Replace `*/versioned/` with `**/versioned/` for versioned resource docs
- Consolidate domain patterns using `**` to cover subdomains automatically
- Remove now-redundant separate subdomain glob patterns

## How It Works

The previous glob patterns used single `*` which only matched one directory level deep. By switching to `**`, the patterns now recursively match at any depth, supporting resources organized in nested folder hierarchies. This also simplifies the domain patterns since `domains/**/docs/` naturally covers `domains/*/subdomains/*/docs/` and similar structures.

## Breaking Changes

None

## Additional Notes

This is a non-breaking change that expands which files are discovered as resource docs.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)