### PR TITLE
fix(core): add tailwind import to embed page and fix hover border safelist

### DIFF
--- a/.changeset/bright-foxes-dance.md
+++ b/.changeset/bright-foxes-dance.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix tailwind v4 migration: add CSS import to embed page and expand hover border safelist with missing shades and colors

--- a/packages/core/eventcatalog/src/pages/diagrams/[id]/[version]/embed.astro
+++ b/packages/core/eventcatalog/src/pages/diagrams/[id]/[version]/embed.astro
@@ -1,4 +1,5 @@
 ---
+import '../../../../styles/tailwind.css';
 import { render } from 'astro:content';
 import components from '@components/MDX/components';
 import config from '@config';

--- a/packages/core/eventcatalog/src/styles/tailwind.css
+++ b/packages/core/eventcatalog/src/styles/tailwind.css
@@ -49,7 +49,7 @@
  * at runtime (e.g. `bg-${color}-50`). Tailwind v4 can't detect these from source
  * scanning, so we explicitly declare them here.
  *
- * Colors used: orange, blue, green, emerald, amber, violet, pink, purple, gray
+ * Colors used: orange, blue, green, emerald, amber, violet, pink, purple, gray, yellow, teal
  * Used in: SchemaListItem, Grids/components, SchemaExplorer, MessageGrid
  */
 @source inline("bg-{orange,blue,green,emerald,amber,violet,pink,purple,gray}-{50,100}");
@@ -62,7 +62,7 @@
 /* Border color variants for MessageGrid cards */
 @source inline("border-{orange,blue,green,emerald,amber,violet,pink,purple,gray}-{200,300}");
 @source inline("{dark:,}border-{orange,blue,green,emerald,amber,violet,pink,purple,gray}-500/{30,50}");
-@source inline("{hover:,dark:hover:,}border-{orange,blue,green,emerald,amber,violet,pink,purple,gray}-{300,500/50}");
+@source inline("{hover:,dark:hover:,}border-{orange,blue,green,emerald,amber,violet,pink,purple,gray,yellow,teal}-{300,400,500,500/50}");
 
 /* Explicit safelist classes used in various components */
 @source inline("bg-{blue,orange}-600");


### PR DESCRIPTION
## Summary
- Add `tailwind.css` import to the diagram embed page (`embed.astro`) which was missing after the Tailwind v4 migration, causing utility classes to be unstyled
- Expand the hover border safelist to include the `-400` and `-500` shades actually used by table column components, and add missing `yellow` and `teal` colors

## Test plan
- [ ] Verify diagram embed pages render with correct Tailwind styling
- [ ] Verify table hover border colors work in light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)