### PR TITLE
Add field-level usage tracking for message consumers

### DIFF
--- a/.changeset/bright-fields-glow.md
+++ b/.changeset/bright-fields-glow.md
@@ -1,0 +1,8 @@
+---
+"@eventcatalog/core": minor
+"@eventcatalog/sdk": minor
+---
+
+feat: add field-level usage tracking for message consumers
+
+Services and domains can now declare which specific fields they depend on in their `receives` (and `sends`) pointers using an optional `fields` array. When declared, a new Field Usage page appears in the message sidebar showing all schema properties alongside their consumers. Supports JSON Schema, Avro, and Protobuf schemas. Includes detection of fields declared by consumers that don't exist in the schema.

--- a/examples/default/domains/E-Commerce/subdomains/Orders/services/InventoryService/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Orders/services/InventoryService/index.mdx
@@ -9,13 +9,28 @@ owners:
 receives:
   - id: UserSignedUp
   - id: OrderConfirmed
+    fields:
+      - orderId
+      - orderItems
+      - totalAmount
     from:
       - id: inventory-service-filter-by-orders-over-100
   - id: OrderAmended
+    fields:
+      - orderId
+      - amendedItems
     from:
       - id: orders-domain-eventbus
   - id: UpdateInventory
+    fields:
+      - productId
+      - quantityChange
+      - warehouseId
   - id: AddInventory
+    fields:
+      - productId
+      - quantity
+      - warehouseId
   - id: DeleteInventory
 sends:
   - id: InventoryAdjusted

--- a/examples/default/domains/E-Commerce/subdomains/Orders/services/NotificationService/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Orders/services/NotificationService/index.mdx
@@ -14,12 +14,40 @@ receives:
     from:
       - id: notifications-queue
   - id: PaymentProcessed
+    fields:
+      - userId
+      - orderId
+      - amount
+      - status
+      - timestamp
     from:
       - id: notifications-queue
   - id: InvoiceGenerated
+    fields:
+      - invoiceId
+      - customerId
+      - status
+      - total
+      - currency
     from:
       - id: notifications-queue
   - id: OutOfStock
+    from:
+      - id: notifications-queue
+  - id: OrderConfirmed
+    fields:
+      - orderId
+      - userId
+      - orderStatus
+      - randomHero
+      - totalAmount
+    from:
+      - id: notifications-queue
+  - id: OrderAmended
+    fields:
+      - orderId
+      - customer
+      - orderStatus
     from:
       - id: notifications-queue
   - id: OrderMetricsCalculated

--- a/examples/default/domains/E-Commerce/subdomains/Orders/services/OrdersService/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Orders/services/OrdersService/index.mdx
@@ -9,6 +9,9 @@ owners:
 receives:
   - id: InventoryAdjusted
     version: 1.x
+    fields:
+      - Name
+      - Department
     from:
       - id: orders-service-sqs-channel
 writesTo:

--- a/examples/default/domains/E-Commerce/subdomains/Orders/services/RegistrationService/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Orders/services/RegistrationService/index.mdx
@@ -15,6 +15,10 @@ sends:
       - id: registrations-domain-eventbus
 receives:
   - id: DeliveryFailed
+    fields:
+      - shipmentId
+      - orderId
+      - failureReason
     from:
       - id: registrations-domain-eventbus
 ---

--- a/examples/default/domains/E-Commerce/subdomains/Orders/services/ShippingService/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Orders/services/ShippingService/index.mdx
@@ -8,25 +8,60 @@ owners:
   - dboyne
 receives:
   - id: PaymentProcessed
+    fields:
+      - orderId
+      - amount
+      - currency
+      - paymentMethod
+    from:
+      - id: orders-domain-eventbus
+  - id: OrderConfirmed
+    fields:
+      - orderId
+      - orderItems
+      - totalAmount
+      - confirmationTimestamp
     from:
       - id: orders-domain-eventbus
 sends:
   - id: ShipmentCreated
+    fields:
+      - shipmentId
+      - orderId
+      - address
+      - items
+      - shippingMethod
     to:
       - id: orders-domain-eventbus
   - id: ReturnInitiated
+    fields:
+      - shipmentId
+      - orderId
     to:
       - id: orders-domain-eventbus
   - id: ShipmentDispatched
+    fields:
+      - shipmentId
+      - orderId
     to:
       - id: orders-domain-eventbus
   - id: ShipmentInTransit
+    fields:
+      - shipmentId
+      - orderId
     to:
       - id: orders-domain-eventbus
   - id: ShipmentDelivered
+    fields:
+      - shipmentId
+      - orderId
     to:
       - id: orders-domain-eventbus
   - id: DeliveryFailed
+    fields:
+      - shipmentId
+      - orderId
+      - failureReason
     to:
       - id: orders-domain-eventbus
 repository:

--- a/examples/default/domains/E-Commerce/subdomains/Payment/services/FraudDetectionService/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Payment/services/FraudDetectionService/index.mdx
@@ -15,6 +15,14 @@ receives:
 sends:
   - id: FraudCheckCompleted
     version: 0.0.1
+    fields:
+      - transactionId
+      - paymentId
+      - riskScore
+      - decision
+      - reasons
+      - confidence
+      - timestamp
   - id: FraudDetected
     version: 0.0.1
   - id: RiskScoreCalculated

--- a/examples/default/domains/E-Commerce/subdomains/Payment/services/PaymentGatewayService/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Payment/services/PaymentGatewayService/index.mdx
@@ -12,10 +12,22 @@ repository:
 receives:
   - id: ProcessPayment
     version: 0.0.1
+    fields:
+      - paymentId
+      - amount
+      - currency
+      - paymentMethod
+      - idempotencyKey
+      - captureImmediately
     from:
       - id: 'payment-domain-eventbus'
   - id: FraudCheckCompleted
     version: 0.0.1
+    fields:
+      - transactionId
+      - paymentId
+      - decision
+      - riskScore
 sends:
   - id: PaymentFailed
     version: 0.0.1

--- a/examples/default/domains/E-Commerce/subdomains/Payment/services/PaymentService/events/PaymentProcessed/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Payment/services/PaymentService/events/PaymentProcessed/index.mdx
@@ -3,6 +3,7 @@ id: PaymentProcessed
 name: Payment Processed
 version: 1.0.0
 summary: Event is triggered after the payment has been successfully processed
+schemaPath: schema.json
 owners:
   - dboyne
 ---

--- a/examples/default/domains/E-Commerce/subdomains/Payment/services/PaymentService/events/PaymentProcessed/schema.json
+++ b/examples/default/domains/E-Commerce/subdomains/Payment/services/PaymentService/events/PaymentProcessed/schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "PaymentProcessed",
+  "description": "Event triggered after a payment has been successfully processed",
+  "properties": {
+    "transactionId": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Unique identifier for the payment transaction"
+    },
+    "userId": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Unique identifier of the user who made the payment"
+    },
+    "orderId": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Unique identifier of the associated order"
+    },
+    "amount": {
+      "type": "number",
+      "description": "The payment amount"
+    },
+    "currency": {
+      "type": "string",
+      "description": "Currency code (ISO 4217)",
+      "default": "USD"
+    },
+    "paymentMethod": {
+      "type": "string",
+      "enum": ["CreditCard", "DebitCard", "BankTransfer", "PayPal", "Crypto"],
+      "description": "The payment method used"
+    },
+    "status": {
+      "type": "string",
+      "enum": ["confirmed", "pending", "failed"],
+      "description": "The outcome status of the payment"
+    },
+    "subscriptionId": {
+      "type": "string",
+      "description": "Subscription identifier, if payment is subscription-related"
+    },
+    "paymentId": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Unique identifier for the payment record"
+    },
+    "confirmationDetails": {
+      "type": "object",
+      "description": "Details from the payment gateway",
+      "properties": {
+        "gatewayResponse": {
+          "type": "string",
+          "description": "Response from the payment gateway"
+        },
+        "transactionId": {
+          "type": "string",
+          "description": "Gateway-specific transaction identifier"
+        }
+      },
+      "required": ["gatewayResponse", "transactionId"]
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Timestamp when the payment was processed"
+    }
+  },
+  "required": ["transactionId", "userId", "orderId", "amount", "currency", "paymentMethod", "status", "paymentId", "confirmationDetails", "timestamp"]
+}

