### PR TITLE
fix(core): use relative content paths in tailwind config

### DIFF
--- a/.changeset/gentle-waves-flow.md
+++ b/.changeset/gentle-waves-flow.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Fix Tailwind content paths to be relative to config file, preventing missing utilities in production builds when Astro runs from a different working directory

--- a/packages/core/eventcatalog/tailwind.config.mjs
+++ b/packages/core/eventcatalog/tailwind.config.mjs
@@ -7,7 +7,12 @@ const theme = config.theme || {};
 /** @type {import('tailwindcss').Config} */
 export default {
   darkMode: ['selector', '[data-theme="dark"]'],
-  content: ['./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}'],
+  content: {
+    // Resolve globs relative to this config file, not process.cwd().
+    // This prevents production builds from missing utilities when Astro is launched from a different working directory.
+    relative: true,
+    files: ['./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}'],
+  },
   theme: {
     extend: {
       fontFamily: {


### PR DESCRIPTION
## What This PR Does

Fixes Tailwind CSS content path resolution in the core package. The `content` config is changed from a simple glob array to an object with `relative: true`, ensuring globs resolve relative to the config file rather than `process.cwd()`. This prevents missing utility classes in production builds when Astro is launched from a different working directory.

## Changes Overview

### Key Changes
- Convert `content` from a string array to an object with `relative: true` and `files` array in `tailwind.config.mjs`

## How It Works

Tailwind CSS supports a `content` object with a `relative` flag. When `relative: true` is set, file globs are resolved relative to the config file's location instead of the current working directory. This ensures consistent class detection regardless of where the build process is invoked from.

## Breaking Changes

None

🤖 Generated with [Claude Code](https://claude.ai/claude-code)