### PR TITLE
feat(core): support flows in nested directories and across domains/services

### DIFF
--- a/.changeset/gentle-waves-flow.md
+++ b/.changeset/gentle-waves-flow.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Support flows in nested directories and across domains and services by using recursive glob patterns

--- a/packages/core/eventcatalog/src/content.config.ts
+++ b/packages/core/eventcatalog/src/content.config.ts
@@ -239,7 +239,7 @@ const flowStep = z
 
 const flows = defineCollection({
   loader: glob({
-    pattern: withIgnoredBuildArtifacts(['**/flows/*/index.(md|mdx)', '**/flows/*/versioned/*/index.(md|mdx)']),
+    pattern: withIgnoredBuildArtifacts(['**/flows/**/index.(md|mdx)', '**/flows/**/versioned/*/index.(md|mdx)']),
     base: projectDirBase,
     generateId: ({ data }) => {
       return `${data.id}-${data.version}`;


### PR DESCRIPTION
Closes https://github.com/event-catalog/eventcatalog/issues/2342

## What This PR Does

Updates the flows content collection glob pattern to use recursive matching (`**/`) instead of single-level matching (`*/`). This allows flows to be documented anywhere in EventCatalog — inside domains, services, or organized in subdirectories.

## Changes Overview

### Key Changes
- Changed flow glob patterns from `**/flows/*/index.(md|mdx)` to `**/flows/**/index.(md|mdx)` for recursive directory discovery
- Changed versioned flow pattern similarly to support nested versioned flows

## How It Works

The Astro content collection loader for flows previously used single-level glob (`*/`) which only matched flows directly inside a `flows/` directory. By switching to recursive glob (`**/`), flows are now discovered at any depth, enabling:
- Flows inside domain directories (e.g., `domains/Payment/flows/checkout/index.md`)
- Flows inside service directories (e.g., `services/OrderService/flows/process-order/index.md`)
- Flows organized in subdirectories (e.g., `flows/onboarding/signup-flow/index.md`)

## Breaking Changes

None

## Additional Notes

The `id` field in flow frontmatter (not the file path) determines routing and references, so nested placement has no impact on how flows are referenced elsewhere in the catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)