--- a/examples/default/domains/E-Commerce/subdomains/Subscriptions/services/BillingService/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Subscriptions/services/BillingService/index.mdx
@@ -13,9 +13,30 @@ repository:
   url: 'https://github.com/eventcatalog/billing-service'
 receives:
   - id: PaymentProcessed
+    fields:
+      - paymentId
+      - amount
+      - currency
+      - subscriptionId
 sends:
   - id: InvoiceGenerated
+    fields:
+      - invoiceId
+      - invoiceNumber
+      - subscriptionId
+      - customerId
+      - status
+      - lineItems
+      - total
+      - currency
+      - billingPeriod
   - id: SubscriptionPaymentDue
+    fields:
+      - subscriptionId
+      - customerId
+      - amount
+      - currency
+      - dueDate
 owners:
   - dboyne
 attachments:

--- a/examples/default/domains/E-Commerce/subdomains/Subscriptions/services/SubscriptionService/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Subscriptions/services/SubscriptionService/index.mdx
@@ -9,6 +9,13 @@ owners:
 receives:
   - id: PaymentProcessed
     version: 0.0.1
+    fields:
+      - transactionId
+      - userId
+      - amount
+      - status
+      - subscriptionId
+      - timestamp
     from:
       - id: 'payments.{env}.events'
         parameters:

