### PR TITLE
refactor(language-server): simplify duplicated code and fix minor issues

### DIFF
--- a/.changeset/clean-foxes-leap.md
+++ b/.changeset/clean-foxes-leap.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/language-server": patch
+---
+
+Simplify duplicated code: extract shared duplicate-check helper in validator, deduplicate inline metadata enrichment in graph builder, eliminate double YAML parsing in AsyncAPI resolver, fix dead code in compiler, and move extractApiInfo to top-level scope

--- a/packages/language-server/src/compiler.ts
+++ b/packages/language-server/src/compiler.ts
@@ -246,7 +246,7 @@ function writeFrontmatterFields(
 function getAnnotationArgValue(
   arg: NamedAnnotationArg | PositionalAnnotationArg,
 ): string | boolean | number {
-  const v = isNamedAnnotationArg(arg) ? arg.value : arg.value;
+  const v = arg.value;
   if (isStringAnnotationValue(v)) return stripQuotes(v.value);
   if (isIdAnnotationValue(v)) return v.value;
   if (isNumberAnnotationValue(v)) return parseInt(v.value, 10);

--- a/packages/language-server/src/ec-validator.ts
+++ b/packages/language-server/src/ec-validator.ts
@@ -52,27 +52,18 @@ export class EcValidator {
     // but event Foo 1.0.0 and event Foo 2.0.0 is allowed.
     const seen = new Map<string, AstNode>();
 
-    function registerDef(
-      def: AstNode & { name: string; body?: AstNode[] },
-    ): void {
-      const version = def.body ? getVersion(def.body) : undefined;
-      const key = version ? `${def.name}@${version}` : def.name;
-      if (seen.has(key)) {
-        const label = version
-          ? `'${def.name}' version ${version}`
-          : `'${def.name}'`;
-        accept("error", `Duplicate resource definition: ${label}`, {
-          node: def,
-          property: "name",
-        });
-      } else {
-        seen.set(key, def);
-      }
-    }
-
     for (const def of program.definitions) {
       if ("name" in def && typeof def.name === "string") {
-        registerDef(def as AstNode & { name: string; body?: AstNode[] });
+        checkAndRegisterDuplicate(
+          seen,
+          def.name,
+          "body" in def && Array.isArray(def.body)
+            ? getVersion(def.body)
+            : undefined,
+          def,
+          "name",
+          accept,
+        );
 
         // Also check inline definitions nested inside domains/services
         if (isDomainDef(def) || isSubdomainDef(def)) {
@@ -95,6 +86,27 @@ export class EcValidator {
   }
 }
 
+/** Check if a name+version pair is already in `seen`; if so, emit an error. */
+function checkAndRegisterDuplicate(
+  seen: Map<string, AstNode>,
+  name: string,
+  version: string | undefined,
+  node: AstNode,
+  property: string,
+  accept: ValidationAcceptor,
+): void {
+  const key = version ? `${name}@${version}` : name;
+  if (seen.has(key)) {
+    const label = version ? `'${name}' version ${version}` : `'${name}'`;
+    accept("error", `Duplicate resource definition: ${label}`, {
+      node,
+      property,
+    });
+  } else {
+    seen.set(key, node);
+  }
+}
+
 function checkNestedDuplicates(
   body: AstNode[],
   seen: Map<string, AstNode>,
@@ -102,35 +114,25 @@ function checkNestedDuplicates(
 ): void {
   for (const item of body) {
     if (isServiceDef(item)) {
-      const version = getVersion(item.body as AstNode[]);
-      const key = version ? `${item.name}@${version}` : item.name;
-      if (seen.has(key)) {
-        const label = version
-          ? `'${item.name}' version ${version}`
-          : `'${item.name}'`;
-        accept("error", `Duplicate resource definition: ${label}`, {
-          node: item,
-          property: "name",
-        });
-      } else {
-        seen.set(key, item);
-      }
+      checkAndRegisterDuplicate(
+        seen,
+        item.name,
+        getVersion(item.body as AstNode[]),
+        item,
+        "name",
+        accept,
+      );
       checkInlineDuplicates(item.body as AstNode[], seen, accept);
     }
     if (isSubdomainDef(item)) {
-      const version = getVersion(item.body as AstNode[]);
-      const key = version ? `${item.name}@${version}` : item.name;
-      if (seen.has(key)) {
-        const label = version
-          ? `'${item.name}' version ${version}`
-          : `'${item.name}'`;
-        accept("error", `Duplicate resource definition: ${label}`, {
-          node: item,
-          property: "name",
-        });
-      } else {
-        seen.set(key, item);
-      }
+      checkAndRegisterDuplicate(
+        seen,
+        item.name,
+        getVersion(item.body as AstNode[]),
+        item,
+        "name",
+        accept,
+      );
       checkNestedDuplicates(item.body as AstNode[], seen, accept);
     }
   }
@@ -143,19 +145,14 @@ function checkInlineDuplicates(
 ): void {
   for (const item of body) {
     if ((isSendsStmt(item) || isReceivesStmt(item)) && item.body.length > 0) {
-      const version = getVersion(item.body as AstNode[]);
-      const key = version ? `${item.messageName}@${version}` : item.messageName;
-      if (seen.has(key)) {
-        const label = version
-          ? `'${item.messageName}' version ${version}`
-          : `'${item.messageName}'`;
-        accept("error", `Duplicate resource definition: ${label}`, {
-          node: item,
-          property: "messageName",
-        });
-      } else {
-        seen.set(key, item);
-      }
+      checkAndRegisterDuplicate(
+        seen,
+        item.messageName,
+        getVersion(item.body as AstNode[]),
+        item,
+        "messageName",
+        accept,
+      );
     }
   }
 }
@@ -272,19 +269,14 @@ function checkVisualizerDuplicates(
         "body" in item && Array.isArray(item.body)
           ? (item.body as AstNode[])
           : [];
-      const version = getVersion(itemBody);
-      const key = version ? `${item.name}@${version}` : item.name;
-      if (seen.has(key)) {
-        const label = version
-          ? `'${item.name}' version ${version}`
-          : `'${item.name}'`;
-        accept("error", `Duplicate resource definition: ${label}`, {
-          node: item,
-          property: "name",
-        });
-      } else {
-        seen.set(key, item);
-      }
+      checkAndRegisterDuplicate(
+        seen,
+        item.name,
+        getVersion(itemBody),
+        item,
+        "name",
+        accept,
+      );
       if (isServiceDef(item)) {
         checkInlineDuplicates(item.body as AstNode[], seen, accept);
       }
@@ -294,19 +286,14 @@ function checkVisualizerDuplicates(
     }
     if (isEventDef(item) || isCommandDef(item) || isQueryDef(item)) {
       if (item.body && item.body.length > 0) {
-        const version = getVersion(item.body as AstNode[]);
-        const key = version ? `${item.name}@${version}` : item.name;
-        if (seen.has(key)) {
-          const label = version
-            ? `'${item.name}' version ${version}`
-            : `'${item.name}'`;
-          accept("error", `Duplicate resource definition: ${label}`, {
-            node: item,
-            property: "name",
-          });
-        } else {
-          seen.set(key, item);
-        }
+        checkAndRegisterDuplicate(
+          seen,
+          item.name,
+          getVersion(item.body as AstNode[]),
+          item,
+          "name",
+          accept,
+        );
       }
     }
   }

--- a/packages/language-server/src/graph.ts
+++ b/packages/language-server/src/graph.ts
@@ -130,6 +130,39 @@ function extractNotes(
   return notes;
 }
 
+function extractApiInfo(body: AstNode[]): {
+  method?: string;
+  path?: string;
+  statusCodes?: number[];
+} {
+  const annotations = getAnnotations(body);
+  for (const ann of annotations) {
+    if (ann.name !== "api") continue;
+    const result: { method?: string; path?: string; statusCodes?: number[] } =
+      {};
+    for (const arg of ann.args) {
+      if (isNamedAnnotationArg(arg)) {
+        const val = isStringAnnotationValue(arg.value)
+          ? stripQuotes(arg.value.value)
+          : isIdAnnotationValue(arg.value)
+            ? arg.value.value
+            : undefined;
+        if (!val) continue;
+        if (arg.key === "method") result.method = val;
+        else if (arg.key === "path") result.path = val;
+        else if (arg.key === "statusCodes") {
+          result.statusCodes = val
+            .split(",")
+            .map(Number)
+            .filter((c) => !isNaN(c));
+        }
+      }
+    }
+    return result;
+  }
+  return {};
+}
+
 export function astToGraph(
   program: Program,
   visualizerName?: string,
@@ -490,6 +523,31 @@ export function astToGraph(
     }
   }
 
+  /** Enrich an existing node with metadata from an inline sends/receives body. */
+  function enrichNodeFromInlineBody(nodeId: string, body: AstNode[]): void {
+    const existing = nodes.find((n) => n.id === nodeId);
+    if (!existing) return;
+    const summary = getSummary(body);
+    if (summary && !existing.metadata.summary)
+      existing.metadata.summary = summary;
+    const schema = getSchema(body);
+    if (schema && !existing.metadata.schema) existing.metadata.schema = schema;
+    const inlineNotes = extractNotes(body);
+    if (inlineNotes.length > 0 && !existing.metadata.notes)
+      existing.metadata.notes = inlineNotes;
+    const inlineApi = extractApiInfo(body);
+    if (inlineApi.method && !existing.metadata.method)
+      existing.metadata.method = inlineApi.method;
+    if (inlineApi.path && !existing.metadata.path)
+      existing.metadata.path = inlineApi.path;
+    if (
+      inlineApi.statusCodes &&
+      inlineApi.statusCodes.length > 0 &&
+      !existing.metadata.statusCodes
+    )
+      existing.metadata.statusCodes = inlineApi.statusCodes;
+  }
+
   // For sends/receives references: resolve to versioned node if it exists, otherwise create
   function resolveOrCreateMsg(
     name: string,
@@ -551,29 +609,7 @@ export function astToGraph(
 
       // Inline body summary + schema + notes + api info
       if (s.body.length > 0) {
-        const existing = nodes.find((n) => n.id === msgNodeId);
-        if (existing) {
-          const summary = getSummary(s.body as AstNode[]);
-          if (summary && !existing.metadata.summary)
-            existing.metadata.summary = summary;
-          const schema = getSchema(s.body as AstNode[]);
-          if (schema && !existing.metadata.schema)
-            existing.metadata.schema = schema;
-          const inlineNotes = extractNotes(s.body as AstNode[]);
-          if (inlineNotes.length > 0 && !existing.metadata.notes)
-            existing.metadata.notes = inlineNotes;
-          const inlineApi = extractApiInfo(s.body as AstNode[]);
-          if (inlineApi.method && !existing.metadata.method)
-            existing.metadata.method = inlineApi.method;
-          if (inlineApi.path && !existing.metadata.path)
-            existing.metadata.path = inlineApi.path;
-          if (
-            inlineApi.statusCodes &&
-            inlineApi.statusCodes.length > 0 &&
-            !existing.metadata.statusCodes
-          )
-            existing.metadata.statusCodes = inlineApi.statusCodes;
-        }
+        enrichNodeFromInlineBody(msgNodeId, s.body as AstNode[]);
       }
 
       // Channel clause (on the sends statement itself)
@@ -648,29 +684,7 @@ export function astToGraph(
       addEdge(msgNodeId, serviceId, "receives", getReceivesLabel(msgType));
 
       if (r.body.length > 0) {
-        const existing = nodes.find((n) => n.id === msgNodeId);
-        if (existing) {
-          const summary = getSummary(r.body as AstNode[]);
-          if (summary && !existing.metadata.summary)
-            existing.metadata.summary = summary;
-          const schema = getSchema(r.body as AstNode[]);
-          if (schema && !existing.metadata.schema)
-            existing.metadata.schema = schema;
-          const inlineNotes = extractNotes(r.body as AstNode[]);
-          if (inlineNotes.length > 0 && !existing.metadata.notes)
-            existing.metadata.notes = inlineNotes;
-          const inlineApi = extractApiInfo(r.body as AstNode[]);
-          if (inlineApi.method && !existing.metadata.method)
-            existing.metadata.method = inlineApi.method;
-          if (inlineApi.path && !existing.metadata.path)
-            existing.metadata.path = inlineApi.path;
-          if (
-            inlineApi.statusCodes &&
-            inlineApi.statusCodes.length > 0 &&
-            !existing.metadata.statusCodes
-          )
-            existing.metadata.statusCodes = inlineApi.statusCodes;
-        }
+        enrichNodeFromInlineBody(msgNodeId, r.body as AstNode[]);
       }
 
       // Channel clause: "from ChannelX" means the service receives via that channel.
@@ -927,39 +941,6 @@ export function astToGraph(
 
     processSends(domId, getSends(body));
     processReceives(domId, getReceives(body));
-  }
-
-  function extractApiInfo(body: AstNode[]): {
-    method?: string;
-    path?: string;
-    statusCodes?: number[];
-  } {
-    const annotations = getAnnotations(body);
-    for (const ann of annotations) {
-      if (ann.name !== "api") continue;
-      const result: { method?: string; path?: string; statusCodes?: number[] } =
-        {};
-      for (const arg of ann.args) {
-        if (isNamedAnnotationArg(arg)) {
-          const val = isStringAnnotationValue(arg.value)
-            ? stripQuotes(arg.value.value)
-            : isIdAnnotationValue(arg.value)
-              ? arg.value.value
-              : undefined;
-          if (!val) continue;
-          if (arg.key === "method") result.method = val;
-          else if (arg.key === "path") result.path = val;
-          else if (arg.key === "statusCodes") {
-            result.statusCodes = val
-              .split(",")
-              .map(Number)
-              .filter((c) => !isNaN(c));
-          }
-        }
-      }
-      return result;
-    }
-    return {};
   }
 
   function processMessage(def: EventDef | CommandDef | QueryDef): void {

--- a/packages/language-server/src/resolvers/asyncapi.ts
+++ b/packages/language-server/src/resolvers/asyncapi.ts
@@ -28,6 +28,7 @@ function resolveRef(doc: any, ref: string): any {
 }
 
 interface ParsedSpec {
+  doc: any;
   messages: Map<string, SpecMessage>;
   channels: Map<string, SpecChannel>;
   errors: ResolveError[];
@@ -42,6 +43,7 @@ export function parseSpec(content: string): ParsedSpec {
     doc = yaml.load(content);
   } catch (e) {
     return {
+      doc: null,
       messages: new Map(),
       channels: new Map(),
       errors: [
@@ -56,6 +58,7 @@ export function parseSpec(content: string): ParsedSpec {
 
   if (!doc || typeof doc !== "object") {
     return {
+      doc: null,
       messages: new Map(),
       channels: new Map(),
       errors: [
@@ -83,7 +86,7 @@ export function parseSpec(content: string): ParsedSpec {
     }
   }
 
-  return { messages, channels, errors: [] };
+  return { doc, messages, channels, errors: [] };
 }
 
 /**
@@ -102,24 +105,23 @@ export function extractService(
   });
 
   const parsed = parseSpec(content);
-  if (parsed.errors.length > 0) {
+  if (parsed.errors.length > 0 || !parsed.doc) {
     return {
       service: emptyService(serviceName || "UnknownService"),
-      errors: parsed.errors,
+      errors:
+        parsed.errors.length > 0
+          ? parsed.errors
+          : [
+              {
+                message: "AsyncAPI file is empty or invalid",
+                line: 1,
+                column: 1,
+              },
+            ],
     };
   }
 
-  // parseSpec returns empty maps for empty/invalid docs, so check that
-  const doc = yaml.load(content) as any;
-  if (!doc || typeof doc !== "object") {
-    return {
-      service: emptyService(serviceName || "UnknownService"),
-      errors: [
-        { message: "AsyncAPI file is empty or invalid", line: 1, column: 1 },
-      ],
-    };
-  }
-
+  const doc = parsed.doc;
   const name =
     serviceName || sanitizeServiceName(doc.info?.title) || "UnknownService";
   const version = doc.info?.version;

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -24,8 +24,9 @@ import {
   saveDraft as saveDraftStore,
   clearDraft as clearDraftStore,
   getSpecFile,
+  peekDraft,
+  peekWorkspaceFiles,
 } from "./stores/workspace";
-import type { DraftState } from "./stores/workspace";
 import {
   ChevronDown,
   AlignLeft,
@@ -458,45 +459,6 @@ const CatalogExportModal = memo(function CatalogExportModal({
 
 let newFileCounter = 1;
 
-/** Peek at a non-workspace draft without loading into the store. */
-function peekDraft(): DraftState | null {
-  try {
-    const raw =
-      localStorage.getItem("ec-compass-draft") ??
-      localStorage.getItem("ec-canvas-draft");
-    if (!raw) return null;
-    const files = JSON.parse(raw);
-    if (!files || typeof files !== "object" || Object.keys(files).length === 0)
-      return null;
-    const activeFile =
-      localStorage.getItem("ec-compass-draft-active") ??
-      localStorage.getItem("ec-canvas-draft-active") ??
-      Object.keys(files)[0];
-    return { files, activeFile };
-  } catch {
-    return null;
-  }
-}
-
-/** Peek at workspace files without loading the full store. */
-function peekWorkspaceFiles(
-  id: string,
-): { files: Record<string, string>; activeFile: string } | null {
-  try {
-    const raw = localStorage.getItem(`ec-workspace-${id}-files`);
-    if (!raw) return null;
-    const files = JSON.parse(raw);
-    if (!files || typeof files !== "object" || Object.keys(files).length === 0)
-      return null;
-    const activeFile =
-      localStorage.getItem(`ec-workspace-${id}-active`) ??
-      Object.keys(files)[0];
-    return { files, activeFile };
-  } catch {
-    return null;
-  }
-}
-
 function getCodeFromUrl(): string | null {
   try {
     const params = new URLSearchParams(window.location.search);
@@ -537,33 +499,19 @@ function getInitialExample(): number {
   return 0;
 }
 
-function getInitialFiles(workspaceId?: string): Record<string, string> {
+function getInitialState(workspaceId?: string): { files: Record<string, string>; activeFile: string } {
+  const defaultState = { files: { "main.ec": "" }, activeFile: "main.ec" };
   if (workspaceId) {
-    const ws = peekWorkspaceFiles(workspaceId);
-    if (ws) return ws.files;
-    return { "main.ec": "" };
+    return peekWorkspaceFiles(workspaceId) ?? defaultState;
   }
   const code = getCodeFromUrl();
-  if (code) return { "main.ec": code };
-  if (isNewRoute()) return { "main.ec": "" };
+  if (code) return { files: { "main.ec": code }, activeFile: "main.ec" };
+  if (isNewRoute()) return defaultState;
   const draft = peekDraft();
-  if (draft) return draft.files;
-  if (shouldShowTemplatePicker()) return { "main.ec": "" };
-  return { ...examples[getInitialExample()].source };
-}
-
-function getInitialActiveFile(workspaceId?: string): string {
-  if (workspaceId) {
-    const ws = peekWorkspaceFiles(workspaceId);
-    if (ws) return ws.activeFile;
-    return "main.ec";
-  }
-  const code = getCodeFromUrl();
-  if (code) return "main.ec";
-  if (isNewRoute()) return "main.ec";
-  const draft = peekDraft();
-  if (draft) return draft.activeFile;
-  return Object.keys(examples[getInitialExample()].source)[0];
+  if (draft) return draft;
+  if (shouldShowTemplatePicker()) return defaultState;
+  const source = examples[getInitialExample()].source;
+  return { files: { ...source }, activeFile: Object.keys(source)[0] };
 }
 
 function downloadBlob(blob: Blob, filename: string): void {
@@ -600,12 +548,11 @@ export default function App() {
   const [showTemplatePicker, setShowTemplatePicker] = useState(() =>
     shouldShowTemplatePicker(workspaceId),
   );
-  const [files, setFiles] = useState<Record<string, string>>(() =>
-    getInitialFiles(workspaceId),
+  const [initialState] = useState(() => getInitialState(workspaceId));
+  const [files, setFiles] = useState<Record<string, string>>(
+    initialState.files,
   );
-  const [activeFile, setActiveFile] = useState(() =>
-    getInitialActiveFile(workspaceId),
-  );
+  const [activeFile, setActiveFile] = useState(initialState.activeFile);
   // Track whether the current session is user-authored content that should be saved
   const isUserDraft = useRef(
     !!workspaceId || !!getCodeFromUrl() || isNewRoute() || !!peekDraft(),
@@ -654,11 +601,8 @@ export default function App() {
     $theme.set(next);
   }, []);
 
-  const handleExampleChange = useCallback(
-    (e: React.ChangeEvent<HTMLSelectElement>) => {
-      if (e.target.value === "") return;
-      const idx = Number(e.target.value);
-      if (e.target.value === "url") return;
+  const loadExample = useCallback(
+    (idx: number) => {
       setSelectedExample(idx);
       setTemplateUnselected(false);
       setLoadedFromUrl(false);
@@ -668,7 +612,6 @@ export default function App() {
       } else {
         clearDraftStore();
       }
-      // Clear ?code param when switching to a built-in example
       const url = new URL(window.location.href);
       url.pathname = getBasePathname();
       url.search = "";
@@ -682,24 +625,21 @@ export default function App() {
     [workspaceId],
   );
 
-  const handleTemplateSelect = useCallback((exampleIndex: number) => {
-    setSelectedExample(exampleIndex);
-    setTemplateUnselected(false);
-    setShowTemplatePicker(false);
-    isUserDraft.current = false;
-    if (workspaceId) {
-      clearWorkspace(workspaceId);
-    } else {
-      clearDraftStore();
-    }
-    const url = new URL(window.location.href);
-    url.hash = `example=${exampleIndex}`;
-    window.history.replaceState(null, "", url.toString());
-    const newFiles = { ...examples[exampleIndex].source };
-    setFiles(newFiles);
-    setActiveFile(Object.keys(newFiles)[0]);
-    setActiveVisualizer(undefined);
-  }, []);
+  const handleExampleChange = useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      if (e.target.value === "" || e.target.value === "url") return;
+      loadExample(Number(e.target.value));
+    },
+    [loadExample],
+  );
+
+  const handleTemplateSelect = useCallback(
+    (exampleIndex: number) => {
+      setShowTemplatePicker(false);
+      loadExample(exampleIndex);
+    },
+    [loadExample],
+  );
 
   const handleBlankStart = useCallback(() => {
     setShowTemplatePicker(false);

--- a/packages/playground/src/components/HeroPreview.tsx
+++ b/packages/playground/src/components/HeroPreview.tsx
@@ -315,32 +315,19 @@ const LiveVisualizer = memo(function LiveVisualizer({ graph, id, portalId }: { g
 
 /** Read-only Monaco editor for the code panel */
 const HeroEditor = memo(function HeroEditor({ value, language }: { value: string; language: string }) {
-  const containerRef = useRef<HTMLDivElement>(null);
   const editorRef = useRef<any>(null);
 
-  useEffect(() => {
-    let disposed = false;
-
-    import('@monaco-editor/react').then((mod) => {
-      // We can't use the React component easily here since we need beforeMount,
-      // so we'll set state to trigger a render instead
-      if (!disposed) {
-        setReady(true);
-      }
-    });
-
-    return () => { disposed = true; };
-  }, []);
-
-  const [ready, setReady] = useState(false);
   const [MonacoEditor, setMonacoEditor] = useState<any>(null);
 
   useEffect(() => {
-    if (!ready) return;
+    let disposed = false;
     import('@monaco-editor/react').then((mod) => {
-      setMonacoEditor(() => mod.default);
+      if (!disposed) {
+        setMonacoEditor(() => mod.default);
+      }
     });
-  }, [ready]);
+    return () => { disposed = true; };
+  }, []);
 
   const handleBeforeMount = useCallback((monaco: any) => {
     // Register EC language + dark theme synchronously before editor mounts

--- a/packages/playground/src/components/NextStepsGuide.tsx
+++ b/packages/playground/src/components/NextStepsGuide.tsx
@@ -1,4 +1,4 @@
-import { useCallback, memo } from "react";
+import { useCallback, useMemo, memo } from "react";
 import { useStore } from "@nanostores/react";
 import { X, ChevronRight, Check, ExternalLink } from "lucide-react";
 import { $workspace, saveWorkspace } from "../stores/workspace";
@@ -206,7 +206,7 @@ export const NextStepsGuide = memo(function NextStepsGuide({
   onDismiss,
 }: NextStepsGuideProps) {
   const ws = useStore($workspace);
-  const completedSteps = new Set(ws.guideDone);
+  const completedSteps = useMemo(() => new Set(ws.guideDone), [ws.guideDone]);
   const steps = getSteps(specKind, specFile, serviceNames, onExportCatalog);
 
   const handleStepClick = useCallback(
@@ -235,10 +235,6 @@ export const NextStepsGuide = memo(function NextStepsGuide({
     [completedSteps, onApplyStep, ws.guideDone],
   );
 
-  const handleDismiss = useCallback(() => {
-    onDismiss();
-  }, [onDismiss]);
-
   const transformSteps = steps.filter(
     (s) => s.type === "transform" || s.type === "action",
   );
@@ -262,7 +258,7 @@ export const NextStepsGuide = memo(function NextStepsGuide({
         <button
           type="button"
           className="next-steps-close"
-          onClick={handleDismiss}
+          onClick={onDismiss}
           aria-label="Dismiss guide"
         >
           <X size={14} />

--- a/packages/playground/src/main.tsx
+++ b/packages/playground/src/main.tsx
@@ -1,4 +1,3 @@
-import { scan } from 'react-scan';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
@@ -6,9 +5,9 @@ import App from './App';
 import Landing from './pages/Landing';
 import './index.css';
 
-// Enable react-scan in development only
+// Enable react-scan in development only (dynamic import to avoid bundling in prod)
 if (import.meta.env.DEV) {
-  scan({ enabled: true });
+  import('react-scan').then((m) => m.scan({ enabled: true }));
 }
 
 /** Show landing page unless the URL carries query params or a hash (shared link). */

--- a/packages/playground/src/stores/workspace.ts
+++ b/packages/playground/src/stores/workspace.ts
@@ -228,6 +228,47 @@ export function clearDraft(): void {
 }
 
 // ---------------------------------------------------------------------------
+// Peek helpers (read from localStorage without updating stores)
+// ---------------------------------------------------------------------------
+
+/** Read draft files+activeFile from localStorage without updating the $draft store. */
+export function peekDraft(): DraftState | null {
+  try {
+    const raw =
+      localStorage.getItem(DRAFT_KEY) ?? localStorage.getItem(LEGACY_DRAFT_KEY);
+    if (!raw) return null;
+    const files = JSON.parse(raw);
+    if (!files || typeof files !== "object" || Object.keys(files).length === 0)
+      return null;
+    const activeFile =
+      localStorage.getItem(DRAFT_ACTIVE_KEY) ??
+      localStorage.getItem(LEGACY_ACTIVE_KEY) ??
+      Object.keys(files)[0];
+    return { files, activeFile };
+  } catch {
+    return null;
+  }
+}
+
+/** Read workspace files+activeFile from localStorage without updating the $workspace store. */
+export function peekWorkspaceFiles(
+  id: string,
+): { files: Record<string, string>; activeFile: string } | null {
+  try {
+    const raw = localStorage.getItem(wsKey(id, "files"));
+    if (!raw) return null;
+    const files = JSON.parse(raw);
+    if (!files || typeof files !== "object" || Object.keys(files).length === 0)
+      return null;
+    const activeFile =
+      localStorage.getItem(wsKey(id, "active")) ?? Object.keys(files)[0];
+    return { files, activeFile };
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What This PR Does

Reduces code duplication across the language-server package by extracting shared helpers, eliminating redundant operations, and fixing minor code quality issues. Also includes playground UX improvements (example loading consolidation, lazy react-scan import, workspace store peek helpers).

## Changes Overview

### Key Changes

**Language Server:**
- Extract `checkAndRegisterDuplicate()` helper in `ec-validator.ts`, replacing 5 copies of the key+seen-map+error pattern
- Extract `enrichNodeFromInlineBody()` in `graph.ts`, deduplicating identical 16-line metadata extraction blocks in `processSends` and `processReceives`
- Move `extractApiInfo()` from nested closure inside `astToGraph` to top-level function (it captured nothing from the closure)
- Eliminate double YAML parsing in `asyncapi.ts` by having `parseSpec` return the parsed doc object
- Fix dead code in `compiler.ts`: redundant ternary `isNamedAnnotationArg(arg) ? arg.value : arg.value` simplified to `arg.value`

**Playground:**
- Consolidate `getInitialFiles` + `getInitialActiveFile` into single `getInitialState`
- Unify `handleExampleChange` and `handleTemplateSelect` via shared `loadExample` callback
- Move `peekDraft` and `peekWorkspaceFiles` from inline App.tsx to workspace store exports
- Lazy-load `react-scan` via dynamic import to avoid bundling in production
- Replace `new Set()` allocation on every render with `useMemo` in NextStepsGuide
- Remove trivial `handleDismiss` wrapper around `onDismiss`

## How It Works

All language-server changes are pure refactors — extracted helpers maintain identical behavior. The `parseSpec` change adds a `doc` field to the return type so callers can reuse the already-parsed YAML document instead of re-parsing. All 336 language-server tests pass unchanged.

## Breaking Changes

None

## Additional Notes

Net result: -62 lines (234 additions, 296 deletions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)