### PR TITLE
fix(core): inherit parent resource version for resource docs without explicit version

### DIFF
--- a/.changeset/gentle-waves-flow.md
+++ b/.changeset/gentle-waves-flow.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix resource docs without explicit version being silently dropped — they now inherit the version from their parent resource

--- a/packages/core/eventcatalog/src/utils/__tests__/collections/resource-docs.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/collections/resource-docs.spec.ts
@@ -82,13 +82,13 @@ const mockResourceDocs = [
     id: 'domains/Payments/versioned/0.9.0/docs/runbooks/legacy-ops.mdx',
     collection: 'resourceDocs',
     filePath: 'domains/Payments/versioned/0.9.0/docs/runbooks/legacy-ops.mdx',
-    data: { id: 'legacy-ops', type: 'runbooks', version: '1.0.0', title: 'Legacy Operations' },
+    data: { id: 'legacy-ops', type: 'runbooks', title: 'Legacy Operations' },
   },
   {
     id: 'domains/Payments/services/BillingService/docs/guides/on-call.mdx',
     collection: 'resourceDocs',
     filePath: 'domains/Payments/services/BillingService/docs/guides/on-call.mdx',
-    data: { id: 'on-call', type: 'guides', version: '1.0.0', title: 'On-call Guide' },
+    data: { id: 'on-call', type: 'guides', title: 'On-call Guide' },
   },
   {
     id: 'domains/Payments/services/BillingService/events/InvoiceIssued/docs/reference/payload.mdx',
@@ -342,6 +342,34 @@ describe('resource-docs', () => {
       resourceCollection: 'domains',
       resourceId: 'random',
       resourceVersion: '1.0.0',
+    });
+  });
+
+  it('when a resource doc does not specify a version, it inherits the version from its parent resource', async () => {
+    const docs = await getResourceDocs();
+    const versionedDoc = docs.find(
+      (doc) =>
+        doc.data.resourceCollection === 'domains' &&
+        doc.data.resourceId === 'Payments' &&
+        doc.data.resourceVersion === '0.9.0' &&
+        doc.data.id === 'legacy-ops'
+    );
+    const resourceScopedDoc = docs.find(
+      (doc) => doc.data.resourceCollection === 'services' && doc.data.resourceId === 'BillingService' && doc.data.id === 'on-call'
+    );
+
+    expect(versionedDoc).toBeDefined();
+    expect(versionedDoc!.data).toMatchObject({
+      version: '0.9.0',
+      latestVersion: '0.9.0',
+      resourceVersion: '0.9.0',
+    });
+
+    expect(resourceScopedDoc).toBeDefined();
+    expect(resourceScopedDoc!.data).toMatchObject({
+      version: '2.0.0',
+      latestVersion: '2.0.0',
+      resourceVersion: '2.0.0',
     });
   });
 });

--- a/packages/core/eventcatalog/src/utils/collections/resource-docs.ts
+++ b/packages/core/eventcatalog/src/utils/collections/resource-docs.ts
@@ -374,10 +374,10 @@ export const getResourceDocs = async (): Promise<ResourceDocEntry[]> => {
       const inferredType = inferDocTypeFromFilePath(doc.filePath);
       const resolvedType = doc.data.type || inferredType || 'pages';
       const resolvedDocId = doc.data.id || inferDocIdFromFilePath(doc.filePath);
-      const resolvedDocVersion = doc.data.version;
       const { resourceCollection, resourceId, resourceVersion } = resolvedResource;
+      const resolvedDocVersion = doc.data.version || resourceVersion;
 
-      if (!resolvedDocId || !resolvedDocVersion) {
+      if (!resolvedDocId) {
         return null;
       }
 


### PR DESCRIPTION
## What This PR Does

Closes #2276

Resource docs that omit a `version` field in their frontmatter were previously silently filtered out and never displayed. This fix makes them inherit the version from their parent resource instead, which is the intuitive expected behavior.

## Changes Overview

### Key Changes
- `resource-docs.ts`: Changed version resolution to fall back to the parent resource's version (`doc.data.version || resourceVersion`) instead of requiring an explicit version
- `resource-docs.ts`: Removed the `!resolvedDocVersion` null check that was filtering out versionless docs
- `resource-docs.spec.ts`: Added test case verifying version inheritance for both versioned resource paths and latest resource paths
- `resource-docs.spec.ts`: Removed hardcoded versions from test mock data to exercise the new fallback logic

## How It Works

When a resource doc (e.g., a runbook inside a service's `/docs/` folder) doesn't specify a `version` in its frontmatter, the system now resolves the version from the parent resource's resolved version. For example, a doc at `services/BillingService/docs/guides/on-call.mdx` without an explicit version will inherit `2.0.0` from the BillingService resource. Similarly, docs under versioned paths like `domains/Payments/versioned/0.9.0/docs/...` correctly inherit `0.9.0`.

## Breaking Changes

None

## Test Plan

- [x] Added test for version inheritance from versioned resource paths
- [x] Added test for version inheritance from latest resource paths
- [x] Existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)