### PR TITLE
fix(core): allow scalar configuration passthrough for OpenAPI spec component

### DIFF
--- a/.changeset/calm-waves-flow.md
+++ b/.changeset/calm-waves-flow.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+allow scalar configuration to be passed through to the OpenAPI spec component via `scalarConfiguration` config option

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/spec/[filename].astro
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/spec/[filename].astro
@@ -9,6 +9,7 @@ import { isEventCatalogChatEnabled } from '@utils/feature';
 import './_styles.css';
 import { Page } from './_[filename].data.ts';
 import { getAbsoluteFilePathForAstroFile } from '@utils/files';
+import config from '@config';
 
 export const prerender = Page.prerender;
 export const getStaticPaths = Page.getStaticPaths;
@@ -85,7 +86,7 @@ if (isRemote) {
             />
           </div>
         )}
-        <OpenAPISpec client:only="react" spec={content} />
+        <OpenAPISpec client:only="react" configuration={config?.scalarConfiguration} spec={content} />
       </div>
     )
   }

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/spec/_OpenAPI.tsx
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/spec/_OpenAPI.tsx
@@ -6,7 +6,10 @@ const ApiReferenceReact = lazy(() =>
   import('@scalar/api-reference-react').then((module) => ({ default: module.ApiReferenceReact }))
 );
 
-const OpenAPISpec = ({ spec }: { spec: string }) => {
+// Any Scalar Configuration for the OpenAPI Component.
+type ScalarConfiguration = any;
+
+const OpenAPISpec = ({ spec, configuration }: { spec: string; configuration?: ScalarConfiguration }) => {
   const [loaded, setLoaded] = useState(false);
   const [isDarkMode, setIsDarkMode] = useState(() => {
     return document.documentElement.getAttribute('data-theme') === 'dark';
@@ -52,6 +55,7 @@ const OpenAPISpec = ({ spec }: { spec: string }) => {
             hideDarkModeToggle: true,
             searchHotKey: 'p',
             showSidebar: true,
+            ...configuration,
           }}
         />
       </Suspense>

--- a/packages/core/src/eventcatalog.config.ts
+++ b/packages/core/src/eventcatalog.config.ts
@@ -76,6 +76,9 @@ type IntegrationsConfig = {
   debug?: boolean;
 };
 
+// Any Scalar Configuration for the OpenAPI Component.
+type ScalarConfiguration = any;
+
 export interface Config {
   title: string;
   tagline: false;
@@ -201,4 +204,5 @@ export interface Config {
     tableConfiguration?: TableConfiguration;
   };
   integrations?: IntegrationsConfig;
+  scalarConfiguration?: ScalarConfiguration;
 }


### PR DESCRIPTION
Closes https://github.com/event-catalog/generators/issues/351

## What This PR Does

Adds a `scalarConfiguration` option to the EventCatalog config that gets passed through to the Scalar OpenAPI reference component. This allows users to customize Scalar behavior (e.g., setting a proxy URL) without forking or patching core.

## Changes Overview

### Key Changes
- Add `scalarConfiguration` property to the `Config` interface in `eventcatalog.config.ts`
- Pass `configuration` prop from the Astro spec page to the `OpenAPISpec` React component
- Spread the configuration object into the Scalar `ApiReferenceReact` component's configuration

## How It Works

The `scalarConfiguration` value from `eventcatalog.config.js` is read in the Astro page and passed as a prop to `_OpenAPI.tsx`. The component spreads these properties into the existing Scalar configuration object, allowing any user-provided options to override or extend the defaults.

## Breaking Changes

None

## Additional Notes

The `ScalarConfiguration` type is set to `any` to avoid coupling to Scalar's internal types, which may change across versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)