### PR TITLE
Fix mouse event type assertions on homepage stat cards

### DIFF
--- a/.changeset/gentle-waves-drift.md
+++ b/.changeset/gentle-waves-drift.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": minor
+---
+
+Add type assertions for mouse event properties on homepage stat cards

--- a/packages/core/eventcatalog/src/pages/_index.astro
+++ b/packages/core/eventcatalog/src/pages/_index.astro
@@ -354,8 +354,8 @@ const quickActions = [
   document.querySelectorAll('.ec-stat-card').forEach((card) => {
     card.addEventListener('mousemove', (e) => {
       const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-      const x = e.clientX - rect.left;
-      const y = e.clientY - rect.top;
+      const x = (e as MouseEvent).clientX - rect.left;
+      const y = (e as MouseEvent).clientY - rect.top;
       (e.currentTarget as HTMLElement).style.setProperty('--mouse-x', `${x}px`);
       (e.currentTarget as HTMLElement).style.setProperty('--mouse-y', `${y}px`);
     });


### PR DESCRIPTION
## What This PR Does

Adds explicit `MouseEvent` type assertions for `clientX` and `clientY` properties in the homepage stat card mousemove handler. This resolves TypeScript type narrowing issues where the generic `Event` type does not expose mouse-specific properties.

## Changes Overview

### Key Changes
- Cast `e` to `MouseEvent` when accessing `clientX` and `clientY` in the stat card mousemove event listener

## How It Works

The `querySelectorAll` event listener callback receives a generic `Event` type. Since `clientX` and `clientY` are only available on `MouseEvent`, explicit type assertions are added to satisfy TypeScript's type checker.

## Breaking Changes

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)