### PR TITLE
fix(core): preserve non-channel sends during channels migration

### DIFF
--- a/.changeset/preserve-mixed-sends-migration.md
+++ b/.changeset/preserve-mixed-sends-migration.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix(core): preserve non-channel sends (e.g. queries) during message-channels-to-service-channels migration. The migration previously rebuilt the `sends`/`receives` arrays from only the subset of entries matching messages with legacy `channels:` frontmatter, silently dropping any other entries (queries, or messages without channels) on disk during dev/build.

--- a/packages/core/src/__tests__/migrations/catalog/queries/GetInventoryItem/index.mdx
+++ b/packages/core/src/__tests__/migrations/catalog/queries/GetInventoryItem/index.mdx
@@ -1,0 +1,9 @@
+---
+id: GetInventoryItem
+name: Get Inventory Item
+version: 1.0.0
+summary: |
+  Retrieves an inventory item by id
+---
+
+Query with no channels defined.

--- a/packages/core/src/__tests__/migrations/catalog/services/MixedSendsService/index.mdx
+++ b/packages/core/src/__tests__/migrations/catalog/services/MixedSendsService/index.mdx
@@ -1,0 +1,20 @@
+---
+id: MixedSendsService
+version: 1.0.0
+name: Mixed Sends Service
+summary: |
+  Service that sends both a legacy-channel event and a query with no channel
+owners:
+  - inventory-management
+sends:
+  - id: OrderAmended
+    version: 0.0.1
+    to:
+      - id: eventbus
+        version: 1.0.0
+  - id: GetInventoryItem
+    version: 1.0.0
+receives: []
+---
+
+Service used to verify the migration preserves non-channel sends (e.g. queries).

--- a/packages/core/src/__tests__/migrations/message-channels-examples/queries/GetInventoryItem/index.mdx
+++ b/packages/core/src/__tests__/migrations/message-channels-examples/queries/GetInventoryItem/index.mdx
@@ -1,0 +1,9 @@
+---
+id: GetInventoryItem
+name: Get Inventory Item
+version: 1.0.0
+summary: |
+  Retrieves an inventory item by id
+---
+
+Query with no channels defined.

--- a/packages/core/src/__tests__/migrations/message-channels-examples/services/MixedSendsService/index.mdx
+++ b/packages/core/src/__tests__/migrations/message-channels-examples/services/MixedSendsService/index.mdx
@@ -1,0 +1,17 @@
+---
+id: MixedSendsService
+version: 1.0.0
+name: Mixed Sends Service
+summary: |
+  Service that sends both a legacy-channel event and a query with no channel
+owners:
+  - inventory-management
+sends:
+  - id: OrderAmended
+    version: 0.0.1
+  - id: GetInventoryItem
+    version: 1.0.0
+receives: []
+---
+
+Service used to verify the migration preserves non-channel sends (e.g. queries).

--- a/packages/core/src/__tests__/migrations/message-channels-to-service-channels.spec.ts
+++ b/packages/core/src/__tests__/migrations/message-channels-to-service-channels.spec.ts
@@ -59,6 +59,26 @@ describe('message-channels-to-service-channels', () => {
     expect(afterData.channels).toBeUndefined();
   });
 
