### PR TITLE
fix(core): resolve schema API returning empty response in SSR mode

### DIFF
--- a/.changeset/fix-schema-api-ssr.md
+++ b/.changeset/fix-schema-api-ssr.md
@@ -1,0 +1,6 @@
+---
+"@eventcatalog/core": patch
+"@eventcatalog/sdk": patch
+---
+
+Fix schema API returning empty response in SSR mode and add getSchemaForMessage SDK function

--- a/packages/core/eventcatalog/src/__tests__/api/message-schemas-api.spec.ts
+++ b/packages/core/eventcatalog/src/__tests__/api/message-schemas-api.spec.ts
@@ -1,13 +1,18 @@
 import type { ContentCollectionKey } from 'astro:content';
-import { expect, describe, it, vi, beforeEach } from 'vitest';
+import { expect, describe, it, vi, beforeEach, afterEach } from 'vitest';
 import { getStaticPaths, GET } from '../../pages/api/schemas/[collection]/[id]/[version]/index.ts';
 import path from 'path';
+import fs from 'node:fs';
 
 const __dirname = path.dirname(new URL(import.meta.url).pathname);
 
 let mockEvents: any[] = [];
 let mockCommands: any[] = [];
 let mockQueries: any[] = [];
+
+let mockGetSchemaForMessage = vi.fn();
+let mockIsEventCatalogScaleEnabled = vi.fn();
+let mockIsSSR = vi.fn().mockReturnValue(false);
 
 vi.mock('astro:content', async (importOriginal) => {
   return {
@@ -24,6 +29,21 @@ vi.mock('astro:content', async (importOriginal) => {
           return Promise.resolve([]);
       }
     },
+  };
+});
+
+vi.mock('@eventcatalog/sdk', () => {
+  return {
+    default: () => ({
+      getSchemaForMessage: (...args: any[]) => mockGetSchemaForMessage(...args),
+    }),
+  };
+});
+
+vi.mock('@utils/feature', () => {
+  return {
+    isEventCatalogScaleEnabled: () => mockIsEventCatalogScaleEnabled(),
+    isSSR: () => mockIsSSR(),
   };
 });
 
@@ -177,9 +197,9 @@ describe('api/schemas/[collection]/[id]/[version]/index.ts', () => {
     });
   });
 
