### PR TITLE
fix(core): prevent first-run vite dep-scan errors on fresh catalogs

### DIFF
--- a/.changeset/calm-waves-settle.md
+++ b/.changeset/calm-waves-settle.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix first-run vite dep-scan errors by adding awaitWriteFinish to chokidar watcher config

--- a/packages/core/eventcatalog/astro.config.mjs
+++ b/packages/core/eventcatalog/astro.config.mjs
@@ -107,10 +107,22 @@ export default defineConfig({
     server: {
       fs: {
         allow: [
-          '..', 
+          '..',
           './node_modules/@fontsource',
           searchForWorkspaceRoot(process.cwd()),
         ]
+      },
+      // Prevent stale FSEvents from triggering a config-dependency restart on first run.
+      // During startup, catalogToAstro copies eventcatalog.config.js into .eventcatalog-core
+      // shortly before Astro/Vite begins watching. On macOS, FSEvents can deliver buffered
+      // notifications for those recent writes, causing Vite to restart mid-dep-scan.
+      // awaitWriteFinish makes chokidar verify the file is stable before emitting events,
+      // filtering out those stale notifications.
+      watch: {
+        awaitWriteFinish: {
+          stabilityThreshold: 100,
+          pollInterval: 50,
+        },
       },
       ...(config.server?.allowedHosts ? { allowedHosts: config.server?.allowedHosts } : {}),
     },


### PR DESCRIPTION
## What This PR Does

Fixes the flood of `vite:dep-scan` errors ("The server is being restarted or closed. Request is outdated") that users see when running `npm run dev` for the first time after creating a new EventCatalog with `npx @eventcatalog/create-eventcatalog@latest`.

## Changes Overview

### Key Changes
- Add `awaitWriteFinish` chokidar option to Vite's watcher config in `astro.config.mjs`

## How It Works

**Root cause**: During dev startup, `catalogToAstro()` copies `eventcatalog.config.js` into `.eventcatalog-core/` shortly before Astro/Vite begins watching. This file is imported by `astro.config.mjs`, making it a Vite config file dependency. On macOS, FSEvents can deliver buffered notifications for those recent writes after chokidar starts watching. Vite interprets these stale events as a config change and restarts the server while the initial dependency scan is still in progress, causing the error flood.

**Fix**: Adding `awaitWriteFinish` with a 100ms stability threshold to chokidar makes it verify a file's size has stabilized before emitting change events. This filters out the stale FSEvents notifications that arrive after the watcher starts, while having no noticeable impact on dev hot-reload speed.

## Breaking Changes

None

## Additional Notes

- The 100ms `stabilityThreshold` is deliberately small — just enough to filter stale events without impacting HMR responsiveness
- This is a race condition that primarily affects macOS due to FSEvents buffering behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)