### PR TITLE
Replace playground.eventcatalog.dev with compass.eventcatalog.dev

### DIFF
--- a/.changeset/swift-clouds-drift.md
+++ b/.changeset/swift-clouds-drift.md
@@ -1,0 +1,6 @@
+---
+"@eventcatalog/cli": patch
+"@eventcatalog/language-server": patch
+---
+
+Replace playground.eventcatalog.dev URLs with compass.eventcatalog.dev

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ PERFORMANCE-ANALYSIS.md
 
 
 .agents/skills/copy*
+ec-test/

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -88,16 +88,16 @@ eventcatalog export [options]
 
 **Options:**
 
-| Option                | Description                                                                                  |
-| --------------------- | -------------------------------------------------------------------------------------------- |
-| `--all`               | Export the entire catalog                                                                    |
-| `--resource <type>`   | Resource type to export (`event`, `command`, `query`, `service`, `domain`, `channel`)        |
-| `--id <id>`           | Export a specific resource by ID (requires `--resource`)                                     |
-| `--version <version>` | Export a specific version (requires `--resource` and `--id`)                                 |
-| `--hydrate`           | Include referenced resources (e.g., messages referenced by a service)                        |
-| `--stdout`            | Print to stdout instead of writing a file                                                    |
-| `--playground`        | Open the exported DSL in the [EventCatalog Playground](https://playground.eventcatalog.dev/) |
-| `--output <path>`     | Custom output file path                                                                      |
+| Option                | Description                                                                               |
+| --------------------- | ----------------------------------------------------------------------------------------- |
+| `--all`               | Export the entire catalog                                                                 |
+| `--resource <type>`   | Resource type to export (`event`, `command`, `query`, `service`, `domain`, `channel`)     |
+| `--id <id>`           | Export a specific resource by ID (requires `--resource`)                                  |
+| `--version <version>` | Export a specific version (requires `--resource` and `--id`)                              |
+| `--hydrate`           | Include referenced resources (e.g., messages referenced by a service)                     |
+| `--stdout`            | Print to stdout instead of writing a file                                                 |
+| `--playground`        | Open the exported DSL in the [EventCatalog Playground](https://compass.eventcatalog.dev/) |
+| `--output <path>`     | Custom output file path                                                                   |
 
 **Examples:**
 

--- a/packages/cli/src/cli/export.ts
+++ b/packages/cli/src/cli/export.ts
@@ -257,7 +257,7 @@ export async function exportCatalog(options: Omit<ExportOptions, 'resource'>): P
 
   if (playground) {
     const encoded = Buffer.from(dsl).toString('base64');
-    const playgroundUrl = `https://playground.eventcatalog.dev/?code=${encoded}`;
+    const playgroundUrl = `https://compass.eventcatalog.dev/?code=${encoded}`;
     await open(playgroundUrl);
     lines.push('', `  Opening in EventCatalog Compass...`);
   } else {
@@ -301,7 +301,7 @@ export async function exportAll(options: ExportOptions): Promise<string> {
 
   if (playground) {
     const encoded = Buffer.from(dsl).toString('base64');
-    const playgroundUrl = `https://playground.eventcatalog.dev/?code=${encoded}`;
+    const playgroundUrl = `https://compass.eventcatalog.dev/?code=${encoded}`;
     await open(playgroundUrl);
     lines.push('', `  Opening in EventCatalog Compass...`);
   } else {
@@ -354,7 +354,7 @@ export async function exportResource(options: ExportOptions): Promise<string> {
 
   if (playground) {
     const encoded = Buffer.from(dsl).toString('base64');
-    const playgroundUrl = `https://playground.eventcatalog.dev/?code=${encoded}`;
+    const playgroundUrl = `https://compass.eventcatalog.dev/?code=${encoded}`;
     await open(playgroundUrl);
     lines.push('', `  Opening in EventCatalog Compass...`);
   } else {

--- a/packages/language-server/docs/src/components/ChannelTransportSelector.astro
+++ b/packages/language-server/docs/src/components/ChannelTransportSelector.astro
@@ -43,7 +43,7 @@ const options: ChannelOption[] = [
 
 const [defaultOption] = options;
 const instanceId = `channel-selector-${Math.random().toString(36).slice(2, 8)}`;
-const playgroundBaseUrl = 'https://playground.eventcatalog.dev/?code=';
+const playgroundBaseUrl = 'https://compass.eventcatalog.dev/?code=';
 
 const buildModelCode = (option: ChannelOption) => `service OrdersService {
   version 1.0.0

--- a/packages/language-server/docs/src/components/Header.astro
+++ b/packages/language-server/docs/src/components/Header.astro
@@ -16,7 +16,7 @@ const shouldRenderSearch =
 		<SiteTitle />
 		<nav class="header-nav">
 			<a href="/">Docs</a>
-			<a href="https://playground.eventcatalog.dev/playground" target="_blank" rel="noopener noreferrer">Playground</a>
+			<a href="https://compass.eventcatalog.dev/playground" target="_blank" rel="noopener noreferrer">Playground</a>
 		</nav>
 	</div>
 	<div class="sl-flex print:hidden">

--- a/packages/language-server/docs/src/components/MarkdownContent.astro
+++ b/packages/language-server/docs/src/components/MarkdownContent.astro
@@ -120,7 +120,7 @@ import '@astrojs/starlight/style/markdown.css';
 </script>
 
 <style>
-  :global(.sl-markdown-content .sl-link-button[href*='playground.eventcatalog.dev']) {
+  :global(.sl-markdown-content .sl-link-button[href*='compass.eventcatalog.dev']) {
     border-color: color-mix(in srgb, var(--sl-color-accent-high) 35%, transparent);
     background:
       linear-gradient(
@@ -134,14 +134,14 @@ import '@astrojs/starlight/style/markdown.css';
     transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
   }
 
-  :global(.sl-markdown-content .sl-link-button[href*='playground.eventcatalog.dev']:hover) {
+  :global(.sl-markdown-content .sl-link-button[href*='compass.eventcatalog.dev']:hover) {
     color: var(--sl-color-white);
     transform: translateY(-1px);
     border-color: color-mix(in srgb, var(--sl-color-accent-high) 60%, transparent);
     box-shadow: 0 10px 22px color-mix(in srgb, var(--sl-color-accent) 35%, transparent);
   }
 
-  :global(.sl-markdown-content .sl-link-button[href*='playground.eventcatalog.dev']::after) {
+  :global(.sl-markdown-content .sl-link-button[href*='compass.eventcatalog.dev']::after) {
     content: ' ->';
     font-size: 0.92em;
   }

--- a/packages/language-server/docs/src/content/docs/get-started/tutorial.mdx
+++ b/packages/language-server/docs/src/content/docs/get-started/tutorial.mdx
@@ -9,7 +9,7 @@ If this is your first time with EventCatalog Compass, this tutorial is for you.
 
 In this tutorial, we will build a tiny architecture model from scratch and see it visually.
 
-To start, open a [blank EventCatalog Compass workspace](https://playground.eventcatalog.dev/playground) in a new tab.
+To start, open a [blank EventCatalog Compass workspace](https://compass.eventcatalog.dev/playground) in a new tab.
 
 Then walk through these steps:
 

--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -23,7 +23,7 @@ Language support and live preview for [EventCatalog](https://eventcatalog.dev) D
 ## Resources
 
 - [Documentation](https://eventcatalog.dev/docs)
-- [Playground](https://playground.eventcatalog.dev)
+- [Playground](https://compass.eventcatalog.dev)
 - [GitHub](https://github.com/event-catalog/eventcatalog)
 - [Discord](https://discord.gg/3rjaZMmrAm)
 


### PR DESCRIPTION
## What This PR Does

Replaces all references to `playground.eventcatalog.dev` with `compass.eventcatalog.dev` across the codebase. The playground has been rebranded to EventCatalog Compass.

## Changes Overview

### Key Changes
- Updated CLI export URLs that open DSL in the browser playground
- Updated CLI README documentation links
- Updated language-server docs site navigation, tutorial, and component links
- Updated VS Code extension README playground link

## How It Works

Simple find-and-replace of the old domain across 7 files in 3 packages (`cli`, `language-server`, `vscode-extension`).

## Breaking Changes

None

## Additional Notes

The VS Code extension marketplace listing will reflect the new URL on the next extension release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)