### PR TITLE
feat(sdk): add operation type to message interfaces

### DIFF
--- a/.changeset/gentle-foxes-dance.md
+++ b/.changeset/gentle-foxes-dance.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/sdk": patch
+---
+
+Add operation type to Event, Command, and Query interfaces in the SDK

--- a/packages/sdk/src/test/commands.test.ts
+++ b/packages/sdk/src/test/commands.test.ts
@@ -404,6 +404,62 @@ describe('Commands SDK', () => {
       expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory', 'index.md'))).toBe(true);
     });
 
+    it('when operation is given, it writes the command with the given operation', async () => {
+      await writeCommand({
+        id: 'UpdateInventory',
+        name: 'Update Inventory',
+        version: '0.0.1',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+        operation: {
+          method: 'PUT',
+          path: '/inventory/{id}',
+          statusCodes: ['200', '404'],
+        },
+      });
+
+      const command = await getCommand('UpdateInventory');
+
+      expect(command).toEqual({
+        id: 'UpdateInventory',
+        name: 'Update Inventory',
+        version: '0.0.1',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+        operation: {
+          method: 'PUT',
+          path: '/inventory/{id}',
+          statusCodes: ['200', '404'],
+        },
+      });
+    });
+
+    it('when operation is given with only a method, it writes the command with the partial operation', async () => {
+      await writeCommand({
+        id: 'UpdateInventory',
+        name: 'Update Inventory',
+        version: '0.0.1',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+        operation: {
+          method: 'DELETE',
+        },
+      });
+
+      const command = await getCommand('UpdateInventory');
+
+      expect(command).toEqual({
+        id: 'UpdateInventory',
+        name: 'Update Inventory',
+        version: '0.0.1',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+        operation: {
+          method: 'DELETE',
+        },
+      });
+    });
+
     it('writes the given command to EventCatalog under the correct path when a path is given', async () => {
       await writeCommand(
         {

--- a/packages/sdk/src/test/events.test.ts
+++ b/packages/sdk/src/test/events.test.ts
@@ -749,6 +749,62 @@ describe('Events SDK', () => {
       expect(fs.existsSync(path.join(CATALOG_PATH, 'events/Inventory/InventoryAdjusted', 'index.mdx'))).toBe(true);
     });
 
+    it('when operation is given, it writes the event with the given operation', async () => {
+      await writeEvent({
+        id: 'InventoryAdjusted',
+        name: 'Inventory Adjusted',
+        version: '0.0.1',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+        operation: {
+          method: 'POST',
+          path: '/inventory/adjust',
+          statusCodes: ['200', '400', '500'],
+        },
+      });
+
+      const event = await getEvent('InventoryAdjusted');
+
+      expect(event).toEqual({
+        id: 'InventoryAdjusted',
+        name: 'Inventory Adjusted',
+        version: '0.0.1',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+        operation: {
+          method: 'POST',
+          path: '/inventory/adjust',
+          statusCodes: ['200', '400', '500'],
+        },
+      });
+    });
+
+    it('when operation is given with only a method, it writes the event with the partial operation', async () => {
+      await writeEvent({
+        id: 'InventoryAdjusted',
+        name: 'Inventory Adjusted',
+        version: '0.0.1',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+        operation: {
+          method: 'GET',
+        },
+      });
+
+      const event = await getEvent('InventoryAdjusted');
+
+      expect(event).toEqual({
+        id: 'InventoryAdjusted',
+        name: 'Inventory Adjusted',
+        version: '0.0.1',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+        operation: {
+          method: 'GET',
+        },
+      });
+    });
+
     it('writes the given event to EventCatalog under the correct path when a path is given', async () => {
       await writeEvent(
         {

--- a/packages/sdk/src/test/queries.test.ts
+++ b/packages/sdk/src/test/queries.test.ts
@@ -659,6 +659,62 @@ describe('Queries SDK', () => {
       expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder', 'index.md'))).toBe(true);
     });
 
+    it('when operation is given, it writes the query with the given operation', async () => {
+      await writeQuery({
+        id: 'GetOrder',
+        name: 'Get Order',
+        version: '0.0.1',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+        operation: {
+          method: 'GET',
+          path: '/orders/{id}',
+          statusCodes: ['200', '404'],
+        },
+      });
+
+      const query = await getQuery('GetOrder');
+
+      expect(query).toEqual({
+        id: 'GetOrder',
+        name: 'Get Order',
+        version: '0.0.1',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+        operation: {
+          method: 'GET',
+          path: '/orders/{id}',
+          statusCodes: ['200', '404'],
+        },
+      });
+    });
+
+    it('when operation is given with only a path, it writes the query with the partial operation', async () => {
+      await writeQuery({
+        id: 'GetOrder',
+        name: 'Get Order',
+        version: '0.0.1',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+        operation: {
+          path: '/orders',
+        },
+      });
+
+      const query = await getQuery('GetOrder');
+
+      expect(query).toEqual({
+        id: 'GetOrder',
+        name: 'Get Order',
+        version: '0.0.1',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+        operation: {
+          path: '/orders',
+        },
+      });
+    });
+
     it('writes the given query to EventCatalog under the correct path when a path is given', async () => {
       await writeQuery(
         {

--- a/packages/sdk/src/types.d.ts
+++ b/packages/sdk/src/types.d.ts
@@ -75,6 +75,12 @@ export interface ChannelPointer extends ResourcePointer {
   parameters?: Record<string, string>;
 }
 
+export type Operation = {
+  method?: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
+  path?: string;
+  statusCodes?: string[];
+};
+
 export type Message = Event | Command | Query;
 
 enum ResourceType {
@@ -107,14 +113,17 @@ interface MessageDetailsPanelProperty {
 
 export interface Event extends BaseSchema {
   channels?: ChannelPointer[];
+  operation?: Operation;
   detailsPanel?: MessageDetailsPanelProperty;
 }
 export interface Command extends BaseSchema {
   channels?: ChannelPointer[];
+  operation?: Operation;
   detailsPanel?: MessageDetailsPanelProperty;
 }
 export interface Query extends BaseSchema {
   channels?: ChannelPointer[];
+  operation?: Operation;
   detailsPanel?: MessageDetailsPanelProperty;
 }
 export interface Channel extends BaseSchema {


### PR DESCRIPTION
## What This PR Does

Adds the `operation` property to the SDK's `Event`, `Command`, and `Query` type interfaces, matching the `operationSchema` already defined in the core Astro content collection schema. This allows SDK users to read and write messages with HTTP operation metadata (method, path, status codes).

## Changes Overview

### Key Changes
- Added `Operation` type to `packages/sdk/src/types.d.ts` with optional `method`, `path`, and `statusCodes` fields
- Added `operation?: Operation` to `Event`, `Command`, and `Query` interfaces
- Added 2 tests each for events, commands, and queries covering full and partial operation properties

## How It Works

The `Operation` type mirrors the `operationSchema` from `content.config.ts`:
- `method`: HTTP method (`GET`, `POST`, `PUT`, `DELETE`, `PATCH`)
- `path`: API endpoint path (e.g., `/orders/{id}`)
- `statusCodes`: Array of status code strings (e.g., `['200', '404']`)

All fields are optional. The SDK's existing `gray-matter` serialization handles the new property automatically — no changes to read/write logic were needed.

## Breaking Changes

None

## Additional Notes

The `operationSchema` was already present in the core content config. This change brings the SDK types in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)