### PR TITLE
feat(create-eventcatalog): add usage examples to default template events

### DIFF
--- a/.changeset/warm-tigers-glow.md
+++ b/.changeset/warm-tigers-glow.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/create-eventcatalog": patch
+---
+
+add usage examples to all events with schemas in the default template

--- a/packages/create-eventcatalog/templates/default/domains/Orders/services/InventoryService/events/InventoryAdjusted/examples/examples.config.yaml
+++ b/packages/create-eventcatalog/templates/default/domains/Orders/services/InventoryService/events/InventoryAdjusted/examples/examples.config.yaml
@@ -1,0 +1,15 @@
+stock-increase.json:
+  name: Stock Increase
+  summary: Inventory increased after receiving a supplier delivery of 200 units at the east warehouse.
+  usage: |
+    curl -X POST http://localhost:3000/api/events/publish \
+      -H "Content-Type: application/json" \
+      -d @stock-increase.json
+
+stock-decrease.json:
+  name: Stock Decrease
+  summary: Inventory decreased by 3 units due to damaged goods identified during warehouse inspection.
+  usage: |
+    curl -X POST http://localhost:3000/api/events/publish \
+      -H "Content-Type: application/json" \
+      -d @stock-decrease.json

--- a/packages/create-eventcatalog/templates/default/domains/Orders/services/InventoryService/events/InventoryAdjusted/examples/stock-decrease.json
+++ b/packages/create-eventcatalog/templates/default/domains/Orders/services/InventoryService/events/InventoryAdjusted/examples/stock-decrease.json
@@ -1,0 +1,23 @@
+{
+  "eventId": "evt_8a9b0c1d-2e3f-4a5b-6c7d-8e9f0a1b2c3d",
+  "eventType": "InventoryAdjusted",
+  "timestamp": "2025-11-17T14:22:09.587Z",
+  "adjustmentId": "adj_40355",
+  "productId": "prod_4102",
+  "productName": "Limited Edition Sneakers",
+  "sku": "LES-42-WHT",
+  "warehouseId": "wh_west_02",
+  "adjustmentType": "DECREASE",
+  "reason": "DAMAGED_GOODS",
+  "previousQuantity": 15,
+  "adjustedQuantity": 3,
+  "newQuantity": 12,
+  "unitCost": 85.0,
+  "currency": "USD",
+  "metadata": {
+    "source": "warehouse-system",
+    "correlationId": "corr_fedcba98-7654-3210-fedc-ba9876543210",
+    "inspectionReportId": "insp_71882",
+    "adjustedBy": "usr_wh_2011"
+  }
+}

--- a/packages/create-eventcatalog/templates/default/domains/Orders/services/InventoryService/events/InventoryAdjusted/examples/stock-increase.json
+++ b/packages/create-eventcatalog/templates/default/domains/Orders/services/InventoryService/events/InventoryAdjusted/examples/stock-increase.json
@@ -1,0 +1,23 @@
+{
+  "eventId": "evt_3d4e5f6a-7b8c-9d0e-1f2a-3b4c5d6e7f8a",
+  "eventType": "InventoryAdjusted",
+  "timestamp": "2025-11-17T07:45:22.310Z",
+  "adjustmentId": "adj_40291",
+  "productId": "prod_1129",
+  "productName": "Wireless Bluetooth Headphones",
+  "sku": "WBH-400-BLK",
+  "warehouseId": "wh_east_01",
+  "adjustmentType": "INCREASE",
+  "reason": "SUPPLIER_DELIVERY",
+  "previousQuantity": 42,
+  "adjustedQuantity": 200,
+  "newQuantity": 242,
+  "unitCost": 22.5,
+  "currency": "USD",
+  "metadata": {
+    "source": "warehouse-system",
+    "correlationId": "corr_12345678-abcd-ef01-2345-6789abcdef01",
+    "purchaseOrderId": "po_20251117_003",
+    "receivedBy": "usr_wh_1044"
+  }
+}

--- a/packages/create-eventcatalog/templates/default/domains/Orders/services/InventoryService/events/OutOfStock/examples/examples.config.yaml
+++ b/packages/create-eventcatalog/templates/default/domains/Orders/services/InventoryService/events/OutOfStock/examples/examples.config.yaml
@@ -1,0 +1,7 @@
+product-depleted.json:
+  name: Product Depleted
+  summary: A product reached zero stock after fulfilling an order, with 3 pending orders still affected.
+  usage: |
+    curl -X POST http://localhost:3000/api/events/publish \
+      -H "Content-Type: application/json" \
+      -d @product-depleted.json

--- a/packages/create-eventcatalog/templates/default/domains/Orders/services/InventoryService/events/OutOfStock/examples/product-depleted.json
+++ b/packages/create-eventcatalog/templates/default/domains/Orders/services/InventoryService/events/OutOfStock/examples/product-depleted.json
@@ -1,0 +1,19 @@
+{
+  "eventId": "evt_4b5c6d7e-8f9a-0b1c-2d3e-4f5a6b7c8d9e",
+  "eventType": "OutOfStock",
+  "timestamp": "2025-11-18T10:05:38.922Z",
+  "productId": "prod_4102",
+  "productName": "Limited Edition Sneakers",
+  "sku": "LES-42-WHT",
+  "warehouseId": "wh_west_02",
+  "previousQuantity": 1,
+  "currentQuantity": 0,
+  "lastSoldOrderId": "ord_86701",
+  "restockEstimate": null,
+  "affectedPendingOrders": 3,
+  "metadata": {
+    "source": "inventory-system",
+    "correlationId": "corr_aabbccdd-eeff-0011-2233-445566778899",
+    "triggeredBy": "order_fulfillment"
+  }
+}

--- a/packages/create-eventcatalog/templates/default/domains/Orders/services/OrdersService/events/OrderAmended/examples/address-change.json
+++ b/packages/create-eventcatalog/templates/default/domains/Orders/services/OrdersService/events/OrderAmended/examples/address-change.json
@@ -1,0 +1,36 @@
+{
+  "eventId": "evt_b7d14e92-6f3a-4c09-9e72-1a5b8d3f6c20",
+  "eventType": "OrderAmended",
+  "timestamp": "2025-11-14T14:05:33.119Z",
+  "orderId": "ord_83102",
+  "userId": "usr_51037",
+  "amendmentType": "ADDRESS_CHANGE",
+  "amendments": [],
+  "shippingAddress": {
+    "previous": {
+      "line1": "42 Oak Street",
+      "line2": "Apt 7B",
+      "city": "Portland",
+      "state": "OR",
+      "postalCode": "97201",
+      "country": "US"
+    },
+    "updated": {
+      "line1": "158 Maple Avenue",
+      "line2": null,
+      "city": "Portland",
+      "state": "OR",
+      "postalCode": "97205",
+      "country": "US"
+    }
+  },
+  "previousOrderTotal": 89.97,
+  "newOrderTotal": 89.97,
+  "currency": "USD",
+  "orderStatus": "confirmed",
+  "metadata": {
+    "source": "mobile-app",
+    "correlationId": "corr_f8e7d6c5-b4a3-2190-fedc-ba0987654321",
+    "userAgent": "EventCatalog-Mobile/2.3.1 (iOS 17.4)"
+  }
+}

--- a/packages/create-eventcatalog/templates/default/domains/Orders/services/OrdersService/events/OrderAmended/examples/examples.config.yaml
+++ b/packages/create-eventcatalog/templates/default/domains/Orders/services/OrdersService/events/OrderAmended/examples/examples.config.yaml
@@ -1,0 +1,15 @@
+quantity-change.json:
+  name: Quantity Change
+  summary: Customer updated the quantity of an item in their order from 1 to 3 units.
+  usage: |
+    curl -X POST http://localhost:3000/api/events/publish \
+      -H "Content-Type: application/json" \
+      -d @quantity-change.json
+
+address-change.json:
+  name: Shipping Address Change
+  summary: Customer changed the shipping address on a confirmed order before dispatch.
+  usage: |
+    curl -X POST http://localhost:3000/api/events/publish \
+      -H "Content-Type: application/json" \
+      -d @address-change.json

--- a/packages/create-eventcatalog/templates/default/domains/Orders/services/OrdersService/events/OrderAmended/examples/quantity-change.json
+++ b/packages/create-eventcatalog/templates/default/domains/Orders/services/OrdersService/events/OrderAmended/examples/quantity-change.json
@@ -1,0 +1,29 @@
+{
+  "eventId": "evt_9a3f2c71-4e88-4b1a-b5d0-83c1e7a2f640",
+  "eventType": "OrderAmended",
+  "timestamp": "2025-11-14T09:23:17.482Z",
+  "orderId": "ord_82451",
+  "userId": "usr_44829",
+  "amendmentType": "QUANTITY_CHANGE",
+  "amendments": [
+    {
+      "productId": "prod_1129",
+      "productName": "Wireless Bluetooth Headphones",
+      "sku": "WBH-400-BLK",
+      "previousQuantity": 1,
+      "newQuantity": 3,
+      "unitPrice": 49.99,
+      "previousLineTotal": 49.99,
+      "newLineTotal": 149.97
+    }
+  ],
+  "previousOrderTotal": 124.98,
+  "newOrderTotal": 224.96,
+  "currency": "USD",
+  "orderStatus": "confirmed",
+  "metadata": {
+    "source": "web",
+    "correlationId": "corr_a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)"
+  }
+}

