### PR TITLE
fix(visualiser): auto-disable animation on large graphs

### DIFF
--- a/.changeset/swift-otters-glide.md
+++ b/.changeset/swift-otters-glide.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/visualiser": patch
+---
+
+Auto-disable message animation when the graph has more than 30 nodes and the user has no stored preference. Explicit `animated` prop, `?animate=` URL param, and localStorage choice still take precedence.

--- a/packages/visualiser/src/components/NodeGraph.tsx
+++ b/packages/visualiser/src/components/NodeGraph.tsx
@@ -89,6 +89,9 @@ import dagre from "dagre";
 // Minimum pixel change to detect layout modifications (avoids floating point comparison issues)
 const POSITION_CHANGE_THRESHOLD = 1;
 
+// Above this node count, auto-disable message animation when the user has no stored preference
+const LARGE_GRAPH_NODE_THRESHOLD = 30;
+
 // Static props for ReactFlow - defined outside component to avoid new references on every render
 const NODE_ORIGIN: [number, number] = [0.1, 0.1];
 const MINIMAP_STYLE = {
@@ -1056,7 +1059,7 @@ const NodeGraphBuilder = ({
   }, [fitView]);
 
   // animate messages, between views
-  // Priority: animated prop > URL parameter > localStorage
+  // Priority: animated prop > URL parameter > localStorage > auto (disabled for large graphs)
   useEffect(() => {
     if (animated !== undefined) {
       setAnimateMessages(animated);
@@ -1077,9 +1080,12 @@ const NodeGraphBuilder = ({
       );
       if (storedAnimateMessages !== null) {
         setAnimateMessages(storedAnimateMessages === "true");
+      } else {
+        // Auto-disable animation for large graphs to keep the canvas responsive
+        setAnimateMessages(initialNodes.length <= LARGE_GRAPH_NODE_THRESHOLD);
       }
     }
-  }, [animated]);
+  }, [animated, initialNodes.length]);
 
   useEffect(() => {
     setEdges((eds) =>


### PR DESCRIPTION
## What This PR Does

Improves the default experience of the visualiser on large node graphs by automatically turning off the message flow animation when the graph has more than 30 nodes. Animated edges are visually noisy and expensive to render at scale, so users opening a busy diagram for the first time would see degraded performance. This change only affects the default — any explicit user preference is preserved.

## Changes Overview

### Key Changes
- Added `LARGE_GRAPH_NODE_THRESHOLD = 30` constant in `packages/visualiser/src/components/NodeGraph.tsx`.
- Extended the existing animation-priority effect so that when no explicit preference exists, the default is derived from `initialNodes.length`.
- Added a changeset marking this as a `patch` bump for `@eventcatalog/visualiser`.

## How It Works

The visualiser already had a preference chain for the animation state. This PR extends the final fallback:

1. `animated` prop (explicit from consumer) — unchanged
2. `?animate=true|false` URL param — unchanged
3. `localStorage["EventCatalog:animateMessages"]` — unchanged
4. **New:** auto — `initialNodes.length <= 30` enables animation, otherwise disables it.

So the auto-threshold only kicks in when the user has never toggled the setting and the page doesn't force a value. Once the user clicks the toggle in the UI, the localStorage value wins for all subsequent renders.

The effect dependency list was updated to include `initialNodes.length` so that when a graph's node count crosses the threshold (e.g. navigation between views), the default recomputes. This is a primitive value, so it does not trigger on drag/position changes.

## Breaking Changes

None. This only changes the default for users with no stored preference.

## Additional Notes

- The threshold of 30 is a reasonable first pass and can be tuned later.
- Users with animation previously enabled via localStorage are unaffected.