### PR TITLE
fix(core): resolve resource docs when folder name differs from frontmatter id

### DIFF
--- a/.changeset/gentle-foxes-march.md
+++ b/.changeset/gentle-foxes-march.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Fix resource docs not appearing when folder name differs from frontmatter id

--- a/packages/core/eventcatalog/src/utils/__tests__/collections/resource-docs.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/collections/resource-docs.spec.ts
@@ -12,10 +12,17 @@ const mockDomains = [
   {
     collection: 'domains',
     data: { id: 'Payments', version: '1.0.0', hidden: false },
+    filePath: 'domains/Payments/index.mdx',
   },
   {
     collection: 'domains',
     data: { id: 'Payments', version: '0.9.0', hidden: false },
+    filePath: 'domains/Payments/versioned/0.9.0/index.mdx',
+  },
+  {
+    collection: 'domains',
+    data: { id: 'random', version: '1.0.0', hidden: false },
+    filePath: 'domains/BoxOffice/index.mdx',
   },
 ];
 
@@ -23,10 +30,12 @@ const mockServices = [
   {
     collection: 'services',
     data: { id: 'BillingService', version: '2.0.0', hidden: false },
+    filePath: 'services/BillingService/index.mdx',
   },
   {
     collection: 'services',
     data: { id: 'BillingService', version: '1.0.0', hidden: false },
+    filePath: 'services/BillingService/versioned/1.0.0/index.mdx',
   },
 ];
 
@@ -34,6 +43,7 @@ const mockEvents = [
   {
     collection: 'events',
     data: { id: 'InvoiceIssued', version: '3.0.0', hidden: false },
+    filePath: 'events/InvoiceIssued/index.mdx',
   },
 ];
 
@@ -97,6 +107,12 @@ const mockResourceDocs = [
     collection: 'resourceDocs',
     filePath: 'domains/Payments/docs/runbooks/hidden.mdx',
     data: { id: 'hidden', type: 'runbooks', version: '1.0.0', title: 'Hidden', hidden: true },
+  },
+  {
+    id: 'domains/BoxOffice/docs/meow.mdx',
+    collection: 'resourceDocs',
+    filePath: 'domains/BoxOffice/docs/meow.mdx',
+    data: { id: 'meow', version: '1.0.0', title: 'Meow' },
   },
 ];
 
@@ -313,6 +329,19 @@ describe('resource-docs', () => {
     expect(grouped[0]).toMatchObject({
       type: 'references',
       label: 'Reference',
+    });
+  });
+
+  it('resolves docs when folder name differs from resource frontmatter id', async () => {
+    const docs = await getResourceDocs();
+    const meowDoc = docs.find((doc) => doc.data.id === 'meow');
+
+    expect(meowDoc).toBeDefined();
+    expect(meowDoc!.data).toMatchObject({
+      id: 'meow',
+      resourceCollection: 'domains',
+      resourceId: 'random',
+      resourceVersion: '1.0.0',
     });
   });
 });

--- a/packages/core/eventcatalog/src/utils/collections/resource-docs.ts
+++ b/packages/core/eventcatalog/src/utils/collections/resource-docs.ts
@@ -1,4 +1,5 @@
 import { getCollection, type CollectionEntry } from 'astro:content';
+import path from 'node:path';
 import { sortVersioned } from './util';
 import { isResourceDocsEnabled } from '@utils/feature';
 
@@ -52,6 +53,7 @@ export type ResourceDocGroup = {
 type ResourceLookup = {
   latestById: Map<string, string>;
   versionsById: Map<string, Set<string>>;
+  folderToId: Map<string, string>;
 };
 
 type InferredResource = {
@@ -200,12 +202,27 @@ const inferResourceFromFilePath = (filePath: string): InferredResource | null =>
   };
 };
 
