### PR TITLE
fix(mcp): create McpServer and transport per-request to fix stateless transport reuse error

### DIFF
--- a/packages/core/eventcatalog/src/enterprise/mcp/mcp-server.ts
+++ b/packages/core/eventcatalog/src/enterprise/mcp/mcp-server.ts
@@ -433,16 +433,8 @@ function createMcpServer() {
   return server;
 }
 
-// Create a single MCP server instance
-const mcpServer = createMcpServer();
-
-// Create transport for handling requests
-const transport = new WebStandardStreamableHTTPServerTransport({
-  sessionIdGenerator: undefined, // Stateless mode
-});
-
-// Connect the server to the transport
-let isConnected = false;
+// MCP server and transport are created per-request to avoid
+// "Stateless transport cannot be reused across requests" errors.
 
 // Create Hono app for MCP routes
 const app = new Hono().basePath('/docs/mcp');
@@ -478,13 +470,15 @@ app.get('/', async (c: Context) => {
 // MCP protocol endpoint - handles POST requests for MCP protocol
 app.post('/', async (c: Context) => {
   try {
-    // Connect server to transport if not already connected
-    if (!isConnected) {
-      await mcpServer.connect(transport);
-      isConnected = true;
-    }
-
-    // Handle the MCP request using the web standard transport
+    // Create fresh server and transport per request — the MCP SDK's
+    // WebStandardStreamableHTTPServerTransport is single-use in stateless
+    // mode: it sets _hasHandledRequest=true after the first call and throws
+    // on any subsequent request. McpServer equally rejects reconnection.
+    const server = createMcpServer();
+    const transport = new WebStandardStreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+    });
+    await server.connect(transport);
     return await transport.handleRequest(c.req.raw);
   } catch (error) {
     console.error('MCP request error:', error);


### PR DESCRIPTION
## Problem

The MCP endpoint (`/docs/mcp`) only handles the **first request** successfully. Every subsequent request — from VS Code, Claude Desktop, or any other MCP client — receives a 500 error:

```
Error: Stateless transport cannot be reused across requests. Create a new transport per request.
```

### Root cause

The MCP SDK's `WebStandardStreamableHTTPServerTransport` is a **single-use object**. After `handleRequest()` is called, it sets an internal `_hasHandledRequest = true` flag and throws on any subsequent request. `McpServer` has the same constraint — it stores the transport on `connect()` and rejects reconnection.

The current implementation creates both as **module-level singletons**:

```ts
// Create a single MCP server instance
const mcpServer = createMcpServer();

// Create transport for handling requests
const transport = new WebStandardStreamableHTTPServerTransport({
  sessionIdGenerator: undefined, // Stateless mode
});

// Connect the server to the transport
let isConnected = false;

app.post('/', async (c: Context) => {
  try {
    // Connect server to transport if not already connected
    if (!isConnected) {
      await mcpServer.connect(transport);
      isConnected = true;
    }
    // Handle the MCP request using the web standard transport
    return await transport.handleRequest(c.req.raw);
  } catch (error) { ... }
});
```

This means the `isConnected` guard prevents reconnection on subsequent requests, but the transport itself rejects any call to `handleRequest()` after the first one — so only the first request ever succeeds.

## Fix

Move `McpServer` and `WebStandardStreamableHTTPServerTransport` instantiation **inside the POST handler** so a fresh pair is created for every request. This is the correct pattern for stateless (sessionless) MCP deployments as recommended by the MCP SDK.

```ts
// MCP server and transport are created per-request to avoid
// "Stateless transport cannot be reused across requests" errors.

app.post('/', async (c: Context) => {
  try {
    const server = createMcpServer();
    const transport = new WebStandardStreamableHTTPServerTransport({
      sessionIdGenerator: undefined,
    });
    await server.connect(transport);
    return await transport.handleRequest(c.req.raw);
  } catch (error) { ... }
});
```

## Testing

Verified by sending multiple consecutive MCP requests to a running EventCatalog dev server:

- `GET /docs/mcp` → 200 with full tool list ✅
- First `POST /docs/mcp` (`initialize`) → valid SSE response with `protocolVersion: "2025-03-26"` ✅
- Second `POST /docs/mcp` (`initialize`) → same success (no reuse error) ✅
- `POST /docs/mcp` (`tools/list`) → all tools returned ✅

Previously, the second `initialize` request would return a 500 error, making VS Code's MCP integration and Claude Desktop unable to use the server after the initial handshake.