### PR TITLE
feat(sdk): hydrate containers in DSL export and rename playground to EventCatalog Canvas

### DIFF
--- a/.changeset/bright-clouds-dance.md
+++ b/.changeset/bright-clouds-dance.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/sdk": minor
+---
+
+Hydrate containers in service DSL export and rename playground to EventCatalog Canvas

--- a/packages/cli/src/cli-docs.ts
+++ b/packages/cli/src/cli-docs.ts
@@ -1664,7 +1664,7 @@ export const cliFunctions: CLIFunctionDoc[] = [
         name: 'playground',
         type: 'boolean',
         required: false,
-        description: 'Open the exported DSL in EventCatalog Modelling',
+        description: 'Open the exported DSL in EventCatalog Canvas',
       },
       { name: 'output', type: 'string', required: false, description: 'Output file path (defaults to <id>.ec or catalog.ec)' },
     ],
@@ -1694,7 +1694,7 @@ export const cliFunctions: CLIFunctionDoc[] = [
         command: 'npx @eventcatalog/cli export --all --hydrate -o my-catalog.ec',
       },
       {
-        description: 'Export and open in EventCatalog Modelling',
+        description: 'Export and open in EventCatalog Canvas',
         command: 'npx @eventcatalog/cli export --resource services --hydrate --playground',
       },
     ],

--- a/packages/cli/src/cli/export.ts
+++ b/packages/cli/src/cli/export.ts
@@ -259,9 +259,9 @@ export async function exportCatalog(options: Omit<ExportOptions, 'resource'>): P
     const encoded = Buffer.from(dsl).toString('base64');
     const playgroundUrl = `https://playground.eventcatalog.dev/?code=${encoded}`;
     await open(playgroundUrl);
-    lines.push('', `  Opening in EventCatalog Modelling...`);
+    lines.push('', `  Opening in EventCatalog Canvas...`);
   } else {
-    lines.push('', `  Tip: Use --playground to open in EventCatalog Modelling`);
+    lines.push('', `  Tip: Use --playground to open in EventCatalog Canvas`);
   }
 
   lines.push('');
@@ -303,9 +303,9 @@ export async function exportAll(options: ExportOptions): Promise<string> {
     const encoded = Buffer.from(dsl).toString('base64');
     const playgroundUrl = `https://playground.eventcatalog.dev/?code=${encoded}`;
     await open(playgroundUrl);
-    lines.push('', `  Opening in EventCatalog Modelling...`);
+    lines.push('', `  Opening in EventCatalog Canvas...`);
   } else {
-    lines.push('', `  Tip: Use --playground to open in EventCatalog Modelling`);
+    lines.push('', `  Tip: Use --playground to open in EventCatalog Canvas`);
   }
 
   lines.push('');
@@ -356,9 +356,9 @@ export async function exportResource(options: ExportOptions): Promise<string> {
     const encoded = Buffer.from(dsl).toString('base64');
     const playgroundUrl = `https://playground.eventcatalog.dev/?code=${encoded}`;
     await open(playgroundUrl);
-    lines.push('', `  Opening in EventCatalog Modelling...`);
+    lines.push('', `  Opening in EventCatalog Canvas...`);
   } else {
-    lines.push('', `  Tip: Use --playground to open in EventCatalog Modelling`);
+    lines.push('', `  Tip: Use --playground to open in EventCatalog Canvas`);
   }
 
   lines.push('');

--- a/packages/cli/src/cli/index.ts
+++ b/packages/cli/src/cli/index.ts
@@ -49,7 +49,7 @@ program
   .option('-v, --version <version>', 'Resource version (defaults to latest)')
   .option('--hydrate', 'Include referenced resources (messages, channels, owners)', false)
   .option('--stdout', 'Print to stdout instead of writing a file', false)
-  .option('--playground', 'Open the exported DSL in EventCatalog Modelling', false)
+  .option('--playground', 'Open the exported DSL in EventCatalog Canvas', false)
   .option('-o, --output <path>', 'Output file path (defaults to <id>.ec or catalog.ec)')
   .action(async (opts) => {
     try {

--- a/packages/cli/src/test/cli-export.test.ts
+++ b/packages/cli/src/test/cli-export.test.ts
@@ -204,7 +204,7 @@ visualizer main {
 
     const filepath = path.resolve('OrderCreated.ec');
     expect(result).toContain(`Exported event 'OrderCreated' to ${filepath}`);
-    expect(result).toContain('Tip: Use --playground to open in EventCatalog Modelling');
+    expect(result).toContain('Tip: Use --playground to open in EventCatalog Canvas');
     expect(fs.existsSync(filepath)).toBe(true);
 
     const content = fs.readFileSync(filepath, 'utf-8');
@@ -226,7 +226,7 @@ visualizer main {
     });
 
     expect(result).toContain(`Exported event 'OrderCreated' to ${outputPath}`);
-    expect(result).toContain('Tip: Use --playground to open in EventCatalog Modelling');
+    expect(result).toContain('Tip: Use --playground to open in EventCatalog Canvas');
     expect(fs.existsSync(outputPath)).toBe(true);
 
     const content = fs.readFileSync(outputPath, 'utf-8');
@@ -247,7 +247,7 @@ visualizer main {
     });
 
     expect(result).toContain(`Exported event 'OrderCreated' to ${outputPath}`);
-    expect(result).toContain('Opening in EventCatalog Modelling...');
+    expect(result).toContain('Opening in EventCatalog Canvas...');
     expect(result).not.toContain('Tip: Use --playground');
   });
 

