### PR TITLE
Default container_type to database when not specified in DSL import

### DIFF
--- a/.changeset/gentle-clouds-drift.md
+++ b/.changeset/gentle-clouds-drift.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/cli": patch
+---
+
+Default container_type to 'database' when not specified in .ec file imports

--- a/packages/cli/src/cli/import.ts
+++ b/packages/cli/src/cli/import.ts
@@ -44,6 +44,10 @@ function normalizeImportedFrontmatter(type: string, frontmatter: Record<string, 
       normalized.access_mode = normalized.accessMode;
       delete normalized.accessMode;
     }
+    // Default container_type to 'database' if not specified in the DSL
+    if (!normalized.container_type) {
+      normalized.container_type = 'database';
+    }
   }
 
   return normalized;

--- a/packages/cli/src/test/import-export/container-refs.test.ts
+++ b/packages/cli/src/test/import-export/container-refs.test.ts
@@ -68,6 +68,23 @@ service OrderService {
     expect(service.readsFrom).toEqual([{ id: 'ReportsStore', version: '2.0.0' }]);
   });
 
+  it('defaults container_type to database for container stubs', async () => {
+    const ecFile = writeEcFile(
+      'test.ec',
+      `service InventoryService {
+  version 1.0.0
+  writes-to container InventoryDb
+}`
+    );
+
+    await importDSL({ files: [ecFile], dir: catalogPath });
+
+    const sdk = createSDK(catalogPath);
+    const container: any = await sdk.getDataStore('InventoryDb', '0.0.1');
+    expect(container).toBeDefined();
+    expect(container.container_type).toBe('database');
+  });
+
   it('nests container stubs under the domain by default', async () => {
     const ecFile = writeEcFile(
       'test.ec',

--- a/packages/cli/src/test/import-export/resource-types.test.ts
+++ b/packages/cli/src/test/import-export/resource-types.test.ts
@@ -114,6 +114,23 @@ diagram system-overview {
     expect(container.accessMode).toBeUndefined();
   });
 
+  it('defaults container_type to database when not specified in DSL', async () => {
+    const ecFile = writeEcFile(
+      'test.ec',
+      `container orders-db {
+  version 1.0.0
+  name "Orders DB"
+}`
+    );
+
+    await importDSL({ files: [ecFile], dir: catalogPath });
+
+    const sdk = createSDK(catalogPath);
+    const container: any = await sdk.getDataStore('orders-db', '1.0.0');
+    expect(container).toBeDefined();
+    expect(container.container_type).toBe('database');
+  });
+
   it('nests domain containers by default', async () => {
     const ecFile = writeEcFile(
       'test.ec',


### PR DESCRIPTION
## What This PR Does

When importing containers from `.ec` files, if the `container-type` statement is omitted, the `container_type` field was left undefined. Since the content schema requires this field, this caused validation failures. This PR defaults `container_type` to `"database"` for any container (explicit or stub) that doesn't specify one.

## Changes Overview

### Key Changes
- Add default `container_type = 'database'` in `normalizeImportedFrontmatter` for containers missing the field
- Add test for explicit containers without `container-type` in DSL
- Add test for stub containers (auto-created from `writes-to`/`reads-from` refs) getting the default

## How It Works

The fix is in `packages/cli/src/cli/import.ts` in the `normalizeImportedFrontmatter` function. After normalizing camelCase to snake_case fields, it checks if `container_type` is still falsy and sets it to `'database'`. This covers both:

1. **Explicitly defined containers** - containers in DSL without a `container-type` statement
2. **Stub containers** - auto-created when a service references a container via `writes-to`/`reads-from` without a standalone container definition

Both paths go through `normalizeImportedFrontmatter` via `mergeImportedFrontmatter`.

## Breaking Changes

None

## Test plan

- [x] Existing container import tests pass (12/12)
- [x] New test: explicit container without `container-type` defaults to `database`
- [x] New test: stub container from `writes-to` ref defaults to `database`

🤖 Generated with [Claude Code](https://claude.com/claude-code)