+  it('preserves sends entries whose messages have no channels (e.g. queries) when other sends match messages-with-channels', async () => {
+    await messageChannelsToServiceChannels();
+
+    const mixedServiceFile = fs.readFileSync(
+      path.join(process.env.PROJECT_DIR!, 'services', 'MixedSendsService', 'index.mdx'),
+      'utf8'
+    );
+    const { data } = matter(mixedServiceFile);
+
+    expect(data.sends).toHaveLength(2);
+
+    const orderAmended = data.sends.find((s: any) => s.id === 'OrderAmended');
+    expect(orderAmended).toBeDefined();
+    expect(orderAmended.to).toEqual([{ id: 'eventbus', version: '1.0.0' }]);
+
+    const getInventoryItem = data.sends.find((s: any) => s.id === 'GetInventoryItem');
+    expect(getInventoryItem).toBeDefined();
+    expect(getInventoryItem.version).toBe('1.0.0');
+  });
+
   it('if messages have multiple channels defined, the migration script will move the channel configuration to the service that sends (to) or receives (from) the message', async () => {
     await messageChannelsToServiceChannels();
 

--- a/packages/core/src/migrations/message-channels-to-service-channels.ts
+++ b/packages/core/src/migrations/message-channels-to-service-channels.ts
@@ -93,20 +93,16 @@ export default async (dir?: string) => {
       data.receives?.filter((receive: any) => messagesWithChannels.some((message: any) => message.id === receive.id)) ?? [];
 
     if (messagesTheServiceSendsThatNeedUpdating.length > 0 || messagesTheServiceReceivesThatNeedUpdating.length > 0) {
-      const newSends = messagesTheServiceSendsThatNeedUpdating.map((send: any) => ({
-        ...send,
-        to: messagesWithChannels
-          .map((message: any) => (message.id === send.id ? message.channels : []))
-          .flat()
-          .filter((channel: any) => channel !== null),
-      }));
-      const newReceives = messagesTheServiceReceivesThatNeedUpdating.map((receive: any) => ({
-        ...receive,
-        from: messagesWithChannels
-          .map((message: any) => (message.id === receive.id ? message.channels : []))
-          .flat()
-          .filter((channel: any) => channel !== null),
-      }));
+      const newSends = (data.sends ?? []).map((send: any) => {
+        const match = messagesWithChannels.find((message: any) => message.id === send.id);
+        if (!match) return send;
+        return { ...send, to: (match.channels ?? []).filter((channel: any) => channel !== null) };
+      });
+      const newReceives = (data.receives ?? []).map((receive: any) => {
+        const match = messagesWithChannels.find((message: any) => message.id === receive.id);
+        if (!match) return receive;
+        return { ...receive, from: (match.channels ?? []).filter((channel: any) => channel !== null) };
+      });
 
       const newData = {
         ...data,


### PR DESCRIPTION
Fixes #2449

## What This PR Does

The `message-channels-to-service-channels` migration runs on every `dev`/`build` to move legacy message-level `channels:` frontmatter into the newer service-level `sends[].to` / `receives[].from` shape. When a service had a mix of sends — some matching messages-with-legacy-channels and some not (e.g. queries, or events with no channels) — the migration silently dropped the non-matching entries from the service's MDX on disk. This PR fixes that so all existing sends/receives survive the migration.

## Changes Overview

### Key Changes
- `packages/core/src/migrations/message-channels-to-service-channels.ts` — rebuild `newSends`/`newReceives` by mapping over the full existing array, enriching only entries that match a legacy-channels message, instead of rebuilding from just the filtered subset.
- Added regression test in `message-channels-to-service-channels.spec.ts`.
- Added fixtures: `MixedSendsService` (sends both a legacy-channel event and a query) and `GetInventoryItem` (query).

## How It Works

**Before:**
```ts
const messagesTheServiceSendsThatNeedUpdating = data.sends?.filter(...); // subset
const newSends = messagesTheServiceSendsThatNeedUpdating.map(...);        // only migrated entries
```
Result: any send not matching a message-with-channels was dropped.

**After:**
```ts
const newSends = (data.sends ?? []).map((send) => {
  const match = messagesWithChannels.find((m) => m.id === send.id);
  if (!match) return send;                             // keep as-is
  return { ...send, to: (match.channels ?? []).filter(Boolean) };
});
```
Result: every existing send is preserved; only matching ones gain a `to:` array.

Same change applied symmetrically to `receives`/`from`.

## Breaking Changes

None. Pure bug fix. All three existing migration tests still pass.

## Additional Notes

- Reproduced exactly the scenario from issue #2449 (service with one `sends` entry pointing at a query + another `sends` entry pointing at an event with `channels:`). New test asserts both entries remain on disk after migration, with the event also gaining its `to:` array.
- The migration still runs on every dev/build; this only changes what it writes.