### PR TITLE
feat(core): add externalSystem flag to services

### DIFF
--- a/.changeset/purple-globes-appear.md
+++ b/.changeset/purple-globes-appear.md
@@ -1,0 +1,16 @@
+---
+"@eventcatalog/core": minor
+"@eventcatalog/sdk": minor
+"@eventcatalog/visualiser": minor
+---
+
+feat: add `externalSystem` flag to services for modelling third-party integrations
+
+Services can now set `externalSystem: true` in their frontmatter to be rendered as external systems. This changes their presentation without changing their capabilities — they still send and receive messages, have owners, and support specifications like any other service.
+
+- Visualiser: external services render purple with a Globe icon and an "External System" badge
+- Sidebar (root): a dedicated "External Systems" section lists externals; the regular "Services" section excludes them
+- Sidebar (domain): externals appear under a new "External Integrations" group, separate from "Services In Domain"
+- Per-service nav badge reads "External System" instead of "Service"
+- `/discover`: a new "External Systems" tab alongside the "Services" tab
+- SDK: the `Service` type now accepts `externalSystem?: boolean`

--- a/examples/default/domains/E-Commerce/index.mdx
+++ b/examples/default/domains/E-Commerce/index.mdx
@@ -11,6 +11,9 @@ domains:
   - id: Payment
   - id: Subscriptions
   - id: MySubdomain
+services:
+  - id: Snowflake
+    version: 1.0.0
 data-products:
   - id: order-analytics
 badges:

