### PR TITLE
ci: cache npm and use --prefer-offline in verify-build workflow

### DIFF
--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -80,13 +80,19 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 24.x
+      - name: Cache npm
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: npm-${{ runner.os }}-${{ hashFiles('examples/default/package-lock.json') }}
+          restore-keys: npm-${{ runner.os }}-
       - name: Download package artifacts
         uses: actions/download-artifact@v4
         with:
           name: eventcatalog-packages-artifact
       - name: Install @eventcatalog packages
         working-directory: examples/default/
-        run: npm install ../../sdk-package.tgz ../../core-package.tgz ../../visualiser-package.tgz
+        run: npm install --prefer-offline ../../sdk-package.tgz ../../core-package.tgz ../../visualiser-package.tgz
       - name: Build EventCatalog
         working-directory: examples/default/
         run: npx eventcatalog build


### PR DESCRIPTION
## What This PR Does

Adds npm caching and `--prefer-offline` to the `build-eventcatalog` job in the verify-build workflow. This reduces the time spent in the "Install @eventcatalog packages" step by using cached dependencies instead of fetching them from the network on every run.

## Changes Overview

### Key Changes
- Add `actions/cache@v4` step to cache `~/.npm` directory, keyed by OS and lockfile hash
- Add `--prefer-offline` flag to `npm install` to prefer cached packages over network fetches

## How It Works

The npm cache is restored before downloading and installing package artifacts. When `--prefer-offline` is set, npm resolves dependencies from the local cache first, only hitting the network for packages not yet cached. The first run after merge will be a cold cache, but subsequent runs should see the install step drop significantly — especially on Windows where it currently takes ~2.5 minutes.

## Breaking Changes

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)