--- a/packages/create-eventcatalog/templates/default/domains/Orders/services/OrdersService/events/OrderCancelled/examples/customer-request.json
+++ b/packages/create-eventcatalog/templates/default/domains/Orders/services/OrdersService/events/OrderCancelled/examples/customer-request.json
@@ -1,0 +1,34 @@
+{
+  "eventId": "evt_c4e81a29-7d52-4f6b-a390-2e9f5b8c1d74",
+  "eventType": "OrderCancelled",
+  "timestamp": "2025-11-15T11:42:08.734Z",
+  "orderId": "ord_84219",
+  "userId": "usr_33741",
+  "cancellationReason": "CUSTOMER_REQUEST",
+  "cancellationNote": "Changed my mind about the purchase",
+  "items": [
+    {
+      "productId": "prod_2045",
+      "productName": "Ergonomic Office Chair",
+      "sku": "EOC-200-GRY",
+      "quantity": 1,
+      "unitPrice": 349.99
+    },
+    {
+      "productId": "prod_3087",
+      "productName": "Standing Desk Mat",
+      "sku": "SDM-100-BLK",
+      "quantity": 1,
+      "unitPrice": 44.99
+    }
+  ],
+  "refundAmount": 394.98,
+  "currency": "USD",
+  "previousStatus": "confirmed",
+  "newStatus": "cancelled",
+  "metadata": {
+    "source": "web",
+    "correlationId": "corr_d2c3b4a5-6789-0123-abcd-456789012345",
+    "cancelledBy": "customer"
+  }
+}

--- a/packages/create-eventcatalog/templates/default/domains/Orders/services/OrdersService/events/OrderCancelled/examples/examples.config.yaml
+++ b/packages/create-eventcatalog/templates/default/domains/Orders/services/OrdersService/events/OrderCancelled/examples/examples.config.yaml
@@ -1,0 +1,15 @@
+customer-request.json:
+  name: Customer Requested Cancellation
+  summary: Customer cancelled a confirmed order containing two items before shipment.
+  usage: |
+    curl -X POST http://localhost:3000/api/events/publish \
+      -H "Content-Type: application/json" \
+      -d @customer-request.json
+
+out-of-stock.json:
+  name: Out of Stock Cancellation
+  summary: System automatically cancelled an order because the product was no longer available from the supplier.
+  usage: |
+    curl -X POST http://localhost:3000/api/events/publish \
+      -H "Content-Type: application/json" \
+      -d @out-of-stock.json

--- a/packages/create-eventcatalog/templates/default/domains/Orders/services/OrdersService/events/OrderCancelled/examples/out-of-stock.json
+++ b/packages/create-eventcatalog/templates/default/domains/Orders/services/OrdersService/events/OrderCancelled/examples/out-of-stock.json
@@ -1,0 +1,28 @@
+{
+  "eventId": "evt_e5f92b38-8c63-4a7d-b401-3f0a6c9d2e85",
+  "eventType": "OrderCancelled",
+  "timestamp": "2025-11-15T16:18:45.291Z",
+  "orderId": "ord_84507",
+  "userId": "usr_28956",
+  "cancellationReason": "OUT_OF_STOCK",
+  "cancellationNote": "Product no longer available from supplier",
+  "items": [
+    {
+      "productId": "prod_4102",
+      "productName": "Limited Edition Sneakers",
+      "sku": "LES-42-WHT",
+      "quantity": 1,
+      "unitPrice": 189.99
+    }
+  ],
+  "refundAmount": 189.99,
+  "currency": "USD",
+  "previousStatus": "confirmed",
+  "newStatus": "cancelled",
+  "metadata": {
+    "source": "system",
+    "correlationId": "corr_a9b8c7d6-5432-1098-fedc-ba9876543210",
+    "cancelledBy": "system",
+    "inventoryCheckId": "inv_chk_77201"
+  }
+}

--- a/packages/create-eventcatalog/templates/default/domains/Orders/services/OrdersService/events/OrderConfirmed/examples/examples.config.yaml
+++ b/packages/create-eventcatalog/templates/default/domains/Orders/services/OrdersService/events/OrderConfirmed/examples/examples.config.yaml
@@ -1,0 +1,15 @@
+standard-order.json:
+  name: Standard Order
+  summary: A typical confirmed order with two items, standard shipping, and credit card payment.
+  usage: |
+    curl -X POST http://localhost:3000/api/events/publish \
+      -H "Content-Type: application/json" \
+      -d @standard-order.json
+
+gift-order.json:
+  name: Gift Order
+  summary: A confirmed gift order with gift wrapping, a personal message, and express shipping.
+  usage: |
+    curl -X POST http://localhost:3000/api/events/publish \
+      -H "Content-Type: application/json" \
+      -d @gift-order.json

--- a/packages/create-eventcatalog/templates/default/domains/Orders/services/OrdersService/events/OrderConfirmed/examples/gift-order.json
+++ b/packages/create-eventcatalog/templates/default/domains/Orders/services/OrdersService/events/OrderConfirmed/examples/gift-order.json
@@ -1,0 +1,38 @@
+{
+  "eventId": "evt_7f8e9d0c-1b2a-3c4d-5e6f-7a8b9c0d1e2f",
+  "eventType": "OrderConfirmed",
+  "timestamp": "2025-11-16T12:15:44.882Z",
+  "orderId": "ord_85412",
+  "userId": "usr_72019",
+  "items": [
+    {
+      "productId": "prod_6300",
+      "productName": "Scented Candle Gift Set",
+      "sku": "SCG-050-AST",
+      "quantity": 1,
+      "unitPrice": 59.99,
+      "lineTotal": 59.99
+    }
+  ],
+  "orderTotal": 65.98,
+  "currency": "USD",
+  "isGift": true,
+  "giftMessage": "Happy Birthday! Hope you enjoy these.",
+  "giftWrapping": true,
+  "giftWrappingCost": 5.99,
+  "shippingAddress": {
+    "line1": "305 Pine Lane",
+    "line2": "Suite 4",
+    "city": "Seattle",
+    "state": "WA",
+    "postalCode": "98101",
+    "country": "US"
+  },
+  "shippingMethod": "express",
+  "estimatedDelivery": "2025-11-18",
+  "paymentMethod": "paypal",
+  "metadata": {
+    "source": "mobile-app",
+    "correlationId": "corr_ffeeddcc-bbaa-9988-7766-554433221100"
+  }
+}

--- a/packages/create-eventcatalog/templates/default/domains/Orders/services/OrdersService/events/OrderConfirmed/examples/standard-order.json
+++ b/packages/create-eventcatalog/templates/default/domains/Orders/services/OrdersService/events/OrderConfirmed/examples/standard-order.json
@@ -1,0 +1,42 @@
+{
+  "eventId": "evt_1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
+  "eventType": "OrderConfirmed",
+  "timestamp": "2025-11-16T08:30:12.654Z",
+  "orderId": "ord_85330",
+  "userId": "usr_61482",
+  "items": [
+    {
+      "productId": "prod_5210",
+      "productName": "USB-C Charging Cable 2m",
+      "sku": "UCC-200-WHT",
+      "quantity": 2,
+      "unitPrice": 14.99,
+      "lineTotal": 29.98
+    },
+    {
+      "productId": "prod_5211",
+      "productName": "Wireless Mouse",
+      "sku": "WM-300-BLK",
+      "quantity": 1,
+      "unitPrice": 34.99,
+      "lineTotal": 34.99
+    }
+  ],
+  "orderTotal": 64.97,
+  "currency": "USD",
+  "shippingAddress": {
+    "line1": "720 Elm Drive",
+    "line2": null,
+    "city": "Austin",
+    "state": "TX",
+    "postalCode": "73301",
+    "country": "US"
+  },
+  "shippingMethod": "standard",
+  "estimatedDelivery": "2025-11-21",
+  "paymentMethod": "credit_card",
+  "metadata": {
+    "source": "web",
+    "correlationId": "corr_11223344-5566-7788-99aa-bbccddeeff00"
+  }
+}

--- a/packages/create-eventcatalog/templates/default/domains/Orders/services/ShippingService/events/DeliveryFailed/examples/address-not-found.json
+++ b/packages/create-eventcatalog/templates/default/domains/Orders/services/ShippingService/events/DeliveryFailed/examples/address-not-found.json
@@ -1,0 +1,23 @@
+{
+  "eventId": "evt_df_60101",
+  "shipmentId": "shp_84201",
+  "orderId": "ord_10482",
+  "failedAt": "2026-03-14T14:30:00Z",
+  "carrier": "FedEx",
+  "trackingNumber": "FX7829041890",
+  "failureReason": "address_not_found",
+  "failureDetails": "Delivery address not found. The provided address does not match any known location.",
+  "deliveryAttempts": 1,
+  "destination": {
+    "line1": "999 Phantom Lane",
+    "city": "Denver",
+    "state": "CO",
+    "zipCode": "80201",
+    "country": "US"
+  },
+  "nextAction": "contact_customer",
+  "customer": {
+    "customerId": "cust_8901",
+    "email": "taylor.morgan@example.com"
+  }
+}