-  describe('GET', () => {
+  describe('GET (static mode)', () => {
     it('returns the given schema when EventCatalog Scale is enabled', async () => {
-      process.env.EVENTCATALOG_SCALE = 'true';
+      mockIsEventCatalogScaleEnabled.mockReturnValue(true);
       const response = await GET({
         request: new Request('http://localhost:4321/api/schemas/events/OrderPlaced/1.0.0'),
         props: { schema: 'test-schema.json' },
@@ -188,7 +208,7 @@ describe('api/schemas/[collection]/[id]/[version]/index.ts', () => {
       expect(await response.text()).toEqual('test-schema.json');
     });
     it('returns an error when EventCatalog Scale is disabled', async () => {
-      process.env.EVENTCATALOG_SCALE = 'false';
+      mockIsEventCatalogScaleEnabled.mockReturnValue(false);
       const response = await GET({
         request: new Request('http://localhost:4321/api/schemas/events/OrderPlaced/1.0.0'),
         props: { schema: 'test-schema.json' },
@@ -197,6 +217,69 @@ describe('api/schemas/[collection]/[id]/[version]/index.ts', () => {
       expect(await response.text()).toEqual(
         '{"error":"feature_not_available_on_server","message":"Schema API is not enabled for this deployment and supported in EventCatalog Scale."}'
       );
+    });
+  });
+
+  describe('GET (SSR mode)', () => {
+    beforeEach(() => {
+      mockGetSchemaForMessage.mockReset();
+      mockIsEventCatalogScaleEnabled.mockReturnValue(true);
+      mockIsSSR.mockReturnValue(true);
+    });
+
+    it('resolves the schema dynamically when props are empty (SSR mode)', async () => {
+      const schemaContent = fs.readFileSync(path.join(__dirname, 'schemas', 'test-schema.json'), 'utf8');
+
+      mockGetSchemaForMessage.mockResolvedValue({ schema: schemaContent, fileName: 'test-schema.json' });
+
+      const response = await GET({
+        request: new Request('http://localhost:4321/api/schemas/events/OrderPlaced/1.0.0'),
+        props: {},
+        params: { collection: 'events', id: 'OrderPlaced', version: '1.0.0' },
+      } as any);
+
+      expect(response.status).toBe(200);
+      expect(await response.text()).toEqual(schemaContent);
+      expect(mockGetSchemaForMessage).toHaveBeenCalledWith('OrderPlaced', '1.0.0');
+    });
+
+    it('passes undefined version to the SDK when version is "latest"', async () => {
+      const schemaContent = fs.readFileSync(path.join(__dirname, 'schemas', 'test-schema.json'), 'utf8');
+
+      mockGetSchemaForMessage.mockResolvedValue({ schema: schemaContent, fileName: 'test-schema.json' });
+
+      const response = await GET({
+        request: new Request('http://localhost:4321/api/schemas/events/OrderPlaced/latest'),
+        props: {},
+        params: { collection: 'events', id: 'OrderPlaced', version: 'latest' },
+      } as any);
+
+      expect(response.status).toBe(200);
+      expect(mockGetSchemaForMessage).toHaveBeenCalledWith('OrderPlaced', undefined);
+    });
+
+    it('returns 404 when the schema is not found in SSR mode', async () => {
+      mockGetSchemaForMessage.mockResolvedValue(undefined);
+
+      const response = await GET({
+        request: new Request('http://localhost:4321/api/schemas/events/NonExistent/1.0.0'),
+        props: {},
+        params: { collection: 'events', id: 'NonExistent', version: '1.0.0' },
+      } as any);
+
+      expect(response.status).toBe(404);
+      expect(await response.json()).toEqual({ error: 'Schema not found' });
+    });
+
+    it('returns 400 when id param is missing in SSR mode', async () => {
+      const response = await GET({
+        request: new Request('http://localhost:4321/api/schemas/events//1.0.0'),
+        props: {},
+        params: { collection: 'events', id: '', version: '1.0.0' },
+      } as any);
+
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({ error: 'Missing id parameter' });
     });
   });
 });

--- a/packages/core/eventcatalog/src/__tests__/api/services-schemas-api.spec.ts
+++ b/packages/core/eventcatalog/src/__tests__/api/services-schemas-api.spec.ts
@@ -1,10 +1,41 @@
 import type { ContentCollectionKey } from 'astro:content';
-import { expect, describe, it, vi } from 'vitest';
+import { expect, describe, it, vi, beforeEach } from 'vitest';
 import { getStaticPaths, GET } from '../../pages/api/schemas/services/[id]/[version]/[specification]/index.ts';
 import path from 'path';
 import fs from 'node:fs';
 
+let mockIsEventCatalogScaleEnabled = vi.fn();
+let mockIsSSR = vi.fn().mockReturnValue(false);
+
 const __dirname = path.dirname(new URL(import.meta.url).pathname);
+
+const mockServices = [
+  {
+    collection: 'services',
+    filePath: path.join(__dirname, 'schemas', 'test-openapi.yml'),
+    data: {
+      name: 'Order Service',
+      id: 'OrderService',
+      version: '1.0.0',
+      summary: 'Order Service summary',
+      specifications: [
+        { type: 'openapi', path: 'test-openapi.yml' },
+        { type: 'asyncapi', path: 'test-asyncapi.yml' },
+      ],
+    },
+  },
+  {
+    collection: 'services',
+    filePath: path.join(__dirname, 'schemas', 'test-openapi.yml'),
+    data: {
+      name: 'Order Service',
+      id: 'OrderService',
+      version: '2.0.0',
+      summary: 'Order Service summary',
+      specifications: [{ type: 'openapi', path: 'test-openapi.yml' }],
+    },
+  },
+];
 
 vi.mock('astro:content', async (importOriginal) => {
   return {
@@ -12,37 +43,18 @@ vi.mock('astro:content', async (importOriginal) => {
     getCollection: (key: ContentCollectionKey) => {
       switch (key) {
         case 'services':
-          return Promise.resolve([
-            {
-              collection: 'services',
-              filePath: path.join(__dirname, 'schemas', 'test-openapi.yml'),
-              data: {
-                name: 'Order Service',
-                id: 'OrderService',
-                version: '1.0.0',
-                summary: 'Order Service summary',
-                specifications: [
-                  { type: 'openapi', path: 'test-openapi.yml' },
-                  { type: 'asyncapi', path: 'test-asyncapi.yml' },
-                ],
-              },
-            },
-            {
-              collection: 'services',
-              filePath: path.join(__dirname, 'schemas', 'test-openapi.yml'),
-              data: {
-                name: 'Order Service',
-                id: 'OrderService',
-                version: '2.0.0',
-                summary: 'Order Service summary',
-                specifications: [{ type: 'openapi', path: 'test-openapi.yml' }],
-              },
-            },
-          ]);
+          return Promise.resolve(mockServices);
         default:
           return Promise.resolve([]);
       }
     },
+  };
+});
+
+vi.mock('@utils/feature', () => {
+  return {
+    isEventCatalogScaleEnabled: () => mockIsEventCatalogScaleEnabled(),
+    isSSR: () => mockIsSSR(),
   };
 });
 
@@ -67,9 +79,9 @@ describe('api/schemas/services/[id]/[version]/[specification]/index.ts', () => {
     });
   });
 
-  describe('GET', () => {
+  describe('GET (static mode)', () => {
     it('returns the given schema when EventCatalog Scale is enabled', async () => {
-      process.env.EVENTCATALOG_SCALE = 'true';
+      mockIsEventCatalogScaleEnabled.mockReturnValue(true);
       const response = await GET({
         request: new Request('http://localhost:4321/api/schemas/services/OrderService/1.0.0/openapi'),
         props: { schema: fs.readFileSync(path.join(__dirname, 'schemas', 'test-openapi.yml'), 'utf8') },
@@ -78,7 +90,7 @@ describe('api/schemas/services/[id]/[version]/[specification]/index.ts', () => {
       expect(await response.text()).toEqual(fs.readFileSync(path.join(__dirname, 'schemas', 'test-openapi.yml'), 'utf8'));
     });
     it('returns an error when EventCatalog Scale is disabled', async () => {
-      process.env.EVENTCATALOG_SCALE = 'false';
+      mockIsEventCatalogScaleEnabled.mockReturnValue(false);
       const response = await GET({
         request: new Request('http://localhost:4321/api/schemas/services/OrderService/1.0.0/openapi'),
         props: { schema: fs.readFileSync(path.join(__dirname, 'schemas', 'test-openapi.yml'), 'utf8') },
@@ -87,6 +99,72 @@ describe('api/schemas/services/[id]/[version]/[specification]/index.ts', () => {
       expect(await response.text()).toEqual(
         '{"error":"feature_not_available_on_server","message":"Schema API is not enabled for this deployment and supported in EventCatalog Scale."}'
       );
+    });
+  });
+
+  describe('GET (SSR mode)', () => {
+    beforeEach(() => {
+      mockIsEventCatalogScaleEnabled.mockReturnValue(true);
+      mockIsSSR.mockReturnValue(true);
+    });
+
+    it('resolves the service specification dynamically when props are empty (SSR mode)', async () => {
+      const expectedSchema = fs.readFileSync(path.join(__dirname, 'schemas', 'test-openapi.yml'), 'utf8');
+
+      const response = await GET({
+        request: new Request('http://localhost:4321/api/schemas/services/OrderService/1.0.0/openapi'),
+        props: {},
+        params: { id: 'OrderService', version: '1.0.0', specification: 'openapi' },
+      } as any);
+
+      expect(response.status).toBe(200);
+      expect(await response.text()).toEqual(expectedSchema);
+    });
+
+    it('resolves different specification types (asyncapi) in SSR mode', async () => {
+      const expectedSchema = fs.readFileSync(path.join(__dirname, 'schemas', 'test-asyncapi.yml'), 'utf8');
+
+      const response = await GET({
+        request: new Request('http://localhost:4321/api/schemas/services/OrderService/1.0.0/asyncapi'),
+        props: {},
+        params: { id: 'OrderService', version: '1.0.0', specification: 'asyncapi' },
+      } as any);
+
+      expect(response.status).toBe(200);
+      expect(await response.text()).toEqual(expectedSchema);
+    });
+
+    it('returns 404 when the service is not found in SSR mode', async () => {
+      const response = await GET({
+        request: new Request('http://localhost:4321/api/schemas/services/NonExistent/1.0.0/openapi'),
+        props: {},
+        params: { id: 'NonExistent', version: '1.0.0', specification: 'openapi' },
+      } as any);
+
+      expect(response.status).toBe(404);
+      expect(await response.json()).toEqual({ error: 'Service not found' });
+    });
+
+    it('returns 404 when the specification type is not found in SSR mode', async () => {
+      const response = await GET({
+        request: new Request('http://localhost:4321/api/schemas/services/OrderService/1.0.0/graphql'),
+        props: {},
+        params: { id: 'OrderService', version: '1.0.0', specification: 'graphql' },
+      } as any);
+
+      expect(response.status).toBe(404);
+      expect(await response.json()).toEqual({ error: 'Specification not found' });
+    });
+
+    it('returns 400 when required params are missing in SSR mode', async () => {
+      const response = await GET({
+        request: new Request('http://localhost:4321/api/schemas/services/OrderService/1.0.0/'),
+        props: {},
+        params: { id: 'OrderService', version: '1.0.0', specification: '' },
+      } as any);
+
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({ error: 'Missing id, version, or specification parameter' });
     });
   });
 });

--- a/packages/core/eventcatalog/src/pages/api/schemas/[collection]/[id]/[version]/index.ts
+++ b/packages/core/eventcatalog/src/pages/api/schemas/[collection]/[id]/[version]/index.ts
@@ -2,6 +2,7 @@ import type { APIRoute } from 'astro';
 import { getCollection } from 'astro:content';
 import path from 'node:path';
 import fs from 'node:fs';
+import utils from '@eventcatalog/sdk';
 import { isEventCatalogScaleEnabled } from '@utils/feature';
 import { sortVersioned } from '@utils/collections/util';
 
@@ -59,7 +60,7 @@ export async function getStaticPaths() {
   return [...versionedPaths, ...latestPaths];
 }
 
-export const GET: APIRoute = async ({ props }) => {
+export const GET: APIRoute = async ({ props, params }) => {
   if (!isEventCatalogScaleEnabled()) {
     return new Response(
       JSON.stringify({
@@ -76,7 +77,34 @@ export const GET: APIRoute = async ({ props }) => {
     );
   }
 
-  return new Response(props.schema, {
+  // In static mode, props are pre-computed by getStaticPaths
+  if (props.schema) {
+    return new Response(props.schema, {
+      headers: { 'Content-Type': 'text/plain' },
+    });
+  }
+
+  // In SSR mode, dynamically resolve the schema using the SDK
+  const { id, version } = params;
+
+  if (!id) {
+    return new Response(JSON.stringify({ error: 'Missing id parameter' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const { getSchemaForMessage } = utils(process.env.PROJECT_DIR || '');
+  const result = await getSchemaForMessage(id, version === 'latest' ? undefined : version);
+
+  if (!result) {
+    return new Response(JSON.stringify({ error: 'Schema not found' }), {
+      status: 404,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  return new Response(result.schema, {
     headers: { 'Content-Type': 'text/plain' },
   });
 };

--- a/packages/core/eventcatalog/src/pages/api/schemas/services/[id]/[version]/[specification]/index.ts
+++ b/packages/core/eventcatalog/src/pages/api/schemas/services/[id]/[version]/[specification]/index.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import fs from 'node:fs';
 import { getSpecificationsForService } from '@utils/collections/services';
 import { isEventCatalogScaleEnabled } from '@utils/feature';
+import { resourceFileExists, readResourceFile } from '@utils/resource-files';
 
 export async function getStaticPaths() {
   const services = await getCollection('services');
@@ -32,7 +33,7 @@ export async function getStaticPaths() {
   );
 }
 
-export const GET: APIRoute = async ({ props }) => {
+export const GET: APIRoute = async ({ props, params }) => {
   if (!isEventCatalogScaleEnabled()) {
     return new Response(
       JSON.stringify({
@@ -45,7 +46,54 @@ export const GET: APIRoute = async ({ props }) => {
       }
     );
   }
-  return new Response(props.schema, {
+
+  // In static mode, props are pre-computed by getStaticPaths
+  if (props.schema) {
+    return new Response(props.schema, {
+      headers: { 'Content-Type': 'text/plain' },
+    });
+  }
+
+  // In SSR mode, dynamically resolve the schema from params
+  const { id, version, specification } = params;
+
+  if (!id || !version || !specification) {
+    return new Response(JSON.stringify({ error: 'Missing id, version, or specification parameter' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const services = await getCollection('services');
+  const service = services.find((s) => s.data.id === id && s.data.version === version);
+
+  if (!service) {
+    return new Response(JSON.stringify({ error: 'Service not found' }), {
+      status: 404,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const specifications = getSpecificationsForService(service);
+  const spec = specifications.find((s) => s.type === specification);
+
+  if (!spec || !resourceFileExists(service, spec.path)) {
+    return new Response(JSON.stringify({ error: 'Specification not found' }), {
+      status: 404,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const schema = readResourceFile(service, spec.path);
+
+  if (!schema) {
+    return new Response(JSON.stringify({ error: 'Specification file could not be read' }), {
+      status: 404,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  return new Response(schema, {
     headers: { 'Content-Type': 'text/plain' },
   });
 };

--- a/packages/language-server/.prettierignore
+++ b/packages/language-server/.prettierignore
@@ -1,1 +1,2 @@
 docs/src/content/**/*.mdx
+src/generated

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -89,6 +89,7 @@ import {
   getMessageBySchemaPath,
   getProducersAndConsumersForMessage,
   getProducersOfSchema,
+  getSchemaForMessage,
 } from './messages';
 
 import { getResourcePath, getResourceFolderName } from './internal/resources';
@@ -1080,6 +1081,15 @@ export default (path: string) => {
      * @returns Service[]
      */
     getProducersOfSchema: getProducersOfSchema(join(path)),
+
+    /**
+     * Returns the schema for a given message (event, command or query) by its id and version.
+     * If no version is given, the latest version is used.
+     * @param id - The id of the message to get the schema for
+     * @param version - Optional version of the message
+     * @returns { schema: string, fileName: string } | undefined
+     */
+    getSchemaForMessage: getSchemaForMessage(join(path)),
 
     /**
      * Returns the owners for a given resource (e.g domain, service, event, command, query, etc.)

--- a/packages/sdk/src/messages.ts
+++ b/packages/sdk/src/messages.ts
@@ -1,8 +1,9 @@
 import { dirname, join } from 'node:path';
+import fsSync from 'node:fs';
 import type { Message, Service } from './types';
 import matter from 'gray-matter';
 import { getResource, getResourcePath, isLatestVersion } from './internal/resources';
-import { getFiles } from './internal/utils';
+import { findFileById, getFiles } from './internal/utils';
 import { getServices } from './services';
 import { satisfies, validRange } from 'semver';
 
@@ -170,3 +171,44 @@ export const getProducersOfSchema = (directory: string) => async (path: string) 
     return [];
   }
 };
+
+/**
+ * Returns the schema for a given message (event, command or query) by its id and version.
+ *
+ * If no version is given, the latest version is used.
+ *
+ * @example
+ * ```ts
+ * import utils from '@eventcatalog/utils';
+ *
+ * const { getSchemaForMessage } = utils('/path/to/eventcatalog');
+ *
+ * // Get the schema for the latest version of the message
+ * const schema = await getSchemaForMessage('InventoryAdjusted');
+ *
+ * // Get the schema for a specific version
+ * const schema = await getSchemaForMessage('InventoryAdjusted', '0.0.1');
+ * ```
+ */
+export const getSchemaForMessage =
+  (directory: string) =>
+  async (id: string, version?: string): Promise<{ schema: string; fileName: string } | undefined> => {
+    const file = await findFileById(directory, id, version);
+    if (!file || !fsSync.existsSync(file)) return undefined;
+
+    const { data } = matter.read(file);
+
+    if (!data.schemaPath) return undefined;
+
+    const resourceDirectory = dirname(file);
+    const pathToSchema = join(resourceDirectory, data.schemaPath);
+
+    if (!fsSync.existsSync(pathToSchema)) return undefined;
+
+    const schema = fsSync.readFileSync(pathToSchema, 'utf8');
+
+    return {
+      schema,
+      fileName: data.schemaPath,
+    };
+  };

--- a/packages/sdk/src/test/messages.test.ts
+++ b/packages/sdk/src/test/messages.test.ts
@@ -7,8 +7,11 @@ const CATALOG_PATH = path.join(__dirname, 'catalog-messages');
 
 const {
   getMessageBySchemaPath,
+  getSchemaForMessage,
   writeEvent,
   addSchemaToEvent,
+  writeCommand,
+  addSchemaToCommand,
   getProducersAndConsumersForMessage,
   writeService,
   addEventToService,
@@ -672,6 +675,156 @@ describe('Messages SDK', () => {
     it('if no producers are found for the schema, an empty array is returned', async () => {
       const producers = await getProducersOfSchema('events/InventoryAdjusted/schema.json');
       expect(producers).toEqual([]);
+    });
+  });
+
+  describe('getSchemaForMessage', () => {
+    it('returns the schema for a message by id and version', async () => {
+      await writeEvent({
+        id: 'InventoryAdjusted',
+        name: 'Inventory Adjusted',
+        version: '0.0.1',
+        schemaPath: 'schema.json',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+      });
+
+      const schemaObj = { type: 'object', properties: { name: { type: 'string' } } };
+      await addSchemaToEvent('InventoryAdjusted', { schema: JSON.stringify(schemaObj), fileName: 'schema.json' });
+
+      const result = await getSchemaForMessage('InventoryAdjusted', '0.0.1');
+
+      expect(result).toBeDefined();
+      expect(JSON.parse(result!.schema)).toEqual(schemaObj);
+      expect(result!.fileName).toEqual('schema.json');
+    });
+
+    it('returns the schema for the latest version when no version is specified', async () => {
+      await writeEvent({
+        id: 'InventoryAdjusted',
+        name: 'Inventory Adjusted',
+        version: '0.0.1',
+        schemaPath: 'schema.json',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+      });
+
+      const schemaObj = { type: 'object', properties: { name: { type: 'string' } } };
+      await addSchemaToEvent('InventoryAdjusted', { schema: JSON.stringify(schemaObj), fileName: 'schema.json' });
+
+      const result = await getSchemaForMessage('InventoryAdjusted');
+
+      expect(result).toBeDefined();
+      expect(JSON.parse(result!.schema)).toEqual(schemaObj);
+      expect(result!.fileName).toEqual('schema.json');
+    });
+
+    it('returns the schema for a versioned message', async () => {
+      await writeEvent({
+        id: 'InventoryAdjusted',
+        name: 'Inventory Adjusted',
+        version: '0.0.1',
+        schemaPath: 'schema.json',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+      });
+
+      const schemaObjV1 = { version: 1 };
+      await addSchemaToEvent('InventoryAdjusted', { schema: JSON.stringify(schemaObjV1), fileName: 'schema.json' });
+
+      await versionEvent('InventoryAdjusted');
+
+      await writeEvent({
+        id: 'InventoryAdjusted',
+        name: 'Inventory Adjusted',
+        version: '1.0.0',
+        schemaPath: 'schema.json',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+      });
+
+      const schemaObjV2 = { version: 2 };
+      await addSchemaToEvent('InventoryAdjusted', { schema: JSON.stringify(schemaObjV2), fileName: 'schema.json' });
+
+      const resultV1 = await getSchemaForMessage('InventoryAdjusted', '0.0.1');
+      expect(resultV1).toBeDefined();
+      expect(JSON.parse(resultV1!.schema)).toEqual(schemaObjV1);
+
+      const resultLatest = await getSchemaForMessage('InventoryAdjusted');
+      expect(resultLatest).toBeDefined();
+      expect(JSON.parse(resultLatest!.schema)).toEqual(schemaObjV2);
+    });
+
+    it('returns undefined when the message does not exist', async () => {
+      const result = await getSchemaForMessage('NonExistent', '0.0.1');
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined when the message has no schemaPath', async () => {
+      await writeEvent({
+        id: 'InventoryAdjusted',
+        name: 'Inventory Adjusted',
+        version: '0.0.1',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+      });
+
+      const result = await getSchemaForMessage('InventoryAdjusted', '0.0.1');
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined when the schema file does not exist on disk', async () => {
+      await writeEvent({
+        id: 'InventoryAdjusted',
+        name: 'Inventory Adjusted',
+        version: '0.0.1',
+        schemaPath: 'missing-schema.json',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+      });
+
+      const result = await getSchemaForMessage('InventoryAdjusted', '0.0.1');
+      expect(result).toBeUndefined();
+    });
+
+    it('works with commands', async () => {
+      await writeCommand({
+        id: 'PlaceOrder',
+        name: 'Place Order',
+        version: '1.0.0',
+        schemaPath: 'schema.json',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+      });
+
+      const schemaObj = { type: 'object' };
+      await addSchemaToCommand('PlaceOrder', { schema: JSON.stringify(schemaObj), fileName: 'schema.json' });
+
+      const result = await getSchemaForMessage('PlaceOrder', '1.0.0');
+
+      expect(result).toBeDefined();
+      expect(JSON.parse(result!.schema)).toEqual(schemaObj);
+      expect(result!.fileName).toEqual('schema.json');
+    });
+
+    it('works with non-JSON schema files (e.g. avro)', async () => {
+      await writeEvent({
+        id: 'InventoryAdjusted',
+        name: 'Inventory Adjusted',
+        version: '0.0.1',
+        schemaPath: 'schema.avro',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+      });
+
+      const avroSchema = 'non-json avro content here';
+      await addSchemaToEvent('InventoryAdjusted', { schema: avroSchema, fileName: 'schema.avro' });
+
+      const result = await getSchemaForMessage('InventoryAdjusted', '0.0.1');
+
+      expect(result).toBeDefined();
+      expect(result!.schema).toEqual(avroSchema);
+      expect(result!.fileName).toEqual('schema.avro');
     });
   });
 });


### PR DESCRIPTION
Closes #2305

## What This PR Does

Fixes the schema API endpoints (`/api/schemas/events|commands|queries/[id]/[version]` and `/api/schemas/services/[id]/[version]/[specification]`) returning HTTP 200 with an empty body when EventCatalog is configured with `output: 'server'` (SSR mode). Also adds a new `getSchemaForMessage` function to the SDK and ignores Langium-generated files from Prettier formatting.

## Changes Overview

### Key Changes
- **Core: Message schema API** - When `props` are empty (SSR mode), the GET handler now dynamically resolves schemas using the SDK's new `getSchemaForMessage` function instead of returning an empty response
- **Core: Service schema API** - Same fix using direct collection lookup and `readResourceFile` for service specifications
- **SDK: `getSchemaForMessage`** - New function that returns the raw schema content and filename for a message (event, command, query) by id and optional version. Falls back to latest when no version is specified
- **Tests** - Added SSR-specific regression tests for both API endpoints with proper `isSSR` mocking, and 8 tests for the new SDK function
- **Language server** - Added `src/generated` to `.prettierignore` to prevent Langium-generated files from causing formatting diffs

## How It Works

In static mode (SSG), Astro calls `getStaticPaths()` at build time which pre-computes schema content into `props`. In SSR mode, `getStaticPaths()` is never called, so `props` is empty. The fix detects empty `props.schema` and falls back to dynamic resolution:

- For messages: uses `getSchemaForMessage(id, version)` from the SDK, which looks up the message's `index.mdx`, reads the `schemaPath` frontmatter field, and returns the file content
- For services: fetches the service from the content collection, finds the matching specification type, and reads it from disk via `readResourceFile`

The `version: 'latest'` param maps to `undefined` in the SDK call, which naturally resolves to the latest (non-versioned) entry.

## Breaking Changes

None

## Test plan

- [x] Existing static mode tests pass (5 message, 3 service)
- [x] New SSR mode tests pass (4 message, 5 service) with proper `isSSR` mocking
- [x] New SDK `getSchemaForMessage` tests pass (8 tests)
- [ ] Manual test: run with `output: 'server'` and verify `curl http://localhost:3000/api/schemas/events/<id>/<version>` returns schema content

🤖 Generated with [Claude Code](https://claude.com/claude-code)