+const getResourceFolderFromFilePath = (filePath: string): string | undefined => {
+  const normalized = normalizePath(filePath);
+  const versionedIndex = normalized.indexOf('/versioned/');
+  if (versionedIndex !== -1) {
+    // e.g. "domains/BoxOffice/versioned/1.0.0/index.mdx" → "domains/BoxOffice"
+    const beforeVersioned = normalized.slice(0, versionedIndex);
+    return path.basename(beforeVersioned) || undefined;
+  }
+  // e.g. "domains/BoxOffice/index.mdx" → "BoxOffice"
+  const dir = path.dirname(normalized);
+  return dir ? path.basename(dir) : undefined;
+};
+
 const buildLookup = (
   resources: Array<{
     data: { id: string; version: string; hidden?: boolean };
+    filePath?: string;
   }>
 ): ResourceLookup => {
   const groupedById = new Map<string, string[]>();
+  const folderToId = new Map<string, string>();
 
   for (const resource of resources) {
     if (resource.data.hidden === true) {
@@ -214,6 +231,13 @@ const buildLookup = (
     const list = groupedById.get(resource.data.id) || [];
     list.push(resource.data.version);
     groupedById.set(resource.data.id, list);
+
+    if (resource.filePath) {
+      const folderName = getResourceFolderFromFilePath(resource.filePath);
+      if (folderName && folderName !== resource.data.id) {
+        folderToId.set(folderName, resource.data.id);
+      }
+    }
   }
 
   const latestById = new Map<string, string>();
@@ -227,7 +251,7 @@ const buildLookup = (
     }
   }
 
-  return { latestById, versionsById };
+  return { latestById, versionsById, folderToId };
 };
 
 const getResourceLookups = async (): Promise<Record<ResourceCollection, ResourceLookup>> => {
@@ -295,15 +319,21 @@ const resolveResourceFromPath = (
     return null;
   }
 
-  const { resourceCollection, resourceId, resourceVersion } = inferredResource;
+  const { resourceCollection, resourceVersion } = inferredResource;
   const lookup = lookups[resourceCollection];
-  const knownVersions = lookup.versionsById.get(resourceId);
+
+  // The inferred resourceId is the folder name from the file path. It may differ
+  // from the actual frontmatter id, so fall back to the folderToId mapping.
+  const folderName = inferredResource.resourceId;
+  const resolvedId = lookup.versionsById.has(folderName) ? folderName : (lookup.folderToId.get(folderName) ?? folderName);
+
+  const knownVersions = lookup.versionsById.get(resolvedId);
 
   if (!knownVersions || knownVersions.size === 0) {
     return null;
   }
 
-  const resolvedResourceVersion = resourceVersion === 'latest' ? (lookup.latestById.get(resourceId) ?? null) : resourceVersion;
+  const resolvedResourceVersion = resourceVersion === 'latest' ? (lookup.latestById.get(resolvedId) ?? null) : resourceVersion;
 
   if (!resolvedResourceVersion || !knownVersions.has(resolvedResourceVersion)) {
     return null;
@@ -311,7 +341,7 @@ const resolveResourceFromPath = (
 
   return {
     resourceCollection,
-    resourceId,
+    resourceId: resolvedId,
     resourceVersion: resolvedResourceVersion,
   };
 };


### PR DESCRIPTION
## What This PR Does

Resource docs (files inside a resource's `/docs/` directory) were silently dropped when the resource's folder name didn't match its frontmatter `id`. For example, a domain at `domains/BoxOffice/` with `id: random` would never show its docs in the sidebar. This fix adds a folder-name-to-id mapping so docs resolve correctly regardless of folder naming.

## Changes Overview

### Key Changes
- Add `folderToId` map to `ResourceLookup` that maps directory names to frontmatter IDs
- Extract folder names from resource `filePath` during lookup building
- Fall back to `folderToId` mapping when direct ID lookup fails in `resolveResourceFromPath`
- Add test for mismatched folder name / frontmatter ID scenario

## How It Works

When building the resource lookup, the system now also records the folder name from each resource entry's `filePath`. In `resolveResourceFromPath`, after extracting the folder name from the doc's path, it first tries the direct lookup (folder name = frontmatter ID). If that fails, it checks `folderToId` to translate the folder name to the actual frontmatter ID, then resolves using the real ID.

## Breaking Changes

None

## Additional Notes

The fix handles versioned entries correctly by extracting the folder name from before the `/versioned/` segment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)