### PR TITLE
feat(playground): add download as catalog export option

### DIFF
--- a/.changeset/bright-catalog-export.md
+++ b/.changeset/bright-catalog-export.md
@@ -1,0 +1,6 @@
+---
+"@eventcatalog/dsl-playground": minor
+"@eventcatalog/language-server": patch
+---
+
+Add "Download as Catalog" export option to the playground that generates a ready-to-run EventCatalog project zip with package.json, config, and compiled content files

--- a/packages/language-server/src/compiler.ts
+++ b/packages/language-server/src/compiler.ts
@@ -685,13 +685,13 @@ function compileContainer(
   const body = cont.body as AstNode[];
   const fm = commonFrontmatter(cont.name, body);
   const ct = getContainerType(body);
-  if (ct) fm.containerType = ct;
+  if (ct) fm.container_type = ct;
   const tech = getTechnology(body);
   if (tech) fm.technology = tech;
   const auth = getAuthoritative(body);
   if (auth !== undefined) fm.authoritative = auth;
   const am = getAccessMode(body);
-  if (am) fm.accessMode = am;
+  if (am) fm.access_mode = am;
   const cl = getClassification(body);
   if (cl) fm.classification = cl;
   const res = getResidency(body);

--- a/packages/language-server/test/compiler.test.ts
+++ b/packages/language-server/test/compiler.test.ts
@@ -299,6 +299,28 @@ describe("compile", () => {
     expect(channelOutput!.content).toContain("Kafka");
   });
 
+  it("compiles a container using container_type and access_mode frontmatter keys", async () => {
+    const program = await parseProgram(`
+      container PaymentsDB {
+        version 1.0.0
+        container-type database
+        technology "PostgreSQL 15"
+        access-mode readWrite
+      }
+    `);
+
+    const outputs = compile(program);
+
+    const containerOutput = outputs.find(
+      (o) => o.path === "containers/PaymentsDB/versioned/1.0.0/index.md",
+    );
+    expect(containerOutput).toBeDefined();
+    expect(containerOutput!.content).toContain('container_type: "database"');
+    expect(containerOutput!.content).toContain('access_mode: "readWrite"');
+    expect(containerOutput!.content).not.toContain("containerType:");
+    expect(containerOutput!.content).not.toContain("accessMode:");
+  });
+
   it("compiles a user", async () => {
     const program = await parseProgram(`
       user dboyne {

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -6,11 +6,12 @@ import { TemplatePicker } from './components/TemplatePicker';
 import { StatusBar } from './components/StatusBar';
 import { CommandPalette } from './components/CommandPalette';
 import type { EditorHandle } from './components/Editor';
-import { useDslParser } from './hooks/useDslParser';
+import { useDslParser, compileDsl } from './hooks/useDslParser';
 import { getErrorsForFile } from './monaco/ec-diagnostics';
 import { examples } from './examples';
 import { createZipBlob } from './utils/zip';
-import { ChevronDown, AlignLeft, Check, Download, Share2, Sun, Moon, X, Copy } from 'lucide-react';
+import { normalizeCompiledCatalogFiles } from './utils/catalog-export';
+import { ChevronDown, AlignLeft, Check, Download, Share2, Sun, Moon, X, Copy, FolderDown } from 'lucide-react';
 import { formatEc } from '@eventcatalog/language-server';
 
 const MIN_PANEL_PCT = 20;
@@ -30,6 +31,7 @@ const AppHeader = memo(function AppHeader({
   onExampleChange,
   loadedFromUrl,
   onExport,
+  onExportCatalog,
   exportRecentlyDownloaded,
   onShare,
   vizTheme,
@@ -40,6 +42,7 @@ const AppHeader = memo(function AppHeader({
   onExampleChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
   loadedFromUrl: boolean;
   onExport: () => void;
+  onExportCatalog: () => void;
   exportRecentlyDownloaded: boolean;
   onShare: () => void;
   vizTheme: 'light' | 'dark';
@@ -50,6 +53,20 @@ const AppHeader = memo(function AppHeader({
     : templateUnselected
       ? ''
       : examples[selectedExample]?.name ?? '';
+
+  const [exportOpen, setExportOpen] = useState(false);
+  const exportRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!exportOpen) return;
+    const onClick = (e: MouseEvent) => {
+      if (exportRef.current && !exportRef.current.contains(e.target as Node)) {
+        setExportOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', onClick);
+    return () => document.removeEventListener('mousedown', onClick);
+  }, [exportOpen]);
 
   return (
     <header className="header">
@@ -91,10 +108,31 @@ const AppHeader = memo(function AppHeader({
         <button className="header-icon-btn" onClick={onShare} title="Share model link">
           <Share2 size={15} />
         </button>
-        <button className="export-btn-header" onClick={onExport}>
-          {exportRecentlyDownloaded ? <Check size={14} /> : <Download size={14} />}
-          Export to EventCatalog
-        </button>
+        <div className="export-dropdown-wrapper" ref={exportRef}>
+          <button className="export-btn-header" onClick={() => setExportOpen((v) => !v)}>
+            {exportRecentlyDownloaded ? <Check size={14} /> : <Download size={14} />}
+            Export
+            <ChevronDown size={12} />
+          </button>
+          {exportOpen && (
+            <div className="export-dropdown">
+              <button className="export-dropdown-item" onClick={() => { setExportOpen(false); onExport(); }}>
+                <Download size={14} />
+                <div>
+                  <span className="export-dropdown-item-title">Download DSL files</span>
+                  <span className="export-dropdown-item-desc">Export .ec files for use with the CLI</span>
+                </div>
+              </button>
+              <button className="export-dropdown-item" onClick={() => { setExportOpen(false); onExportCatalog(); }}>
+                <FolderDown size={14} />
+                <div>
+                  <span className="export-dropdown-item-title">Download as Catalog</span>
+                  <span className="export-dropdown-item-desc">Ready-to-run project — just npm install and start</span>
+                </div>
+              </button>
+            </div>
+          )}
+        </div>
       </div>
     </header>
   );
@@ -216,6 +254,64 @@ const ExportHelpModal = memo(function ExportHelpModal({
         </div>
 
         <p className="export-modal-tip">Tip: add <code>--dry-run</code> first to preview changes before writing files.</p>
+      </div>
+    </div>
+  );
+});
+
+const CatalogExportModal = memo(function CatalogExportModal({
+  organizationName,
+  onOrganizationNameChange,
+  onCreateCatalog,
+  isExporting,
+  onClose,
+}: {
+  organizationName: string;
+  onOrganizationNameChange: (value: string) => void;
+  onCreateCatalog: () => void;
+  isExporting: boolean;
+  onClose: () => void;
+}) {
+  return (
+    <div className="export-modal-overlay" onClick={onClose} role="presentation">
+      <div className="export-modal export-modal--compact" role="dialog" aria-modal="true" aria-label="Export catalog" onClick={(e) => e.stopPropagation()}>
+        <div className="export-modal-header">
+          <h2>Customize Your Catalog</h2>
+          <button className="export-modal-close" onClick={onClose} title="Close">
+            <X size={16} />
+          </button>
+        </div>
+        <p className="export-modal-lead">
+          We will customize your catalog for your organization.
+        </p>
+        <form
+          className="catalog-export-form"
+          onSubmit={(event) => {
+            event.preventDefault();
+            onCreateCatalog();
+          }}
+        >
+          <label htmlFor="organization-name" className="catalog-export-label">
+            Organization Name
+          </label>
+          <input
+            id="organization-name"
+            className="catalog-export-input"
+            type="text"
+            value={organizationName}
+            onChange={(e) => onOrganizationNameChange(e.target.value)}
+            placeholder="My Organization"
+            autoFocus
+            disabled={isExporting}
+          />
+          <button
+            className="catalog-export-submit"
+            type="submit"
+            disabled={isExporting || organizationName.trim().length === 0}
+          >
+            {isExporting ? 'Creating Zip...' : 'Create Catalog Zip'}
+          </button>
+        </form>
       </div>
     </div>
   );
@@ -402,6 +498,9 @@ export default function App() {
   const [shareUrl, setShareUrl] = useState<string | null>(null);
   const [exportRecentlyDownloaded, setExportRecentlyDownloaded] = useState(false);
   const [latestExport, setLatestExport] = useState<ExportResult | null>(null);
+  const [showCatalogExport, setShowCatalogExport] = useState(false);
+  const [catalogOrganizationName, setCatalogOrganizationName] = useState('My Organization');
+  const [isCatalogExporting, setIsCatalogExporting] = useState(false);
   const handleShare = useCallback(() => {
     const allContent = Object.values(files).join('\n');
     const encoded = btoa(unescape(encodeURIComponent(allContent)));
@@ -442,17 +541,114 @@ export default function App() {
     setTimeout(() => setExportRecentlyDownloaded(false), 2000);
   }, [files]);
 
+  const handleOpenCatalogExport = useCallback(() => {
+    setShowCatalogExport(true);
+  }, []);
+
+  const handleExportCatalog = useCallback(async () => {
+    const organizationName = catalogOrganizationName.trim();
+    if (!organizationName) return;
+    const organizationSlug =
+      organizationName
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '') || 'my-organization';
+    const catalogFolderName = `${organizationSlug}-catalog`;
+
+    setIsCatalogExporting(true);
+
+    try {
+      const compiled = normalizeCompiledCatalogFiles(await compileDsl(files));
+
+      if (compiled.length === 0) {
+        return;
+      }
+
+      const catalogId = crypto.randomUUID();
+
+      const packageJson = JSON.stringify({
+        name: catalogFolderName,
+        version: '0.1.0',
+        private: true,
+        scripts: {
+          dev: 'eventcatalog dev',
+          build: 'eventcatalog build',
+          start: 'eventcatalog start',
+          preview: 'eventcatalog preview',
+        },
+        dependencies: {
+          '@eventcatalog/core': 'latest',
+        },
+      }, null, 2);
+
+      const configJs = `/** @type {import('@eventcatalog/core/bin/eventcatalog.config').Config} */
+export default {
+  title: 'EventCatalog',
+  tagline: 'Discover, Explore and Document your Event Driven Architectures.',
+  organizationName: ${JSON.stringify(organizationName)},
+  homepageLink: 'https://eventcatalog.dev/',
+  output: 'static',
+  trailingSlash: false,
+  base: '/',
+  navigation: {
+    pages: ['list:all'],
+  },
+  logo: {
+    alt: 'EventCatalog Logo',
+    src: '/logo.png',
+    text: 'EventCatalog',
+  },
+  cId: '${catalogId}',
+};
+`;
+      const readmeMd = `# ${organizationName} Catalog
+
+Welcome to your generated EventCatalog project.
+
+## Helpful Links
+
+- [Fundamentals of EventCatalog](https://www.eventcatalog.dev/docs/development/getting-started/fundamentals)
+- [Documenting your first domain](https://www.eventcatalog.dev/docs/development/guides/domains/creating-domains/adding-domains)
+- [Documenting services](https://www.eventcatalog.dev/docs/development/guides/services/introduction)
+- [Integrating with OpenAPI and AsyncAPI](https://www.eventcatalog.dev/integrations)
+- [Join the Discord community](https://eventcatalog.dev/discord)
+`;
+
+      const zipFiles = [
+        { name: `${catalogFolderName}/package.json`, content: packageJson },
+        { name: `${catalogFolderName}/eventcatalog.config.js`, content: configJs },
+        { name: `${catalogFolderName}/README.md`, content: readmeMd },
+        ...compiled.map((file) => ({
+          name: `${catalogFolderName}/${file.path}`,
+          content: file.content,
+        })),
+      ];
+
+      const blob = createZipBlob(zipFiles);
+      downloadBlob(blob, `${catalogFolderName}.zip`);
+
+      setShowCatalogExport(false);
+      setExportRecentlyDownloaded(true);
+      setTimeout(() => setExportRecentlyDownloaded(false), 2000);
+    } catch (err) {
+      console.error('Catalog export error:', err);
+    } finally {
+      setIsCatalogExporting(false);
+    }
+  }, [catalogOrganizationName, files]);
+
   useEffect(() => {
-    if (!latestExport && !shareUrl) return;
+    if (!latestExport && !shareUrl && !showCatalogExport) return;
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
         setLatestExport(null);
         setShareUrl(null);
+        setShowCatalogExport(false);
       }
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, [latestExport, shareUrl]);
+  }, [latestExport, shareUrl, showCatalogExport]);
 
   // Persist files to localStorage so user work survives page refreshes
   useEffect(() => {
@@ -554,6 +750,7 @@ export default function App() {
         onExampleChange={handleExampleChange}
         loadedFromUrl={loadedFromUrl}
         onExport={handleExportForImport}
+        onExportCatalog={handleOpenCatalogExport}
         exportRecentlyDownloaded={exportRecentlyDownloaded}
         onShare={handleShare}
         vizTheme={vizTheme}
@@ -625,6 +822,15 @@ export default function App() {
       />
       {shareUrl && <ShareLinkModal shareUrl={shareUrl} onClose={() => setShareUrl(null)} />}
       {latestExport && <ExportHelpModal exportResult={latestExport} onClose={() => setLatestExport(null)} />}
+      {showCatalogExport && (
+        <CatalogExportModal
+          organizationName={catalogOrganizationName}
+          onOrganizationNameChange={setCatalogOrganizationName}
+          onCreateCatalog={handleExportCatalog}
+          isExporting={isCatalogExporting}
+          onClose={() => setShowCatalogExport(false)}
+        />
+      )}
       {showTemplatePicker && <TemplatePicker onSelect={handleTemplateSelect} onBlank={handleBlankStart} />}
       <CommandPalette
         open={cmdkOpen}

--- a/packages/playground/src/hooks/useDslParser.ts
+++ b/packages/playground/src/hooks/useDslParser.ts
@@ -9,6 +9,7 @@ interface ParseResult {
 
 let langiumServices: any = null;
 let astToGraphFn: any = null;
+let compileFn: any = null;
 let docCounter = 1;
 
 const urlFetchCache = new Map<string, string>();
@@ -97,6 +98,7 @@ async function initServices() {
 
   langiumServices = langModule.createEcServices(EmptyFileSystem);
   astToGraphFn = langModule.astToGraph;
+  compileFn = langModule.compile;
 }
 
 export interface FileOffsets {
@@ -234,6 +236,53 @@ async function parseMultiFile(inputFiles: Record<string, string>, activeVisualiz
     errors: [...fetchErrors, ...fullResult.errors],
     fileOffsets,
   };
+}
+
+export interface CompiledFile {
+  path: string;
+  content: string;
+}
+
+export async function compileDsl(files: Record<string, string>): Promise<CompiledFile[]> {
+  await initServices();
+  const { URI } = await import('langium');
+
+  const { files: resolvedFiles } = await resolveUrlImports(files);
+  const filenames = Object.keys(resolvedFiles);
+
+  // Regex to match local file imports (not HTTP/HTTPS)
+  const localImportRe = /import\s*\{[^}]*\}\s*from\s*"(?!https?:\/\/)([^"]+)"\s*\n?/g;
+
+  // Concatenate all files (same as parseMultiFile)
+  const parts: string[] = [];
+  for (const filename of filenames) {
+    let content = resolvedFiles[filename];
+    content = content.replace(localImportRe, '');
+    parts.push(content);
+  }
+  const combinedSource = parts.join('\n');
+
+  const uri = URI.parse(`file:///compile-${docCounter++}.ec`);
+  const document = langiumServices.shared.workspace.LangiumDocumentFactory.fromString(combinedSource, uri);
+  langiumServices.shared.workspace.LangiumDocuments.addDocument(document);
+  await langiumServices.shared.workspace.DocumentBuilder.build([document]);
+
+  const parserErrors = document.parseResult.parserErrors;
+  if (parserErrors.length > 0) {
+    try {
+      langiumServices.shared.workspace.LangiumDocuments.deleteDocument(uri);
+    } catch {}
+    throw new Error(`DSL has parse errors: ${parserErrors[0].message}`);
+  }
+
+  const program = document.parseResult.value;
+  const compiled: CompiledFile[] = compileFn(program, { nested: true });
+
+  try {
+    langiumServices.shared.workspace.LangiumDocuments.deleteDocument(uri);
+  } catch {}
+
+  return compiled;
 }
 
 export function useDslParser(files: Record<string, string>, activeVisualizer?: string) {

--- a/packages/playground/src/index.css
+++ b/packages/playground/src/index.css
@@ -127,6 +127,68 @@ html, body, #root {
   background: #9333ea;
 }
 
+.export-dropdown-wrapper {
+  position: relative;
+}
+
+.export-dropdown {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  width: 280px;
+  background: var(--modal-bg);
+  border: 1px solid var(--shell-border);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+  z-index: 50;
+  overflow: hidden;
+}
+
+.export-dropdown-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  width: 100%;
+  padding: 10px 12px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+  font-family: inherit;
+  color: var(--modal-text);
+  transition: background 0.1s;
+}
+
+.export-dropdown-item:hover {
+  background: var(--shell-control-bg);
+}
+
+.export-dropdown-item + .export-dropdown-item {
+  border-top: 1px solid var(--shell-border);
+}
+
+.export-dropdown-item > svg {
+  flex-shrink: 0;
+  margin-top: 2px;
+  color: var(--shell-muted);
+}
+
+.export-dropdown-item > div {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.export-dropdown-item-title {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.export-dropdown-item-desc {
+  font-size: 11px;
+  color: var(--shell-muted);
+}
+
 .header-actions {
   margin-left: auto;
   display: flex;
@@ -510,6 +572,10 @@ body.resizing .editor-pane {
   padding: 18px;
 }
 
+.export-modal--compact {
+  width: min(520px, 100%);
+}
+
 .export-modal-header {
   display: flex;
   align-items: center;
@@ -610,6 +676,58 @@ body.resizing .editor-pane {
   margin: 4px 0 0;
   color: var(--shell-muted);
   font-size: 12px;
+}
+
+.catalog-export-form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.catalog-export-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--shell-text);
+}
+
+.catalog-export-input {
+  height: 36px;
+  border: 1px solid var(--shell-control-border);
+  border-radius: 8px;
+  background: var(--shell-control-bg);
+  color: var(--shell-text);
+  padding: 0 12px;
+  font-size: 13px;
+  font-family: inherit;
+  outline: none;
+}
+
+.catalog-export-input:focus {
+  border-color: #a855f7;
+  box-shadow: 0 0 0 2px rgba(168, 85, 247, 0.2);
+}
+
+.catalog-export-submit {
+  margin-top: 6px;
+  height: 36px;
+  border: none;
+  border-radius: 8px;
+  background: #a855f7;
+  color: #fff;
+  font-size: 13px;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.catalog-export-submit:hover:not(:disabled) {
+  background: #9333ea;
+}
+
+.catalog-export-submit:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 .share-modal-note {

--- a/packages/playground/src/utils/catalog-export.ts
+++ b/packages/playground/src/utils/catalog-export.ts
@@ -1,0 +1,100 @@
+import type { CompiledFile } from '../hooks/useDslParser';
+
+const VERSIONED_INDEX_MD_PATH = /^(.*)\/versioned\/([^/]+)\/index\.md$/;
+const ROOT_INDEX_MD_PATH = /^(.*)\/index\.md$/;
+const VERSION_COLLATOR = new Intl.Collator(undefined, {
+  numeric: true,
+  sensitivity: 'base',
+});
+const RESOURCE_HELP_TEXT = '*You can add any markdown in this file to help your teams get more context about this resource.*';
+
+function toMdxPath(path: string): string {
+  return path.endsWith('.md') ? `${path.slice(0, -3)}.mdx` : path;
+}
+
+function compareVersions(a: string, b: string): number {
+  return VERSION_COLLATOR.compare(a, b);
+}
+
+function withResourceGuidance(path: string, content: string): string {
+  if (!path.endsWith('/index.mdx')) return content;
+
+  const hasNodeGraph = content.includes('<NodeGraph/>') || content.includes('<NodeGraph />');
+  const hasGuidance = content.includes(RESOURCE_HELP_TEXT);
+
+  let nextContent = content.trimEnd();
+  if (!hasNodeGraph) {
+    nextContent += '\n\n<NodeGraph/>';
+  }
+  if (!hasGuidance) {
+    nextContent += `\n\n${RESOURCE_HELP_TEXT}`;
+  }
+
+  return `${nextContent}\n`;
+}
+
+/**
+ * Compiler output writes versioned resources as ".../versioned/<version>/index.md".
+ * For catalog export zip files we want CLI-like structure:
+ * - latest version at ".../index.mdx"
+ * - older versions under ".../versioned/<version>/index.mdx"
+ * - md files converted to mdx
+ */
+export function normalizeCompiledCatalogFiles(compiled: CompiledFile[]): CompiledFile[] {
+  const rootsByBase = new Set<string>();
+  const versionedByBase = new Map<string, string[]>();
+
+  for (const file of compiled) {
+    const versionedMatch = file.path.match(VERSIONED_INDEX_MD_PATH);
+    if (versionedMatch) {
+      const [, basePath, version] = versionedMatch;
+      const versions = versionedByBase.get(basePath);
+      if (versions) {
+        versions.push(version);
+      } else {
+        versionedByBase.set(basePath, [version]);
+      }
+      continue;
+    }
+
+    const rootMatch = file.path.match(ROOT_INDEX_MD_PATH);
+    if (rootMatch) {
+      rootsByBase.add(rootMatch[1]);
+    }
+  }
+
+  const latestVersionByBase = new Map<string, string>();
+  for (const [basePath, versions] of versionedByBase) {
+    if (rootsByBase.has(basePath) || versions.length === 0) continue;
+
+    let latest = versions[0];
+    for (let i = 1; i < versions.length; i++) {
+      if (compareVersions(versions[i], latest) > 0) {
+        latest = versions[i];
+      }
+    }
+    latestVersionByBase.set(basePath, latest);
+  }
+
+  const normalized = new Map<string, CompiledFile>();
+
+  for (const file of compiled) {
+    const versionedMatch = file.path.match(VERSIONED_INDEX_MD_PATH);
+    if (versionedMatch) {
+      const [, basePath, version] = versionedMatch;
+      const hasRoot = rootsByBase.has(basePath);
+      const latestVersion = latestVersionByBase.get(basePath);
+      const path =
+        !hasRoot && latestVersion === version
+          ? `${basePath}/index.mdx`
+          : `${basePath}/versioned/${version}/index.mdx`;
+      normalized.set(path, { ...file, path, content: withResourceGuidance(path, file.content) });
+      continue;
+    }
+
+    const path = toMdxPath(file.path);
+    normalized.set(path, { ...file, path, content: withResourceGuidance(path, file.content) });
+  }
+
+  return Array.from(normalized.values());
+}


### PR DESCRIPTION
## Summary
- Add "Download as Catalog" export option to the playground that generates a ready-to-run EventCatalog project zip
- Replace single export button with dropdown offering both DSL file export and full catalog export
- Add organization name form modal for customizing the generated catalog
- Fix compiler to use snake_case keys (`container_type`, `access_mode`) for container frontmatter

## What This PR Does

Adds a new export option to the EventCatalog Canvas (playground) that lets users download a ready-to-run EventCatalog project as a zip file. Instead of exporting `.ec` DSL files and running CLI commands to import them, users can now get a complete catalog project that just needs `npm install && npm run dev`.

## How It Works

1. User clicks "Export" → dropdown shows two options
2. "Download as Catalog" opens a modal to enter organization name
3. `compileDsl()` concatenates all `.ec` files, parses via Langium, and calls `compile(program, { nested: true })` — all in the browser
4. `normalizeCompiledCatalogFiles()` transforms paths (latest version at root, `.mdx` extension, adds `<NodeGraph/>`)
5. Generated zip contains: `package.json`, `eventcatalog.config.js`, `README.md`, and all content files
6. User unzips, runs `npm install && npm run dev` — catalog is running

## Test plan
- [ ] Test "Download DSL files" still works as before
- [ ] Test "Download as Catalog" with single-file DSL
- [ ] Test "Download as Catalog" with multi-file DSL
- [ ] Verify generated zip can be unzipped, `npm install`ed, and `npm run dev` starts successfully
- [ ] Test organization name customization appears in config and README
- [ ] Test container compiler outputs `container_type` and `access_mode` (not camelCase)

🤖 Generated with [Claude Code](https://claude.com/claude-code)