--- a/packages/create-eventcatalog/templates/default/domains/Orders/services/ShippingService/events/DeliveryFailed/examples/customer-unavailable.json
+++ b/packages/create-eventcatalog/templates/default/domains/Orders/services/ShippingService/events/DeliveryFailed/examples/customer-unavailable.json
@@ -1,0 +1,40 @@
+{
+  "eventId": "evt_df_60108",
+  "shipmentId": "shp_84305",
+  "orderId": "ord_10596",
+  "failedAt": "2026-03-15T17:45:00Z",
+  "carrier": "UPS",
+  "trackingNumber": "1Z9R8F030392850142",
+  "failureReason": "customer_unavailable",
+  "failureDetails": "Customer unavailable. Three delivery attempts were made with no response.",
+  "deliveryAttempts": 3,
+  "attemptHistory": [
+    {
+      "attempt": 1,
+      "timestamp": "2026-03-13T10:30:00Z",
+      "notes": "No answer at door"
+    },
+    {
+      "attempt": 2,
+      "timestamp": "2026-03-14T14:15:00Z",
+      "notes": "No answer at door, left notice"
+    },
+    {
+      "attempt": 3,
+      "timestamp": "2026-03-15T17:45:00Z",
+      "notes": "Final attempt, no answer"
+    }
+  ],
+  "destination": {
+    "line1": "310 Oak Avenue",
+    "city": "Seattle",
+    "state": "WA",
+    "zipCode": "98101",
+    "country": "US"
+  },
+  "nextAction": "return_to_warehouse",
+  "customer": {
+    "customerId": "cust_9340",
+    "email": "chris.baker@example.com"
+  }
+}

--- a/packages/create-eventcatalog/templates/default/domains/Orders/services/ShippingService/events/DeliveryFailed/examples/damaged-in-transit.json
+++ b/packages/create-eventcatalog/templates/default/domains/Orders/services/ShippingService/events/DeliveryFailed/examples/damaged-in-transit.json
@@ -1,0 +1,33 @@
+{
+  "eventId": "evt_df_60115",
+  "shipmentId": "shp_84410",
+  "orderId": "ord_10703",
+  "failedAt": "2026-03-13T08:20:00Z",
+  "carrier": "FedEx",
+  "trackingNumber": "FX7829042104",
+  "failureReason": "damaged_in_transit",
+  "failureDetails": "Package damaged in transit. Item was returned to the warehouse for inspection.",
+  "deliveryAttempts": 0,
+  "damageReport": {
+    "reportId": "dmg_5501",
+    "severity": "major",
+    "description": "Outer packaging crushed, visible damage to contents",
+    "reportedBy": "warehouse_staff",
+    "photos": [
+      "https://cdn.shipping.example.com/damage-reports/dmg_5501_01.jpg",
+      "https://cdn.shipping.example.com/damage-reports/dmg_5501_02.jpg"
+    ]
+  },
+  "destination": {
+    "line1": "88 River Road",
+    "city": "Portland",
+    "state": "OR",
+    "zipCode": "97201",
+    "country": "US"
+  },
+  "nextAction": "reship_order",
+  "customer": {
+    "customerId": "cust_9412",
+    "email": "sam.nguyen@example.com"
+  }
+}

--- a/packages/create-eventcatalog/templates/default/domains/Orders/services/ShippingService/events/DeliveryFailed/examples/examples.config.yaml
+++ b/packages/create-eventcatalog/templates/default/domains/Orders/services/ShippingService/events/DeliveryFailed/examples/examples.config.yaml
@@ -1,0 +1,23 @@
+address-not-found.json:
+  name: Address Not Found
+  summary: Delivery failed because the provided address could not be located by the carrier.
+  usage: |
+    curl -X POST http://localhost:3000/events/publish \
+      -H "Content-Type: application/json" \
+      -d @address-not-found.json
+
+customer-unavailable.json:
+  name: Customer Unavailable
+  summary: Three delivery attempts were made but the customer was not available to receive the package.
+  usage: |
+    curl -X POST http://localhost:3000/events/publish \
+      -H "Content-Type: application/json" \
+      -d @customer-unavailable.json
+
+damaged-in-transit.json:
+  name: Damaged in Transit
+  summary: Package was damaged during shipping and returned to the warehouse for inspection.
+  usage: |
+    curl -X POST http://localhost:3000/events/publish \
+      -H "Content-Type: application/json" \
+      -d @damaged-in-transit.json

--- a/packages/create-eventcatalog/templates/default/domains/Orders/services/ShippingService/events/ReturnInitiated/examples/defective-item.json
+++ b/packages/create-eventcatalog/templates/default/domains/Orders/services/ShippingService/events/ReturnInitiated/examples/defective-item.json
@@ -1,0 +1,33 @@
+{
+  "eventId": "evt_ret_70301",
+  "returnId": "ret_22010",
+  "shipmentId": "shp_88190",
+  "orderId": "ord_10450",
+  "initiatedAt": "2026-03-09T10:22:00Z",
+  "reason": "defective_item",
+  "reasonDetails": "Screen has a dead pixel cluster in the upper-left corner. Noticed after unboxing.",
+  "items": [
+    {
+      "itemId": "item_30291",
+      "sku": "ELEC-MON-27-4K",
+      "name": "27\" 4K Monitor",
+      "quantity": 1,
+      "pricePerUnit": 449.99
+    }
+  ],
+  "customer": {
+    "customerId": "cust_8842",
+    "email": "alex.rivera@example.com"
+  },
+  "returnMethod": "carrier_pickup",
+  "returnLabel": {
+    "carrier": "UPS",
+    "trackingNumber": "1Z9R8F030392811204",
+    "labelUrl": "https://cdn.shipping.example.com/return-labels/ret_22010.pdf"
+  },
+  "refundEstimate": {
+    "amount": 449.99,
+    "currency": "USD",
+    "method": "original_payment"
+  }
+}

--- a/packages/create-eventcatalog/templates/default/domains/Orders/services/ShippingService/events/ReturnInitiated/examples/examples.config.yaml
+++ b/packages/create-eventcatalog/templates/default/domains/Orders/services/ShippingService/events/ReturnInitiated/examples/examples.config.yaml
@@ -1,0 +1,15 @@
+defective-item.json:
+  name: Defective Item Return
+  summary: A return initiated for a defective monitor with a dead pixel, scheduled for carrier pickup with full refund.
+  usage: |
+    curl -X POST http://localhost:3000/events/publish \
+      -H "Content-Type: application/json" \
+      -d @defective-item.json
+
+wrong-item.json:
+  name: Wrong Item Received
+  summary: A return initiated because the customer received the wrong product, with drop-off return and automatic reshipping.
+  usage: |
+    curl -X POST http://localhost:3000/events/publish \
+      -H "Content-Type: application/json" \
+      -d @wrong-item.json

--- a/packages/create-eventcatalog/templates/default/domains/Orders/services/ShippingService/events/ReturnInitiated/examples/wrong-item.json
+++ b/packages/create-eventcatalog/templates/default/domains/Orders/services/ShippingService/events/ReturnInitiated/examples/wrong-item.json
@@ -1,0 +1,51 @@
+{
+  "eventId": "evt_ret_70305",
+  "returnId": "ret_22014",
+  "shipmentId": "shp_88201",
+  "orderId": "ord_10468",
+  "initiatedAt": "2026-03-10T08:15:00Z",
+  "reason": "wrong_item",
+  "reasonDetails": "Ordered navy blue running shoes size 10, received black hiking boots size 11.",
+  "items": [
+    {
+      "itemId": "item_30310",
+      "sku": "SHOE-HIKE-BLK-11",
+      "name": "Trail Hiking Boots - Black (Size 11)",
+      "quantity": 1,
+      "pricePerUnit": 129.95
+    }
+  ],
+  "expectedItems": [
+    {
+      "sku": "SHOE-RUN-NVY-10",
+      "name": "Performance Running Shoes - Navy (Size 10)",
+      "quantity": 1
+    }
+  ],
+  "customer": {
+    "customerId": "cust_9103",
+    "email": "jamie.patel@example.com"
+  },
+  "returnMethod": "drop_off",
+  "dropOffLocations": [
+    {
+      "name": "UPS Store - Downtown",
+      "address": "142 Main St, Portland, OR 97201"
+    },
+    {
+      "name": "UPS Store - Mall",
+      "address": "8500 SE Sunnyside Rd, Portland, OR 97086"
+    }
+  ],
+  "returnLabel": {
+    "carrier": "UPS",
+    "trackingNumber": "1Z9R8F030392811280",
+    "labelUrl": "https://cdn.shipping.example.com/return-labels/ret_22014.pdf"
+  },
+  "refundEstimate": {
+    "amount": 129.95,
+    "currency": "USD",
+    "method": "original_payment"
+  },
+  "reshipping": true
+}

--- a/packages/create-eventcatalog/templates/default/domains/Orders/services/ShippingService/events/ShipmentCreated/examples/examples.config.yaml
+++ b/packages/create-eventcatalog/templates/default/domains/Orders/services/ShippingService/events/ShipmentCreated/examples/examples.config.yaml
@@ -1,0 +1,15 @@
+single-package.json:
+  name: Single Package Shipment
+  summary: A new shipment created with a single package containing two books, shipped via standard USPS.
+  usage: |
+    curl -X POST http://localhost:3000/events/publish \
+      -H "Content-Type: application/json" \
+      -d @single-package.json
+
+multi-package.json:
+  name: Multi-Package Shipment
+  summary: A new shipment created with two packages (monitor and peripherals) for express delivery via FedEx.
+  usage: |
+    curl -X POST http://localhost:3000/events/publish \
+      -H "Content-Type: application/json" \
+      -d @multi-package.json

