### PR TITLE
fix(core): use theme CSS variables for dark mode in Flow border and footer

### DIFF
--- a/.changeset/gentle-waves-dance.md
+++ b/.changeset/gentle-waves-dance.md
@@ -1,0 +1,6 @@
+---
+"@eventcatalog/core": patch
+"@eventcatalog/create-eventcatalog": patch
+---
+
+fix dark mode for embedded Flow border and footer text by using theme CSS variables instead of hardcoded colors

--- a/examples/default/components/footer.astro
+++ b/examples/default/components/footer.astro
@@ -3,6 +3,6 @@ import config from '@config';
 ---
 
 <div class="w-full text-right">
-  <span class="italic text-gray-800">Event-driven architecture documentation: {config.organizationName}</span>
+  <span class="italic text-[rgb(var(--ec-page-text-muted))]">Event-driven architecture documentation: {config.organizationName}</span>
 </div>
 

--- a/packages/core/eventcatalog/src/components/MDX/Flow/Flow.astro
+++ b/packages/core/eventcatalog/src/components/MDX/Flow/Flow.astro
@@ -44,7 +44,7 @@ const nodesWithLayout = applyLayoutToNodes(nodes, savedLayout);
 }
 
 <div
-  class="h-[30em] my-6 mb-12 w-full relative border border-gray-200 rounded-md"
+  class="h-[30em] my-6 mb-12 w-full relative border border-[rgb(var(--ec-page-border))] rounded-md"
   id={`${id}-portal`}
   style={{
     maxHeight: maxHeight ? `${maxHeight}em` : `30em`,

--- a/packages/create-eventcatalog/templates/default/components/footer.astro
+++ b/packages/create-eventcatalog/templates/default/components/footer.astro
@@ -3,6 +3,6 @@ import config from '@config';
 ---
 
 <div class="w-full text-right">
-  <span class="italic text-gray-800">Event-driven architecture documentation: {config.organizationName}</span>
+  <span class="italic text-[rgb(var(--ec-page-text-muted))]">Event-driven architecture documentation: {config.organizationName}</span>
 </div>
 


### PR DESCRIPTION
## What This PR Does

Fixes dark mode styling for two components that were using hardcoded Tailwind colors instead of theme CSS variables. The embedded Flow diagram border appeared white in dark mode, and the page footer text was nearly invisible.

## Changes Overview

### Key Changes
- **Flow.astro**: Replace `border-gray-200` with `border-[rgb(var(--ec-page-border))]` so the embedded flow border adapts to dark mode
- **footer.astro** (example + template): Replace `text-gray-800` with `text-[rgb(var(--ec-page-text-muted))]` so footer text is visible in dark mode

## How It Works

Both fixes follow the existing EventCatalog theming convention of using CSS variables (`--ec-page-border`, `--ec-page-text-muted`) instead of hardcoded Tailwind color classes. These variables are defined in the theme files and automatically switch values based on the active theme (light/dark).

## Breaking Changes

None

## Additional Notes

The `custom-defined-components/footer.astro` file is gitignored (generated at build time), so the fix is applied to the tracked source templates in `examples/default/` and `create-eventcatalog/templates/default/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)