### PR TITLE
fix(core): continue running generators when one fails

### DIFF
--- a/.changeset/gentle-rivers-flow.md
+++ b/.changeset/gentle-rivers-flow.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": minor
+---
+
+Continue running remaining generators when one fails instead of stopping the entire generation process

--- a/packages/core/src/generate.js
+++ b/packages/core/src/generate.js
@@ -29,6 +29,8 @@ export const generate = async (PROJECT_DIRECTORY) => {
       return;
     }
 
+    const errors = [];
+
     for (const generator of generators) {
       let plugin = generator[0];
       const pluginConfig = generator[1];
@@ -48,17 +50,21 @@ export const generate = async (PROJECT_DIRECTORY) => {
         const generator = getDefaultExport(importedGenerator);
 
         await generator({ eventCatalogConfig: {} }, pluginConfig);
-
-        // Use importedGenerator here
       } catch (error) {
-        logger.error('Error loading plugin:', 'generator');
+        logger.error(`Failed to run generator "${plugin}":`, 'generator');
         console.error(error);
-        await cleanup(PROJECT_DIRECTORY);
-        return;
+        errors.push({ plugin, error });
       }
     }
 
     await cleanup(PROJECT_DIRECTORY);
+
+    if (errors.length > 0) {
+      logger.error(`${errors.length} generator(s) failed:`, 'generator');
+      for (const { plugin } of errors) {
+        logger.error(`  - ${plugin}`, 'generator');
+      }
+    }
   } catch (error) {
     // Failed to generate clean up...
     console.error(error);


### PR DESCRIPTION
Closes #2346

## What This PR Does

Previously, when any generator threw an error during `npm run generate`, the entire generation process stopped immediately and all subsequent generators were skipped. This fix makes the generator loop continue processing remaining generators after a failure, collecting errors and reporting a summary at the end.

## Changes Overview

### Key Changes
- Replace early `return` on generator error with error collection and `continue` behavior
- Improve error message to include the name of the failed generator plugin
- Add summary of all failed generators printed after the loop completes
- Remove redundant `cleanup()` call from the catch block (cleanup now always runs once at the end)

## How It Works

The `catch` block inside the generator loop no longer calls `return`. Instead, it pushes the error into an `errors` array and lets the `for` loop continue to the next generator. After all generators have been attempted, cleanup runs once, and if any errors were collected, a summary is logged listing all failed generators.

## Breaking Changes

None

## Additional Notes

This addresses the scenario described in #2346 where a user with 35+ OpenAPI generators had the entire process halted by a single spec parsing error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)