--- a/packages/language-server/docs/astro.config.mjs
+++ b/packages/language-server/docs/astro.config.mjs
@@ -4,7 +4,7 @@ import starlight from "@astrojs/starlight";
 export default defineConfig({
   integrations: [
     starlight({
-      title: "EventCatalog Modeling",
+      title: "EventCatalog Canvas",
       description:
         "Use .ec files to model architecture quickly and sync to and from EventCatalog with the CLI.",
       social: {

--- a/packages/language-server/docs/ec.config.mjs
+++ b/packages/language-server/docs/ec.config.mjs
@@ -19,7 +19,7 @@ const isEcLanguage = (language) =>
   language === "ec" || language === "eventcatalog";
 
 const ecPlaygroundPlugin = {
-  name: "EventCatalog Modelling Link",
+  name: "EventCatalog Canvas Link",
   baseStyles: `
 	.frame.is-ec :nth-child(1 of .ec-line) .code {
 		padding-inline-end: calc(14rem + var(--ec-codePaddingInline));
@@ -92,10 +92,10 @@ const ecPlaygroundPlugin = {
             href: `${playgroundBaseUrl}${encoded}`,
             target: "_blank",
             rel: "noopener noreferrer",
-            title: "Open in EventCatalog Modelling",
-            "aria-label": "Open in EventCatalog Modelling",
+            title: "Open in EventCatalog Canvas",
+            "aria-label": "Open in EventCatalog Canvas",
           },
-          "EventCatalog Modelling",
+          "EventCatalog Canvas",
         ),
       );
     },

--- a/packages/language-server/docs/src/components/ChannelTransportSelector.astro
+++ b/packages/language-server/docs/src/components/ChannelTransportSelector.astro
@@ -112,7 +112,7 @@ const toPlaygroundUrl = (option: ChannelOption) => {
       <div data-channel-panel={option.id} hidden={option.id !== defaultOption.id}>
         <p class="ec-channel-selector__actions">
           <a href={toPlaygroundUrl(option)} target="_blank" rel="noopener noreferrer">
-            Open this version in EventCatalog Modelling
+            Open this version in EventCatalog Canvas
           </a>
         </p>
         <Code code={buildDiffCode(option)} lang="diff" meta='title="main.ec"' />

--- a/packages/language-server/docs/src/content/docs/examples/playground/aws-event-pipeline.mdx
+++ b/packages/language-server/docs/src/content/docs/examples/playground/aws-event-pipeline.mdx
@@ -5,14 +5,14 @@ description: "Cross-domain EventBridge routing with SQS queues on AWS"
 
 import { LinkButton } from "@astrojs/starlight/components";
 
-This example mirrors the `AWS Event Pipeline` template in the EventCatalog Modelling.
+This example mirrors the `AWS Event Pipeline` template in the EventCatalog Canvas.
 
 <LinkButton
   href="https://playground.eventcatalog.dev/#example=14"
   target="_blank"
   rel="noopener noreferrer"
 >
-  Open in EventCatalog Modelling
+  Open in EventCatalog Canvas
 </LinkButton>
 
 ### `main.ec`

--- a/packages/language-server/docs/src/content/docs/examples/playground/banking-with-subdomains.mdx
+++ b/packages/language-server/docs/src/content/docs/examples/playground/banking-with-subdomains.mdx
@@ -5,14 +5,14 @@ description: "Banking domain organized with subdomains for different banking fun
 
 import { LinkButton } from "@astrojs/starlight/components";
 
-This example mirrors the `Banking with Subdomains` template in the EventCatalog Modelling.
+This example mirrors the `Banking with Subdomains` template in the EventCatalog Canvas.
 
 <LinkButton
   href="https://playground.eventcatalog.dev/#example=9"
   target="_blank"
   rel="noopener noreferrer"
 >
-  Open in EventCatalog Modelling
+  Open in EventCatalog Canvas
 </LinkButton>
 
 ### `main.ec`

--- a/packages/language-server/docs/src/content/docs/examples/playground/channel-routing.mdx
+++ b/packages/language-server/docs/src/content/docs/examples/playground/channel-routing.mdx
@@ -5,14 +5,14 @@ description: "IoT pipeline with channel-to-channel routing (Kafka → Kafka → 
 
 import { LinkButton } from "@astrojs/starlight/components";
 
-This example mirrors the `Channel Routing` template in the EventCatalog Modelling.
+This example mirrors the `Channel Routing` template in the EventCatalog Canvas.
 
 <LinkButton
   href="https://playground.eventcatalog.dev/#example=13"
   target="_blank"
   rel="noopener noreferrer"
 >
-  Open in EventCatalog Modelling
+  Open in EventCatalog Canvas
 </LinkButton>
 
 ### `main.ec`

--- a/packages/language-server/docs/src/content/docs/examples/playground/data-products.mdx
+++ b/packages/language-server/docs/src/content/docs/examples/playground/data-products.mdx
@@ -5,14 +5,14 @@ description: "Analytical data products with inputs and outputs"
 
 import { LinkButton } from "@astrojs/starlight/components";
 
-This example mirrors the `Data Products` template in the EventCatalog Modelling.
+This example mirrors the `Data Products` template in the EventCatalog Canvas.
 
 <LinkButton
   href="https://playground.eventcatalog.dev/#example=6"
   target="_blank"
   rel="noopener noreferrer"
 >
-  Open in EventCatalog Modelling
+  Open in EventCatalog Canvas
 </LinkButton>
 
 ### `main.ec`

--- a/packages/language-server/docs/src/content/docs/examples/playground/e-commerce-platform.mdx
+++ b/packages/language-server/docs/src/content/docs/examples/playground/e-commerce-platform.mdx
@@ -5,14 +5,14 @@ description: "E-commerce with Kafka messaging and HTTP commands"
 
 import { LinkButton } from "@astrojs/starlight/components";
 
-This example mirrors the `E-Commerce Platform` template in the EventCatalog Modelling.
+This example mirrors the `E-Commerce Platform` template in the EventCatalog Canvas.
 
 <LinkButton
   href="https://playground.eventcatalog.dev/#example=3"
   target="_blank"
   rel="noopener noreferrer"
 >
-  Open in EventCatalog Modelling
+  Open in EventCatalog Canvas
 </LinkButton>
 
 ### `main.ec`

--- a/packages/language-server/docs/src/content/docs/examples/playground/enterprise-e-commerce.mdx
+++ b/packages/language-server/docs/src/content/docs/examples/playground/enterprise-e-commerce.mdx
@@ -5,14 +5,14 @@ description: "Complex enterprise system with 8 domains and multiple channels"
 
 import { LinkButton } from "@astrojs/starlight/components";
 
-This example mirrors the `Enterprise E-Commerce` template in the EventCatalog Modelling.
+This example mirrors the `Enterprise E-Commerce` template in the EventCatalog Canvas.
 
 <LinkButton
   href="https://playground.eventcatalog.dev/#example=11"
   target="_blank"
   rel="noopener noreferrer"
 >
-  Open in EventCatalog Modelling
+  Open in EventCatalog Canvas
 </LinkButton>
 
 ### `main.ec`

--- a/packages/language-server/docs/src/content/docs/examples/playground/event-driven-saga.mdx
+++ b/packages/language-server/docs/src/content/docs/examples/playground/event-driven-saga.mdx
@@ -5,14 +5,14 @@ description: "Choreography-based saga with NServiceBus"
 
 import { LinkButton } from "@astrojs/starlight/components";
 
-This example mirrors the `Event-Driven Saga` template in the EventCatalog Modelling.
+This example mirrors the `Event-Driven Saga` template in the EventCatalog Canvas.
 
 <LinkButton
   href="https://playground.eventcatalog.dev/#example=4"
   target="_blank"
   rel="noopener noreferrer"
 >
-  Open in EventCatalog Modelling
+  Open in EventCatalog Canvas
 </LinkButton>
 
 ### `main.ec`

--- a/packages/language-server/docs/src/content/docs/examples/playground/flow-e-commerce-checkout.mdx
+++ b/packages/language-server/docs/src/content/docs/examples/playground/flow-e-commerce-checkout.mdx
@@ -5,14 +5,14 @@ description: "Complex flow with validation, fraud detection, parallel processing
 
 import { LinkButton } from "@astrojs/starlight/components";
 
-This example mirrors the `Flow: E-Commerce Checkout` template in the EventCatalog Modelling.
+This example mirrors the `Flow: E-Commerce Checkout` template in the EventCatalog Canvas.
 
 <LinkButton
   href="https://playground.eventcatalog.dev/#example=16"
   target="_blank"
   rel="noopener noreferrer"
 >
-  Open in EventCatalog Modelling
+  Open in EventCatalog Canvas
 </LinkButton>
 
 ### `main.ec`

--- a/packages/language-server/docs/src/content/docs/examples/playground/flow-order-fulfillment.mdx
+++ b/packages/language-server/docs/src/content/docs/examples/playground/flow-order-fulfillment.mdx
@@ -5,14 +5,14 @@ description: "PM-friendly business flow with when-blocks, branching, and converg
 
 import { LinkButton } from "@astrojs/starlight/components";
 
-This example mirrors the `Flow: Order Fulfillment` template in the EventCatalog Modelling.
+This example mirrors the `Flow: Order Fulfillment` template in the EventCatalog Canvas.
 
 <LinkButton
   href="https://playground.eventcatalog.dev/#example=15"
   target="_blank"
   rel="noopener noreferrer"
 >
-  Open in EventCatalog Modelling
+  Open in EventCatalog Canvas
 </LinkButton>
 
 ### `main.ec`

--- a/packages/language-server/docs/src/content/docs/examples/playground/minimal-service.mdx
+++ b/packages/language-server/docs/src/content/docs/examples/playground/minimal-service.mdx
@@ -5,14 +5,14 @@ description: "Simplest possible service definition"
 
 import { LinkButton } from "@astrojs/starlight/components";
 
-This example mirrors the `Minimal Service` template in the EventCatalog Modelling.
+This example mirrors the `Minimal Service` template in the EventCatalog Canvas.
 
 <LinkButton
   href="https://playground.eventcatalog.dev/#example=2"
   target="_blank"
   rel="noopener noreferrer"
 >
-  Open in EventCatalog Modelling
+  Open in EventCatalog Canvas
 </LinkButton>
 
 ### `main.ec`

--- a/packages/language-server/docs/src/content/docs/examples/playground/multi-file-with-imports.mdx
+++ b/packages/language-server/docs/src/content/docs/examples/playground/multi-file-with-imports.mdx
@@ -5,14 +5,14 @@ description: "Demonstrates splitting definitions across files with imports"
 
 import { LinkButton } from "@astrojs/starlight/components";
 
-This example mirrors the `Multi-File with Imports` template in the EventCatalog Modelling.
+This example mirrors the `Multi-File with Imports` template in the EventCatalog Canvas.
 
 <LinkButton
   href="https://playground.eventcatalog.dev/#example=7"
   target="_blank"
   rel="noopener noreferrer"
 >
-  Open in EventCatalog Modelling
+  Open in EventCatalog Canvas
 </LinkButton>
 
 ### `main.ec`

--- a/packages/language-server/docs/src/content/docs/examples/playground/notes-and-annotations.mdx
+++ b/packages/language-server/docs/src/content/docs/examples/playground/notes-and-annotations.mdx
@@ -5,14 +5,14 @@ description: "Attach notes to resources for context, decisions, and reminders"
 
 import { LinkButton } from "@astrojs/starlight/components";
 
-This example mirrors the `Notes & Annotations` template in the EventCatalog Modelling.
+This example mirrors the `Notes & Annotations` template in the EventCatalog Canvas.
 
 <LinkButton
   href="https://playground.eventcatalog.dev/#example=12"
   target="_blank"
   rel="noopener noreferrer"
 >
-  Open in EventCatalog Modelling
+  Open in EventCatalog Canvas
 </LinkButton>
 
 ### `main.ec`

--- a/packages/language-server/docs/src/content/docs/examples/playground/order-service-showcase.mdx
+++ b/packages/language-server/docs/src/content/docs/examples/playground/order-service-showcase.mdx
@@ -5,14 +5,14 @@ description: "Service with events, drafts, deprecations, notes, and channels"
 
 import { LinkButton } from "@astrojs/starlight/components";
 
-This example mirrors the `Order Service Showcase` template in the EventCatalog Modelling.
+This example mirrors the `Order Service Showcase` template in the EventCatalog Canvas.
 
 <LinkButton
   href="https://playground.eventcatalog.dev/#example=1"
   target="_blank"
   rel="noopener noreferrer"
 >
-  Open in EventCatalog Modelling
+  Open in EventCatalog Canvas
 </LinkButton>
 
 ### `main.ec`

--- a/packages/language-server/docs/src/content/docs/examples/playground/payment-domain.mdx
+++ b/packages/language-server/docs/src/content/docs/examples/playground/payment-domain.mdx
@@ -5,14 +5,14 @@ description: "Payment processing with RabbitMQ messaging"
 
 import { LinkButton } from "@astrojs/starlight/components";
 
-This example mirrors the `Payment Domain` template in the EventCatalog Modelling.
+This example mirrors the `Payment Domain` template in the EventCatalog Canvas.
 
 <LinkButton
   href="https://playground.eventcatalog.dev/#example=0"
   target="_blank"
   rel="noopener noreferrer"
 >
-  Open in EventCatalog Modelling
+  Open in EventCatalog Canvas
 </LinkButton>
 
 ### `main.ec`

--- a/packages/language-server/docs/src/content/docs/examples/playground/planning-future-services.mdx
+++ b/packages/language-server/docs/src/content/docs/examples/playground/planning-future-services.mdx
@@ -5,14 +5,14 @@ description: "Demonstrates planning future services and migrations using draft m
 
 import { LinkButton } from "@astrojs/starlight/components";
 
-This example mirrors the `Planning Future Services` template in the EventCatalog Modelling.
+This example mirrors the `Planning Future Services` template in the EventCatalog Canvas.
 
 <LinkButton
   href="https://playground.eventcatalog.dev/#example=10"
   target="_blank"
   rel="noopener noreferrer"
 >
-  Open in EventCatalog Modelling
+  Open in EventCatalog Canvas
 </LinkButton>
 
 ### `main.ec`

--- a/packages/language-server/docs/src/content/docs/examples/playground/post-it-style.mdx
+++ b/packages/language-server/docs/src/content/docs/examples/playground/post-it-style.mdx
@@ -5,14 +5,14 @@ description: "Visual post-it note style rendering"
 
 import { LinkButton } from "@astrojs/starlight/components";
 
-This example mirrors the `Post-It Style` template in the EventCatalog Modelling.
+This example mirrors the `Post-It Style` template in the EventCatalog Canvas.
 
 <LinkButton
   href="https://playground.eventcatalog.dev/#example=5"
   target="_blank"
   rel="noopener noreferrer"
 >
-  Open in EventCatalog Modelling
+  Open in EventCatalog Canvas
 </LinkButton>
 
 ### `main.ec`

--- a/packages/language-server/docs/src/content/docs/examples/playground/remote-url-imports.mdx
+++ b/packages/language-server/docs/src/content/docs/examples/playground/remote-url-imports.mdx
@@ -5,14 +5,14 @@ description: "Import definitions from remote URLs (GitHub, Gist, etc.)"
 
 import { LinkButton } from "@astrojs/starlight/components";
 
-This example mirrors the `Remote URL Imports` template in the EventCatalog Modelling.
+This example mirrors the `Remote URL Imports` template in the EventCatalog Canvas.
 
 <LinkButton
   href="https://playground.eventcatalog.dev/#example=8"
   target="_blank"
   rel="noopener noreferrer"
 >
-  Open in EventCatalog Modelling
+  Open in EventCatalog Canvas
 </LinkButton>
 
 ### `main.ec`

--- a/packages/language-server/docs/src/content/docs/get-started/tutorial.mdx
+++ b/packages/language-server/docs/src/content/docs/get-started/tutorial.mdx
@@ -5,11 +5,11 @@ description: Build your first EventCatalog model and move it into and out of Eve
 
 import { Steps } from "@astrojs/starlight/components";
 
-If this is your first time with EventCatalog Modeling, this tutorial is for you.
+If this is your first time with EventCatalog Canvas, this tutorial is for you.
 
 In this tutorial, we will build a tiny architecture model from scratch and see it visually.
 
-To start, open a [blank EventCatalog Modelling workspace](https://playground.eventcatalog.dev/) in a new tab.
+To start, open a [blank EventCatalog Canvas workspace](https://playground.eventcatalog.dev/) in a new tab.
 
 Then walk through these steps:
 

--- a/packages/language-server/docs/src/content/docs/guides/designing-target-architectures.md
+++ b/packages/language-server/docs/src/content/docs/guides/designing-target-architectures.md
@@ -1,6 +1,6 @@
 ---
 title: Designing target architectures
-description: Use EventCatalog Modeling to design future-state architecture before implementation.
+description: Use EventCatalog Canvas to design future-state architecture before implementation.
 ---
 
 This guide is for architects who want to design a target architecture before teams start building. You can take existing EventCatalog resources, export them to `.ec` models, and then iterate on future-state ideas in Git.
@@ -41,7 +41,7 @@ Then edit `target.ec` with planned changes (new services, message routes, channe
 
 Commit `target.ec` and review it with your team in a PR so the architecture discussion happens in code review, not disconnected docs.
 
-For quick visual collaboration, open the model in EventCatalog Modelling:
+For quick visual collaboration, open the model in EventCatalog Canvas:
 
 - https://playground.eventcatalog.dev/
 

--- a/packages/language-server/docs/src/content/docs/guides/exporting-ec.md
+++ b/packages/language-server/docs/src/content/docs/guides/exporting-ec.md
@@ -32,7 +32,7 @@ npx @eventcatalog/cli --dir ./catalog export --resource event --id OrderCreated 
 
 - `--hydrate`: Include referenced resources in output.
 - `--output <path>`: Write to a specific file.
-- `--playground`: Open exported DSL in EventCatalog Modelling.
+- `--playground`: Open exported DSL in EventCatalog Canvas.
 
 ## Current export scope
 

--- a/packages/language-server/docs/src/content/docs/guides/from-design-to-documentation.md
+++ b/packages/language-server/docs/src/content/docs/guides/from-design-to-documentation.md
@@ -7,7 +7,7 @@ This guide shows the end-to-end path from `.ec` design work to published EventCa
 
 ```mermaid
 flowchart LR
-  A[Design in .ec] --> B[Review in PR / EventCatalog Modelling]
+  A[Design in .ec] --> B[Review in PR / EventCatalog Canvas]
   B --> C[Dry-run import]
   C --> D[Import approved model]
   D --> E[Updated EventCatalog docs]
@@ -25,7 +25,7 @@ Model your domains, services, messages, channels, and notes in `main.ec`.
 
 ## Step 2: Share and review the design
 
-Use Git PRs for architecture review and optionally share a visual link via EventCatalog Modelling:
+Use Git PRs for architecture review and optionally share a visual link via EventCatalog Canvas:
 
 - https://playground.eventcatalog.dev/new
 

--- a/packages/language-server/docs/src/content/docs/guides/getting-feedback-from-designs.md
+++ b/packages/language-server/docs/src/content/docs/guides/getting-feedback-from-designs.md
@@ -49,8 +49,8 @@ event CheckoutSubmitted {
 4. Resolve notes by updating the model.
 5. Import the approved model into EventCatalog.
 
-## Optional: use EventCatalog Modelling for live feedback
+## Optional: use EventCatalog Canvas for live feedback
 
-You can paste your model into EventCatalog Modelling, share the link in your PR, and discuss the design with visual context:
+You can paste your model into EventCatalog Canvas, share the link in your PR, and discuss the design with visual context:
 
 - https://playground.eventcatalog.dev/

--- a/packages/language-server/docs/src/content/docs/guides/remote-fetching-models.md
+++ b/packages/language-server/docs/src/content/docs/guides/remote-fetching-models.md
@@ -34,7 +34,7 @@ visualizer main {
 
 ## Try it quickly
 
-- EventCatalog Modelling example: `https://playground.eventcatalog.dev/#example=8`
+- EventCatalog Canvas example: `https://playground.eventcatalog.dev/#example=8`
 
 ## Using with CLI import
 

--- a/packages/language-server/docs/src/content/docs/guides/using-ai-to-generate-diagrams.md
+++ b/packages/language-server/docs/src/content/docs/guides/using-ai-to-generate-diagrams.md
@@ -15,12 +15,12 @@ Use the **Copy as Markdown** button at the top right of the page, then paste it 
 
 ## Step 2: Give your requirements
 
-Ask the LLM to create a diagram in EventCatalog Modeling DSL.
+Ask the LLM to create a diagram in EventCatalog Canvas DSL.
 
 Use this prompt template:
 
 ```text
-You are generating EventCatalog Modeling (.ec) code.
+You are generating EventCatalog Canvas (.ec) code.
 Follow this DSL specification exactly:
 [PASTE SPECIFICATION HERE]
 
@@ -39,7 +39,7 @@ Return only valid .ec code, no explanation.
 
 ## Step 3: Review and refine the generated model
 
-Paste the output into EventCatalog Modelling and iterate with your team:
+Paste the output into EventCatalog Canvas and iterate with your team:
 
 - https://playground.eventcatalog.dev/new
 

--- a/packages/language-server/docs/src/content/docs/index.md
+++ b/packages/language-server/docs/src/content/docs/index.md
@@ -1,9 +1,9 @@
 ---
-title: EventCatalog Modeling
+title: EventCatalog Canvas
 description: Model your event-driven architecture in .ec and keep it in sync with EventCatalog.
 ---
 
-EventCatalog Modeling helps you define architecture as code in `.ec` files, review changes in Git, and sync those models with EventCatalog.
+EventCatalog Canvas helps you define architecture as code in `.ec` files, review changes in Git, and sync those models with EventCatalog.
 
 :::caution[Beta]
 The `.ec` docs experience is in beta.

--- a/packages/language-server/docs/src/content/docs/resources/channels.mdx
+++ b/packages/language-server/docs/src/content/docs/resources/channels.mdx
@@ -12,7 +12,7 @@ import { LinkButton } from "@astrojs/starlight/components";
   target="_blank"
   rel="noopener noreferrer"
 >
-  Open in EventCatalog Modelling
+  Open in EventCatalog Canvas
 </LinkButton>
 
 ## Example

--- a/packages/language-server/docs/src/content/docs/resources/data-products.mdx
+++ b/packages/language-server/docs/src/content/docs/resources/data-products.mdx
@@ -12,7 +12,7 @@ import { LinkButton } from "@astrojs/starlight/components";
   target="_blank"
   rel="noopener noreferrer"
 >
-  Open in EventCatalog Modelling
+  Open in EventCatalog Canvas
 </LinkButton>
 
 ## Example

--- a/packages/language-server/docs/src/content/docs/resources/databases.mdx
+++ b/packages/language-server/docs/src/content/docs/resources/databases.mdx
@@ -12,7 +12,7 @@ Databases are modeled with `container` and `container-type database`.
   target="_blank"
   rel="noopener noreferrer"
 >
-  Open in EventCatalog Modelling
+  Open in EventCatalog Canvas
 </LinkButton>
 
 ## Example

--- a/packages/language-server/docs/src/content/docs/resources/domains.mdx
+++ b/packages/language-server/docs/src/content/docs/resources/domains.mdx
@@ -12,7 +12,7 @@ import { LinkButton } from "@astrojs/starlight/components";
   target="_blank"
   rel="noopener noreferrer"
 >
-  Open in EventCatalog Modelling
+  Open in EventCatalog Canvas
 </LinkButton>
 
 ## Example

--- a/packages/language-server/docs/src/content/docs/resources/messages.mdx
+++ b/packages/language-server/docs/src/content/docs/resources/messages.mdx
@@ -1,6 +1,6 @@
 ---
 title: Messages
-description: Model events, commands, and queries in EventCatalog Modeling.
+description: Model events, commands, and queries in EventCatalog Canvas.
 ---
 
 import { LinkButton } from "@astrojs/starlight/components";
@@ -16,7 +16,7 @@ Messages are facts, intents, or requests that move between services.
   target="_blank"
   rel="noopener noreferrer"
 >
-  Open in EventCatalog Modelling
+  Open in EventCatalog Canvas
 </LinkButton>
 
 ## Example

--- a/packages/language-server/docs/src/content/docs/resources/services.mdx
+++ b/packages/language-server/docs/src/content/docs/resources/services.mdx
@@ -12,7 +12,7 @@ import { LinkButton } from "@astrojs/starlight/components";
   target="_blank"
   rel="noopener noreferrer"
 >
-  Open in EventCatalog Modelling
+  Open in EventCatalog Canvas
 </LinkButton>
 
 ## Example

--- a/packages/playground/README.md
+++ b/packages/playground/README.md
@@ -1,8 +1,8 @@
-# EventCatalog Modelling
+# EventCatalog Canvas
 
 > **Beta** - This package is in active development.
 
-A browser-based EventCatalog Modelling workspace for the [EventCatalog DSL](../language-server/README.md). Write `.ec` code in a Monaco editor with syntax highlighting, completions, and diagnostics, and see your architecture visualised in real time.
+A browser-based EventCatalog Canvas workspace for the [EventCatalog DSL](../language-server/README.md). Write `.ec` code in a Monaco editor with syntax highlighting, completions, and diagnostics, and see your architecture visualised in real time.
 
 ## Getting Started
 
@@ -14,4 +14,4 @@ Open `http://localhost:5173/new` to start from a blank canvas with no template s
 
 ## How It Works
 
-EventCatalog Modelling uses the `@eventcatalog/language-server` to parse DSL input and the `@eventcatalog/visualiser` to render the resulting architecture graph. As you type, your DSL is parsed and the visualisation updates live.
+EventCatalog Canvas uses the `@eventcatalog/language-server` to parse DSL input and the `@eventcatalog/visualiser` to render the resulting architecture graph. As you type, your DSL is parsed and the visualisation updates live.

--- a/packages/playground/index.html
+++ b/packages/playground/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='6' fill='%236C3FEF'/%3E%3Cpath d='M17.5 5L10 18h5.5L14.5 27 22 14h-5.5z' fill='%23FFF' stroke='%23FFF' stroke-width='1.5' stroke-linejoin='round'/%3E%3C/svg%3E" />
-    <title>EventCatalog Modelling</title>
+    <title>EventCatalog Canvas</title>
   </head>
   <body style="margin: 0">
     <div id="root"></div>

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -49,7 +49,7 @@ const AppHeader = memo(function AppHeader({
     <header className="header">
       <div className="header-logo">
         <Zap size={20} />
-        <h1>EventCatalog Modelling</h1>
+        <h1>EventCatalog Canvas</h1>
       </div>
       <div className="example-select-wrapper">
         <select
@@ -153,7 +153,7 @@ const ShareLinkModal = memo(function ShareLinkModal({
           </button>
         </div>
 
-        <p className="export-modal-lead">Share this URL with your team so they can open the same model in EventCatalog Modelling.</p>
+        <p className="export-modal-lead">Share this URL with your team so they can open the same model in EventCatalog Canvas.</p>
 
         <div className="command-row">
           <code>{shareUrl}</code>

--- a/packages/sdk/src/dsl/container.ts
+++ b/packages/sdk/src/dsl/container.ts
@@ -1,0 +1,39 @@
+import type { Container } from '../types';
+import { serializeBaseFields } from './utils';
+
+export function containerToDSL(resource: Container): string {
+  const lines: string[] = [];
+  const baseFields = serializeBaseFields(resource);
+  if (baseFields) lines.push(baseFields);
+
+  if (resource.container_type) {
+    lines.push(`  container-type ${resource.container_type}`);
+  }
+
+  if (resource.technology) {
+    lines.push(`  technology "${resource.technology}"`);
+  }
+
+  if (resource.authoritative === true) {
+    lines.push(`  authoritative true`);
+  }
+
+  if (resource.access_mode) {
+    lines.push(`  access-mode ${resource.access_mode}`);
+  }
+
+  if (resource.classification) {
+    lines.push(`  classification ${resource.classification}`);
+  }
+
+  if (resource.residency) {
+    lines.push(`  residency "${resource.residency}"`);
+  }
+
+  if (resource.retention) {
+    lines.push(`  retention "${resource.retention}"`);
+  }
+
+  const body = lines.join('\n');
+  return `container ${resource.id} {\n${body}\n}`;
+}

--- a/packages/sdk/src/dsl/index.ts
+++ b/packages/sdk/src/dsl/index.ts
@@ -1,9 +1,10 @@
-import type { Event, Command, Query, Service, Domain, Team, User, Channel } from '../types';
+import type { Event, Command, Query, Service, Domain, Team, User, Channel, Container } from '../types';
 import { messageToDSL } from './message';
 import { serviceToDSL } from './service';
 import { domainToDSL } from './domain';
 import { teamToDSL, userToDSL } from './owner';
 import { channelToDSL } from './channel';
+import { containerToDSL } from './container';
 import { buildMessageTypeIndex, resolveMessageType, msgVersionMatches } from './utils';
 import type { MessageType, MessageTypeIndex } from './utils';
 
@@ -25,6 +26,7 @@ export interface ResourceResolvers {
   getDomain: (id: string, version?: string) => Promise<Domain | undefined>;
   getChannel: (id: string, version?: string) => Promise<Channel | undefined>;
   getChannels: (options?: { latestOnly?: boolean }) => Promise<Channel[]>;
+  getContainer: (id: string, version?: string) => Promise<Container | undefined>;
   getTeam: (id: string) => Promise<Team | undefined>;
   getUser: (id: string) => Promise<User | undefined>;
 }
@@ -94,6 +96,20 @@ async function hydrateChannels(resource: Service | Domain, resolvers: ResourceRe
     for (const ch of channels) {
       await hydrateChannel(ch.id, ch.version, resolvers, seen, parts);
     }
+  }
+}
+
+async function hydrateContainers(resource: Service, resolvers: ResourceResolvers, seen: Set<string>, parts: string[]) {
+  const allContainers = [...(resource.writesTo || []), ...(resource.readsFrom || [])];
+  for (const ref of allContainers) {
+    const key = `container:${ref.id}@${ref.version || 'latest'}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    const container = await resolvers.getContainer(ref.id, ref.version);
+    if (!container) continue;
+
+    parts.push(containerToDSL(container));
   }
 }
 
@@ -230,6 +246,7 @@ export const toDSL =
           if (options.hydrate) {
             await hydrateOwners(res.owners, resolvers, seen, parts);
             await hydrateChannels(res as Service, resolvers, seen, parts);
+            await hydrateContainers(res as Service, resolvers, seen, parts);
           }
           parts.push(
             await serviceToDSL(

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1341,6 +1341,7 @@ export default (path: string) => {
       getDomain: getDomain(join(path, 'domains')),
       getChannel: getChannel(join(path)),
       getChannels: getChannels(join(path)),
+      getContainer: getDataStore(join(path)),
       getTeam: getTeam(join(path, 'teams')),
       getUser: getUser(join(path, 'users')),
     }),

--- a/packages/sdk/src/test/dsl/services.test.ts
+++ b/packages/sdk/src/test/dsl/services.test.ts
@@ -5,7 +5,8 @@ import fs from 'node:fs';
 
 const CATALOG_PATH = path.join(__dirname, 'catalog-dsl-services');
 
-const { writeEvent, writeCommand, writeQuery, writeService, writeChannel, writeTeam, writeUser, toDSL } = utils(CATALOG_PATH);
+const { writeEvent, writeCommand, writeQuery, writeService, writeChannel, writeTeam, writeUser, writeDataStore, toDSL } =
+  utils(CATALOG_PATH);
 
 beforeEach(() => {
   fs.rmSync(CATALOG_PATH, { recursive: true, force: true });
@@ -791,6 +792,225 @@ service OrderService {
       expect(dsl).toContain('receives event OrderCreated@1.0.0');
       expect(dsl).toContain('receives event OrderUpdated@1.0.0');
       expect(dsl.match(/service BillingService \{/g)?.length || 0).toBe(1);
+    });
+  });
+
+  describe('hydrate containers', () => {
+    it('hydrates containers referenced in writes-to', async () => {
+      await writeDataStore({
+        id: 'OrdersDB',
+        name: 'Orders Database',
+        version: '1.0.0',
+        container_type: 'database',
+        technology: 'postgres@14',
+        markdown: '',
+      });
+
+      const dsl = await toDSL(
+        {
+          id: 'OrderService',
+          name: 'Order Service',
+          version: '1.0.0',
+          writesTo: [{ id: 'OrdersDB', version: '1.0.0' }],
+          markdown: '',
+        },
+        { type: 'service', hydrate: true }
+      );
+
+      expect(dsl).toBe(`container OrdersDB {
+  version 1.0.0
+  name "Orders Database"
+  container-type database
+  technology "postgres@14"
+}
+
+service OrderService {
+  version 1.0.0
+  name "Order Service"
+  writes-to container OrdersDB@1.0.0
+}`);
+    });
+
+    it('hydrates containers referenced in reads-from', async () => {
+      await writeDataStore({
+        id: 'InventoryDB',
+        name: 'Inventory Database',
+        version: '2.0.0',
+        container_type: 'database',
+        markdown: '',
+      });
+
+      const dsl = await toDSL(
+        {
+          id: 'OrderService',
+          name: 'Order Service',
+          version: '1.0.0',
+          readsFrom: [{ id: 'InventoryDB', version: '2.0.0' }],
+          markdown: '',
+        },
+        { type: 'service', hydrate: true }
+      );
+
+      expect(dsl).toBe(`container InventoryDB {
+  version 2.0.0
+  name "Inventory Database"
+  container-type database
+}
+
+service OrderService {
+  version 1.0.0
+  name "Order Service"
+  reads-from container InventoryDB@2.0.0
+}`);
+    });
+
+    it('hydrates both writes-to and reads-from containers', async () => {
+      await writeDataStore({
+        id: 'OrdersDB',
+        name: 'Orders Database',
+        version: '1.0.0',
+        container_type: 'database',
+        markdown: '',
+      });
+      await writeDataStore({
+        id: 'InventoryDB',
+        name: 'Inventory Database',
+        version: '2.0.0',
+        container_type: 'cache',
+        technology: 'redis',
+        markdown: '',
+      });
+
+      const dsl = await toDSL(
+        {
+          id: 'OrderService',
+          name: 'Order Service',
+          version: '1.0.0',
+          writesTo: [{ id: 'OrdersDB', version: '1.0.0' }],
+          readsFrom: [{ id: 'InventoryDB', version: '2.0.0' }],
+          markdown: '',
+        },
+        { type: 'service', hydrate: true }
+      );
+
+      expect(dsl).toBe(`container OrdersDB {
+  version 1.0.0
+  name "Orders Database"
+  container-type database
+}
+
+container InventoryDB {
+  version 2.0.0
+  name "Inventory Database"
+  container-type cache
+  technology "redis"
+}
+
+service OrderService {
+  version 1.0.0
+  name "Order Service"
+  writes-to container OrdersDB@1.0.0
+  reads-from container InventoryDB@2.0.0
+}`);
+    });
+
+    it('deduplicates containers referenced in both writes-to and reads-from', async () => {
+      await writeDataStore({
+        id: 'OrdersDB',
+        name: 'Orders Database',
+        version: '1.0.0',
+        container_type: 'database',
+        markdown: '',
+      });
+
+      const dsl = await toDSL(
+        {
+          id: 'OrderService',
+          name: 'Order Service',
+          version: '1.0.0',
+          writesTo: [{ id: 'OrdersDB', version: '1.0.0' }],
+          readsFrom: [{ id: 'OrdersDB', version: '1.0.0' }],
+          markdown: '',
+        },
+        { type: 'service', hydrate: true }
+      );
+
+      expect(dsl).toBe(`container OrdersDB {
+  version 1.0.0
+  name "Orders Database"
+  container-type database
+}
+
+service OrderService {
+  version 1.0.0
+  name "Order Service"
+  writes-to container OrdersDB@1.0.0
+  reads-from container OrdersDB@1.0.0
+}`);
+    });
+
+    it('skips containers that cannot be resolved', async () => {
+      const dsl = await toDSL(
+        {
+          id: 'OrderService',
+          name: 'Order Service',
+          version: '1.0.0',
+          writesTo: [{ id: 'NonExistentDB', version: '1.0.0' }],
+          markdown: '',
+        },
+        { type: 'service', hydrate: true }
+      );
+
+      expect(dsl).toBe(`service OrderService {
+  version 1.0.0
+  name "Order Service"
+  writes-to container NonExistentDB@1.0.0
+}`);
+    });
+
+    it('hydrates container with all fields', async () => {
+      await writeDataStore({
+        id: 'OrdersDB',
+        name: 'Orders Database',
+        version: '1.0.0',
+        container_type: 'database',
+        technology: 'postgres@14',
+        authoritative: true,
+        access_mode: 'readWrite',
+        classification: 'confidential',
+        residency: 'us-east-1',
+        retention: '7 years',
+        markdown: '',
+      });
+
+      const dsl = await toDSL(
+        {
+          id: 'OrderService',
+          name: 'Order Service',
+          version: '1.0.0',
+          writesTo: [{ id: 'OrdersDB', version: '1.0.0' }],
+          markdown: '',
+        },
+        { type: 'service', hydrate: true }
+      );
+
+      expect(dsl).toBe(`container OrdersDB {
+  version 1.0.0
+  name "Orders Database"
+  container-type database
+  technology "postgres@14"
+  authoritative true
+  access-mode readWrite
+  classification confidential
+  residency "us-east-1"
+  retention "7 years"
+}
+
+service OrderService {
+  version 1.0.0
+  name "Order Service"
+  writes-to container OrdersDB@1.0.0
+}`);
     });
   });
 


### PR DESCRIPTION
## What This PR Does

Two changes: (1) When hydrating a service's DSL export, containers referenced via `writesTo`/`readsFrom` are now included as full container definitions in the output, matching the existing behavior for messages and channels. (2) Renames all references from "EventCatalog Modelling/Modeling" to "EventCatalog Canvas" across the playground, CLI, and language-server docs.

## Changes Overview

### Key Changes
- **New `containerToDSL` function** (`packages/sdk/src/dsl/container.ts`) serializes Container resources to DSL format with all fields (container-type, technology, authoritative, access-mode, classification, residency, retention)
- **Container hydration** in `packages/sdk/src/dsl/index.ts` — adds `hydrateContainers()` function and `getContainer` resolver to `ResourceResolvers`
- **Wired `getContainer` resolver** in `packages/sdk/src/index.ts` using the existing `getDataStore` function
- **6 new tests** covering writes-to, reads-from, both together, deduplication, unresolvable containers, and full field serialization
- **Renamed** "EventCatalog Modelling"/"EventCatalog Modeling" to "EventCatalog Canvas" across 41 files (playground, CLI, docs)

## How It Works

Container hydration follows the same pattern as channel/message hydration. When `hydrate: true` is passed to `toDSL` for a service, the new `hydrateContainers()` function iterates over `writesTo` and `readsFrom` pointers, resolves each container via the `getContainer` resolver, and prepends the full container DSL definition before the service block. Deduplication is handled via the existing `seen` set.

## Breaking Changes

None

## Additional Notes

The `getContainer` resolver maps to the existing `getDataStore` SDK function since containers are stored as "data stores" internally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)