### PR TITLE
fix(visualiser): center multi-line edge labels and fix save button theming

### DIFF
--- a/.changeset/centered-edge-labels-and-theme-save.md
+++ b/.changeset/centered-edge-labels-and-theme-save.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/visualiser": patch
+---
+
+fix(visualiser): center multi-line edge labels, add backgrounds to data-store edges, and make the "Layout changed" Save button theme-safe

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -7,7 +7,6 @@
 - 8f724a7: feat: add `externalSystem` flag to services for modelling third-party integrations
 
   Services can now set `externalSystem: true` in their frontmatter to be rendered as external systems. This changes their presentation without changing their capabilities — they still send and receive messages, have owners, and support specifications like any other service.
-
   - Visualiser: external services render purple with a Globe icon and an "External System" badge
   - Sidebar (root): a dedicated "External Systems" section lists externals; the regular "Services" section excludes them
   - Sidebar (domain): externals appear under a new "External Integrations" group, separate from "Services In Domain"

--- a/packages/visualiser/src/components/NodeGraph.tsx
+++ b/packages/visualiser/src/components/NodeGraph.tsx
@@ -1882,7 +1882,7 @@ const NodeGraphBuilder = ({
                   <button
                     onClick={handleQuickSaveLayout}
                     disabled={isSavingLayout}
-                    className="text-xs font-medium text-[rgb(var(--ec-accent-text))] bg-[rgb(var(--ec-accent-subtle))] hover:bg-[rgb(var(--ec-accent-subtle)/0.7)] px-2 py-1 rounded transition-colors disabled:opacity-50"
+                    className="text-xs font-medium text-white bg-[rgb(var(--ec-accent))] hover:bg-[rgb(var(--ec-accent-hover))] px-2 py-1 rounded transition-colors disabled:opacity-50"
                   >
                     {isSavingLayout ? "Saving..." : "Save"}
                   </button>

--- a/packages/visualiser/src/edges/AnimatedMessageEdge.tsx
+++ b/packages/visualiser/src/edges/AnimatedMessageEdge.tsx
@@ -110,6 +110,7 @@ const AnimatedMessageEdge = memo(
       [lines],
     );
     const labelWidth = Math.max(longestLine.length * 6.5 + 16, 50);
+    const firstLineDy = `${-((lines.length - 1) * 1.2) / 2}em`;
 
     return (
       <>
@@ -150,7 +151,7 @@ const AnimatedMessageEdge = memo(
               <tspan
                 key={i}
                 x={labelX}
-                dy={i === 0 ? 0 : "1.2em"}
+                dy={i === 0 ? firstLineDy : "1.2em"}
                 style={i === 0 ? TSPAN_NORMAL_STYLE : TSPAN_ITALIC_STYLE}
               >
                 {line}

--- a/packages/visualiser/src/edges/MultilineEdgeLabel.tsx
+++ b/packages/visualiser/src/edges/MultilineEdgeLabel.tsx
@@ -30,6 +30,16 @@ export default memo(function MultilineEdgeLabel(props: EdgeProps) {
   });
 
   const lines = useMemo(() => String(label ?? "").split("\n"), [label]);
+  const firstLineDy = useMemo(
+    () => `${-((lines.length - 1) * 1.2) / 2}em`,
+    [lines.length],
+  );
+  const longestLine = useMemo(
+    () => lines.reduce((a, b) => (a.length > b.length ? a : b), ""),
+    [lines],
+  );
+  const labelWidth = Math.max(longestLine.length * 5.5 + 14, 44);
+  const labelHeight = lines.length * 12 + 4;
 
   return (
     <>
@@ -42,7 +52,21 @@ export default memo(function MultilineEdgeLabel(props: EdgeProps) {
         style={style as any}
       />
 
-      {/* Optional: bigger hitbox for hover/selection */}
+      {label && (
+        <rect
+          x={labelX - labelWidth / 2}
+          y={labelY - labelHeight / 2}
+          width={labelWidth}
+          height={labelHeight}
+          fill="rgb(var(--ec-card-bg))"
+          fillOpacity={0.95}
+          stroke="rgb(var(--ec-page-border))"
+          strokeWidth={0.75}
+          rx={5}
+          ry={5}
+          pointerEvents="none"
+        />
+      )}
 
       <text
         x={labelX}
@@ -57,7 +81,7 @@ export default memo(function MultilineEdgeLabel(props: EdgeProps) {
           <tspan
             key={i}
             x={labelX}
-            dy={i === 0 ? 0 : "1.2em"}
+            dy={i === 0 ? firstLineDy : "1.2em"}
             style={i === 0 ? TSPAN_NORMAL_STYLE : TSPAN_ITALIC_STYLE}
           >
             {line}


### PR DESCRIPTION
## What This PR Does

Fixes three small but visible issues in the visualiser:

1. Multi-line edge labels (e.g. "publishes event", "reads from (tech)") were visually off-centre — the second italic line dropped below the edge anchor point.
2. The `reads from`, `writes to`, and `reads and writes to` edges had no rounded background, so the label text sat directly on top of the edge path and gridlines.
3. The "Layout changed → Save" button rendered pale/invisible in light mode because the standalone visualiser theme defines `--ec-accent-text` as white, which is unreadable on the `--ec-accent-subtle` lavender background.

## Changes Overview

### Key Changes
- `packages/visualiser/src/edges/MultilineEdgeLabel.tsx`: shift the first `<tspan>` up by `-((n-1) * 1.2 / 2)em` so the whole text block is centred around `labelY`; add a rounded rect background sized to the text using `--ec-card-bg` fill and `--ec-page-border` stroke (matches `AnimatedMessageEdge`).
- `packages/visualiser/src/edges/AnimatedMessageEdge.tsx`: apply the same first-line `dy` fix so the text block aligns with the already-centred rect.
- `packages/visualiser/src/components/NodeGraph.tsx`: replace the "Save" button's accent-subtle/accent-text pair with a solid `--ec-accent` background and white text, with `--ec-accent-hover` on hover. Matches the `StepWalkthrough` primary button pattern and works in every theme.

## How It Works

**Multi-line centring:** SVG `<text>` with `dominantBaseline="middle"` anchors the first line on `labelY`. Prior code left the first line at `dy=0` and shifted each subsequent line down by `1.2em`, so multi-line labels drifted below the anchor. New code computes `firstLineDy = -((lines.length - 1) * 1.2 / 2)em` so the block centres around `labelY`. Single-line labels are unaffected (dy = 0).

**Edge backgrounds:** `MultilineEdgeLabel` now renders a `<rect>` behind the text, sized from the longest line (`length * 5.5 + 14`, min 44px) and number of lines (`n * 12 + 4`), positioned centred on `labelY` to match the centred text.

**Save button:** The visualiser's standalone `styles.css` defines `--ec-accent-text` as white in light mode (intended for text on accent backgrounds), paired with a pale lavender `--ec-accent-subtle`. Using them together produced near-invisible text. Swapping to solid accent + white text is unambiguous across every theme (purple/sunset/ocean/sapphire/forest) in both light and dark.

## Breaking Changes

None.

## Additional Notes

- Previously the invalid CSS `rgb(var(--ec-accent-subtle) / 0.7)` was also being emitted as a hover style; in dark themes `--ec-accent-subtle` already contains its own alpha, producing malformed `rgb(R G B / 0.3 / 0.7)`. The rewrite removes that.
- No changes to rendering behaviour for single-line edge labels.