--- a/examples/default/domains/E-Commerce/services/Snowflake/index.mdx
+++ b/examples/default/domains/E-Commerce/services/Snowflake/index.mdx
@@ -1,0 +1,67 @@
+---
+id: Snowflake
+name: Snowflake
+version: 1.0.0
+summary: |
+  Cloud data warehouse used by FlowMart as the destination for all
+  analytical event streams. Owned and operated by Snowflake — modelled
+  here as an external system the E-Commerce domain ships data into.
+externalSystem: true
+repository:
+  url: https://github.com/snowflakedb/snowflake-connector-python
+receives:
+  - id: OrderConfirmed
+    version: 0.0.1
+  - id: PaymentComplete
+    version: 0.0.1
+  - id: ShipmentDelivered
+    version: 0.0.1
+  - id: UserSubscriptionStarted
+    version: 0.0.1
+  - id: InventoryAdjusted
+---
+
+import Footer from '@catalog/components/footer.astro'
+
+## Overview
+
+[Snowflake](https://www.snowflake.com) is FlowMart's cloud data warehouse. Every business-critical event published by the E-Commerce domain is streamed into Snowflake where it powers analytics, reporting, and the [[data-product|order-analytics]] data product.
+
+It is **owned and operated by Snowflake**, not by our team — so it appears in the catalog as an external system. We connect to it via the Snowflake Streaming API and the official drivers.
+
+<NodeGraph />
+
+## Streaming Architecture
+
+Events are streamed into Snowflake using a per-domain Kafka → Snowpipe Streaming pipeline:
+
+- **Orders subdomain** → `RAW.ORDERS` schema
+- **Payment subdomain** → `RAW.PAYMENTS` schema
+- **Subscriptions subdomain** → `RAW.SUBSCRIPTIONS` schema
+
+dbt models then transform the raw event data into the curated marts that back our [[data-product|order-analytics]] data product.
+
+## Receives
+
+Snowflake is a **sink** in this catalog — it consumes events but does not publish any. The events streamed into Snowflake are:
+
+- [[event|OrderConfirmed]] — every confirmed order, used for revenue analytics and conversion funnels
+- [[event|PaymentComplete]] — completed payments, used for revenue recognition
+- [[event|ShipmentDelivered]] — delivery completion, used for fulfillment SLA tracking
+- [[event|UserSubscriptionStarted]] — new subscriptions, used for MRR/ARR reporting
+- [[event|InventoryAdjusted]] — inventory movement, used for supply-chain analytics
+
+## Account & Region
+
+| Property | Value |
+|---|---|
+| Account | `flowmart-prod.eu-west-1` |
+| Edition | Business Critical |
+| Region | AWS `eu-west-1` |
+| Warehouse | `ANALYTICS_WH` (auto-suspend 60s) |
+
+## Cost
+
+Snowflake credits are budgeted per-quarter and tracked in the FinOps dashboard. The largest consumer is the dbt build that runs every 15 minutes against the curated marts.
+
+<Footer />

--- a/examples/default/domains/E-Commerce/subdomains/Payment/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Payment/index.mdx
@@ -20,6 +20,8 @@ services:
     version: 0.0.1
   - id: PaymentGatewayService
     version: 0.0.1
+  - id: Stripe
+    version: 1.0.0
 entities:
   - id: Invoice
   - id: Payment

--- a/examples/default/domains/E-Commerce/subdomains/Payment/services/PaymentGatewayService/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Payment/services/PaymentGatewayService/index.mdx
@@ -28,8 +28,14 @@ receives:
       - paymentId
       - decision
       - riskScore
+  - id: StripeChargeSucceeded
+    version: 0.0.1
+  - id: StripeChargeFailed
+    version: 0.0.1
 sends:
   - id: PaymentFailed
+    version: 0.0.1
+  - id: ChargeCard
     version: 0.0.1
 owners:
   - dboyne

--- a/examples/default/domains/E-Commerce/subdomains/Payment/services/Stripe/commands/ChargeCard/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Payment/services/Stripe/commands/ChargeCard/index.mdx
@@ -1,0 +1,39 @@
+---
+id: ChargeCard
+version: 0.0.1
+name: Charge Card
+summary: |
+  Request sent from PaymentGatewayService to Stripe to charge a customer's card.
+  Maps to Stripe's `POST /v1/charges` API.
+badges:
+  - content: External API Call
+    backgroundColor: purple
+    textColor: white
+operation:
+  method: POST
+  path: /v1/charges
+  statusCodes: ['200', '402', '429']
+---
+
+import Footer from '@catalog/components/footer.astro'
+
+## Overview
+
+`ChargeCard` represents the request our [[service|PaymentGatewayService]] makes to the [[service|Stripe]] external system to charge a customer's card. It is the catalog's view of Stripe's [Create a Charge](https://stripe.com/docs/api/charges/create) API call.
+
+## Example Request
+
+```json
+{
+  "amount": 4999,
+  "currency": "usd",
+  "source": "tok_visa_4242",
+  "description": "Order #pay_123456",
+  "metadata": {
+    "paymentId": "pay_123456",
+    "customerId": "cust_XYZ789"
+  }
+}
+```
+
+<Footer />

--- a/examples/default/domains/E-Commerce/subdomains/Payment/services/Stripe/events/StripeChargeFailed/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Payment/services/Stripe/events/StripeChargeFailed/index.mdx
@@ -1,0 +1,40 @@
+---
+id: StripeChargeFailed
+version: 0.0.1
+name: Stripe Charge Failed
+summary: Stripe webhook event delivered when a charge attempt fails
+badges:
+  - content: Webhook
+    backgroundColor: purple
+    textColor: white
+---
+
+import Footer from '@catalog/components/footer.astro'
+
+## Overview
+
+`StripeChargeFailed` is the catalog representation of Stripe's `charge.failed` webhook. It is delivered to the [[service|PaymentGatewayService]] webhook endpoint when a card charge cannot be completed.
+
+## Example Payload
+
+```json
+{
+  "id": "evt_1NXyZ2eZvKYlo2C0def456",
+  "type": "charge.failed",
+  "data": {
+    "object": {
+      "id": "ch_3NXyZ2eZvKYlo2C00abc",
+      "amount": 4999,
+      "currency": "usd",
+      "status": "failed",
+      "failure_code": "card_declined",
+      "failure_message": "Your card was declined.",
+      "metadata": {
+        "paymentId": "pay_123456"
+      }
+    }
+  }
+}
+```
+
+<Footer />

--- a/examples/default/domains/E-Commerce/subdomains/Payment/services/Stripe/events/StripeChargeSucceeded/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Payment/services/Stripe/events/StripeChargeSucceeded/index.mdx
@@ -1,0 +1,38 @@
+---
+id: StripeChargeSucceeded
+version: 0.0.1
+name: Stripe Charge Succeeded
+summary: Stripe webhook event delivered when a charge completes successfully
+badges:
+  - content: Webhook
+    backgroundColor: purple
+    textColor: white
+---
+
+import Footer from '@catalog/components/footer.astro'
+
+## Overview
+
+`StripeChargeSucceeded` is the catalog representation of Stripe's `charge.succeeded` webhook. It is delivered to the [[service|PaymentGatewayService]] webhook endpoint when a card charge completes.
+
+## Example Payload
+
+```json
+{
+  "id": "evt_1NXyZ2eZvKYlo2C0abc123",
+  "type": "charge.succeeded",
+  "data": {
+    "object": {
+      "id": "ch_3NXyZ2eZvKYlo2C00xyz",
+      "amount": 4999,
+      "currency": "usd",
+      "status": "succeeded",
+      "metadata": {
+        "paymentId": "pay_123456"
+      }
+    }
+  }
+}
+```
+
+<Footer />

--- a/examples/default/domains/E-Commerce/subdomains/Payment/services/Stripe/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Payment/services/Stripe/index.mdx
@@ -1,0 +1,42 @@
+---
+id: Stripe
+name: Stripe
+version: 1.0.0
+summary: |
+  External payment processor used by the Payment domain to charge cards and
+  receive webhook events for charge outcomes.
+externalSystem: true
+repository:
+  url: https://github.com/stripe/stripe-node
+receives:
+  - id: ChargeCard
+    version: 0.0.1
+sends:
+  - id: StripeChargeSucceeded
+    version: 0.0.1
+  - id: StripeChargeFailed
+    version: 0.0.1
+---
+
+import Footer from '@catalog/components/footer.astro'
+
+## Overview
+
+[Stripe](https://stripe.com) is the external payment processor we use to charge customer cards. It is owned and operated by Stripe, not by our team — it is modelled here as an **external system** so the catalog can show how our [[service|PaymentGatewayService]] integrates with it.
+
+The [[service|PaymentGatewayService]] sends [[command|ChargeCard]] requests to Stripe and consumes the resulting webhook events:
+
+- [[event|StripeChargeSucceeded]] — delivered when a charge completes
+- [[event|StripeChargeFailed]] — delivered when a charge is declined or errors
+
+<NodeGraph />
+
+## API Version
+
+We pin to Stripe API version `2024-06-20`. When Stripe releases a new API version we evaluate the changelog before bumping. The catalog version (`1.0.0`) tracks our integration contract, not the upstream Stripe API date.
+
+## Webhooks
+
+Stripe webhooks are delivered to `POST /webhooks/stripe` on the [[service|PaymentGatewayService]]. The signing secret is rotated quarterly and stored in AWS Secrets Manager.
+
+<Footer />

--- a/packages/core/eventcatalog/src/components/Tables/Discover/DiscoverTable.tsx
+++ b/packages/core/eventcatalog/src/components/Tables/Discover/DiscoverTable.tsx
@@ -22,6 +22,7 @@ export type CollectionType =
   | 'commands'
   | 'queries'
   | 'services'
+  | 'external-systems'
   | 'domains'
   | 'flows'
   | 'containers'

--- a/packages/core/eventcatalog/src/components/Tables/Discover/columns.tsx
+++ b/packages/core/eventcatalog/src/components/Tables/Discover/columns.tsx
@@ -104,7 +104,10 @@ const createActionsColumn = (collectionType: CollectionType, tableConfiguration:
       const item = info.row.original;
       const href = buildUrl(`/docs/${item.collection}/${item.data.id}/${item.data.version}`);
       const nodeKey = `${item.collection}-${item.data.id}-${item.data.version}`;
-      const badgeLabel = collectionType.charAt(0).toUpperCase() + collectionType.slice(1, -1);
+      const badgeLabel =
+        collectionType === 'external-systems'
+          ? 'External System'
+          : collectionType.charAt(0).toUpperCase() + collectionType.slice(1, -1);
 
       return (
         <div className="flex items-center gap-0.5">
@@ -612,6 +615,7 @@ export const getDiscoverColumns = (collectionType: CollectionType, tableConfigur
     case 'queries':
       return getQueryColumns(tableConfiguration);
     case 'services':
+    case 'external-systems':
       return getServiceColumns(tableConfiguration);
     case 'domains':
       return getDomainColumns(tableConfiguration);

--- a/packages/core/eventcatalog/src/content.config.ts
+++ b/packages/core/eventcatalog/src/content.config.ts
@@ -456,6 +456,7 @@ const services = defineCollection({
       writesTo: z.array(pointer).optional(),
       readsFrom: z.array(pointer).optional(),
       flows: z.array(pointer).optional(),
+      externalSystem: z.boolean().optional(),
       detailsPanel: z
         .object({
           domains: detailPanelPropertySchema.optional(),

--- a/packages/core/eventcatalog/src/pages/discover/[type]/_index.data.ts
+++ b/packages/core/eventcatalog/src/pages/discover/[type]/_index.data.ts
@@ -13,14 +13,28 @@ export class Page extends HybridPage {
     const { getServices } = await import('@utils/collections/services');
     const { getDataProducts } = await import('@utils/collections/data-products');
 
+    const getInternalServices = async () => (await getServices()).filter((s) => !s.data.externalSystem);
+    const getExternalServices = async () => (await getServices()).filter((s) => s.data.externalSystem);
+
     const loaders = {
       ...pageDataLoader,
       flows: getFlows,
-      services: getServices,
+      services: getInternalServices,
+      'external-systems': getExternalServices,
       'data-products': getDataProducts,
     };
 
-    const itemTypes = ['events', 'commands', 'queries', 'domains', 'services', 'flows', 'containers', 'data-products'] as const;
+    const itemTypes = [
+      'events',
+      'commands',
+      'queries',
+      'domains',
+      'services',
+      'external-systems',
+      'flows',
+      'containers',
+      'data-products',
+    ] as const;
     const allItems = await Promise.all(itemTypes.map((type) => loaders[type]()));
 
     return allItems.flatMap((items, index) => ({
@@ -45,10 +59,14 @@ export class Page extends HybridPage {
     const { getServices } = await import('@utils/collections/services');
     const { getDataProducts } = await import('@utils/collections/data-products');
 
+    const getInternalServices = async () => (await getServices()).filter((s) => !s.data.externalSystem);
+    const getExternalServices = async () => (await getServices()).filter((s) => s.data.externalSystem);
+
     const loaders = {
       ...pageDataLoader,
       flows: getFlows,
-      services: getServices,
+      services: getInternalServices,
+      'external-systems': getExternalServices,
       'data-products': getDataProducts,
     };
 

--- a/packages/core/eventcatalog/src/pages/discover/[type]/index.astro
+++ b/packages/core/eventcatalog/src/pages/discover/[type]/index.astro
@@ -1,5 +1,12 @@
 ---
-import { QueueListIcon, RectangleGroupIcon, BoltIcon, ChatBubbleLeftIcon, CubeIcon } from '@heroicons/react/24/outline';
+import {
+  QueueListIcon,
+  RectangleGroupIcon,
+  BoltIcon,
+  ChatBubbleLeftIcon,
+  CubeIcon,
+  GlobeAltIcon,
+} from '@heroicons/react/24/outline';
 import ServerIcon from '@heroicons/react/24/outline/ServerIcon';
 import { MagnifyingGlassIcon } from '@heroicons/react/20/solid';
 import { DatabaseIcon } from 'lucide-react';
@@ -30,6 +37,8 @@ const events = await getEvents();
 const queries = await getQueries();
 const commands = await getCommands();
 const services = await getServices();
+const internalServices = services.filter((s) => !s.data.externalSystem);
+const externalServices = services.filter((s) => s.data.externalSystem);
 const domains = await getDomains({ getAllVersions: false });
 const flows = await getFlows();
 const containers = await getContainers();
@@ -96,6 +105,16 @@ const typeConfig: Record<
       { id: 'isDeprecated', label: 'Is Deprecated' },
     ],
   },
+  'external-systems': {
+    label: 'External Systems',
+    propertyOptions: [
+      { id: 'hasSpecifications', label: 'Has Specifications' },
+      { id: 'hasOwners', label: 'Has Owners' },
+      { id: 'hasRepository', label: 'Has Repository' },
+      { id: 'hasDataDependencies', label: 'Has Data Dependencies' },
+      { id: 'isDeprecated', label: 'Is Deprecated' },
+    ],
+  },
   flows: {
     label: 'Flows',
     propertyOptions: [
@@ -125,8 +144,10 @@ const typeConfig: Record<
 
 const currentTypeConfig = typeConfig[type] || typeConfig.events;
 
+// External systems reuse the user's `services.tableConfiguration` so customisations apply to both tabs
+const tableConfigurationKey = type === 'external-systems' ? 'services' : type;
 // @ts-ignore
-const tableConfiguration = config[type as keyof typeof config]?.tableConfiguration ?? { columns: {} };
+const tableConfiguration = config[tableConfigurationKey as keyof typeof config]?.tableConfiguration ?? { columns: {} };
 
 const tabs = [
   {
@@ -139,13 +160,22 @@ const tabs = [
     visible: domains.length > 0,
   },
   {
-    label: `Services (${services.length})`,
+    label: `Services (${internalServices.length})`,
     href: buildUrl('/discover/services'),
     isActive: type === 'services',
     icon: ServerIcon,
     activeColor: 'pink',
-    enabled: services.length > 0,
-    visible: services.length > 0,
+    enabled: internalServices.length > 0,
+    visible: internalServices.length > 0,
+  },
+  {
+    label: `External Systems (${externalServices.length})`,
+    href: buildUrl('/discover/external-systems'),
+    isActive: type === 'external-systems',
+    icon: GlobeAltIcon,
+    activeColor: 'purple',
+    enabled: externalServices.length > 0,
+    visible: externalServices.length > 0,
   },
   {
     label: `Data (${containers.length})`,
@@ -278,23 +308,24 @@ const allSubdomainIds = new Set(
   domains.flatMap((d: any) => (d.data?.domains || []).map((sd: any) => sd.data?.id || sd.id)).filter(Boolean)
 );
 
-// For services, enrich with domain information
-const enrichedData =
-  type === 'services'
-    ? await Promise.all(
-        data.map(async (service: any) => {
-          const serviceDomains = await getDomainsForService(service);
-          return {
-            ...service,
-            enrichedDomains: serviceDomains.map((d: any) => ({
-              id: d.data.id,
-              name: d.data.name,
-              version: d.data.version,
-            })),
-          };
-        })
-      )
-    : data;
+const isServiceLike = type === 'services' || type === 'external-systems';
+
+// For services and external systems, enrich with domain information
+const enrichedData = isServiceLike
+  ? await Promise.all(
+      data.map(async (service: any) => {
+        const serviceDomains = await getDomainsForService(service);
+        return {
+          ...service,
+          enrichedDomains: serviceDomains.map((d: any) => ({
+            id: d.data.id,
+            name: d.data.name,
+            version: d.data.version,
+          })),
+        };
+      })
+    )
+  : data;
 
 const tableData = enrichedData.map((d: any) => ({
   collection: d.collection,
@@ -303,10 +334,10 @@ const tableData = enrichedData.map((d: any) => ({
   hasServices: type === 'domains' ? (d.data?.services || []).length > 0 : false,
   isSubdomain: type === 'domains' ? allSubdomainIds.has(d.data.id) : false,
   // Service-specific properties
-  domains: type === 'services' ? d.enrichedDomains : undefined,
-  hasSpecifications: type === 'services' ? hasSpecifications(d) : false,
-  hasRepository: type === 'services' ? !!d.data?.repository?.url : false,
-  hasDataDependencies: type === 'services' ? (d.data?.writesTo || []).length > 0 || (d.data?.readsFrom || []).length > 0 : false,
+  domains: isServiceLike ? d.enrichedDomains : undefined,
+  hasSpecifications: isServiceLike ? hasSpecifications(d) : false,
+  hasRepository: isServiceLike ? !!d.data?.repository?.url : false,
+  hasDataDependencies: isServiceLike ? (d.data?.writesTo || []).length > 0 || (d.data?.readsFrom || []).length > 0 : false,
   // Data-product-specific properties
   hasInputs: type === 'data-products' ? (d.data?.inputs || []).length > 0 : false,
   hasOutputs: type === 'data-products' ? (d.data?.outputs || []).length > 0 : false,
@@ -371,8 +402,8 @@ const uniqueDomains = domains.map((d) => ({
   version: d.data.version,
 }));
 
-// Show domains filter only for services
-const showDomainsFilter = type === 'services';
+// Show domains filter only for services and external systems
+const showDomainsFilter = isServiceLike;
 
 const title = `${currentTypeConfig.label} (${data.length})`;
 ---

--- a/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/sidebar-builder.spec.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/sidebar-builder.spec.ts
@@ -748,6 +748,111 @@ describe('getNestedSideBarData', () => {
       });
     });
 
+    describe('external systems', () => {
+      it('renders an "External Integrations" section in a domain with services that have externalSystem: true, and excludes them from "Services In Domain"', async () => {
+        const { writeDomain, writeService } = utils(CATALOG_FOLDER);
+
+        await writeDomain({
+          id: 'Shipping',
+          name: 'Shipping',
+          version: '0.0.1',
+          markdown: 'Shipping',
+          services: [
+            { id: 'ShippingService', version: '0.0.1' },
+            { id: 'Stripe', version: '1.0.0' },
+          ],
+        });
+
+        await writeService({
+          id: 'ShippingService',
+          name: 'ShippingService',
+          version: '0.0.1',
+          markdown: 'ShippingService',
+        });
+
+        await writeService({
+          id: 'Stripe',
+          name: 'Stripe',
+          version: '1.0.0',
+          markdown: 'Stripe',
+          externalSystem: true,
+        });
+
+        const navigationData = await getNestedSideBarData();
+        const domainNode = getNavigationConfigurationByKey('domain:Shipping:0.0.1', navigationData);
+
+        const servicesInDomainSection = getChildNodeByTitle('Services In Domain', domainNode.pages ?? []);
+        const externalIntegrationsSection = getChildNodeByTitle('External Integrations', domainNode.pages ?? []);
+
+        expect(servicesInDomainSection.pages).toEqual(['service:ShippingService:0.0.1']);
+        expect(externalIntegrationsSection).toEqual(
+          expect.objectContaining({
+            type: 'group',
+            title: 'External Integrations',
+            icon: 'Globe',
+            pages: ['service:Stripe:1.0.0'],
+          })
+        );
+      });
+
+      it('renders a separate "list:external-systems" root node and excludes externals from "list:services"', async () => {
+        const { writeService } = utils(CATALOG_FOLDER);
+
+        await writeService({
+          id: 'ShippingService',
+          name: 'ShippingService',
+          version: '0.0.1',
+          markdown: 'ShippingService',
+        });
+
+        await writeService({
+          id: 'Stripe',
+          name: 'Stripe',
+          version: '1.0.0',
+          markdown: 'Stripe',
+          externalSystem: true,
+        });
+
+        const navigationData = await getNestedSideBarData();
+
+        const servicesList = getNavigationConfigurationByKey('list:services', navigationData);
+        const externalSystemsList = getNavigationConfigurationByKey('list:external-systems', navigationData);
+
+        expect(servicesList.pages).toEqual(['service:ShippingService:0.0.1']);
+        expect(externalSystemsList).toEqual(
+          expect.objectContaining({
+            type: 'item',
+            title: 'External Systems',
+            icon: 'Globe',
+            pages: ['service:Stripe:1.0.0'],
+          })
+        );
+      });
+
+      it('renders the per-service nav item with badge "External System" when externalSystem is true', async () => {
+        const { writeService } = utils(CATALOG_FOLDER);
+
+        await writeService({
+          id: 'Stripe',
+          name: 'Stripe',
+          version: '1.0.0',
+          markdown: 'Stripe',
+          externalSystem: true,
+        });
+
+        const navigationData = await getNestedSideBarData();
+        const serviceNode = getNavigationConfigurationByKey('service:Stripe:1.0.0', navigationData);
+
+        expect(serviceNode).toEqual(
+          expect.objectContaining({
+            type: 'item',
+            title: 'Stripe',
+            badge: 'External System',
+          })
+        );
+      });
+    });
+
     describe('owners section', () => {
       it('is not listed if the domain does not have any owners', async () => {
         const { writeDomain } = utils(CATALOG_FOLDER);

--- a/packages/core/eventcatalog/src/stores/sidebar-store/builders/domain.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/builders/domain.ts
@@ -16,8 +16,11 @@ import { pluralizeMessageType } from '@utils/collections/messages';
 import { getSpecificationsForDomain } from '@utils/collections/domains';
 
 export const buildDomainNode = (domain: CollectionEntry<'domains'>, owners: any[], context: ResourceGroupContext): NavNode => {
-  const servicesInDomain = domain.data.services || [];
+  const allServicesInDomain = domain.data.services || [];
+  const servicesInDomain = allServicesInDomain.filter((service) => !(service as any).data?.externalSystem);
+  const externalSystemsInDomain = allServicesInDomain.filter((service) => (service as any).data?.externalSystem);
   const renderServices = servicesInDomain.length > 0 && shouldRenderSideBarSection(domain, 'services');
+  const renderExternalSystems = externalSystemsInDomain.length > 0 && shouldRenderSideBarSection(domain, 'services');
 
   const dataProductsInDomain = domain.data['data-products'] || [];
   const renderDataProducts = dataProductsInDomain.length > 0 && shouldRenderSideBarSection(domain, 'data-products');
@@ -178,6 +181,12 @@ export const buildDomainNode = (domain: CollectionEntry<'domains'>, owners: any[
         title: 'Services In Domain',
         icon: 'Server',
         pages: servicesInDomain.map((service) => `service:${(service as any).data.id}:${(service as any).data.version}`),
+      },
+      renderExternalSystems && {
+        type: 'group',
+        title: 'External Integrations',
+        icon: 'Globe',
+        pages: externalSystemsInDomain.map((service) => `service:${(service as any).data.id}:${(service as any).data.version}`),
       },
       renderDataProducts && {
         type: 'group',

--- a/packages/core/eventcatalog/src/stores/sidebar-store/builders/service.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/builders/service.ts
@@ -63,10 +63,12 @@ export const buildServiceNode = (
   const diagramNavItems = buildDiagramNavItems(serviceDiagrams, context.diagrams);
   const hasDiagrams = diagramNavItems.length > 0;
 
+  const isExternalSystem = !!service.data.externalSystem;
+
   return {
     type: 'item',
     title: service.data.name,
-    badge: 'Service',
+    badge: isExternalSystem ? 'External System' : 'Service',
     summary: service.data.summary,
     pages: [
       buildQuickReferenceSection(

--- a/packages/core/eventcatalog/src/stores/sidebar-store/state.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/state.ts
@@ -374,11 +374,21 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
     pages: domains.map((domain) => `domain:${domain.data.id}:${domain.data.version}`),
   });
 
-  const servicesList = createLeaf(services, {
+  const internalServices = services.filter((service) => !service.data.externalSystem);
+  const externalServices = services.filter((service) => service.data.externalSystem);
+
+  const servicesList = createLeaf(internalServices, {
     type: 'item',
     title: 'Services',
     icon: 'Server',
-    pages: services.map((service) => `service:${service.data.id}:${service.data.version}`),
+    pages: internalServices.map((service) => `service:${service.data.id}:${service.data.version}`),
+  });
+
+  const externalSystemsList = createLeaf(externalServices, {
+    type: 'item',
+    title: 'External Systems',
+    icon: 'Globe',
+    pages: externalServices.map((service) => `service:${service.data.id}:${service.data.version}`),
   });
 
   const eventsList = createLeaf(events, {
@@ -480,6 +490,7 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
   const allChildrenKeys = [
     'list:domains',
     'list:services',
+    'list:external-systems',
     'list:messages',
     'list:channels',
     'list:flows',
@@ -491,6 +502,7 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
   const allChildrenNodes = [
     domainsList,
     servicesList,
+    externalSystemsList,
     messagesList,
     channelList,
     flowsList,
@@ -515,6 +527,7 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
   const allNodes: Record<string, NavNode> = {
     ...(domainsList ? { 'list:domains': domainsList } : {}),
     ...(servicesList ? { 'list:services': servicesList } : {}),
+    ...(externalSystemsList ? { 'list:external-systems': externalSystemsList } : {}),
     ...(eventsList ? { 'list:events': eventsList } : {}),
     ...(commandsList ? { 'list:commands': commandsList } : {}),
     ...(queriesList ? { 'list:queries': queriesList } : {}),

--- a/packages/sdk/src/types.d.ts
+++ b/packages/sdk/src/types.d.ts
@@ -179,6 +179,7 @@ export interface Service extends BaseSchema {
   writesTo?: ResourcePointer[];
   readsFrom?: ResourcePointer[];
   flows?: ResourcePointer[];
+  externalSystem?: boolean;
   specifications?: Specifications | Specification[];
   detailsPanel?: {
     domains?: DetailPanelProperty;

--- a/packages/visualiser/src/nodes/service/ServiceNode.tsx
+++ b/packages/visualiser/src/nodes/service/ServiceNode.tsx
@@ -1,5 +1,5 @@
 import { memo, useMemo } from "react";
-import { ServerIcon } from "lucide-react";
+import { ServerIcon, Globe } from "lucide-react";
 import {
   OwnerIndicator,
   normalizeOwners,
@@ -161,8 +161,10 @@ const ServiceMessageFlow = memo(function ServiceMessageFlow({
 
 const GlowHandle = memo(function GlowHandle({
   side,
+  external,
 }: {
   side: "left" | "right";
+  external?: boolean;
 }) {
   return (
     <div
@@ -174,10 +176,14 @@ const GlowHandle = memo(function GlowHandle({
         width: 12,
         height: 12,
         borderRadius: "50%",
-        background: "linear-gradient(135deg, #ec4899, #be185d)",
+        background: external
+          ? "linear-gradient(135deg, #a855f7, #7e22ce)"
+          : "linear-gradient(135deg, #ec4899, #be185d)",
         border: "2px solid rgb(var(--ec-page-bg))",
         zIndex: 20,
-        animation: "ec-service-handle-pulse 2s ease-in-out infinite",
+        animation: external
+          ? "ec-external-handle-pulse 2s ease-in-out infinite"
+          : "ec-service-handle-pulse 2s ease-in-out infinite",
         pointerEvents: "none",
       }}
     />
@@ -188,6 +194,105 @@ function classNames(...classes: any) {
   return classes.filter(Boolean).join(" ");
 }
 
+type PostItPalette = {
+  Icon: typeof ServerIcon;
+  label: string;
+  gradient: string;
+  draftBorder: string;
+  corner: string;
+  ring: string;
+  iconClass: string;
+  labelClass: string;
+  nameText: string;
+  nameTextDeprecated: string;
+  versionClass: string;
+  summaryClass: string;
+};
+
+const POST_IT_SERVICE: PostItPalette = {
+  Icon: ServerIcon,
+  label: "Service",
+  gradient: "linear-gradient(135deg, #fbcfe8 0%, #f9a8d4 40%, #ec4899 100%)",
+  draftBorder: "rgba(236, 72, 153, 0.5)",
+  corner: "#db2777",
+  ring: "ring-2 ring-pink-400/60 ring-offset-1",
+  iconClass: "w-3 h-3 text-pink-900/50",
+  labelClass: "text-[8px] font-bold text-pink-900/50 uppercase tracking-widest",
+  nameText: "text-pink-950",
+  nameTextDeprecated: "text-pink-950/40 line-through",
+  versionClass: "text-[9px] text-pink-900/40 font-semibold mt-0.5",
+  summaryClass:
+    "mt-2 pt-1.5 border-t border-pink-900/10 text-[9px] text-pink-950/60 leading-relaxed overflow-hidden",
+};
+
+const POST_IT_EXTERNAL: PostItPalette = {
+  Icon: Globe,
+  label: "External System",
+  gradient: "linear-gradient(135deg, #e9d5ff 0%, #c084fc 40%, #a855f7 100%)",
+  draftBorder: "rgba(168, 85, 247, 0.5)",
+  corner: "#7e22ce",
+  ring: "ring-2 ring-purple-400/60 ring-offset-1",
+  iconClass: "w-3 h-3 text-purple-900/50",
+  labelClass:
+    "text-[8px] font-bold text-purple-900/50 uppercase tracking-widest",
+  nameText: "text-purple-950",
+  nameTextDeprecated: "text-purple-950/40 line-through",
+  versionClass: "text-[9px] text-purple-900/40 font-semibold mt-0.5",
+  summaryClass:
+    "mt-2 pt-1.5 border-t border-purple-900/10 text-[9px] text-purple-950/60 leading-relaxed overflow-hidden",
+};
+
+type DefaultPalette = {
+  Icon: typeof ServerIcon;
+  label: string;
+  ring: string;
+  borderSolid: string;
+  borderDraftDark: string;
+  borderDraftLight: string;
+  draftStripeDark: string;
+  draftStripeLight: string;
+  nodeBgVar: string;
+  shadowColor: string;
+  badgeBg: string;
+  ownerAccent: string;
+  ownerBorder: string;
+  ownerIcon: string;
+};
+
+const DEFAULT_SERVICE: DefaultPalette = {
+  Icon: ServerIcon,
+  label: "Service",
+  ring: "ring-2 ring-pink-400/60 ring-offset-2",
+  borderSolid: "border-pink-500",
+  borderDraftDark: "border-dashed border-pink-400",
+  borderDraftLight: "border-dashed border-pink-400/60",
+  draftStripeDark: "rgba(236,72,153,0.25)",
+  draftStripeLight: "rgba(236,72,153,0.15)",
+  nodeBgVar: "var(--ec-service-node-bg, rgb(var(--ec-card-bg)))",
+  shadowColor: "rgba(236, 72, 153, 0.15)",
+  badgeBg: "bg-pink-500",
+  ownerAccent: "bg-pink-400",
+  ownerBorder: "rgba(236,72,153,0.08)",
+  ownerIcon: "text-pink-300",
+};
+
+const DEFAULT_EXTERNAL: DefaultPalette = {
+  Icon: Globe,
+  label: "External System",
+  ring: "ring-2 ring-purple-400/60 ring-offset-2",
+  borderSolid: "border-purple-500",
+  borderDraftDark: "border-dashed border-purple-400",
+  borderDraftLight: "border-dashed border-purple-400/60",
+  draftStripeDark: "rgba(168,85,247,0.25)",
+  draftStripeLight: "rgba(168,85,247,0.15)",
+  nodeBgVar: "var(--ec-external-node-bg, rgb(var(--ec-card-bg)))",
+  shadowColor: "rgba(168, 85, 247, 0.15)",
+  badgeBg: "bg-purple-500",
+  ownerAccent: "bg-purple-400",
+  ownerBorder: "rgba(168,85,247,0.08)",
+  ownerIcon: "text-purple-300",
+};
+
 type ServiceNodeData = EventCatalogResource & {
   service: ServiceType;
 };
@@ -195,16 +300,25 @@ type ServiceNodeData = EventCatalogResource & {
 export type ServiceNode = Node<ServiceNodeData, "service">;
 
 function PostItService(props: ServiceNode) {
-  const { version, name, summary, deprecated, draft, notes, specifications } =
-    props.data.service;
+  const {
+    version,
+    name,
+    summary,
+    deprecated,
+    draft,
+    notes,
+    specifications,
+    externalSystem,
+  } = props.data.service;
   const mode = props.data.mode || "simple";
   const isDark = useDarkMode();
+  const p = externalSystem ? POST_IT_EXTERNAL : POST_IT_SERVICE;
 
   return (
     <div
       className={classNames(
         "relative min-w-44 max-w-56 min-h-[120px]",
-        props?.selected ? "ring-2 ring-pink-400/60 ring-offset-1" : "",
+        props?.selected ? p.ring : "",
       )}
     >
       <Handle
@@ -224,16 +338,14 @@ function PostItService(props: ServiceNode) {
       <div
         className="absolute inset-0"
         style={{
-          background: draft
-            ? "repeating-linear-gradient(135deg, #fbcfe8 0%, #f9a8d4 40%, #ec4899 100%)"
-            : "linear-gradient(135deg, #fbcfe8 0%, #f9a8d4 40%, #ec4899 100%)",
+          background: p.gradient,
           boxShadow:
             "1px 1px 3px rgba(0,0,0,0.15), 3px 4px 8px rgba(0,0,0,0.08)",
           transform: "rotate(1deg)",
           border: deprecated
             ? "2px dashed rgba(239, 68, 68, 0.5)"
             : draft
-              ? "2px dashed rgba(236, 72, 153, 0.5)"
+              ? `2px dashed ${p.draftBorder}`
               : "none",
         }}
       >
@@ -248,24 +360,17 @@ function PostItService(props: ServiceNode) {
             height: 0,
             borderStyle: "solid",
             borderWidth: "18px 0 0 18px",
-            borderColor: "#db2777 transparent transparent transparent",
+            borderColor: `${p.corner} transparent transparent transparent`,
             opacity: 0.3,
           }}
         />
       </div>
 
-      {/* Content sits on top, unrotated */}
       <div className="relative px-3.5 py-3">
-        {/* Type label row */}
         <div className="flex items-center justify-between mb-2">
           <div className="flex items-center gap-1">
-            <ServerIcon
-              className="w-3 h-3 text-pink-900/50"
-              strokeWidth={2.5}
-            />
-            <span className="text-[8px] font-bold text-pink-900/50 uppercase tracking-widest">
-              Service
-            </span>
+            <p.Icon className={p.iconClass} strokeWidth={2.5} />
+            <span className={p.labelClass}>{p.label}</span>
           </div>
           {draft && (
             <span className="text-[8px] font-extrabold text-amber-900 bg-amber-100 border border-dashed border-amber-400 px-1.5 py-0.5 rounded uppercase">
@@ -279,27 +384,20 @@ function PostItService(props: ServiceNode) {
           )}
         </div>
 
-        {/* Name */}
         <div
           className={classNames(
             "text-[13px] font-bold leading-snug",
-            deprecated ? "text-pink-950/40 line-through" : "text-pink-950",
+            deprecated ? p.nameTextDeprecated : p.nameText,
           )}
         >
           {name}
         </div>
 
-        {/* Version */}
-        {version && (
-          <div className="text-[9px] text-pink-900/40 font-semibold mt-0.5">
-            v{version}
-          </div>
-        )}
+        {version && <div className={p.versionClass}>v{version}</div>}
 
-        {/* Summary */}
         {mode === "full" && summary && (
           <div
-            className="mt-2 pt-1.5 border-t border-pink-900/10 text-[9px] text-pink-950/60 leading-relaxed overflow-hidden"
+            className={p.summaryClass}
             style={LINE_CLAMP_STYLE}
             title={summary}
           >
@@ -307,7 +405,6 @@ function PostItService(props: ServiceNode) {
           </div>
         )}
 
-        {/* Spec badges */}
         {!!specifications && (
           <div className="mt-1.5 flex justify-end">
             <SpecBadges specifications={specifications} isDark={isDark} />
@@ -319,8 +416,16 @@ function PostItService(props: ServiceNode) {
 }
 
 function DefaultService(props: ServiceNode) {
-  const { version, name, summary, deprecated, draft, notes, specifications } =
-    props.data.service;
+  const {
+    version,
+    name,
+    summary,
+    deprecated,
+    draft,
+    notes,
+    specifications,
+    externalSystem,
+  } = props.data.service;
   const mode = props.data.mode || "simple";
   const owners = useMemo(
     () => normalizeOwners(props.data.service.owners),
@@ -333,24 +438,28 @@ function DefaultService(props: ServiceNode) {
     ? "rgba(239,68,68,0.25)"
     : "rgba(239,68,68,0.1)";
 
+  const p = externalSystem ? DEFAULT_EXTERNAL : DEFAULT_SERVICE;
+  const draftStripe = isDark ? p.draftStripeDark : p.draftStripeLight;
+  const borderDraft = isDark ? p.borderDraftDark : p.borderDraftLight;
+
   return (
     <div
       className={classNames(
         "relative min-w-48 max-w-60 rounded-xl border-2 overflow-visible",
-        props?.selected ? "ring-2 ring-pink-400/60 ring-offset-2" : "",
+        props?.selected ? p.ring : "",
         deprecated
           ? "border-dashed border-red-500"
           : draft
-            ? `border-dashed ${isDark ? "border-pink-400" : "border-pink-400/60"}`
-            : "border-pink-500",
+            ? borderDraft
+            : p.borderSolid,
       )}
       style={{
         background: deprecated
-          ? `repeating-linear-gradient(135deg, transparent, transparent 6px, ${deprecatedStripe} 6px, ${deprecatedStripe} 7px), var(--ec-service-node-bg, rgb(var(--ec-card-bg)))`
+          ? `repeating-linear-gradient(135deg, transparent, transparent 6px, ${deprecatedStripe} 6px, ${deprecatedStripe} 7px), ${p.nodeBgVar}`
           : draft
-            ? `repeating-linear-gradient(135deg, transparent, transparent 4px, ${isDark ? "rgba(236,72,153,0.25)" : "rgba(236,72,153,0.15)"} 4px, ${isDark ? "rgba(236,72,153,0.25)" : "rgba(236,72,153,0.15)"} 4.5px), repeating-linear-gradient(45deg, transparent, transparent 4px, ${isDark ? "rgba(236,72,153,0.25)" : "rgba(236,72,153,0.15)"} 4px, ${isDark ? "rgba(236,72,153,0.25)" : "rgba(236,72,153,0.15)"} 4.5px), var(--ec-service-node-bg, rgb(var(--ec-card-bg)))`
-            : "var(--ec-service-node-bg, rgb(var(--ec-card-bg)))",
-        boxShadow: "0 2px 12px rgba(236, 72, 153, 0.15)",
+            ? `repeating-linear-gradient(135deg, transparent, transparent 4px, ${draftStripe} 4px, ${draftStripe} 4.5px), repeating-linear-gradient(45deg, transparent, transparent 4px, ${draftStripe} 4px, ${draftStripe} 4.5px), ${p.nodeBgVar}`
+            : p.nodeBgVar,
+        boxShadow: `0 2px 12px ${p.shadowColor}`,
       }}
     >
       <Handle
@@ -366,25 +475,28 @@ function DefaultService(props: ServiceNode) {
       {notes && notes.length > 0 && (
         <NotesIndicator notes={notes} resourceName={name} />
       )}
-      {targetConnections.length > 0 && <GlowHandle side="left" />}
-      {sourceConnections.length > 0 && <GlowHandle side="right" />}
+      {targetConnections.length > 0 && (
+        <GlowHandle side="left" external={externalSystem} />
+      )}
+      {sourceConnections.length > 0 && (
+        <GlowHandle side="right" external={externalSystem} />
+      )}
 
-      {/* Badge positioned outside top-left corner */}
       <div className="absolute -top-2.5 left-2.5 flex items-center gap-1.5 z-10">
         <span
           className={classNames(
             "inline-flex items-center gap-1 text-[7px] font-bold uppercase tracking-widest text-white px-1.5 py-0.5 rounded shadow-sm",
-            deprecated ? "bg-red-500" : "bg-pink-500",
+            deprecated ? "bg-red-500" : p.badgeBg,
           )}
         >
-          <ServerIcon className="w-2.5 h-2.5" strokeWidth={2.5} />
-          Service{draft && " (Draft)"}
+          <p.Icon className="w-2.5 h-2.5" strokeWidth={2.5} />
+          {p.label}
+          {draft && " (Draft)"}
           {deprecated && " (Deprecated)"}
         </span>
       </div>
 
       <div className="px-3 pt-3.5 pb-2.5">
-        {/* Name + version */}
         <div className="flex items-baseline gap-1">
           <span className="text-[13px] font-semibold leading-snug text-[rgb(var(--ec-page-text))]">
             {name}
@@ -396,7 +508,6 @@ function DefaultService(props: ServiceNode) {
           )}
         </div>
 
-        {/* Summary */}
         {mode === "full" && summary && (
           <div
             className="mt-1.5 text-[9px] text-[rgb(var(--ec-page-text-muted))] leading-relaxed overflow-hidden"
@@ -407,13 +518,12 @@ function DefaultService(props: ServiceNode) {
           </div>
         )}
 
-        {/* Owners + Spec badges row */}
         <div className="flex items-end justify-between gap-1">
           <OwnerIndicator
             owners={owners}
-            accentColor="bg-pink-400"
-            borderColor="rgba(236,72,153,0.08)"
-            iconClass="text-pink-300"
+            accentColor={p.ownerAccent}
+            borderColor={p.ownerBorder}
+            iconClass={p.ownerIcon}
           />
           {!!specifications && (
             <SpecBadges specifications={specifications} isDark={isDark} />

--- a/packages/visualiser/src/types/index.ts
+++ b/packages/visualiser/src/types/index.ts
@@ -56,6 +56,7 @@ export type Service = {
   draft?: boolean;
   notes?: Note[];
   specifications?: unknown;
+  externalSystem?: boolean;
 };
 
 /**


### PR DESCRIPTION
## What This PR Does

Introduces a new `externalSystem: true` flag on the service schema so teams can model third-party dependencies (Stripe, Twilio, Snowflake, Auth0, etc.) as first-class services in EventCatalog. The flag does not create a new resource type — external systems share the full services schema and capabilities. It changes only how they are presented, so the systems you own are visually and organisationally separable from the ones you depend on.

## Changes Overview

### Key Changes

- **Schema**: `externalSystem: z.boolean().optional()` added to the services collection (`packages/core/eventcatalog/src/content.config.ts`).
- **SDK**: `externalSystem?: boolean` added to the `Service` interface (`packages/sdk/src/types.d.ts`).
- **Visualiser**: `ServiceNode` renders purple with a Globe icon and an "External System" badge when the flag is set. Both the default and post-it variants are updated via two module-scope palette objects (`packages/visualiser/src/nodes/service/ServiceNode.tsx`, `packages/visualiser/src/types/index.ts`).
- **Sidebar (root)**: `list:services` now excludes externals; a new `list:external-systems` section lists them separately (`packages/core/eventcatalog/src/stores/sidebar-store/state.ts`).
- **Sidebar (domain)**: inside a domain, externals appear under a new "External Integrations" group alongside (but separate from) "Services In Domain" (`packages/core/eventcatalog/src/stores/sidebar-store/builders/domain.ts`).
- **Per-service nav badge**: reads "External System" instead of "Service" when the flag is set (`packages/core/eventcatalog/src/stores/sidebar-store/builders/service.ts`).
- **Discover**: new `/discover/external-systems` tab alongside `/discover/services`. Both share the services columns; the tab counts and data loaders filter by the flag (`packages/core/eventcatalog/src/pages/discover/[type]/index.astro`, `_index.data.ts`, `components/Tables/Discover/DiscoverTable.tsx`, `columns.tsx`).
- **Tests**: three new tests cover the root sidebar split, the domain sidebar group, and the per-service badge (`sidebar-builder.spec.ts`).
- **Demo catalog**: added **Stripe** (Payment subdomain) with `ChargeCard` command + `StripeChargeSucceeded` / `StripeChargeFailed` webhook events, wired into `PaymentGatewayService`. Added **Snowflake** at the E-Commerce domain root, receiving analytics events from across all three subdomains.

## How It Works

A service marked `externalSystem: true` flows through the same pipelines as any other service. At render time:

- The visualiser reads the flag off `service.data` and selects a purple palette (matching the existing ExternalSystem node colors) instead of the pink services palette.
- The sidebar builder splits the services array by the flag before constructing list nodes, so the existing per-service builder is reused unchanged.
- The discover page uses the same \`getServiceColumns\` as the services tab; the \`external-systems\` route filters the services collection down to flagged entries.

Because the flag only affects presentation and grouping, no migration is required. Existing service definitions continue to work without change.

## Breaking Changes

None. The flag is optional and defaults to \`false\` (regular service).

## Additional Notes

- The demo catalog change makes this visible on the default example, so maintainers can see the feature working without any configuration.
- The per-service page itself is unchanged — external systems look like regular services internally; only the category labels in the sidebar and discover tab differ.
- Follow-up candidates (not in this PR): optional \`external-systems\` key in the domain \`detailsPanel\` schema to let users toggle the new sidebar group independently from the existing \`services\` toggle; consideration of whether to remove the now-redundant \`ExternalSystem.tsx\` / \`ExternalSystem2.tsx\` visualiser node components that predate this feature.