### PR TITLE
fix(visualiser): re-enable hide/show channels toggle

### DIFF
--- a/.changeset/bright-channels-toggle.md
+++ b/.changeset/bright-channels-toggle.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/visualiser": patch
+---
+
+Re-enable hide/show channels toggle in the visualiser

--- a/packages/visualiser/src/components/NodeGraph.tsx
+++ b/packages/visualiser/src/components/NodeGraph.tsx
@@ -67,6 +67,7 @@ import StepWalkthrough from "./StepWalkthrough";
 import StudioModal from "./StudioModal";
 import FocusModeModal from "./FocusModeModal";
 import MermaidView from "./MermaidView";
+import { useChannelVisibility } from "../hooks/use-channel-visibility";
 import VisualizerDropdownContent from "./VisualizerDropdownContent";
 import NodeContextMenu from "./NodeContextMenu";
 import { convertToMermaid } from "../utils/export-mermaid";
@@ -403,17 +404,13 @@ const NodeGraphBuilder = ({
     () => initialNodes.some((node: any) => node.type === "channels"),
     [initialNodes],
   );
-  // TODO: Re-enable channel visibility feature
-  // const { hideChannels, toggleChannelsVisibility } = useChannelVisibility({
-  //   nodes,
-  //   edges,
-  //   setNodes,
-  //   setEdges,
-  //   skipProcessing: !hasChannels,
-  // });
-  // Temporary implementation
-  const hideChannels = false;
-  const toggleChannelsVisibility = () => {};
+  const { hideChannels, toggleChannelsVisibility } = useChannelVisibility({
+    nodes,
+    edges,
+    setNodes,
+    setEdges,
+    skipProcessing: !hasChannels,
+  });
   const searchRef = useRef<VisualiserSearchRef>(null);
   const reactFlowWrapperRef = useRef<HTMLDivElement>(null);
   const scrollableContainerRef = useRef<HTMLElement | null>(null);


### PR DESCRIPTION
## What This PR Does

Re-enables the hide/show channels toggle in the visualiser that was previously disabled with a TODO comment. The feature allows users to toggle channel node visibility in node graphs, hiding intermediate channel nodes and reconnecting edges directly between services and messages.

## Changes Overview

### Key Changes
- Added import for `useChannelVisibility` hook in `NodeGraph.tsx`
- Replaced the no-op stub (`hideChannels = false`, `toggleChannelsVisibility = () => {}`) with the actual `useChannelVisibility` hook call
- The existing hook implementation handles filtering channel nodes, reconnecting edges, re-layouting with dagre, and persisting preference to localStorage

## How It Works

The `useChannelVisibility` hook was already fully implemented in `packages/visualiser/src/hooks/use-channel-visibility.ts` but was not being used. The hook:
1. Filters out nodes with `type === "channels"` when toggled
2. Reconstructs edges using `rootSourceAndTarget` metadata to create direct service-to-message connections
3. Re-layouts the graph using dagre
4. Persists the user's preference to localStorage (`EventCatalog:hideChannels`)

## Breaking Changes

None

## Additional Notes

The toggle only appears in the visualiser dropdown menu when the graph contains channel nodes (`hasChannels` check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)