### PR TITLE
fix(core): restore context menu on flow diagram nodes

### DIFF
--- a/.changeset/flow-context-menu.md
+++ b/.changeset/flow-context-menu.md
@@ -1,0 +1,6 @@
+---
+"@eventcatalog/core": patch
+"@eventcatalog/visualiser": patch
+---
+
+fix: restore custom right-click context menu for message and service nodes in flow diagrams. `flows-node-graph` now populates `contextMenu` on step nodes (previously only non-flow graphs did, so flow pages fell through to the browser default menu). Context-menu items also get explicit colour and no-underline styling so they no longer inherit browser-default purple/underlined link styling when the host page has no link resets.

--- a/packages/core/eventcatalog/src/utils/__tests__/flows/node-graph.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/flows/node-graph.spec.ts
@@ -74,6 +74,7 @@ describe('Flows NodeGraph', () => {
             id: 'PaymentProcessed',
             version: '0.0.1',
           },
+          contextMenu: expect.any(Array),
         },
         position: { x: expect.any(Number), y: expect.any(Number) },
         type: 'events',
@@ -117,6 +118,45 @@ describe('Flows NodeGraph', () => {
       expect(nodes).toEqual(expect.arrayContaining(expectedNodes));
 
       expect(edges).toEqual(expect.arrayContaining([expect.objectContaining(expectedEdges[0])]));
+    });
+
+    it('attaches a contextMenu to message step nodes so right-click shows the custom menu (issue #2216)', async () => {
+      const { nodes } = await getNodesAndEdges({ id: 'PaymentFlow', version: '1.0.0' });
+
+      const messageNode = nodes.find((n: any) => n.id === 'step-3');
+      expect(messageNode).toBeDefined();
+      expect(messageNode?.data.contextMenu).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            label: 'Read documentation',
+            href: expect.stringContaining('/docs/events/PaymentProcessed/0.0.1'),
+          }),
+          expect.objectContaining({ label: 'Read changelog' }),
+        ])
+      );
+    });
+
+    it('attaches a contextMenu to service step nodes', async () => {
+      const { nodes } = await getNodesAndEdges({ id: 'CancelSubscription', version: '1.0.0' });
+
+      const serviceNode = nodes.find((n: any) => n.data?.service?.data?.id === 'SubscriptionService');
+      expect(serviceNode).toBeDefined();
+      expect(serviceNode?.data.contextMenu).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            label: 'Read documentation',
+            href: expect.stringContaining('/docs/services/SubscriptionService/0.0.1'),
+          }),
+        ])
+      );
+    });
+
+    it('does not attach a contextMenu to plain step nodes (no resource)', async () => {
+      const { nodes } = await getNodesAndEdges({ id: 'PaymentFlow', version: '1.0.0' });
+
+      const plainStep = nodes.find((n: any) => n.id === 'step-1');
+      expect(plainStep).toBeDefined();
+      expect(plainStep?.data.contextMenu).toBeUndefined();
     });
 
     it('should resolves the correct node when it is a service with version as latest', async () => {
@@ -212,6 +252,7 @@ describe('Flows NodeGraph', () => {
                 id: 'PaymentProcessed',
                 version: '0.0.1',
               },
+              contextMenu: expect.any(Array),
             },
             position: { x: expect.any(Number), y: expect.any(Number) },
             type: 'events',

--- a/packages/core/eventcatalog/src/utils/node-graphs/flows-node-graph.ts
+++ b/packages/core/eventcatalog/src/utils/node-graphs/flows-node-graph.ts
@@ -1,6 +1,13 @@
 import { getCollection, type CollectionEntry } from 'astro:content';
 import dagre from 'dagre';
-import { createDagreGraph, calculatedNodes, DEFAULT_NODE_WIDTH, DEFAULT_NODE_HEIGHT } from '@utils/node-graphs/utils/utils';
+import {
+  createDagreGraph,
+  calculatedNodes,
+  DEFAULT_NODE_WIDTH,
+  DEFAULT_NODE_HEIGHT,
+  buildContextMenuForResource,
+  buildContextMenuForService,
+} from '@utils/node-graphs/utils/utils';
 import { MarkerType } from '@xyflow/react';
 import type { Node as NodeType } from '@xyflow/react';
 import { createVersionedMap, findInMap } from '@utils/collections/util';
@@ -101,9 +108,31 @@ export const getNodesAndEdges = async ({ id, defaultFlow, version, mode = 'simpl
       type: step.type,
     } as NodeType;
 
-    if (step.service) node.data.service = { ...step.service, ...step.service.data };
-    if (step.flow) node.data.flow = { ...step.flow, ...step.flow.data };
-    if (step.message) node.data.message = { ...step.message, ...step.message.data };
+    if (step.service) {
+      node.data.service = { ...step.service, ...step.service.data };
+      node.data.contextMenu = buildContextMenuForService({
+        id: step.service.data.id,
+        version: step.service.data.version,
+        specifications: step.service.data.specifications,
+        repository: step.service.data.repository,
+      });
+    }
+    if (step.flow) {
+      node.data.flow = { ...step.flow, ...step.flow.data };
+      node.data.contextMenu = buildContextMenuForResource({
+        collection: 'flows',
+        id: step.flow.data.id,
+        version: step.flow.data.version,
+      });
+    }
+    if (step.message) {
+      node.data.message = { ...step.message, ...step.message.data };
+      node.data.contextMenu = buildContextMenuForResource({
+        collection: step.message.collection,
+        id: step.message.data.id,
+        version: step.message.data.version,
+      });
+    }
     if (step.actor) {
       node.data.actor = { ...step.actor, ...step.actor.data };
       node.data = { ...node.data, ...step.actor };

--- a/packages/visualiser/src/components/NodeContextMenu.tsx
+++ b/packages/visualiser/src/components/NodeContextMenu.tsx
@@ -31,7 +31,7 @@ export default memo(function NodeContextMenu({
               )}
               <ContextMenu.Item
                 asChild
-                className="text-sm px-2 py-1.5 outline-none cursor-pointer hover:bg-orange-100 rounded-sm flex items-center"
+                className="text-sm px-2 py-1.5 outline-none cursor-pointer hover:bg-orange-100 rounded-sm flex items-center text-gray-900 hover:text-gray-900 visited:text-gray-900 no-underline hover:no-underline visited:no-underline"
               >
                 <a
                   href={item.href}


### PR DESCRIPTION
Fixes #2216

## What This PR Does

Right-clicking a message (event/command/query) or service node inside a `<Flow />` diagram showed the browser's default context menu instead of EventCatalog's custom one. Every other node-graph builder (services, containers, data-products, messages, etc.) attaches `contextMenu` data to its nodes — the flow builder was the only one that didn't. This PR makes it consistent. While fixing that, also pins the anchor styling inside the menu so items no longer render in browser-default purple-and-underlined when viewed in hosts without a link reset.

## Changes Overview

### Key Changes
- `packages/core/eventcatalog/src/utils/node-graphs/flows-node-graph.ts` — import `buildContextMenuForResource` / `buildContextMenuForService`; attach `node.data.contextMenu` for message, service, and sub-flow step types.
- `packages/visualiser/src/components/NodeContextMenu.tsx` — add explicit `text-gray-900`, `no-underline`, and matching `hover:` / `visited:` variants to the item class so menu links render consistently regardless of host-page CSS.
- Added three regression tests in `packages/core/eventcatalog/src/utils/__tests__/flows/node-graph.spec.ts`:
  - `contextMenu` populated on message step nodes
  - `contextMenu` populated on service step nodes
  - `contextMenu` absent on plain (no-resource) step nodes
- Updated two existing flow tests whose `expectedNodes` asserted the exact shape of step-3's `data` — added `contextMenu: expect.any(Array)` to accommodate the new field.

## How It Works

Inside `wrapWithContextMenu` in `NodeGraph.tsx`, the wrapper early-returns the bare node component when `props.data?.contextMenu` is empty. Flow builder only populated `data.step`, `data.message`, `data.service`, etc. — never `data.contextMenu` — so right-click always fell through to the browser.

Fix is mechanical: wherever the builder already hydrates the resolved resource onto `node.data`, call the appropriate menu builder with the same ids, e.g.:

```ts
if (step.message) {
  node.data.message = { ...step.message, ...step.message.data };
  node.data.contextMenu = buildContextMenuForResource({
    collection: step.message.collection, // 'events' | 'commands' | 'queries'
    id: step.message.data.id,
    version: step.message.data.version,
  });
}
```

Service steps use `buildContextMenuForService` (which also pulls in spec / repo menu items). Sub-flow steps use `buildContextMenuForResource` with `collection: 'flows'`.

The styling patch just hardcodes colour + no-underline on the menu's `<a>` tags so they render consistently without relying on any host-page link reset.

## Breaking Changes

None. Pure bug fix. All 413 `utils/__tests__` tests pass; all 8 flow-graph tests pass.

## Additional Notes

- Two packages affected, one changeset covering both (`@eventcatalog/core` + `@eventcatalog/visualiser`, patch).
- Visual regression was reported as "styled purple and underline" in the menu — also fixed here rather than left for a follow-up, since the root cause (no explicit link styling) is in the same flow path.