### PR TITLE
Fix #2352: Add visual notes and grouping annotations to Flow steps

### DIFF
--- a/packages/core/eventcatalog/src/content.config.ts
+++ b/packages/core/eventcatalog/src/content.config.ts
@@ -310,6 +310,15 @@ const flows = defineCollection({
             return typesUsed === 0 || typesUsed === 1;
           })
       ),
+      annotations: z
+        .array(
+          z.object({
+            title: z.string(),
+            description: z.string().optional(),
+            steps: z.array(z.union([z.string(), z.number()])),
+          })
+        )
+        .optional(),
     })
     .extend(baseSchema.shape),
 });

--- a/packages/core/eventcatalog/src/utils/__tests__/flows/node-graph.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/flows/node-graph.spec.ts
@@ -267,5 +267,35 @@ describe('Flows NodeGraph', () => {
       expect(nodes).toEqual([]);
       expect(edges).toEqual([]);
     });
+
+    describe('when the flow has annotations', () => {
+      it('should attach annotations to the matching nodes', async () => {
+        const flowWithAnnotations = [
+          {
+            ...mockFlow[0],
+            data: {
+              ...mockFlow[0].data,
+              annotations: [
+                { title: 'Fallback Mechanism', description: 'Triggered on failure.', steps: [4] },
+                { title: 'Happy Path', steps: [1, 2] },
+              ],
+            },
+          },
+        ];
+        vi.spyOn(await import('astro:content'), 'getCollection').mockImplementation((key: string) => {
+          if (key === 'flows') return Promise.resolve(flowWithAnnotations) as any;
+          if (key === 'events') return Promise.resolve(mockEvents) as any;
+          return Promise.resolve([]) as any;
+        });
+
+        const { nodes } = await getNodesAndEdges({ id: 'PaymentFlow', version: '1.0.0' });
+
+        const node1 = nodes.find((n: any) => n.id === 'step-1');
+        const node4 = nodes.find((n: any) => n.id === 'step-4');
+
+        expect(node1?.data?.annotations).toEqual(expect.arrayContaining([expect.objectContaining({ title: 'Happy Path' })]));
+        expect(node4?.data?.annotations).toEqual(expect.arrayContaining([expect.objectContaining({ title: 'Fallback Mechanism' })]));
+      });
+    });
   });
 });

--- a/packages/core/eventcatalog/src/utils/node-graphs/flows-node-graph.ts
+++ b/packages/core/eventcatalog/src/utils/node-graphs/flows-node-graph.ts
@@ -73,6 +73,7 @@ export const getNodesAndEdges = async ({ id, defaultFlow, version, mode = 'simpl
   const flowMap = createVersionedMap(flows);
 
   const steps = flow?.data.steps || [];
+  const annotations = flow?.data.annotations || [];
 
   //  Hydrate the steps with information they may need.
   const hydratedSteps = steps.map((step: any) => {
@@ -110,6 +111,8 @@ export const getNodesAndEdges = async ({ id, defaultFlow, version, mode = 'simpl
     }
     if (step.externalSystem) node.data.externalSystem = { ...step.externalSystem, ...step.externalSystem.data };
     if (step.custom) node.data.custom = { ...step.custom, ...step.custom.data };
+    const nodeAnnotations = annotations.filter((a: any) => a.steps.includes(step.id));
+    if (nodeAnnotations.length > 0) node.data.annotations = nodeAnnotations;
     nodes.push(node);
   });
 


### PR DESCRIPTION
Closes #2352

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://www.eventcatalog.dev/docs/contributing/overview

Happy contributing!

-->

## Motivation

Complex Flows often contain several structurally similar steps that differ only in purpose or context (e.g., four consecutive calls to the same external service for different edge cases). Without a native annotation mechanism, authors are forced to explain these nuances in the main Markdown body, creating a back-and-forth disconnect between the prose and the diagram.

This PR implements the `annotations` array in the Flow frontmatter schema, allowing authors to attach titled, described notes to specific step IDs directly in the YAML:

```yaml
annotations:
  - title: "Fallback Mechanism"
    description: "These steps are only triggered if the primary payment gateway fails."
    steps: ["step-3", "step-4"]
  - title: "Legacy Support"
    description: "This step is deprecated and will be removed in v2."
    steps: ["step-5"]
```

**Schema (`content.config.ts`):** Added an optional `annotations` field to the flows collection schema — an array of objects with a required `title`, optional `description`, and a required `steps` array accepting both strings and numbers.

**Graph logic (`flows-node-graph.ts`):** In `getNodesAndEdges`, after the existing hydration loop, annotations are filtered per step via `annotations.filter((a) => a.steps.includes(step.id))` and attached to the node's `data.annotations` property when at least one match exists. This keeps annotation data co-located with the node, making it straightforward for rendering layers to consume.

**Tests (`node-graph.spec.ts`):** Added a `when the flow has annotations` test case that mocks a flow with two annotations targeting steps 1, 2, and 4, then asserts that `node1.data.annotations` contains `{ title: 'Happy Path' }` and `node4.data.annotations` contains `{ title: 'Fallback Mechanism' }`.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*