--- a/packages/core/eventcatalog/src/content.config.ts
+++ b/packages/core/eventcatalog/src/content.config.ts
@@ -67,6 +67,7 @@ const channelPointer = z
 const sendsPointer = z.object({
   id: z.string(),
   version: z.string().optional().default('latest'),
+  fields: z.array(z.string()).optional(),
   to: z
     .array(
       z.object({
@@ -80,6 +81,7 @@ const sendsPointer = z.object({
 const receivesPointer = z.object({
   id: z.string(),
   version: z.string().optional().default('latest'),
+  fields: z.array(z.string()).optional(),
   from: z
     .array(
       z.object({

--- a/packages/core/eventcatalog/src/enterprise/print/components/PrintSchemaPropertiesTable.astro
+++ b/packages/core/eventcatalog/src/enterprise/print/components/PrintSchemaPropertiesTable.astro
@@ -1,58 +1,16 @@
 ---
+import { extractSchemaProperties } from '@utils/schema-utils';
+
 interface Props {
   schema: any;
   isAvro: boolean;
 }
 
-interface SchemaProperty {
-  name: string;
-  type: string;
-  description: string;
-  required: boolean;
-}
-
 const { schema, isAvro } = Astro.props;
 
-function getAvroTypeName(type: any): string {
-  if (typeof type === 'string') return type;
-  if (Array.isArray(type)) {
-    return type.map((t) => (typeof t === 'string' ? t : t.type || 'complex')).join(' | ');
-  }
-  if (typeof type === 'object' && type !== null) {
-    if (type.type === 'array' && type.items) {
-      return `array<${getAvroTypeName(type.items)}>`;
-    }
-    return type.type || 'complex';
-  }
-  return 'unknown';
-}
-
-function extractProperties(schema: any, isAvro: boolean): SchemaProperty[] {
-  if (!schema) return [];
-
-  if (isAvro && schema.fields) {
-    return schema.fields.map((field: any) => ({
-      name: field.name,
-      type: getAvroTypeName(field.type),
-      description: field.doc || '',
-      required: !Array.isArray(field.type) || !field.type.includes('null'),
-    }));
-  }
-
-  if (schema.properties) {
-    const required = schema.required || [];
-    return Object.entries(schema.properties).map(([name, prop]: [string, any]) => ({
-      name,
-      type: prop.type || (prop.enum ? 'enum' : prop.$ref ? '$ref' : 'object'),
-      description: prop.description || '',
-      required: required.includes(name),
-    }));
-  }
-
-  return [];
-}
-
-const properties = extractProperties(schema, isAvro);
+const schemaContent = typeof schema === 'string' ? schema : JSON.stringify(schema);
+const format = isAvro ? 'avro' : 'json';
+const properties = extractSchemaProperties(schemaContent, format);
 ---
 
 {

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/field-lineage/_index.data.ts
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/field-lineage/_index.data.ts
@@ -1,0 +1,64 @@
+import { isSSR } from '@utils/feature';
+import { HybridPage } from '@utils/page-loaders/hybrid-page';
+import type { PageTypes } from '@types';
+
+const MESSAGE_TYPES: PageTypes[] = ['events', 'commands', 'queries'];
+
+export class Page extends HybridPage {
+  static get prerender(): boolean {
+    return !isSSR();
+  }
+
+  static async getStaticPaths(): Promise<Array<{ params: any; props: any }>> {
+    if (isSSR()) {
+      return [];
+    }
+
+    const { pageDataLoader } = await import('@utils/page-loaders/page-data-loader');
+
+    const allItems = await Promise.all(MESSAGE_TYPES.map((type) => pageDataLoader[type]()));
+
+    return allItems.flatMap((items, index) =>
+      items.map((item) => ({
+        params: {
+          type: MESSAGE_TYPES[index],
+          id: item.data.id,
+          version: item.data.version,
+        },
+        props: {
+          type: MESSAGE_TYPES[index],
+          ...item,
+        },
+      }))
+    );
+  }
+
+  protected static async fetchData(params: any) {
+    const { type, id, version } = params;
+
+    if (!type || !id || !version || !MESSAGE_TYPES.includes(type)) {
+      return null;
+    }
+
+    const { pageDataLoader } = await import('@utils/page-loaders/page-data-loader');
+
+    const items = await pageDataLoader[type as PageTypes]();
+    const item = items.find((i) => i.data.id === id && i.data.version === version);
+
+    if (!item) {
+      return null;
+    }
+
+    return {
+      type,
+      ...item,
+    };
+  }
+
+  protected static createNotFoundResponse(): Response {
+    return new Response(null, {
+      status: 404,
+      statusText: 'Field usage not found',
+    });
+  }
+}

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/field-lineage/index.astro
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/field-lineage/index.astro
@@ -1,0 +1,368 @@
+---
+import Footer from '@layouts/Footer.astro';
+import { BoltIcon, ChatBubbleLeftIcon, MagnifyingGlassIcon, ServerIcon } from '@heroicons/react/24/outline';
+import { getCollection } from 'astro:content';
+import path from 'node:path';
+
+import { buildUrl } from '@utils/url-builder';
+import VerticalSideBarLayout from '@layouts/VerticalSideBarLayout.astro';
+import { ClientRouter } from 'astro:transitions';
+import { satisfies } from '@utils/collections/util';
+import { readResourceFile } from '@utils/resource-files';
+import { extractSchemaProperties, type SchemaProperty } from '@utils/schema-utils';
+
+import { Page } from './_index.data';
+
+export const prerender = Page.prerender;
+export const getStaticPaths = Page.getStaticPaths;
+
+// Get data
+const props = await Page.getData(Astro);
+
+const { data, collection } = props;
+const messageId = data.id;
+const messageVersion = data.version;
+const latestVersion = data.latestVersion || messageVersion;
+
+// Get all services to find field usage
+const allServices = await getCollection('services');
+
+const matchesVersion = (pointerVersion: string | undefined) => {
+  if (pointerVersion === 'latest' || pointerVersion === undefined) {
+    return messageVersion === latestVersion;
+  }
+  return satisfies(messageVersion, pointerVersion);
+};
+
+// Read schema and extract property metadata
+const schemaPropertyMap = new Map<string, SchemaProperty>();
+if (data.schemaPath) {
+  const schemaContent = readResourceFile(props, data.schemaPath);
+  if (schemaContent) {
+    const format = path.extname(data.schemaPath).slice(1);
+    const properties = extractSchemaProperties(schemaContent, format);
+    for (const prop of properties) {
+      schemaPropertyMap.set(prop.name, prop);
+    }
+  }
+}
+
+// Build field usage: field → list of { service, direction }
+type FieldConsumer = {
+  resourceId: string;
+  resourceName: string;
+  resourceVersion: string;
+  direction: 'receives' | 'sends';
+};
+
+const fieldMap = new Map<string, FieldConsumer[]>();
+
+// Scan services
+for (const service of allServices) {
+  for (const pointer of service.data.receives || []) {
+    if (pointer.id === messageId && matchesVersion(pointer.version) && pointer.fields?.length) {
+      for (const field of pointer.fields) {
+        if (!fieldMap.has(field)) fieldMap.set(field, []);
+        fieldMap.get(field)!.push({
+          resourceId: service.data.id,
+          resourceName: service.data.name || service.data.id,
+          resourceVersion: service.data.version,
+          direction: 'receives',
+        });
+      }
+    }
+  }
+  for (const pointer of service.data.sends || []) {
+    if (pointer.id === messageId && matchesVersion(pointer.version) && pointer.fields?.length) {
+      for (const field of pointer.fields) {
+        if (!fieldMap.has(field)) fieldMap.set(field, []);
+        fieldMap.get(field)!.push({
+          resourceId: service.data.id,
+          resourceName: service.data.name || service.data.id,
+          resourceVersion: service.data.version,
+          direction: 'sends',
+        });
+      }
+    }
+  }
+}
+
+// Ensure all schema properties appear, even without consumers
+for (const [name] of schemaPropertyMap) {
+  if (!fieldMap.has(name)) {
+    fieldMap.set(name, []);
+  }
+}
+
+// Split into matched (in schema or no schema exists) and unmatched (declared but not in schema)
+const hasSchema = schemaPropertyMap.size > 0;
+const matchedFields: [string, FieldConsumer[]][] = [];
+const unmatchedFields: [string, FieldConsumer[]][] = [];
+
+for (const [field, consumers] of fieldMap) {
+  if (!hasSchema || schemaPropertyMap.has(field)) {
+    matchedFields.push([field, consumers]);
+  } else if (consumers.length > 0) {
+    // Only show unmatched if someone actually declared this field
+    unmatchedFields.push([field, consumers]);
+  }
+}
+
+const sortedFields = matchedFields.sort(([a], [b]) => a.localeCompare(b));
+const sortedUnmatchedFields = unmatchedFields.sort(([a], [b]) => a.localeCompare(b));
+
+const getBadge = () => {
+  if (collection === 'events') {
+    return { badgeType: 'event', content: 'Event', icon: BoltIcon };
+  }
+  if (collection === 'commands') {
+    return { badgeType: 'command', content: 'Command', icon: ChatBubbleLeftIcon };
+  }
+  if (collection === 'queries') {
+    return { badgeType: 'query', content: 'Query', icon: MagnifyingGlassIcon };
+  }
+};
+
+const badge = getBadge();
+---
+
+<VerticalSideBarLayout title="Field Usage">
+  <main class="w-full md:pt-4 px-8 overflow-y-auto h-full max-w-[95%]">
+    <nav aria-label="Breadcrumb" class="flex">
+      <ol role="list" class="flex items-center space-x-2">
+        <li>
+          <div>
+            <a
+              href={buildUrl(`/docs/${collection}/${data.id}/${data.version}`)}
+              class="text-sm font-medium text-[rgb(var(--ec-page-text-muted))] hover:text-[rgb(var(--ec-page-text))]"
+            >
+              {data.name}
+            </a>
+          </div>
+        </li>
+        <li>
+          <div class="flex items-center">
+            <svg
+              fill="currentColor"
+              viewBox="0 0 20 20"
+              aria-hidden="true"
+              class="h-5 w-5 flex-shrink-0 text-[rgb(var(--ec-page-border))]"
+            >
+              <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z"></path>
+            </svg>
+            <span class="text-sm font-medium text-[rgb(var(--ec-page-text-muted))]"> Field Usage </span>
+          </div>
+        </li>
+      </ol>
+    </nav>
+    <div class="border-b border-[rgb(var(--ec-page-border))] flex justify-between items-start py-4 w-full">
+      <div>
+        <h2 class="text-2xl md:text-4xl font-bold text-[rgb(var(--ec-page-text))]">{data.name} (Field Usage)</h2>
+        <h2 class="text-lg pt-2 text-[rgb(var(--ec-page-text-muted))] font-light">
+          Track which services depend on specific fields of this message.
+        </h2>
+        {
+          badge && (
+            <div class="flex flex-wrap items-center gap-2 py-2 pt-4">
+              <span
+                class="text-sm font-medium px-2 py-1 rounded-md space-x-1 flex items-center"
+                style={`background-color: rgb(var(--ec-badge-${badge.badgeType}-bg)); color: rgb(var(--ec-badge-${badge.badgeType}-text));`}
+              >
+                {badge.icon && <badge.icon className="w-4 h-4 inline-block mr-1" />}
+                <span>{badge.content}</span>
+              </span>
+              <button
+                id="filter-consumed-btn"
+                type="button"
+                class="inline-flex items-center gap-1.5 px-2 py-1 text-xs rounded-md border border-[rgb(var(--ec-page-border))] text-[rgb(var(--ec-page-text-muted))] hover:bg-[rgb(var(--ec-card-bg))] transition-colors"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  class="h-3.5 w-3.5"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  stroke-width="2"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z"
+                  />
+                </svg>
+                <span id="filter-consumed-label">Consumed only</span>
+              </button>
+            </div>
+          )
+        }
+      </div>
+    </div>
+
+    {
+      sortedFields.length === 0 && (
+        <div class="py-8 text-[rgb(var(--ec-page-text-muted))]">
+          <p>
+            No field usage data found. Services can declare which fields they depend on using the{' '}
+            <code class="bg-[rgb(var(--ec-card-bg))] px-1.5 py-0.5 rounded text-sm">fields</code> property in their{' '}
+            <code class="bg-[rgb(var(--ec-card-bg))] px-1.5 py-0.5 rounded text-sm">sends</code> or{' '}
+            <code class="bg-[rgb(var(--ec-card-bg))] px-1.5 py-0.5 rounded text-sm">receives</code> configuration.
+          </p>
+        </div>
+      )
+    }
+
+    {
+      sortedFields.length > 0 && (
+        <div class="py-6">
+          <div class="overflow-x-auto">
+            <table id="field-usage-table" class="min-w-full">
+              <thead>
+                <tr class="border-b border-[rgb(var(--ec-page-border))]">
+                  <th class="text-left py-3 px-4 text-sm font-semibold text-[rgb(var(--ec-page-text))]">Field</th>
+                  <th class="text-left py-3 px-4 text-sm font-semibold text-[rgb(var(--ec-page-text))]">Type</th>
+                  <th class="text-left py-3 px-4 text-sm font-semibold text-[rgb(var(--ec-page-text))]">Description</th>
+                  <th class="text-left py-3 px-4 text-sm font-semibold text-[rgb(var(--ec-page-text))]">Consumers</th>
+                </tr>
+              </thead>
+              <tbody>
+                {sortedFields.map(([field, consumers]) => {
+                  const schemaProp = schemaPropertyMap.get(field);
+                  const isRequired = schemaProp?.required ?? false;
+                  return (
+                    <tr
+                      class="field-row border-b border-[rgb(var(--ec-page-border)/0.5)] hover:bg-[rgb(var(--ec-card-bg)/0.3)] transition-colors"
+                      data-has-consumers={consumers.length > 0 ? 'true' : 'false'}
+                    >
+                      <td class="py-3 px-4">
+                        <div class="flex items-baseline gap-2">
+                          <span class="font-semibold text-sm text-[rgb(var(--ec-page-text))]">{field}</span>
+                          {isRequired && <span class="text-xs text-[rgb(var(--ec-accent))]">required</span>}
+                        </div>
+                      </td>
+                      <td class="py-3 px-4">
+                        {schemaProp?.type ? (
+                          <span class="font-mono text-xs text-[rgb(var(--ec-accent))]">{schemaProp.type}</span>
+                        ) : (
+                          <span class="text-xs text-[rgb(var(--ec-page-text-muted))]">—</span>
+                        )}
+                      </td>
+                      <td class="py-3 px-4">
+                        <span class="text-xs text-[rgb(var(--ec-page-text-muted))]">{schemaProp?.description || '—'}</span>
+                      </td>
+                      <td class="py-3 px-4">
+                        <div class="flex flex-col gap-1">
+                          {consumers.length > 0 ? (
+                            consumers.map((consumer) => (
+                              <a
+                                href={buildUrl(`/docs/services/${consumer.resourceId}/${consumer.resourceVersion}`)}
+                                class="inline-flex items-center gap-1.5 text-xs text-[rgb(var(--ec-page-text-muted))] hover:text-[rgb(var(--ec-accent))] transition-colors"
+                              >
+                                <ServerIcon className="h-3.5 w-3.5 text-pink-500 shrink-0" />
+                                <span class="truncate">{consumer.resourceName}</span>
+                              </a>
+                            ))
+                          ) : (
+                            <span class="text-xs text-[rgb(var(--ec-page-text-muted))]">—</span>
+                          )}
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+
+          {sortedUnmatchedFields.length > 0 && (
+            <div class="mt-8">
+              <div class="flex items-center gap-2 mb-3">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  class="h-5 w-5 text-amber-500"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  stroke-width="2"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+                  />
+                </svg>
+                <h3 class="text-sm font-semibold text-[rgb(var(--ec-page-text))]">Fields not found in schema</h3>
+              </div>
+              <p class="text-xs text-[rgb(var(--ec-page-text-muted))] mb-4">
+                These fields are declared by consumers but do not exist in the message schema. This may indicate outdated
+                documentation, a typo, or a missing field in the schema.
+              </p>
+              <div class="overflow-x-auto">
+                <table class="min-w-full">
+                  <thead>
+                    <tr class="border-b border-[rgb(var(--ec-page-border))]">
+                      <th class="text-left py-3 px-4 text-sm font-semibold text-[rgb(var(--ec-page-text))]">Field</th>
+                      <th class="text-left py-3 px-4 text-sm font-semibold text-[rgb(var(--ec-page-text))]">Declared by</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {sortedUnmatchedFields.map(([field, consumers]) => (
+                      <tr class="border-b border-[rgb(var(--ec-page-border)/0.5)]">
+                        <td class="py-3 px-4">
+                          <code class="text-sm font-mono font-semibold text-amber-500">{field}</code>
+                        </td>
+                        <td class="py-3 px-4">
+                          <div class="flex flex-col gap-1">
+                            {consumers.map((consumer) => (
+                              <a
+                                href={buildUrl(`/docs/services/${consumer.resourceId}/${consumer.resourceVersion}`)}
+                                class="inline-flex items-center gap-1.5 text-xs text-[rgb(var(--ec-page-text-muted))] hover:text-[rgb(var(--ec-accent))] transition-colors"
+                              >
+                                <ServerIcon className="h-3.5 w-3.5 text-pink-500 shrink-0" />
+                                <span class="truncate">{consumer.resourceName}</span>
+                              </a>
+                            ))}
+                          </div>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+        </div>
+      )
+    }
+
+    <Footer />
+  </main>
+  <ClientRouter />
+</VerticalSideBarLayout>
+
+<script>
+  document.addEventListener('astro:page-load', () => {
+    const btn = document.getElementById('filter-consumed-btn');
+    const label = document.getElementById('filter-consumed-label');
+    if (!btn || !label) return;
+
+    let filtered = false;
+
+    btn.addEventListener('click', () => {
+      filtered = !filtered;
+      const rows = document.querySelectorAll('.field-row');
+      rows.forEach((row) => {
+        const el = row as HTMLElement;
+        if (filtered && el.dataset.hasConsumers === 'false') {
+          el.style.display = 'none';
+        } else {
+          el.style.display = '';
+        }
+      });
+
+      label.textContent = filtered ? 'All fields' : 'Consumed only';
+      btn.classList.toggle('bg-[rgb(var(--ec-accent-subtle))]', filtered);
+      btn.classList.toggle('text-[rgb(var(--ec-accent))]', filtered);
+      btn.classList.toggle('border-[rgb(var(--ec-accent))]', filtered);
+    });
+  });
+</script>

--- a/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/sidebar-builder.spec.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/sidebar-builder.spec.ts
@@ -1941,6 +1941,111 @@ describe('getNestedSideBarData', () => {
       });
     });
 
+    describe('field usage section', () => {
+      it('the field usage link is shown when a service declares fields for the message', async () => {
+        const { writeEvent, writeService } = utils(CATALOG_FOLDER);
+        await writeEvent({
+          id: 'PaymentProcessed',
+          name: 'Payment Processed',
+          version: '0.0.1',
+          markdown: 'Payment Processed',
+          schemaPath: 'schema.json',
+        });
+        await writeService({
+          id: 'ShippingService',
+          name: 'Shipping Service',
+          version: '0.0.1',
+          markdown: 'Shipping Service',
+          receives: [{ id: 'PaymentProcessed', version: '0.0.1', fields: ['orderId', 'amount'] }],
+        });
+
+        const navigationData = await getNestedSideBarData();
+        const messageNode = getNavigationConfigurationByKey('event:PaymentProcessed:0.0.1', navigationData);
+        expect(messageNode).toHaveNavigationLink({
+          type: 'item',
+          title: 'Field Usage',
+          href: '/docs/events/PaymentProcessed/0.0.1/field-lineage',
+        });
+      });
+
+      it('the field usage link is not shown when no service declares fields for the message', async () => {
+        const { writeEvent, writeService } = utils(CATALOG_FOLDER);
+        await writeEvent({
+          id: 'PaymentProcessed',
+          name: 'Payment Processed',
+          version: '0.0.1',
+          markdown: 'Payment Processed',
+          schemaPath: 'schema.json',
+        });
+        await writeService({
+          id: 'ShippingService',
+          name: 'Shipping Service',
+          version: '0.0.1',
+          markdown: 'Shipping Service',
+          receives: [{ id: 'PaymentProcessed', version: '0.0.1' }],
+        });
+
+        const navigationData = await getNestedSideBarData();
+        const messageNode = getNavigationConfigurationByKey('event:PaymentProcessed:0.0.1', navigationData);
+        expect(messageNode).not.toHaveNavigationLink({
+          type: 'item',
+          title: 'Field Usage',
+          href: '/docs/events/PaymentProcessed/0.0.1/field-lineage',
+        });
+      });
+
+      it('the field usage link is not shown when the message has no schema', async () => {
+        const { writeEvent, writeService } = utils(CATALOG_FOLDER);
+        await writeEvent({
+          id: 'PaymentProcessed',
+          name: 'Payment Processed',
+          version: '0.0.1',
+          markdown: 'Payment Processed',
+        });
+        await writeService({
+          id: 'ShippingService',
+          name: 'Shipping Service',
+          version: '0.0.1',
+          markdown: 'Shipping Service',
+          receives: [{ id: 'PaymentProcessed', version: '0.0.1', fields: ['orderId', 'amount'] }],
+        });
+
+        const navigationData = await getNestedSideBarData();
+        const messageNode = getNavigationConfigurationByKey('event:PaymentProcessed:0.0.1', navigationData);
+        expect(messageNode).not.toHaveNavigationLink({
+          type: 'item',
+          title: 'Field Usage',
+          href: '/docs/events/PaymentProcessed/0.0.1/field-lineage',
+        });
+      });
+
+      it('the field usage link is shown when a service declares fields in its sends for the message', async () => {
+        const { writeEvent, writeService } = utils(CATALOG_FOLDER);
+        await writeEvent({
+          id: 'InventoryAdjusted',
+          name: 'Inventory Adjusted',
+          version: '1.0.0',
+          markdown: 'Inventory Adjusted',
+          schemaPath: 'schema.json',
+        });
+        await writeService({
+          id: 'InventoryService',
+          name: 'Inventory Service',
+          version: '0.0.1',
+          markdown: 'Inventory Service',
+          sends: [{ id: 'InventoryAdjusted', version: '1.0.0', fields: ['productId', 'quantity'] }],
+        });
+
+        const navigationData = await getNestedSideBarData();
+        const messageNode = getNavigationConfigurationByKey('event:InventoryAdjusted:1.0.0', navigationData);
+        expect(messageNode).toHaveNavigationLink({
+          type: 'item',
+          title: 'Field Usage',
+          href: '/docs/events/InventoryAdjusted/1.0.0/field-lineage',
+        });
+      });
+    });
+
     describe('producers section', () => {
       it('is not listed if the no services produce the message', async () => {
         const { writeEvent } = utils(CATALOG_FOLDER);

--- a/packages/core/eventcatalog/src/stores/sidebar-store/builders/message.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/builders/message.ts
@@ -16,7 +16,8 @@ import { isVisualiserEnabled, isChangelogEnabled } from '@utils/feature';
 export const buildMessageNode = (
   message: CollectionEntry<'events' | 'commands' | 'queries'>,
   owners: any[],
-  context: ResourceGroupContext
+  context: ResourceGroupContext,
+  hasFieldUsage: boolean = false
 ): NavNode => {
   const producers = message.data.producers || [];
   const consumers = message.data.consumers || [];
@@ -101,7 +102,12 @@ export const buildMessageNode = (
             title: `Schema (${getSchemaFormatFromURL(message.data.schemaPath!).toUpperCase()})`,
             href: buildUrl(`/schemas/${collection}/${message.data.id}/${message.data.version}`),
           },
-        ],
+          hasFieldUsage && {
+            type: 'item',
+            title: 'Field Usage',
+            href: buildUrl(`/docs/${collection}/${message.data.id}/${message.data.version}/field-lineage`),
+          },
+        ].filter(Boolean),
       },
       renderProducers && {
         type: 'group',

--- a/packages/core/eventcatalog/src/stores/sidebar-store/state.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/state.ts
@@ -203,11 +203,25 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
     {} as Record<string, NavNode | string>
   );
 
+  // Build a set of message IDs that have field usage declared by any service.
+  // We use rawServices (from getCollection) because the hydrated services replace
+  // sends/receives pointers with resolved message entries, which strips the fields property.
+  const messagesWithFieldUsage = new Set<string>();
+  for (const service of rawServices) {
+    for (const pointer of service.data.sends || []) {
+      if (pointer.fields?.length) messagesWithFieldUsage.add(pointer.id);
+    }
+    for (const pointer of service.data.receives || []) {
+      if (pointer.fields?.length) messagesWithFieldUsage.add(pointer.id);
+    }
+  }
+
   const messageNodes = messagesWithOwners.reduce(
     (acc, { message, owners }) => {
       const type = pluralizeMessageType(message as any);
       const versionedKey = `${type}:${message.data.id}:${message.data.version}`;
-      acc[versionedKey] = buildMessageNode(message, owners, context);
+      const hasFieldUsage = messagesWithFieldUsage.has(message.data.id);
+      acc[versionedKey] = buildMessageNode(message, owners, context, hasFieldUsage);
       if (message.data.latestVersion === message.data.version) {
         // Store reference to versioned key instead of duplicating the full node
         acc[`${type}:${message.data.id}`] = versionedKey;

--- a/packages/core/eventcatalog/src/utils/__tests__/schema-utils.test.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/schema-utils.test.ts
@@ -1,0 +1,299 @@
+import { describe, it, expect } from 'vitest';
+import { extractSchemaProperties } from '../schema-utils';
+
+describe('extractSchemaProperties', () => {
+  describe('when given empty or invalid content', () => {
+    it('returns an empty array when content is empty', () => {
+      expect(extractSchemaProperties('', 'json')).toEqual([]);
+    });
+
+    it('returns an empty array when JSON is malformed', () => {
+      expect(extractSchemaProperties('{ broken json', 'json')).toEqual([]);
+    });
+
+    it('returns an empty array when JSON has no properties or fields', () => {
+      expect(extractSchemaProperties('{"type": "object"}', 'json')).toEqual([]);
+    });
+  });
+
+  describe('when parsing a JSON Schema', () => {
+    it('extracts field names, types, and descriptions from properties', () => {
+      const schema = JSON.stringify({
+        type: 'object',
+        properties: {
+          orderId: { type: 'string', description: 'Unique order identifier' },
+          amount: { type: 'number', description: 'Total amount' },
+        },
+      });
+
+      const result = extractSchemaProperties(schema, 'json');
+
+      expect(result).toEqual([
+        { name: 'orderId', type: 'string', description: 'Unique order identifier', required: false },
+        { name: 'amount', type: 'number', description: 'Total amount', required: false },
+      ]);
+    });
+
+    it('marks fields listed in the required array as required', () => {
+      const schema = JSON.stringify({
+        type: 'object',
+        properties: {
+          orderId: { type: 'string', description: 'Unique order identifier' },
+          notes: { type: 'string', description: 'Optional notes' },
+        },
+        required: ['orderId'],
+      });
+
+      const result = extractSchemaProperties(schema, 'json');
+
+      expect(result[0].required).toBe(true);
+      expect(result[1].required).toBe(false);
+    });
+
+    it('defaults description to empty string when not provided', () => {
+      const schema = JSON.stringify({
+        type: 'object',
+        properties: {
+          orderId: { type: 'string' },
+        },
+      });
+
+      const result = extractSchemaProperties(schema, 'json');
+
+      expect(result[0].description).toBe('');
+    });
+
+    it('detects enum types when no explicit type is set', () => {
+      const schema = JSON.stringify({
+        type: 'object',
+        properties: {
+          status: { enum: ['active', 'inactive'], description: 'Current status' },
+        },
+      });
+
+      const result = extractSchemaProperties(schema, 'json');
+
+      expect(result[0].type).toBe('enum');
+    });
+
+    it('detects $ref types when no explicit type is set', () => {
+      const schema = JSON.stringify({
+        type: 'object',
+        properties: {
+          address: { $ref: '#/definitions/Address', description: 'Shipping address' },
+        },
+      });
+
+      const result = extractSchemaProperties(schema, 'json');
+
+      expect(result[0].type).toBe('$ref');
+    });
+
+    it('falls back to object type when no type, enum, or $ref is set', () => {
+      const schema = JSON.stringify({
+        type: 'object',
+        properties: {
+          metadata: { description: 'Extra metadata' },
+        },
+      });
+
+      const result = extractSchemaProperties(schema, 'json');
+
+      expect(result[0].type).toBe('object');
+    });
+  });
+
+  describe('when parsing an Avro schema', () => {
+    it('extracts field names, types, and doc descriptions', () => {
+      const schema = JSON.stringify({
+        type: 'record',
+        name: 'OrderEvent',
+        fields: [
+          { name: 'orderId', type: 'string', doc: 'The order ID' },
+          { name: 'totalAmount', type: 'double', doc: 'Total order amount' },
+        ],
+      });
+
+      const result = extractSchemaProperties(schema, 'avro');
+
+      expect(result).toEqual([
+        { name: 'orderId', type: 'string', description: 'The order ID', required: true },
+        { name: 'totalAmount', type: 'double', description: 'Total order amount', required: true },
+      ]);
+    });
+
+    it('treats simple-typed fields as required', () => {
+      const schema = JSON.stringify({
+        type: 'record',
+        name: 'Event',
+        fields: [{ name: 'id', type: 'string' }],
+      });
+
+      const result = extractSchemaProperties(schema, 'avro');
+
+      expect(result[0].required).toBe(true);
+    });
+
+    it('treats union types that include null as optional', () => {
+      const schema = JSON.stringify({
+        type: 'record',
+        name: 'Event',
+        fields: [{ name: 'notes', type: ['null', 'string'], doc: 'Optional notes' }],
+      });
+
+      const result = extractSchemaProperties(schema, 'avro');
+
+      expect(result[0].required).toBe(false);
+      expect(result[0].type).toBe('null | string');
+    });
+
+    it('treats union types without null as required', () => {
+      const schema = JSON.stringify({
+        type: 'record',
+        name: 'Event',
+        fields: [{ name: 'payload', type: ['string', 'int'] }],
+      });
+
+      const result = extractSchemaProperties(schema, 'avro');
+
+      expect(result[0].required).toBe(true);
+      expect(result[0].type).toBe('string | int');
+    });
+
+    it('formats array types as array<itemType>', () => {
+      const schema = JSON.stringify({
+        type: 'record',
+        name: 'Event',
+        fields: [
+          {
+            name: 'tags',
+            type: { type: 'array', items: 'string' },
+            doc: 'List of tags',
+          },
+        ],
+      });
+
+      const result = extractSchemaProperties(schema, 'avro');
+
+      expect(result[0].type).toBe('array<string>');
+    });
+
+    it('formats nested record types using the record type name', () => {
+      const schema = JSON.stringify({
+        type: 'record',
+        name: 'Event',
+        fields: [
+          {
+            name: 'address',
+            type: { type: 'record', name: 'Address', fields: [] },
+            doc: 'Shipping address',
+          },
+        ],
+      });
+
+      const result = extractSchemaProperties(schema, 'avro');
+
+      expect(result[0].type).toBe('record');
+    });
+
+    it('defaults description to empty string when doc is not provided', () => {
+      const schema = JSON.stringify({
+        type: 'record',
+        name: 'Event',
+        fields: [{ name: 'id', type: 'string' }],
+      });
+
+      const result = extractSchemaProperties(schema, 'avro');
+
+      expect(result[0].description).toBe('');
+    });
+  });
+
+  describe('when parsing a Protobuf schema', () => {
+    it('extracts field names and types from message definitions', () => {
+      const proto = `
+syntax = "proto3";
+
+message PaymentEvent {
+  string transaction_id = 1;
+  double amount = 2;
+  string currency = 3;
+}`;
+
+      const result = extractSchemaProperties(proto, 'proto');
+
+      expect(result).toEqual([
+        { name: 'transaction_id', type: 'string', description: '', required: false },
+        { name: 'amount', type: 'double', description: '', required: false },
+        { name: 'currency', type: 'string', description: '', required: false },
+      ]);
+    });
+
+    it('captures inline comments as field descriptions', () => {
+      const proto = `
+message Event {
+  string id = 1; // Unique event identifier
+  int32 priority = 2; // Processing priority level
+}`;
+
+      const result = extractSchemaProperties(proto, 'proto');
+
+      expect(result[0].description).toBe('Unique event identifier');
+      expect(result[1].description).toBe('Processing priority level');
+    });
+
+    it('includes the modifier in the type for repeated fields', () => {
+      const proto = `
+message Event {
+  repeated string tags = 1;
+}`;
+
+      const result = extractSchemaProperties(proto, 'proto');
+
+      expect(result[0].type).toBe('repeated string');
+    });
+
+    it('includes the modifier in the type for optional fields', () => {
+      const proto = `
+message Event {
+  optional string notes = 1;
+}`;
+
+      const result = extractSchemaProperties(proto, 'proto');
+
+      expect(result[0].type).toBe('optional string');
+    });
+
+    it('returns an empty array when there are no field definitions', () => {
+      const proto = `
+syntax = "proto3";
+
+message Empty {
+}`;
+
+      const result = extractSchemaProperties(proto, 'proto');
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('when the format is unknown', () => {
+    it('attempts JSON parsing and returns results if valid', () => {
+      const schema = JSON.stringify({
+        type: 'object',
+        properties: {
+          id: { type: 'string', description: 'An ID' },
+        },
+      });
+
+      const result = extractSchemaProperties(schema, 'yaml');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('id');
+    });
+
+    it('returns an empty array if content is not valid JSON', () => {
+      expect(extractSchemaProperties('not json', 'xml')).toEqual([]);
+    });
+  });
+});

--- a/packages/core/eventcatalog/src/utils/schema-utils.ts
+++ b/packages/core/eventcatalog/src/utils/schema-utils.ts
@@ -1,0 +1,77 @@
+export interface SchemaProperty {
+  name: string;
+  type: string;
+  description: string;
+  required: boolean;
+}
+
+function getAvroTypeName(type: any): string {
+  if (typeof type === 'string') return type;
+  if (Array.isArray(type)) {
+    return type.map((t) => (typeof t === 'string' ? t : t.type || 'complex')).join(' | ');
+  }
+  if (typeof type === 'object' && type !== null) {
+    if (type.type === 'array' && type.items) {
+      return `array<${getAvroTypeName(type.items)}>`;
+    }
+    return type.type || 'complex';
+  }
+  return 'unknown';
+}
+
+function parseProtoFields(content: string): SchemaProperty[] {
+  const properties: SchemaProperty[] = [];
+  // Match lines like: string field_name = 1; // optional comment
+  // or: repeated string field_name = 2;
+  const fieldRegex = /^\s*(repeated\s+|optional\s+|required\s+)?(\w+)\s+(\w+)\s*=\s*\d+\s*;(?:\s*\/\/\s*(.*))?/gm;
+  let match;
+  while ((match = fieldRegex.exec(content)) !== null) {
+    const modifier = (match[1] || '').trim();
+    const type = modifier ? `${modifier} ${match[2]}` : match[2];
+    properties.push({
+      name: match[3],
+      type,
+      description: match[4]?.trim() || '',
+      required: false,
+    });
+  }
+  return properties;
+}
+
+export function extractSchemaProperties(content: string, format: string): SchemaProperty[] {
+  if (!content) return [];
+
+  if (format === 'proto') {
+    return parseProtoFields(content);
+  }
+
+  // JSON Schema and Avro are both JSON-based
+  try {
+    const schema = JSON.parse(content);
+
+    // Avro: has top-level "fields" array
+    if (schema.fields && Array.isArray(schema.fields)) {
+      return schema.fields.map((field: any) => ({
+        name: field.name,
+        type: getAvroTypeName(field.type),
+        description: field.doc || '',
+        required: !Array.isArray(field.type) || !field.type.includes('null'),
+      }));
+    }
+
+    // JSON Schema: has "properties" object
+    if (schema.properties) {
+      const required = schema.required || [];
+      return Object.entries(schema.properties).map(([name, prop]: [string, any]) => ({
+        name,
+        type: prop.type || (prop.enum ? 'enum' : prop.$ref ? '$ref' : 'object'),
+        description: prop.description || '',
+        required: required.includes(name),
+      }));
+    }
+  } catch {
+    // Failed to parse, return empty
+  }
+
+  return [];
+}

--- a/packages/sdk/src/domains.ts
+++ b/packages/sdk/src/domains.ts
@@ -11,7 +11,7 @@ import {
   versionResource,
   writeResource,
 } from './internal/resources';
-import { findFileById, invalidateFileCache, readMdxFile, uniqueVersions } from './internal/utils';
+import { findFileById, invalidateFileCache, readMdxFile, uniqueVersions, buildMessagePointer } from './internal/utils';
 import matter from 'gray-matter';
 
 /**
@@ -514,7 +514,8 @@ export const addDataProductToDomain =
  * ```
  */
 export const addMessageToDomain =
-  (directory: string) => async (id: string, direction: string, message: { id: string; version: string }, version?: string) => {
+  (directory: string) =>
+  async (id: string, direction: string, message: { id: string; version: string; fields?: string[] }, version?: string) => {
     let domain: Domain = await getDomain(directory)(id, version);
     const domainPath = await getResourcePath(directory, id, version);
     const extension = path.extname(domainPath?.fullPath || '');
@@ -529,7 +530,7 @@ export const addMessageToDomain =
           return;
         }
       }
-      domain.sends.push({ id: message.id, version: message.version });
+      domain.sends.push(buildMessagePointer(message));
     } else if (direction === 'receives') {
       if (domain.receives === undefined) {
         domain.receives = [];
@@ -540,7 +541,7 @@ export const addMessageToDomain =
           return;
         }
       }
-      domain.receives.push({ id: message.id, version: message.version });
+      domain.receives.push(buildMessagePointer(message));
     } else {
       throw new Error(`Direction ${direction} is invalid, only 'receives' and 'sends' are supported`);
     }

--- a/packages/sdk/src/dsl/utils.ts
+++ b/packages/sdk/src/dsl/utils.ts
@@ -46,12 +46,14 @@ interface ChannelPointer {
 interface SendsPointer {
   id: string;
   version?: string;
+  fields?: string[];
   to?: ChannelPointer[];
 }
 
 interface ReceivesPointer {
   id: string;
   version?: string;
+  fields?: string[];
   from?: ChannelPointer[];
 }
 

--- a/packages/sdk/src/internal/utils.ts
+++ b/packages/sdk/src/internal/utils.ts
@@ -309,6 +309,12 @@ export const copyDir = async (catalogDir: string, source: string, target: string
 };
 
 // Makes sure values in sends/recieves are unique
+export const buildMessagePointer = (message: { id: string; version: string; fields?: string[] }) => {
+  const pointer: { id: string; version: string; fields?: string[] } = { id: message.id, version: message.version };
+  if (message.fields) pointer.fields = message.fields;
+  return pointer;
+};
+
 export const uniqueVersions = (messages: { id: string; version: string }[]): { id: string; version: string }[] => {
   const uniqueSet = new Set();
 

--- a/packages/sdk/src/services.ts
+++ b/packages/sdk/src/services.ts
@@ -13,7 +13,7 @@ import {
   getResourcePath,
   toResource,
 } from './internal/resources';
-import { findFileById, invalidateFileCache, uniqueVersions } from './internal/utils';
+import { findFileById, invalidateFileCache, uniqueVersions, buildMessagePointer } from './internal/utils';
 
 /**
  * Returns a service from EventCatalog.
@@ -397,7 +397,8 @@ export const getSpecificationFilesForService = (directory: string) => async (id:
  */
 
 export const addMessageToService =
-  (directory: string) => async (id: string, direction: string, event: { id: string; version: string }, version?: string) => {
+  (directory: string) =>
+  async (id: string, direction: string, event: { id: string; version: string; fields?: string[] }, version?: string) => {
     let service: Service = await getService(directory)(id, version);
     const servicePath = await getResourcePath(directory, id, version);
     const extension = extname(servicePath?.fullPath || '');
@@ -412,7 +413,7 @@ export const addMessageToService =
           return;
         }
       }
-      service.sends.push({ id: event.id, version: event.version });
+      service.sends.push(buildMessagePointer(event));
     } else if (direction === 'receives') {
       if (service.receives === undefined) {
         service.receives = [];
@@ -423,7 +424,7 @@ export const addMessageToService =
           return;
         }
       }
-      service.receives.push({ id: event.id, version: event.version });
+      service.receives.push(buildMessagePointer(event));
     } else {
       throw new Error(`Direction ${direction} is invalid, only 'receives' and 'sends' are supported`);
     }

--- a/packages/sdk/src/test/domains.test.ts
+++ b/packages/sdk/src/test/domains.test.ts
@@ -1331,6 +1331,121 @@ describe('Domain SDK', () => {
       });
     });
 
+    describe('fields support on sends and receives', () => {
+      it('persists fields when writing a domain with sends that declare produced fields', async () => {
+        await writeDomain({
+          id: 'Orders',
+          name: 'Orders Domain',
+          version: '0.0.1',
+          summary: 'This is a summary',
+          markdown: '# Hello world',
+          sends: [{ id: 'OrderCreated', version: '1.0.0', fields: ['orderId', 'userId', 'totalAmount'] }],
+        });
+
+        const domain = await getDomain('Orders');
+
+        expect(domain.sends).toEqual([{ id: 'OrderCreated', version: '1.0.0', fields: ['orderId', 'userId', 'totalAmount'] }]);
+      });
+
+      it('persists fields when writing a domain with receives that declare consumed fields', async () => {
+        await writeDomain({
+          id: 'Orders',
+          name: 'Orders Domain',
+          version: '0.0.1',
+          summary: 'This is a summary',
+          markdown: '# Hello world',
+          receives: [{ id: 'PaymentProcessed', version: '1.0.0', fields: ['orderId', 'amount', 'status'] }],
+        });
+
+        const domain = await getDomain('Orders');
+
+        expect(domain.receives).toEqual([{ id: 'PaymentProcessed', version: '1.0.0', fields: ['orderId', 'amount', 'status'] }]);
+      });
+
+      it('includes fields when adding an event to a domain sends', async () => {
+        await writeDomain({
+          id: 'Orders',
+          name: 'Orders Domain',
+          version: '0.0.1',
+          summary: 'This is a summary',
+          markdown: '# Hello world',
+        });
+
+        await addEventToDomain('Orders', 'sends', {
+          id: 'OrderCreated',
+          version: '1.0.0',
+          fields: ['orderId', 'userId'],
+        });
+
+        const domain = await getDomain('Orders');
+
+        expect(domain.sends).toEqual([{ id: 'OrderCreated', version: '1.0.0', fields: ['orderId', 'userId'] }]);
+      });
+
+      it('includes fields when adding an event to a domain receives', async () => {
+        await writeDomain({
+          id: 'Orders',
+          name: 'Orders Domain',
+          version: '0.0.1',
+          summary: 'This is a summary',
+          markdown: '# Hello world',
+        });
+
+        await addEventToDomain('Orders', 'receives', {
+          id: 'PaymentProcessed',
+          version: '1.0.0',
+          fields: ['orderId', 'amount', 'currency'],
+        });
+
+        const domain = await getDomain('Orders');
+
+        expect(domain.receives).toEqual([
+          { id: 'PaymentProcessed', version: '1.0.0', fields: ['orderId', 'amount', 'currency'] },
+        ]);
+      });
+
+      it('preserves existing fields on receives when adding a new message', async () => {
+        await writeDomain({
+          id: 'Orders',
+          name: 'Orders Domain',
+          version: '0.0.1',
+          summary: 'This is a summary',
+          markdown: '# Hello world',
+          receives: [{ id: 'PaymentProcessed', version: '1.0.0', fields: ['orderId', 'amount'] }],
+        });
+
+        await addEventToDomain('Orders', 'receives', {
+          id: 'ShipmentDelivered',
+          version: '1.0.0',
+          fields: ['shipmentId', 'orderId'],
+        });
+
+        const domain = await getDomain('Orders');
+
+        expect(domain.receives).toEqual([
+          { id: 'PaymentProcessed', version: '1.0.0', fields: ['orderId', 'amount'] },
+          { id: 'ShipmentDelivered', version: '1.0.0', fields: ['shipmentId', 'orderId'] },
+        ]);
+      });
+
+      it('does not include fields property when fields are not provided', async () => {
+        await writeDomain({
+          id: 'Orders',
+          name: 'Orders Domain',
+          version: '0.0.1',
+          summary: 'This is a summary',
+          markdown: '# Hello world',
+        });
+
+        await addEventToDomain('Orders', 'sends', { id: 'OrderCreated', version: '1.0.0' });
+
+        const domain = await getDomain('Orders');
+
+        expect(domain.sends).toEqual([{ id: 'OrderCreated', version: '1.0.0' }]);
+        expect(domain.sends![0]).not.toHaveProperty('fields');
+      });
+    });
+
     describe('file handling', () => {
       it('preserves .md format when adding messages', async () => {
         await writeDomain(

--- a/packages/sdk/src/test/services.test.ts
+++ b/packages/sdk/src/test/services.test.ts
@@ -1336,6 +1336,150 @@ describe('Services SDK', () => {
       });
     });
   });
+
+  describe('fields support on sends and receives', () => {
+    it('persists fields when writing a service with sends that declare consumed fields', async () => {
+      await writeService({
+        id: 'InventoryService',
+        name: 'Inventory Service',
+        version: '0.0.1',
+        summary: 'Service that handles the inventory',
+        markdown: '# Hello world',
+        sends: [{ id: 'InventoryAdjusted', version: '1.0.0', fields: ['productId', 'quantity', 'warehouseId'] }],
+      });
+
+      const service = await getService('InventoryService');
+
+      expect(service.sends).toEqual([
+        { id: 'InventoryAdjusted', version: '1.0.0', fields: ['productId', 'quantity', 'warehouseId'] },
+      ]);
+    });
+
+    it('persists fields when writing a service with receives that declare consumed fields', async () => {
+      await writeService({
+        id: 'ShippingService',
+        name: 'Shipping Service',
+        version: '0.0.1',
+        summary: 'Service that handles shipping',
+        markdown: '# Hello world',
+        receives: [{ id: 'PaymentProcessed', version: '1.0.0', fields: ['orderId', 'amount', 'currency'] }],
+      });
+
+      const service = await getService('ShippingService');
+
+      expect(service.receives).toEqual([{ id: 'PaymentProcessed', version: '1.0.0', fields: ['orderId', 'amount', 'currency'] }]);
+    });
+
+    it('includes fields when adding an event to a service sends', async () => {
+      await writeService({
+        id: 'InventoryService',
+        name: 'Inventory Service',
+        version: '0.0.1',
+        summary: 'Service that handles the inventory',
+        markdown: '# Hello world',
+      });
+
+      await addEventToService(
+        'InventoryService',
+        'sends',
+        { id: 'InventoryAdjusted', version: '1.0.0', fields: ['productId', 'quantity'] },
+        '0.0.1'
+      );
+
+      const service = await getService('InventoryService');
+
+      expect(service.sends).toEqual([{ id: 'InventoryAdjusted', version: '1.0.0', fields: ['productId', 'quantity'] }]);
+    });
+
+    it('includes fields when adding an event to a service receives', async () => {
+      await writeService({
+        id: 'NotificationService',
+        name: 'Notification Service',
+        version: '0.0.1',
+        summary: 'Service that handles notifications',
+        markdown: '# Hello world',
+      });
+
+      await addEventToService(
+        'NotificationService',
+        'receives',
+        { id: 'InvoiceGenerated', version: '1.0.0', fields: ['invoiceId', 'customerId', 'total'] },
+        '0.0.1'
+      );
+
+      const service = await getService('NotificationService');
+
+      expect(service.receives).toEqual([
+        { id: 'InvoiceGenerated', version: '1.0.0', fields: ['invoiceId', 'customerId', 'total'] },
+      ]);
+    });
+
+    it('preserves existing fields on sends when adding a new message', async () => {
+      await writeService({
+        id: 'BillingService',
+        name: 'Billing Service',
+        version: '0.0.1',
+        summary: 'Service that handles billing',
+        markdown: '# Hello world',
+        sends: [{ id: 'InvoiceGenerated', version: '1.0.0', fields: ['invoiceId', 'total'] }],
+      });
+
+      await addEventToService(
+        'BillingService',
+        'sends',
+        { id: 'SubscriptionPaymentDue', version: '1.0.0', fields: ['subscriptionId', 'amount'] },
+        '0.0.1'
+      );
+
+      const service = await getService('BillingService');
+
+      expect(service.sends).toEqual([
+        { id: 'InvoiceGenerated', version: '1.0.0', fields: ['invoiceId', 'total'] },
+        { id: 'SubscriptionPaymentDue', version: '1.0.0', fields: ['subscriptionId', 'amount'] },
+      ]);
+    });
+
+    it('does not include fields property when fields are not provided', async () => {
+      await writeService({
+        id: 'InventoryService',
+        name: 'Inventory Service',
+        version: '0.0.1',
+        summary: 'Service that handles the inventory',
+        markdown: '# Hello world',
+      });
+
+      await addEventToService('InventoryService', 'sends', { id: 'OutOfStock', version: '1.0.0' }, '0.0.1');
+
+      const service = await getService('InventoryService');
+
+      expect(service.sends).toEqual([{ id: 'OutOfStock', version: '1.0.0' }]);
+      expect(service.sends![0]).not.toHaveProperty('fields');
+    });
+
+    it('includes fields when adding a command to a service receives', async () => {
+      await writeService({
+        id: 'InventoryService',
+        name: 'Inventory Service',
+        version: '0.0.1',
+        summary: 'Service that handles the inventory',
+        markdown: '# Hello world',
+      });
+
+      await addCommandToService(
+        'InventoryService',
+        'receives',
+        { id: 'UpdateInventory', version: '1.0.0', fields: ['productId', 'quantityChange', 'warehouseId'] },
+        '0.0.1'
+      );
+
+      const service = await getService('InventoryService');
+
+      expect(service.receives).toEqual([
+        { id: 'UpdateInventory', version: '1.0.0', fields: ['productId', 'quantityChange', 'warehouseId'] },
+      ]);
+    });
+  });
+
   describe('addCommandToService', () => {
     it('takes an existing command and adds it to the sends of an existing service', async () => {
       await writeService({

--- a/packages/sdk/src/types.d.ts
+++ b/packages/sdk/src/types.d.ts
@@ -54,12 +54,14 @@ export type ResourcePointer = {
 export type SendsPointer = {
   id: string;
   version?: string;
+  fields?: string[];
   to?: ChannelPointer[];
 };
 
 export type ReceivesPointer = {
   id: string;
   version?: string;
+  fields?: string[];
   from?: ChannelPointer[];
 };
 


### PR DESCRIPTION
## What This PR Does

Adds an optional `fields` property to sends/receives pointers, allowing services and domains to declare which specific fields of a message they depend on. When field usage is declared, a new Field Usage page appears in the message sidebar showing all schema properties alongside their consumers. This gives producers visibility into which fields are heavily depended on before making schema changes.

## Changes Overview

### Key Changes

**Schema & Types**
- Added `fields: z.array(z.string()).optional()` to `sendsPointer` and `receivesPointer` in `content.config.ts`
- Added `fields?: string[]` to `SendsPointer` and `ReceivesPointer` in SDK types and DSL utils

**New Field Usage Page**
- New Astro page at `/docs/{type}/{id}/{version}/field-lineage` with data loader
- Table view with Field, Type, Description, Consumers columns
- Schema metadata auto-extracted from JSON Schema, Avro, and Protobuf
- "Consumed only" filter button in the page header
- "Fields not found in schema" warning section for mismatched declarations

**Sidebar Integration**
- Field Usage link appears under "API & Contracts" only when a message has both a schema and field usage declared
- Uses raw service collection data to check for fields (hydrated services strip pointer metadata)

**SDK**
- `addMessageToService` and `addMessageToDomain` accept and persist `fields`
- Shared `buildMessagePointer()` helper extracted to avoid duplication

**Schema Parsing Utility**
- New `schema-utils.ts` with `extractSchemaProperties()` supporting JSON Schema, Avro, and Protobuf
- Refactored `PrintSchemaPropertiesTable.astro` to reuse this utility instead of its own inline copy

**Example Catalog**
- Added field declarations to 10+ services across Orders, Payment, and Subscriptions domains
- Added `PaymentProcessed` JSON schema
- Coverage across JSON Schema, Avro, and Protobuf schema formats

## Test Plan

- [x] 23 tests for `schema-utils.ts` (JSON Schema, Avro, Protobuf, edge cases)
- [x] 7 tests for service fields support in SDK
- [x] 6 tests for domain fields support in SDK
- [x] 4 tests for sidebar field usage link visibility
- [ ] Manual: verify Field Usage page renders correctly for PaymentProcessed event in example catalog
- [ ] Manual: verify sidebar link only appears when fields are declared

## Breaking Changes

None. The `fields` property is optional and all existing catalogs work unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)