--- a/packages/create-eventcatalog/templates/default/domains/Orders/services/ShippingService/events/ShipmentCreated/examples/multi-package.json
+++ b/packages/create-eventcatalog/templates/default/domains/Orders/services/ShippingService/events/ShipmentCreated/examples/multi-package.json
@@ -1,0 +1,76 @@
+{
+  "eventId": "evt_sc_12005",
+  "shipmentId": "shp_88245",
+  "orderId": "ord_10558",
+  "createdAt": "2026-03-10T11:00:00Z",
+  "status": "created",
+  "customer": {
+    "customerId": "cust_9225",
+    "name": "David Kim",
+    "email": "david.kim@example.com"
+  },
+  "shippingAddress": {
+    "line1": "500 Technology Square",
+    "line2": "Apt 12B",
+    "city": "San Francisco",
+    "state": "CA",
+    "zipCode": "94105",
+    "country": "US"
+  },
+  "shippingMethod": "express",
+  "carrier": "FedEx",
+  "packages": [
+    {
+      "packageId": "pkg_44350",
+      "weightKg": 8.5,
+      "dimensions": {
+        "lengthCm": 60,
+        "widthCm": 45,
+        "heightCm": 35
+      },
+      "items": [
+        {
+          "itemId": "item_30420",
+          "sku": "ELEC-MON-32-4K",
+          "name": "32\" 4K Professional Monitor",
+          "quantity": 1
+        }
+      ],
+      "fragile": true
+    },
+    {
+      "packageId": "pkg_44351",
+      "weightKg": 3.2,
+      "dimensions": {
+        "lengthCm": 40,
+        "widthCm": 30,
+        "heightCm": 20
+      },
+      "items": [
+        {
+          "itemId": "item_30421",
+          "sku": "ELEC-KB-MECH-01",
+          "name": "Mechanical Keyboard",
+          "quantity": 1
+        },
+        {
+          "itemId": "item_30422",
+          "sku": "ELEC-MOUSE-ERG-01",
+          "name": "Ergonomic Wireless Mouse",
+          "quantity": 1
+        },
+        {
+          "itemId": "item_30423",
+          "sku": "ELEC-DOCK-USB-01",
+          "name": "USB-C Docking Station",
+          "quantity": 1
+        }
+      ]
+    }
+  ],
+  "estimatedDelivery": "2026-03-12T14:00:00Z",
+  "shippingCost": {
+    "amount": 24.99,
+    "currency": "USD"
+  }
+}

--- a/packages/create-eventcatalog/templates/default/domains/Orders/services/ShippingService/events/ShipmentCreated/examples/single-package.json
+++ b/packages/create-eventcatalog/templates/default/domains/Orders/services/ShippingService/events/ShipmentCreated/examples/single-package.json
@@ -1,0 +1,51 @@
+{
+  "eventId": "evt_sc_12001",
+  "shipmentId": "shp_88240",
+  "orderId": "ord_10550",
+  "createdAt": "2026-03-10T07:30:00Z",
+  "status": "created",
+  "customer": {
+    "customerId": "cust_9210",
+    "name": "Emily Watson",
+    "email": "emily.watson@example.com"
+  },
+  "shippingAddress": {
+    "line1": "742 Evergreen Terrace",
+    "city": "Austin",
+    "state": "TX",
+    "zipCode": "73301",
+    "country": "US"
+  },
+  "shippingMethod": "standard",
+  "carrier": "USPS",
+  "packages": [
+    {
+      "packageId": "pkg_44320",
+      "weightKg": 1.2,
+      "dimensions": {
+        "lengthCm": 25,
+        "widthCm": 18,
+        "heightCm": 10
+      },
+      "items": [
+        {
+          "itemId": "item_30400",
+          "sku": "BOOK-PROG-TS-01",
+          "name": "Programming TypeScript",
+          "quantity": 1
+        },
+        {
+          "itemId": "item_30401",
+          "sku": "BOOK-PROG-RS-01",
+          "name": "The Rust Programming Language",
+          "quantity": 1
+        }
+      ]
+    }
+  ],
+  "estimatedDelivery": "2026-03-16T18:00:00Z",
+  "shippingCost": {
+    "amount": 5.99,
+    "currency": "USD"
+  }
+}

--- a/packages/create-eventcatalog/templates/default/domains/Orders/services/ShippingService/events/ShipmentDelivered/examples/examples.config.yaml
+++ b/packages/create-eventcatalog/templates/default/domains/Orders/services/ShippingService/events/ShipmentDelivered/examples/examples.config.yaml
@@ -1,0 +1,15 @@
+front-door-delivery.json:
+  name: Front Door Delivery
+  summary: A standard delivery left at the customer's front door with photo proof of delivery.
+  usage: |
+    curl -X POST http://localhost:3000/events/publish \
+      -H "Content-Type: application/json" \
+      -d @front-door-delivery.json
+
+signed-delivery.json:
+  name: Signed Delivery
+  summary: A delivery requiring recipient signature, hand-delivered and signed by the customer.
+  usage: |
+    curl -X POST http://localhost:3000/events/publish \
+      -H "Content-Type: application/json" \
+      -d @signed-delivery.json

--- a/packages/create-eventcatalog/templates/default/domains/Orders/services/ShippingService/events/ShipmentDelivered/examples/front-door-delivery.json
+++ b/packages/create-eventcatalog/templates/default/domains/Orders/services/ShippingService/events/ShipmentDelivered/examples/front-door-delivery.json
@@ -1,0 +1,30 @@
+{
+  "eventId": "evt_del_40210",
+  "shipmentId": "shp_88214",
+  "orderId": "ord_10482",
+  "deliveredAt": "2026-03-14T11:42:00Z",
+  "carrier": "FedEx",
+  "trackingNumber": "FX7829041635",
+  "deliveryType": "front_door",
+  "signatureRequired": false,
+  "deliveryLocation": {
+    "type": "front_door",
+    "notes": "Left at front door per customer instructions"
+  },
+  "proofOfDelivery": {
+    "photoUrl": "https://cdn.shipping.example.com/delivery-photos/shp_88214.jpg",
+    "gpsCoordinates": {
+      "latitude": 42.3601,
+      "longitude": -71.0589
+    }
+  },
+  "recipient": {
+    "name": "Sarah Johnson",
+    "address": {
+      "city": "Boston",
+      "state": "MA",
+      "zipCode": "02101",
+      "country": "US"
+    }
+  }
+}

--- a/packages/create-eventcatalog/templates/default/domains/Orders/services/ShippingService/events/ShipmentDelivered/examples/signed-delivery.json
+++ b/packages/create-eventcatalog/templates/default/domains/Orders/services/ShippingService/events/ShipmentDelivered/examples/signed-delivery.json
@@ -1,0 +1,31 @@
+{
+  "eventId": "evt_del_40215",
+  "shipmentId": "shp_88220",
+  "orderId": "ord_10517",
+  "deliveredAt": "2026-03-12T15:08:00Z",
+  "carrier": "UPS",
+  "trackingNumber": "1Z9R8F030392847582",
+  "deliveryType": "signed",
+  "signatureRequired": true,
+  "deliveryLocation": {
+    "type": "hand_delivered",
+    "notes": "Signed by recipient at front door"
+  },
+  "proofOfDelivery": {
+    "signedBy": "Michael Chen",
+    "signatureUrl": "https://cdn.shipping.example.com/signatures/shp_88220.png",
+    "gpsCoordinates": {
+      "latitude": 40.7128,
+      "longitude": -74.006
+    }
+  },
+  "recipient": {
+    "name": "Michael Chen",
+    "address": {
+      "city": "New York",
+      "state": "NY",
+      "zipCode": "10001",
+      "country": "US"
+    }
+  }
+}

--- a/packages/create-eventcatalog/templates/default/domains/Orders/services/ShippingService/events/ShipmentDispatched/examples/examples.config.yaml
+++ b/packages/create-eventcatalog/templates/default/domains/Orders/services/ShippingService/events/ShipmentDispatched/examples/examples.config.yaml
@@ -1,0 +1,15 @@
+standard-shipping.json:
+  name: Standard Shipping Dispatch
+  summary: A shipment dispatched via standard ground shipping from the East Coast warehouse to Boston.
+  usage: |
+    curl -X POST http://localhost:3000/events/publish \
+      -H "Content-Type: application/json" \
+      -d @standard-shipping.json
+
+express-shipping.json:
+  name: Express Shipping Dispatch
+  summary: A high-priority express shipment dispatched for next-day delivery via UPS.
+  usage: |
+    curl -X POST http://localhost:3000/events/publish \
+      -H "Content-Type: application/json" \
+      -d @express-shipping.json

--- a/packages/create-eventcatalog/templates/default/domains/Orders/services/ShippingService/events/ShipmentDispatched/examples/express-shipping.json
+++ b/packages/create-eventcatalog/templates/default/domains/Orders/services/ShippingService/events/ShipmentDispatched/examples/express-shipping.json
@@ -1,0 +1,33 @@
+{
+  "eventId": "evt_sd_29302",
+  "shipmentId": "shp_88215",
+  "orderId": "ord_10499",
+  "dispatchedAt": "2026-03-10T14:30:00Z",
+  "carrier": "UPS",
+  "trackingNumber": "1Z9R8F030392847561",
+  "shippingMethod": "express",
+  "estimatedDelivery": "2026-03-11T12:00:00Z",
+  "priority": true,
+  "warehouse": {
+    "id": "wh_central_03",
+    "name": "Central Fulfillment Hub",
+    "location": "Chicago, IL"
+  },
+  "destination": {
+    "city": "Minneapolis",
+    "state": "MN",
+    "zipCode": "55401",
+    "country": "US"
+  },
+  "packages": [
+    {
+      "packageId": "pkg_44210",
+      "weightKg": 0.8,
+      "dimensions": {
+        "lengthCm": 22,
+        "widthCm": 15,
+        "heightCm": 10
+      }
+    }
+  ]
+}

