### PR TITLE
fix : #2276 Allow optional version in resource-docs.

### DIFF
--- a/.changeset/polite-towns-study.md
+++ b/.changeset/polite-towns-study.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Allow optional version in resource-docs

--- a/packages/core/eventcatalog/src/utils/__tests__/collections/resource-docs.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/collections/resource-docs.spec.ts
@@ -91,6 +91,12 @@ const mockResourceDocs = [
     data: { id: 'on-call', type: 'guides', version: '1.0.0', title: 'On-call Guide' },
   },
   {
+    id: 'services/BillingService/docs/general.mdx',
+    collection: 'resourceDocs',
+    filePath: 'services/BillingService/docs/general.mdx',
+    data: { title: 'General Service Information' },
+  },
+  {
     id: 'domains/Payments/services/BillingService/events/InvoiceIssued/docs/reference/payload.mdx',
     collection: 'resourceDocs',
     filePath: 'domains/Payments/services/BillingService/events/InvoiceIssued/docs/reference/payload.mdx',
@@ -210,6 +216,16 @@ describe('resource-docs', () => {
           data: expect.objectContaining({
             id: 'on-call',
             type: 'guides',
+            resourceCollection: 'services',
+            resourceId: 'BillingService',
+            resourceVersion: '2.0.0',
+          }),
+        }),
+        expect.objectContaining({
+          data: expect.objectContaining({
+            id: 'general',
+            type: 'pages',
+            version: '2.0.0',
             resourceCollection: 'services',
             resourceId: 'BillingService',
             resourceVersion: '2.0.0',
@@ -343,5 +359,21 @@ describe('resource-docs', () => {
       resourceId: 'random',
       resourceVersion: '1.0.0',
     });
+  });
+
+  it('inherits resource version when doc version and summary are omitted', async () => {
+    const docsForService = await getResourceDocsForResource('services', 'BillingService', '2.0.0');
+    const generalDoc = docsForService.find((doc) => doc.data.id === 'general');
+
+    expect(generalDoc).toBeDefined();
+    expect(generalDoc!.data).toMatchObject({
+      id: 'general',
+      type: 'pages',
+      version: '2.0.0',
+      resourceCollection: 'services',
+      resourceId: 'BillingService',
+      resourceVersion: '2.0.0',
+    });
+    expect(generalDoc!.data.summary).toBeUndefined();
   });
 });

--- a/packages/core/eventcatalog/src/utils/collections/resource-docs.ts
+++ b/packages/core/eventcatalog/src/utils/collections/resource-docs.ts
@@ -374,8 +374,8 @@ export const getResourceDocs = async (): Promise<ResourceDocEntry[]> => {
       const inferredType = inferDocTypeFromFilePath(doc.filePath);
       const resolvedType = doc.data.type || inferredType || 'pages';
       const resolvedDocId = doc.data.id || inferDocIdFromFilePath(doc.filePath);
-      const resolvedDocVersion = doc.data.version;
       const { resourceCollection, resourceId, resourceVersion } = resolvedResource;
+      const resolvedDocVersion = doc.data.version || resourceVersion;
 
       if (!resolvedDocId || !resolvedDocVersion) {
         return null;


### PR DESCRIPTION
Allow optional version in resource-docs. https://github.com/event-catalog/eventcatalog/issues/2276