### PR TITLE
fix(core): include visualiser dist in tailwind content paths

### DIFF
--- a/.changeset/bright-tables-glow.md
+++ b/.changeset/bright-tables-glow.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Include visualiser dist files in tailwind content paths for published package installs

--- a/packages/core/eventcatalog/tailwind.config.mjs
+++ b/packages/core/eventcatalog/tailwind.config.mjs
@@ -13,8 +13,10 @@ export default {
     relative: true,
     files: [
       './src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}',
-      // Include visualizer components so core Tailwind generates their utilities.
+      // Workspace/dev: include visualizer source files so core Tailwind generates their utilities.
       '../../visualiser/src/**/*.{js,jsx,ts,tsx}',
+      // Published package/install: visualizer ships compiled JS in dist (no src folder).
+      '../../visualiser/dist/**/*.{js,cjs,mjs}',
     ],
   },
   theme: {


### PR DESCRIPTION
Follows up on #2250

## What This PR Does

Adds the visualiser `dist/` directory to core's Tailwind content paths. When EventCatalog is installed as a published package (rather than developed in the monorepo), the visualiser ships compiled JS in `dist/` instead of source files in `src/`. Without this path, Tailwind misses utility classes used by the visualiser, causing missing styles.

## Changes Overview

### Key Changes
- Add `../../visualiser/dist/**/*.{js,cjs,mjs}` to Tailwind content paths in `tailwind.config.mjs`
- Clarify comments distinguishing workspace/dev vs published package paths

## How It Works

Tailwind CSS scans content paths to determine which utility classes to include in the output. The visualiser source (`src/`) is already included for local development, but published installs only have compiled output in `dist/`. Adding the dist path ensures Tailwind generates all required utilities in both environments.

## Breaking Changes

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)