--- a/packages/create-eventcatalog/templates/default/domains/Orders/services/ShippingService/events/ShipmentDispatched/examples/standard-shipping.json
+++ b/packages/create-eventcatalog/templates/default/domains/Orders/services/ShippingService/events/ShipmentDispatched/examples/standard-shipping.json
@@ -1,0 +1,32 @@
+{
+  "eventId": "evt_sd_29301",
+  "shipmentId": "shp_88214",
+  "orderId": "ord_10482",
+  "dispatchedAt": "2026-03-10T09:15:00Z",
+  "carrier": "FedEx",
+  "trackingNumber": "FX7829041635",
+  "shippingMethod": "standard",
+  "estimatedDelivery": "2026-03-15T18:00:00Z",
+  "warehouse": {
+    "id": "wh_east_01",
+    "name": "East Coast Distribution Center",
+    "location": "Newark, NJ"
+  },
+  "destination": {
+    "city": "Boston",
+    "state": "MA",
+    "zipCode": "02101",
+    "country": "US"
+  },
+  "packages": [
+    {
+      "packageId": "pkg_44102",
+      "weightKg": 2.3,
+      "dimensions": {
+        "lengthCm": 30,
+        "widthCm": 20,
+        "heightCm": 15
+      }
+    }
+  ]
+}

--- a/packages/create-eventcatalog/templates/default/domains/Orders/services/ShippingService/events/ShipmentInTransit/examples/domestic-transit.json
+++ b/packages/create-eventcatalog/templates/default/domains/Orders/services/ShippingService/events/ShipmentInTransit/examples/domestic-transit.json
@@ -1,0 +1,48 @@
+{
+  "eventId": "evt_tr_55010",
+  "shipmentId": "shp_88214",
+  "orderId": "ord_10482",
+  "timestamp": "2026-03-12T06:20:00Z",
+  "carrier": "FedEx",
+  "trackingNumber": "FX7829041635",
+  "transitType": "domestic",
+  "currentLocation": {
+    "facility": "FedEx Ground Hub",
+    "city": "Hartford",
+    "state": "CT",
+    "country": "US",
+    "coordinates": {
+      "latitude": 41.7658,
+      "longitude": -72.6734
+    }
+  },
+  "origin": {
+    "city": "Newark",
+    "state": "NJ",
+    "country": "US"
+  },
+  "destination": {
+    "city": "Boston",
+    "state": "MA",
+    "country": "US"
+  },
+  "status": "in_transit",
+  "estimatedDelivery": "2026-03-15T18:00:00Z",
+  "transitHistory": [
+    {
+      "location": "Newark, NJ",
+      "status": "picked_up",
+      "timestamp": "2026-03-10T09:15:00Z"
+    },
+    {
+      "location": "Edison, NJ",
+      "status": "departed_facility",
+      "timestamp": "2026-03-10T22:00:00Z"
+    },
+    {
+      "location": "Hartford, CT",
+      "status": "arrived_at_facility",
+      "timestamp": "2026-03-12T06:20:00Z"
+    }
+  ]
+}

--- a/packages/create-eventcatalog/templates/default/domains/Orders/services/ShippingService/events/ShipmentInTransit/examples/examples.config.yaml
+++ b/packages/create-eventcatalog/templates/default/domains/Orders/services/ShippingService/events/ShipmentInTransit/examples/examples.config.yaml
@@ -1,0 +1,15 @@
+domestic-transit.json:
+  name: Domestic Transit Update
+  summary: A shipment moving between facilities within the US, currently at a ground hub in Connecticut.
+  usage: |
+    curl -X POST http://localhost:3000/events/publish \
+      -H "Content-Type: application/json" \
+      -d @domestic-transit.json
+
+international-transit.json:
+  name: International Transit Update
+  summary: An international shipment routed through London with customs clearance, en route from the US to Germany.
+  usage: |
+    curl -X POST http://localhost:3000/events/publish \
+      -H "Content-Type: application/json" \
+      -d @international-transit.json

--- a/packages/create-eventcatalog/templates/default/domains/Orders/services/ShippingService/events/ShipmentInTransit/examples/international-transit.json
+++ b/packages/create-eventcatalog/templates/default/domains/Orders/services/ShippingService/events/ShipmentInTransit/examples/international-transit.json
@@ -1,0 +1,61 @@
+{
+  "eventId": "evt_tr_55018",
+  "shipmentId": "shp_88230",
+  "orderId": "ord_10534",
+  "timestamp": "2026-03-11T18:45:00Z",
+  "carrier": "DHL",
+  "trackingNumber": "DHL4829173650",
+  "transitType": "international",
+  "currentLocation": {
+    "facility": "DHL International Gateway",
+    "city": "London",
+    "country": "GB",
+    "coordinates": {
+      "latitude": 51.47,
+      "longitude": -0.4543
+    }
+  },
+  "origin": {
+    "city": "New York",
+    "state": "NY",
+    "country": "US"
+  },
+  "destination": {
+    "city": "Berlin",
+    "country": "DE"
+  },
+  "status": "in_transit",
+  "estimatedDelivery": "2026-03-16T14:00:00Z",
+  "customs": {
+    "status": "cleared",
+    "clearedAt": "2026-03-11T14:30:00Z",
+    "declarationNumber": "GB-CUS-2026-0384751"
+  },
+  "transitHistory": [
+    {
+      "location": "New York, US",
+      "status": "picked_up",
+      "timestamp": "2026-03-09T16:00:00Z"
+    },
+    {
+      "location": "JFK Airport, US",
+      "status": "departed_country",
+      "timestamp": "2026-03-10T02:30:00Z"
+    },
+    {
+      "location": "London Heathrow, GB",
+      "status": "arrived_at_hub",
+      "timestamp": "2026-03-11T10:15:00Z"
+    },
+    {
+      "location": "London, GB",
+      "status": "customs_cleared",
+      "timestamp": "2026-03-11T14:30:00Z"
+    },
+    {
+      "location": "London, GB",
+      "status": "in_transit_to_destination",
+      "timestamp": "2026-03-11T18:45:00Z"
+    }
+  ]
+}

--- a/packages/create-eventcatalog/templates/default/domains/Payment/services/FraudDetectionService/events/FraudCheckCompleted/examples/check-flagged.json
+++ b/packages/create-eventcatalog/templates/default/domains/Payment/services/FraudDetectionService/events/FraudCheckCompleted/examples/check-flagged.json
@@ -1,0 +1,50 @@
+{
+  "eventId": "evt_fc_a7b8c9d0-7890-bcde-f012-345678901234",
+  "timestamp": "2024-03-16T19:05:50.219Z",
+  "type": "FraudCheckCompleted",
+  "source": "fraud-detection-service",
+  "data": {
+    "checkId": "chk_9e0f1a2b-3c4d-5e6f-7a8b-9c0d1e2f3a4b",
+    "assessmentId": "risk_4d5e6f7a-8b9c-0d1e-2f3a-4b5c6d7e8f9a",
+    "paymentId": "pay_6f7a8b9c-0d1e-2f3a-4b5c-6d7e8f9a0b1c",
+    "orderId": "ord_92860445",
+    "customerId": "cust_31207",
+    "result": "flagged",
+    "riskScore": 82,
+    "riskLevel": "high",
+    "checksPerformed": [
+      {
+        "name": "identity_verification",
+        "status": "passed",
+        "details": "Customer identity verified"
+      },
+      {
+        "name": "card_bin_check",
+        "status": "passed",
+        "details": "Card BIN matches issuing bank"
+      },
+      {
+        "name": "address_verification",
+        "status": "warning",
+        "details": "AVS returned partial match - postal code mismatch"
+      },
+      {
+        "name": "geolocation_check",
+        "status": "failed",
+        "details": "IP geolocation (Lagos, Nigeria) does not match billing country (US)"
+      },
+      {
+        "name": "impossible_travel_check",
+        "status": "failed",
+        "details": "Impossible travel detected between Portland, OR and Lagos in 2 hours"
+      }
+    ],
+    "processingTimeMs": 1205,
+    "fraudDetected": true,
+    "completedAt": "2024-03-16T19:05:50.219Z"
+  },
+  "metadata": {
+    "correlationId": "corr_11aa22bb-33cc-44dd-55ee-66ff77008899",
+    "modelVersion": "fraud-ml-v3.2.1"
+  }
+}

