### PR TITLE
feat(llm): Add ressources docs in llms.txt

### DIFF
--- a/packages/core/eventcatalog/src/pages/docs/llm/llms-full.txt.ts
+++ b/packages/core/eventcatalog/src/pages/docs/llm/llms-full.txt.ts
@@ -1,7 +1,7 @@
 import { getCollection, type CollectionEntry } from 'astro:content';
 import type { APIRoute } from 'astro';
 import fs from 'fs';
-import { isCustomDocsEnabled } from '@utils/feature';
+import { isCustomDocsEnabled, isResourceDocsEnabled, isLLMSTxtEnabled } from '@utils/feature';
 import { addSchemaToMarkdown } from '@utils/llms';
 
 type AllowedCollections =
@@ -30,8 +30,7 @@ const channels = await getCollection('channels');
 const flows = await getCollection('flows');
 const containers = await getCollection('containers');
 const customDocs = await getCollection('customPages');
-
-import { isLLMSTxtEnabled } from '@utils/feature';
+const resourceDocs = isResourceDocsEnabled() ? await getCollection('resourceDocs') : [];
 
 export const GET: APIRoute = async ({ params, request }) => {
   if (!isLLMSTxtEnabled()) {
@@ -54,6 +53,10 @@ export const GET: APIRoute = async ({ params, request }) => {
 
   if (isCustomDocsEnabled()) {
     resources.push(...(customDocs as CollectionEntry<AllowedCollections>[]));
+  }
+
+  if (isResourceDocsEnabled()) {
+    resources.push(...(resourceDocs as CollectionEntry<AllowedCollections>[]));
   }
 
   const content = resources

--- a/packages/core/eventcatalog/src/pages/docs/llm/llms.txt.ts
+++ b/packages/core/eventcatalog/src/pages/docs/llm/llms.txt.ts
@@ -2,8 +2,9 @@ import { getCollection } from 'astro:content';
 import config from '@config';
 import type { APIRoute } from 'astro';
 
-import { isCustomDocsEnabled } from '@utils/feature';
+import { isCustomDocsEnabled, isResourceDocsEnabled } from '@utils/feature';
 import { getUbiquitousLanguage } from '@utils/collections/domains';
+import { getResourceDocs } from '@utils/collections/resource-docs';
 
 const events = await getCollection('events');
 const commands = await getCollection('commands');
@@ -22,6 +23,7 @@ const containers = await getCollection('containers');
 const entities = await getCollection('entities');
 
 const customDocs = await getCollection('customPages');
+const resourceDocsList = isResourceDocsEnabled() ? await getResourceDocs() : [];
 
 const ubiquitousLanguages: Record<string, { id: string; version: string; properties: any }[]> = {};
 
@@ -94,6 +96,14 @@ export const GET: APIRoute = async ({ params, request }) => {
   const formatCustomDoc = (item: any, route: string) =>
     `- [${item.data.title}](${baseUrl}/${route}/${item.id.replace('docs\/', '')}.mdx) - ${item.data.summary || ''}`;
 
+  const formatResourceDoc = (doc: any) => {
+    const { resourceCollection, resourceId, resourceVersion, type, id } = doc.data;
+    const title = doc.data.title || id || doc.id;
+    const docUrl = `${baseUrl}/docs/${resourceCollection}/${resourceId}/${resourceVersion}/${type}/${id}`;
+    const parentUrl = `${baseUrl}/docs/${resourceCollection}/${resourceId}/${resourceVersion}`;
+    return `- [${title}](${docUrl}) - (${resourceCollection}: [${resourceId}](${parentUrl})) ${doc.data.summary ? `- ${doc.data.summary}` : ''}`;
+  };
+
   const content = [
     `# ${config.organizationName} EventCatalog Documentation\n`,
     `> ${config.tagline}\n`,
@@ -126,6 +136,9 @@ export const GET: APIRoute = async ({ params, request }) => {
     users.map((item) => formatSimpleItem(item, 'users')).join('\n'),
     ...(isCustomDocsEnabled()
       ? ['\n## Custom Docs', customDocs.map((item) => formatCustomDoc(item, 'docs/custom')).join('\n')]
+      : []),
+    ...(isResourceDocsEnabled() && resourceDocsList.length > 0
+      ? ['\n## Resource Docs', resourceDocsList.map(formatResourceDoc).join('\n')]
       : []),
   ].join('\n');
 


### PR DESCRIPTION
## Motivation

Resource docs (`domains/*/docs/`, `services/*/docs/`, etc.) were not included in `llms.txt`, making them invisible to the MCP server. This PR adds them to both `llms.txt` and `llms-full.txt`, with a direct link to their parent resource (domain, service…) to preserve the knowledge graph context for LLMs.