--- a/packages/create-eventcatalog/templates/default/domains/Payment/services/FraudDetectionService/events/FraudCheckCompleted/examples/check-passed.json
+++ b/packages/create-eventcatalog/templates/default/domains/Payment/services/FraudDetectionService/events/FraudCheckCompleted/examples/check-passed.json
@@ -1,0 +1,45 @@
+{
+  "eventId": "evt_fc_f6a7b8c9-6789-abcd-ef01-234567890123",
+  "timestamp": "2024-03-15T10:59:05.118Z",
+  "type": "FraudCheckCompleted",
+  "source": "fraud-detection-service",
+  "data": {
+    "checkId": "chk_3a4b5c6d-7e8f-9a0b-1c2d-3e4f5a6b7c8d",
+    "assessmentId": "risk_7a8b9c0d-1e2f-3a4b-5c6d-7e8f9a0b1c2d",
+    "paymentId": "pay_4b5c6d7e-8f9a-0b1c-2d3e-4f5a6b7c8d9e",
+    "orderId": "ord_92840123",
+    "customerId": "cust_10482",
+    "result": "passed",
+    "riskScore": 12,
+    "riskLevel": "low",
+    "checksPerformed": [
+      {
+        "name": "identity_verification",
+        "status": "passed",
+        "details": "Customer identity verified against government records"
+      },
+      {
+        "name": "card_bin_check",
+        "status": "passed",
+        "details": "Card BIN matches issuing bank in expected region"
+      },
+      {
+        "name": "address_verification",
+        "status": "passed",
+        "details": "AVS check returned full match on street and postal code"
+      },
+      {
+        "name": "velocity_check",
+        "status": "passed",
+        "details": "Transaction frequency within normal parameters"
+      }
+    ],
+    "processingTimeMs": 342,
+    "fraudDetected": false,
+    "completedAt": "2024-03-15T10:59:05.118Z"
+  },
+  "metadata": {
+    "correlationId": "corr_b2c3d4e5-f6a7-8901-bcde-f23456789012",
+    "modelVersion": "fraud-ml-v3.2.1"
+  }
+}

--- a/packages/create-eventcatalog/templates/default/domains/Payment/services/FraudDetectionService/events/FraudCheckCompleted/examples/examples.config.yaml
+++ b/packages/create-eventcatalog/templates/default/domains/Payment/services/FraudDetectionService/events/FraudCheckCompleted/examples/examples.config.yaml
@@ -1,0 +1,15 @@
+check-passed.json:
+  name: Check Passed
+  summary: All fraud checks passed for a low-risk returning customer. Identity, card BIN, address, and velocity checks all cleared in 342ms.
+  usage: |
+    curl -X POST http://localhost:3000/events/publish \
+      -H "Content-Type: application/json" \
+      -d @check-passed.json
+
+check-flagged.json:
+  name: Check Flagged
+  summary: Fraud check flagged due to geolocation mismatch and impossible travel detection. Address verification returned a partial match.
+  usage: |
+    curl -X POST http://localhost:3000/events/publish \
+      -H "Content-Type: application/json" \
+      -d @check-flagged.json

--- a/packages/create-eventcatalog/templates/default/domains/Payment/services/PaymentGatewayService/events/PaymentFailed/examples/card-declined.json
+++ b/packages/create-eventcatalog/templates/default/domains/Payment/services/PaymentGatewayService/events/PaymentFailed/examples/card-declined.json
@@ -1,0 +1,38 @@
+{
+  "eventId": "evt_pf_8a3b1c9d-4e5f-6a7b-8c9d-0e1f2a3b4c5d",
+  "timestamp": "2024-03-15T14:23:47.892Z",
+  "type": "PaymentFailed",
+  "source": "payment-gateway-service",
+  "data": {
+    "paymentId": "pay_7f8e9d0c-1b2a-3c4d-5e6f-7a8b9c0d1e2f",
+    "orderId": "ord_92847561",
+    "customerId": "cust_10482",
+    "amount": 249.99,
+    "currency": "USD",
+    "paymentMethod": {
+      "type": "credit_card",
+      "brand": "visa",
+      "last4": "4242",
+      "expiryMonth": 11,
+      "expiryYear": 2026
+    },
+    "failureReason": "card_declined",
+    "failureCode": "DECLINED_GENERIC",
+    "failureMessage": "The card was declined. Please contact your card issuer for more information.",
+    "gatewayResponse": {
+      "gatewayId": "gw_stripe",
+      "transactionId": "txn_3PqR5sT7uV9wX1y",
+      "responseCode": "05",
+      "avsCheck": "pass",
+      "cvvCheck": "pass"
+    },
+    "retryable": true,
+    "attemptNumber": 1,
+    "maxAttempts": 3
+  },
+  "metadata": {
+    "correlationId": "corr_a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    "ipAddress": "192.168.1.42",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)"
+  }
+}

--- a/packages/create-eventcatalog/templates/default/domains/Payment/services/PaymentGatewayService/events/PaymentFailed/examples/examples.config.yaml
+++ b/packages/create-eventcatalog/templates/default/domains/Payment/services/PaymentGatewayService/events/PaymentFailed/examples/examples.config.yaml
@@ -1,0 +1,23 @@
+card-declined.json:
+  name: Card Declined
+  summary: Payment failed because the card was declined by the issuing bank with a generic decline code.
+  usage: |
+    curl -X POST http://localhost:3000/events/publish \
+      -H "Content-Type: application/json" \
+      -d @card-declined.json
+
+insufficient-funds.json:
+  name: Insufficient Funds
+  summary: Payment failed due to insufficient funds on a Mastercard for a high-value order.
+  usage: |
+    curl -X POST http://localhost:3000/events/publish \
+      -H "Content-Type: application/json" \
+      -d @insufficient-funds.json
+
+expired-card.json:
+  name: Expired Card
+  summary: Payment failed because the customer attempted to use an expired Amex card. This failure is non-retryable.
+  usage: |
+    curl -X POST http://localhost:3000/events/publish \
+      -H "Content-Type: application/json" \
+      -d @expired-card.json

--- a/packages/create-eventcatalog/templates/default/domains/Payment/services/PaymentGatewayService/events/PaymentFailed/examples/expired-card.json
+++ b/packages/create-eventcatalog/templates/default/domains/Payment/services/PaymentGatewayService/events/PaymentFailed/examples/expired-card.json
@@ -1,0 +1,38 @@
+{
+  "eventId": "evt_pf_5c6d7e8f-9a0b-1c2d-3e4f-5a6b7c8d9e0f",
+  "timestamp": "2024-03-16T09:12:05.671Z",
+  "type": "PaymentFailed",
+  "source": "payment-gateway-service",
+  "data": {
+    "paymentId": "pay_9e8d7c6b-5a4f-3e2d-1c0b-9a8f7e6d5c4b",
+    "orderId": "ord_92853298",
+    "customerId": "cust_30692",
+    "amount": 54.5,
+    "currency": "EUR",
+    "paymentMethod": {
+      "type": "credit_card",
+      "brand": "amex",
+      "last4": "1003",
+      "expiryMonth": 1,
+      "expiryYear": 2024
+    },
+    "failureReason": "expired_card",
+    "failureCode": "CARD_EXPIRED",
+    "failureMessage": "The card has expired. Please use a different payment method.",
+    "gatewayResponse": {
+      "gatewayId": "gw_stripe",
+      "transactionId": "txn_OpQrStUvWxYz123",
+      "responseCode": "54",
+      "avsCheck": "unavailable",
+      "cvvCheck": "fail"
+    },
+    "retryable": false,
+    "attemptNumber": 1,
+    "maxAttempts": 3
+  },
+  "metadata": {
+    "correlationId": "corr_11223344-5566-7788-99aa-bbccddeeff00",
+    "ipAddress": "172.16.0.55",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 17_3 like Mac OS X)"
+  }
+}

--- a/packages/create-eventcatalog/templates/default/domains/Payment/services/PaymentGatewayService/events/PaymentFailed/examples/insufficient-funds.json
+++ b/packages/create-eventcatalog/templates/default/domains/Payment/services/PaymentGatewayService/events/PaymentFailed/examples/insufficient-funds.json
@@ -1,0 +1,38 @@
+{
+  "eventId": "evt_pf_2d3e4f5a-6b7c-8d9e-0f1a-2b3c4d5e6f7a",
+  "timestamp": "2024-03-15T16:45:12.334Z",
+  "type": "PaymentFailed",
+  "source": "payment-gateway-service",
+  "data": {
+    "paymentId": "pay_1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
+    "orderId": "ord_92851034",
+    "customerId": "cust_20571",
+    "amount": 1299.0,
+    "currency": "USD",
+    "paymentMethod": {
+      "type": "credit_card",
+      "brand": "mastercard",
+      "last4": "8910",
+      "expiryMonth": 3,
+      "expiryYear": 2027
+    },
+    "failureReason": "insufficient_funds",
+    "failureCode": "INSUFFICIENT_FUNDS",
+    "failureMessage": "The card has insufficient funds to complete this transaction.",
+    "gatewayResponse": {
+      "gatewayId": "gw_stripe",
+      "transactionId": "txn_9AbCdEfGhIjKlMn",
+      "responseCode": "51",
+      "avsCheck": "pass",
+      "cvvCheck": "pass"
+    },
+    "retryable": true,
+    "attemptNumber": 1,
+    "maxAttempts": 3
+  },
+  "metadata": {
+    "correlationId": "corr_f7e6d5c4-b3a2-1098-7654-321fedcba098",
+    "ipAddress": "10.0.0.88",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"
+  }
+}

--- a/packages/create-eventcatalog/templates/default/domains/Payment/services/PaymentService/events/PaymentInitiated/examples/examples.config.yaml
+++ b/packages/create-eventcatalog/templates/default/domains/Payment/services/PaymentService/events/PaymentInitiated/examples/examples.config.yaml
@@ -1,0 +1,15 @@
+standard-checkout.json:
+  name: Standard Checkout
+  summary: Payment initiated through the standard web checkout flow with a Visa credit card and multiple items.
+  usage: |
+    curl -X POST http://localhost:3000/events/publish \
+      -H "Content-Type: application/json" \
+      -d @standard-checkout.json
+
+express-checkout.json:
+  name: Express Checkout
+  summary: Payment initiated via Apple Pay express checkout on mobile for a single item with a discount code applied.
+  usage: |
+    curl -X POST http://localhost:3000/events/publish \
+      -H "Content-Type: application/json" \
+      -d @express-checkout.json

--- a/packages/create-eventcatalog/templates/default/domains/Payment/services/PaymentService/events/PaymentInitiated/examples/express-checkout.json
+++ b/packages/create-eventcatalog/templates/default/domains/Payment/services/PaymentService/events/PaymentInitiated/examples/express-checkout.json
@@ -1,0 +1,45 @@
+{
+  "eventId": "evt_pi_9f8e7d6c-5b4a-3f2e-1d0c-9b8a7f6e5d4c",
+  "timestamp": "2024-03-16T07:33:41.890Z",
+  "type": "PaymentInitiated",
+  "source": "payment-service",
+  "data": {
+    "paymentId": "pay_3e2d1c0b-9a8f-7e6d-5c4b-3a2f1e0d9c8b",
+    "orderId": "ord_92855010",
+    "customerId": "cust_55832",
+    "amount": 29.99,
+    "currency": "USD",
+    "paymentMethod": {
+      "type": "apple_pay",
+      "brand": "mastercard",
+      "last4": "7654",
+      "walletType": "apple_pay"
+    },
+    "checkoutType": "express",
+    "shippingAddress": {
+      "line1": "890 Broadway",
+      "city": "New York",
+      "state": "NY",
+      "postalCode": "10003",
+      "country": "US"
+    },
+    "items": [
+      {
+        "productId": "prod_8210",
+        "name": "Phone Case - Clear",
+        "quantity": 1,
+        "unitPrice": 29.99
+      }
+    ],
+    "discountCode": "SAVE10",
+    "taxAmount": 2.66,
+    "shippingCost": 0.0,
+    "initiatedAt": "2024-03-16T07:33:41.890Z"
+  },
+  "metadata": {
+    "correlationId": "corr_c3d4e5f6-a7b8-9012-cdef-345678901234",
+    "channel": "mobile_app",
+    "ipAddress": "10.0.0.201",
+    "sessionId": "sess_2r3s4t5u6v7w8x9y"
+  }
+}

--- a/packages/create-eventcatalog/templates/default/domains/Payment/services/PaymentService/events/PaymentInitiated/examples/standard-checkout.json
+++ b/packages/create-eventcatalog/templates/default/domains/Payment/services/PaymentService/events/PaymentInitiated/examples/standard-checkout.json
@@ -1,0 +1,52 @@
+{
+  "eventId": "evt_pi_1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
+  "timestamp": "2024-03-15T10:58:22.104Z",
+  "type": "PaymentInitiated",
+  "source": "payment-service",
+  "data": {
+    "paymentId": "pay_4b5c6d7e-8f9a-0b1c-2d3e-4f5a6b7c8d9e",
+    "orderId": "ord_92840123",
+    "customerId": "cust_10482",
+    "amount": 189.97,
+    "currency": "USD",
+    "paymentMethod": {
+      "type": "credit_card",
+      "brand": "visa",
+      "last4": "4242",
+      "expiryMonth": 11,
+      "expiryYear": 2026
+    },
+    "checkoutType": "standard",
+    "shippingAddress": {
+      "line1": "123 Main Street",
+      "city": "San Francisco",
+      "state": "CA",
+      "postalCode": "94102",
+      "country": "US"
+    },
+    "items": [
+      {
+        "productId": "prod_5001",
+        "name": "Wireless Headphones",
+        "quantity": 1,
+        "unitPrice": 149.99
+      },
+      {
+        "productId": "prod_5032",
+        "name": "USB-C Cable",
+        "quantity": 2,
+        "unitPrice": 19.99
+      }
+    ],
+    "discountCode": null,
+    "taxAmount": 15.58,
+    "shippingCost": 0.0,
+    "initiatedAt": "2024-03-15T10:58:22.104Z"
+  },
+  "metadata": {
+    "correlationId": "corr_b2c3d4e5-f6a7-8901-bcde-f23456789012",
+    "channel": "web",
+    "ipAddress": "192.168.1.42",
+    "sessionId": "sess_7k8l9m0n1o2p3q4r"
+  }
+}

--- a/packages/create-eventcatalog/templates/default/domains/Payment/services/PaymentService/events/PaymentProcessed/examples/examples.config.yaml
+++ b/packages/create-eventcatalog/templates/default/domains/Payment/services/PaymentService/events/PaymentProcessed/examples/examples.config.yaml
@@ -1,0 +1,15 @@
+successful-payment.json:
+  name: Successful Payment
+  summary: A standard credit card payment completed successfully for a domestic order with multiple items.
+  usage: |
+    curl -X POST http://localhost:3000/events/publish \
+      -H "Content-Type: application/json" \
+      -d @successful-payment.json
+
+international-payment.json:
+  name: International Payment
+  summary: Payment processed for an international order in GBP with currency conversion details included.
+  usage: |
+    curl -X POST http://localhost:3000/events/publish \
+      -H "Content-Type: application/json" \
+      -d @international-payment.json

--- a/packages/create-eventcatalog/templates/default/domains/Payment/services/PaymentService/events/PaymentProcessed/examples/international-payment.json
+++ b/packages/create-eventcatalog/templates/default/domains/Payment/services/PaymentService/events/PaymentProcessed/examples/international-payment.json
@@ -1,0 +1,48 @@
+{
+  "eventId": "evt_pp_d4e5f6a7-b8c9-0d1e-2f3a-4b5c6d7e8f9a",
+  "timestamp": "2024-03-15T18:22:10.556Z",
+  "type": "PaymentProcessed",
+  "source": "payment-service",
+  "data": {
+    "paymentId": "pay_8f9a0b1c-2d3e-4f5a-6b7c-8d9e0f1a2b3c",
+    "orderId": "ord_92847892",
+    "customerId": "cust_44219",
+    "amount": 74.5,
+    "currency": "GBP",
+    "paymentMethod": {
+      "type": "credit_card",
+      "brand": "mastercard",
+      "last4": "3391"
+    },
+    "status": "completed",
+    "transactionId": "txn_Uk4Lm5Np6Qr7St8",
+    "processingFee": 2.46,
+    "netAmount": 72.04,
+    "currencyConversion": {
+      "originalCurrency": "GBP",
+      "originalAmount": 74.5,
+      "convertedCurrency": "USD",
+      "convertedAmount": 94.27,
+      "exchangeRate": 1.2654
+    },
+    "billingAddress": {
+      "line1": "45 Oxford Road",
+      "city": "London",
+      "postalCode": "W1D 2DZ",
+      "country": "GB"
+    },
+    "items": [
+      {
+        "productId": "prod_7820",
+        "name": "Running Shoes - Size 10",
+        "quantity": 1,
+        "unitPrice": 74.5
+      }
+    ],
+    "completedAt": "2024-03-15T18:22:10.556Z"
+  },
+  "metadata": {
+    "correlationId": "corr_e5f6a7b8-c9d0-1e2f-3a4b-5c6d7e8f9a0b",
+    "channel": "mobile_app"
+  }
+}

--- a/packages/create-eventcatalog/templates/default/domains/Payment/services/PaymentService/events/PaymentProcessed/examples/successful-payment.json
+++ b/packages/create-eventcatalog/templates/default/domains/Payment/services/PaymentService/events/PaymentProcessed/examples/successful-payment.json
@@ -1,0 +1,48 @@
+{
+  "eventId": "evt_pp_a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "timestamp": "2024-03-15T11:04:33.218Z",
+  "type": "PaymentProcessed",
+  "source": "payment-service",
+  "data": {
+    "paymentId": "pay_4b5c6d7e-8f9a-0b1c-2d3e-4f5a6b7c8d9e",
+    "orderId": "ord_92840123",
+    "customerId": "cust_10482",
+    "amount": 189.97,
+    "currency": "USD",
+    "paymentMethod": {
+      "type": "credit_card",
+      "brand": "visa",
+      "last4": "4242"
+    },
+    "status": "completed",
+    "transactionId": "txn_XyZ1AbC2DeF3GhI",
+    "processingFee": 5.8,
+    "netAmount": 184.17,
+    "billingAddress": {
+      "line1": "123 Main Street",
+      "city": "San Francisco",
+      "state": "CA",
+      "postalCode": "94102",
+      "country": "US"
+    },
+    "items": [
+      {
+        "productId": "prod_5001",
+        "name": "Wireless Headphones",
+        "quantity": 1,
+        "unitPrice": 149.99
+      },
+      {
+        "productId": "prod_5032",
+        "name": "USB-C Cable",
+        "quantity": 2,
+        "unitPrice": 19.99
+      }
+    ],
+    "completedAt": "2024-03-15T11:04:33.218Z"
+  },
+  "metadata": {
+    "correlationId": "corr_b2c3d4e5-f6a7-8901-bcde-f23456789012",
+    "channel": "web"
+  }
+}

--- a/packages/create-eventcatalog/templates/default/domains/Subscriptions/services/BillingService/events/SubscriptionPaymentDue/examples/examples.config.yaml
+++ b/packages/create-eventcatalog/templates/default/domains/Subscriptions/services/BillingService/events/SubscriptionPaymentDue/examples/examples.config.yaml
@@ -1,0 +1,7 @@
+upcoming-renewal.json:
+  name: Upcoming Renewal Payment
+  summary: A payment reminder generated 3 days before a Pro Monthly subscription renewal is due.
+  usage: |
+    curl -X POST http://localhost:3000/events/publish \
+      -H "Content-Type: application/json" \
+      -d @upcoming-renewal.json

--- a/packages/create-eventcatalog/templates/default/domains/Subscriptions/services/BillingService/events/SubscriptionPaymentDue/examples/upcoming-renewal.json
+++ b/packages/create-eventcatalog/templates/default/domains/Subscriptions/services/BillingService/events/SubscriptionPaymentDue/examples/upcoming-renewal.json
@@ -1,0 +1,28 @@
+{
+  "eventId": "evt_pay_due_5a72bf",
+  "eventType": "SubscriptionPaymentDue",
+  "timestamp": "2024-04-12T06:00:00Z",
+  "data": {
+    "subscriptionId": "sub_9f84kd02",
+    "userId": "usr_28471",
+    "plan": {
+      "planId": "plan_monthly_pro",
+      "name": "Pro Monthly"
+    },
+    "amount": 32.39,
+    "currency": "USD",
+    "dueDate": "2024-04-15",
+    "billingPeriod": {
+      "start": "2024-04-15",
+      "end": "2024-05-15"
+    },
+    "paymentMethodId": "pm_card_4242",
+    "paymentMethodLast4": "4242",
+    "remindersSent": 1,
+    "daysUntilDue": 3
+  },
+  "metadata": {
+    "correlationId": "corr_due_001",
+    "version": "1.0.0"
+  }
+}

--- a/packages/create-eventcatalog/templates/default/domains/Subscriptions/services/SubscriptionService/events/UserSubscriptionCancelled/examples/examples.config.yaml
+++ b/packages/create-eventcatalog/templates/default/domains/Subscriptions/services/SubscriptionService/events/UserSubscriptionCancelled/examples/examples.config.yaml
@@ -1,0 +1,15 @@
+voluntary-cancellation.json:
+  name: Voluntary Cancellation
+  summary: A customer voluntarily cancels their Pro Monthly subscription, effective at the end of the current billing cycle.
+  usage: |
+    curl -X POST http://localhost:3000/events/publish \
+      -H "Content-Type: application/json" \
+      -d @voluntary-cancellation.json
+
+payment-failure.json:
+  name: Payment Failure Cancellation
+  summary: System automatically cancels an Enterprise Annual subscription after 3 consecutive failed payment attempts.
+  usage: |
+    curl -X POST http://localhost:3000/events/publish \
+      -H "Content-Type: application/json" \
+      -d @payment-failure.json

--- a/packages/create-eventcatalog/templates/default/domains/Subscriptions/services/SubscriptionService/events/UserSubscriptionCancelled/examples/payment-failure.json
+++ b/packages/create-eventcatalog/templates/default/domains/Subscriptions/services/SubscriptionService/events/UserSubscriptionCancelled/examples/payment-failure.json
@@ -1,0 +1,25 @@
+{
+  "eventId": "evt_sub_cancel_b19c3f",
+  "eventType": "UserSubscriptionCancelled",
+  "timestamp": "2024-07-03T08:12:55Z",
+  "data": {
+    "subscriptionId": "sub_7j21np48",
+    "userId": "usr_41839",
+    "plan": {
+      "planId": "plan_annual_enterprise",
+      "name": "Enterprise Annual"
+    },
+    "cancellationReason": "payment_failure",
+    "cancellationNote": "Automatic cancellation after 3 failed payment attempts",
+    "cancelledBy": "system",
+    "effectiveDate": "2024-07-03",
+    "refundAmount": 0,
+    "failedPaymentAttempts": 3,
+    "lastPaymentAttempt": "2024-07-02T23:00:00Z",
+    "subscriptionDurationDays": 182
+  },
+  "metadata": {
+    "correlationId": "corr_aa11bb22",
+    "version": "1.0.0"
+  }
+}

--- a/packages/create-eventcatalog/templates/default/domains/Subscriptions/services/SubscriptionService/events/UserSubscriptionCancelled/examples/voluntary-cancellation.json
+++ b/packages/create-eventcatalog/templates/default/domains/Subscriptions/services/SubscriptionService/events/UserSubscriptionCancelled/examples/voluntary-cancellation.json
@@ -1,0 +1,23 @@
+{
+  "eventId": "evt_sub_cancel_4d82ea",
+  "eventType": "UserSubscriptionCancelled",
+  "timestamp": "2024-05-20T16:45:12Z",
+  "data": {
+    "subscriptionId": "sub_9f84kd02",
+    "userId": "usr_28471",
+    "plan": {
+      "planId": "plan_monthly_pro",
+      "name": "Pro Monthly"
+    },
+    "cancellationReason": "no_longer_needed",
+    "cancellationNote": "Switching to a competitor product",
+    "cancelledBy": "customer",
+    "effectiveDate": "2024-06-15",
+    "refundAmount": 0,
+    "subscriptionDurationDays": 67
+  },
+  "metadata": {
+    "correlationId": "corr_cd45ef67",
+    "version": "1.0.0"
+  }
+}

--- a/packages/create-eventcatalog/templates/default/domains/Subscriptions/services/SubscriptionService/events/UserSubscriptionStarted/examples/annual-plan.json
+++ b/packages/create-eventcatalog/templates/default/domains/Subscriptions/services/SubscriptionService/events/UserSubscriptionStarted/examples/annual-plan.json
@@ -1,0 +1,26 @@
+{
+  "eventId": "evt_sub_start_e91f2a",
+  "eventType": "UserSubscriptionStarted",
+  "timestamp": "2024-06-01T14:05:33Z",
+  "data": {
+    "subscriptionId": "sub_3k72mf91",
+    "userId": "usr_55102",
+    "plan": {
+      "planId": "plan_annual_enterprise",
+      "name": "Enterprise Annual",
+      "billingCycle": "annual",
+      "price": 499.0,
+      "currency": "USD"
+    },
+    "trialPeriodDays": 0,
+    "startDate": "2024-06-01",
+    "nextBillingDate": "2025-06-01",
+    "paymentMethodId": "pm_card_1881",
+    "source": "sales_team",
+    "discountCode": "ENTERPRISE20"
+  },
+  "metadata": {
+    "correlationId": "corr_ff93aa12",
+    "version": "1.0.0"
+  }
+}

--- a/packages/create-eventcatalog/templates/default/domains/Subscriptions/services/SubscriptionService/events/UserSubscriptionStarted/examples/examples.config.yaml
+++ b/packages/create-eventcatalog/templates/default/domains/Subscriptions/services/SubscriptionService/events/UserSubscriptionStarted/examples/examples.config.yaml
@@ -1,0 +1,15 @@
+monthly-plan.json:
+  name: Monthly Plan Subscription
+  summary: A user subscribes to the Pro Monthly plan with a 14-day trial period via web checkout.
+  usage: |
+    curl -X POST http://localhost:3000/events/publish \
+      -H "Content-Type: application/json" \
+      -d @monthly-plan.json
+
+annual-plan.json:
+  name: Annual Enterprise Plan
+  summary: A user subscribes to the Enterprise Annual plan through the sales team with a discount code applied.
+  usage: |
+    curl -X POST http://localhost:3000/events/publish \
+      -H "Content-Type: application/json" \
+      -d @annual-plan.json

--- a/packages/create-eventcatalog/templates/default/domains/Subscriptions/services/SubscriptionService/events/UserSubscriptionStarted/examples/monthly-plan.json
+++ b/packages/create-eventcatalog/templates/default/domains/Subscriptions/services/SubscriptionService/events/UserSubscriptionStarted/examples/monthly-plan.json
@@ -1,0 +1,25 @@
+{
+  "eventId": "evt_sub_start_7a3b1c",
+  "eventType": "UserSubscriptionStarted",
+  "timestamp": "2024-03-15T09:22:41Z",
+  "data": {
+    "subscriptionId": "sub_9f84kd02",
+    "userId": "usr_28471",
+    "plan": {
+      "planId": "plan_monthly_pro",
+      "name": "Pro Monthly",
+      "billingCycle": "monthly",
+      "price": 29.99,
+      "currency": "USD"
+    },
+    "trialPeriodDays": 14,
+    "startDate": "2024-03-15",
+    "nextBillingDate": "2024-04-15",
+    "paymentMethodId": "pm_card_4242",
+    "source": "web_checkout"
+  },
+  "metadata": {
+    "correlationId": "corr_ab12cd34",
+    "version": "1.0.0"
+  }
+}


### PR DESCRIPTION
## Summary

- Add usage examples to all 18 events with schemas in the `create-eventcatalog` default template
- Each event gets 1-3 realistic JSON example files with an `examples.config.yaml` providing name, summary, and usage metadata
- New projects scaffolded with `create-eventcatalog` will include examples out of the box

## Test plan

- [ ] Scaffold a new project with `npx @eventcatalog/create-eventcatalog` and verify examples appear in event directories
- [ ] Verify examples render in the Schema Explorer "Usage Examples" tab (requires #2325)

🤖 Generated with [Claude Code](https://claude.com/claude-code)