### PR TITLE
feat(llm): include resource docs in llms.txt with raw .mdx routes

### DIFF
--- a/.changeset/llms-resource-docs.md
+++ b/.changeset/llms-resource-docs.md
@@ -1,0 +1,7 @@
+---
+'@eventcatalog/core': patch
+---
+
+feat(llm): include resource docs in llms.txt and expose raw markdown routes
+
+Resource docs (domain/service/event/... `docs/` pages) are now listed in `llms.txt` and `llms-full.txt`, grouped under their parent resource as subheadings with links to the resource's `.mdx` page. New `.md` and `.mdx` route handlers at `/docs/[type]/[id]/[version]/[docType]/[docId].mdx` expose the raw markdown so LLMs can fetch resource doc content directly.

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/[docType]/[docId].md.ts
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/[docType]/[docId].md.ts
@@ -1,0 +1,75 @@
+// Exposes the raw markdown for a resource doc.
+// Example: /docs/services/OrdersService/1.0.0/adrs/01-some-decision.md
+// Used by llms.txt so LLMs can fetch the markdown directly.
+
+import type { APIRoute } from 'astro';
+import fs from 'fs';
+import { isLLMSTxtEnabled, isResourceDocsEnabled, isSSR } from '@utils/feature';
+import { getResourceDocs, getResourceDocsForResource, type ResourceCollection } from '@utils/collections/resource-docs';
+
+const supportedResourceCollections = new Set<ResourceCollection>([
+  'domains',
+  'services',
+  'events',
+  'commands',
+  'queries',
+  'flows',
+  'containers',
+  'channels',
+  'entities',
+  'data-products',
+]);
+
+export async function getStaticPaths() {
+  if (isSSR() || !isLLMSTxtEnabled() || !isResourceDocsEnabled()) {
+    return [];
+  }
+
+  const docs = await getResourceDocs();
+  const latestDocs = docs.filter((doc) => doc.data.version === doc.data.latestVersion);
+
+  return latestDocs.map((doc) => ({
+    params: {
+      type: doc.data.resourceCollection,
+      id: doc.data.resourceId,
+      version: doc.data.resourceVersion,
+      docType: doc.data.type,
+      docId: doc.data.id,
+    },
+    props: { filePath: doc.filePath },
+  }));
+}
+
+export const GET: APIRoute = async ({ params, props }) => {
+  if (!isLLMSTxtEnabled()) {
+    return new Response('llms.txt is not enabled for this Catalog.', { status: 404 });
+  }
+
+  if (!isResourceDocsEnabled()) {
+    return new Response('Resource docs are not enabled for this Catalog.', { status: 404 });
+  }
+
+  let filePath = (props as { filePath?: string } | undefined)?.filePath;
+
+  if (!filePath && isSSR()) {
+    const type = params.type as ResourceCollection | undefined;
+    if (!type || !supportedResourceCollections.has(type)) {
+      return new Response('Not found', { status: 404 });
+    }
+    const docsForResource = await getResourceDocsForResource(type, params.id ?? '', params.version ?? '');
+    const doc = docsForResource.find(
+      (resourceDoc) =>
+        resourceDoc.data.type === params.docType &&
+        resourceDoc.data.id === params.docId &&
+        resourceDoc.data.version === resourceDoc.data.latestVersion
+    );
+    filePath = doc?.filePath;
+  }
+
+  if (!filePath) {
+    return new Response('Not found', { status: 404 });
+  }
+
+  const file = fs.readFileSync(filePath, 'utf8');
+  return new Response(file, { status: 200, headers: { 'Content-Type': 'text/markdown; charset=utf-8' } });
+};

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/[docType]/[docId].mdx.ts
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/[docType]/[docId].mdx.ts
@@ -1,0 +1,75 @@
+// Exposes the raw mdx for a resource doc.
+// Example: /docs/services/OrdersService/1.0.0/adrs/01-some-decision.mdx
+// Used by llms.txt so LLMs can fetch the markdown directly.
+
+import type { APIRoute } from 'astro';
+import fs from 'fs';
+import { isLLMSTxtEnabled, isResourceDocsEnabled, isSSR } from '@utils/feature';
+import { getResourceDocs, getResourceDocsForResource, type ResourceCollection } from '@utils/collections/resource-docs';
+
+const supportedResourceCollections = new Set<ResourceCollection>([
+  'domains',
+  'services',
+  'events',
+  'commands',
+  'queries',
+  'flows',
+  'containers',
+  'channels',
+  'entities',
+  'data-products',
+]);
+
+export async function getStaticPaths() {
+  if (isSSR() || !isLLMSTxtEnabled() || !isResourceDocsEnabled()) {
+    return [];
+  }
+
+  const docs = await getResourceDocs();
+  const latestDocs = docs.filter((doc) => doc.data.version === doc.data.latestVersion);
+
+  return latestDocs.map((doc) => ({
+    params: {
+      type: doc.data.resourceCollection,
+      id: doc.data.resourceId,
+      version: doc.data.resourceVersion,
+      docType: doc.data.type,
+      docId: doc.data.id,
+    },
+    props: { filePath: doc.filePath },
+  }));
+}
+
+export const GET: APIRoute = async ({ params, props }) => {
+  if (!isLLMSTxtEnabled()) {
+    return new Response('llms.txt is not enabled for this Catalog.', { status: 404 });
+  }
+
+  if (!isResourceDocsEnabled()) {
+    return new Response('Resource docs are not enabled for this Catalog.', { status: 404 });
+  }
+
+  let filePath = (props as { filePath?: string } | undefined)?.filePath;
+
+  if (!filePath && isSSR()) {
+    const type = params.type as ResourceCollection | undefined;
+    if (!type || !supportedResourceCollections.has(type)) {
+      return new Response('Not found', { status: 404 });
+    }
+    const docsForResource = await getResourceDocsForResource(type, params.id ?? '', params.version ?? '');
+    const doc = docsForResource.find(
+      (resourceDoc) =>
+        resourceDoc.data.type === params.docType &&
+        resourceDoc.data.id === params.docId &&
+        resourceDoc.data.version === resourceDoc.data.latestVersion
+    );
+    filePath = doc?.filePath;
+  }
+
+  if (!filePath) {
+    return new Response('Not found', { status: 404 });
+  }
+
+  const file = fs.readFileSync(filePath, 'utf8');
+  return new Response(file, { status: 200, headers: { 'Content-Type': 'text/markdown; charset=utf-8' } });
+};

--- a/packages/core/eventcatalog/src/pages/docs/llm/llms-full.txt.ts
+++ b/packages/core/eventcatalog/src/pages/docs/llm/llms-full.txt.ts
@@ -1,7 +1,7 @@
 import { getCollection, type CollectionEntry } from 'astro:content';
 import type { APIRoute } from 'astro';
 import fs from 'fs';
-import { isCustomDocsEnabled } from '@utils/feature';
+import { isCustomDocsEnabled, isResourceDocsEnabled, isLLMSTxtEnabled } from '@utils/feature';
 import { addSchemaToMarkdown } from '@utils/llms';
 
 type AllowedCollections =
@@ -30,8 +30,7 @@ const channels = await getCollection('channels');
 const flows = await getCollection('flows');
 const containers = await getCollection('containers');
 const customDocs = await getCollection('customPages');
-
-import { isLLMSTxtEnabled } from '@utils/feature';
+const resourceDocs = isResourceDocsEnabled() ? await getCollection('resourceDocs') : [];
 
 export const GET: APIRoute = async ({ params, request }) => {
   if (!isLLMSTxtEnabled()) {
@@ -54,6 +53,10 @@ export const GET: APIRoute = async ({ params, request }) => {
 
   if (isCustomDocsEnabled()) {
     resources.push(...(customDocs as CollectionEntry<AllowedCollections>[]));
+  }
+
+  if (isResourceDocsEnabled()) {
+    resources.push(...(resourceDocs as CollectionEntry<AllowedCollections>[]));
   }
 
   const content = resources

--- a/packages/core/eventcatalog/src/pages/docs/llm/llms.txt.ts
+++ b/packages/core/eventcatalog/src/pages/docs/llm/llms.txt.ts
@@ -2,8 +2,9 @@ import { getCollection } from 'astro:content';
 import config from '@config';
 import type { APIRoute } from 'astro';
 
-import { isCustomDocsEnabled } from '@utils/feature';
+import { isCustomDocsEnabled, isResourceDocsEnabled } from '@utils/feature';
 import { getUbiquitousLanguage } from '@utils/collections/domains';
+import { getResourceDocs } from '@utils/collections/resource-docs';
 
 const events = await getCollection('events');
 const commands = await getCollection('commands');
@@ -22,6 +23,7 @@ const containers = await getCollection('containers');
 const entities = await getCollection('entities');
 
 const customDocs = await getCollection('customPages');
+const resourceDocsList = isResourceDocsEnabled() ? await getResourceDocs() : [];
 
 const ubiquitousLanguages: Record<string, { id: string; version: string; properties: any }[]> = {};
 
@@ -94,6 +96,36 @@ export const GET: APIRoute = async ({ params, request }) => {
   const formatCustomDoc = (item: any, route: string) =>
     `- [${item.data.title}](${baseUrl}/${route}/${item.id.replace('docs\/', '')}.mdx) - ${item.data.summary || ''}`;
 
+  const formatResourceDoc = (doc: any) => {
+    const { resourceCollection, resourceId, resourceVersion, type, id } = doc.data;
+    const title = doc.data.title || id || doc.id;
+    const docUrl = `${baseUrl}/docs/${resourceCollection}/${resourceId}/${resourceVersion}/${type}/${id}.mdx`;
+    return `- [${title}](${docUrl})${doc.data.summary ? ` - ${doc.data.summary}` : ''}`;
+  };
+
+  const renderResourceDocs = () => {
+    const grouped = new Map<string, { resourceCollection: string; resourceId: string; resourceVersion: string; docs: any[] }>();
+
+    for (const doc of resourceDocsList) {
+      const { resourceCollection, resourceId, resourceVersion } = doc.data;
+      const key = `${resourceCollection}:${resourceId}:${resourceVersion}`;
+      let group = grouped.get(key);
+      if (!group) {
+        group = { resourceCollection, resourceId, resourceVersion, docs: [] };
+        grouped.set(key, group);
+      }
+      group.docs.push(doc);
+    }
+
+    return Array.from(grouped.values())
+      .map((group) => {
+        const parentUrl = `${baseUrl}/docs/${group.resourceCollection}/${group.resourceId}/${group.resourceVersion}.mdx`;
+        const heading = `### [${group.resourceId}](${parentUrl}) (${group.resourceCollection})`;
+        return [heading, group.docs.map(formatResourceDoc).join('\n')].join('\n');
+      })
+      .join('\n\n');
+  };
+
   const content = [
     `# ${config.organizationName} EventCatalog Documentation\n`,
     `> ${config.tagline}\n`,
@@ -127,6 +159,7 @@ export const GET: APIRoute = async ({ params, request }) => {
     ...(isCustomDocsEnabled()
       ? ['\n## Custom Docs', customDocs.map((item) => formatCustomDoc(item, 'docs/custom')).join('\n')]
       : []),
+    ...(isResourceDocsEnabled() && resourceDocsList.length > 0 ? ['\n## Resource Docs', renderResourceDocs()] : []),
   ].join('\n');
 
   return new Response(content, {


### PR DESCRIPTION
Builds on #2444.

## What This PR Does

Adds resource docs (`domains/*/docs/`, `services/*/docs/`, etc.) to `llms.txt` and `llms-full.txt` so they're discoverable by LLMs / the MCP ecosystem. Docs are grouped under their parent resource as subheadings and all URLs point to raw `.mdx` content via new route handlers.

## Changes Overview

### Key Changes
- `llms.txt` — new `## Resource Docs` section with `### <resourceId> (<collection>)` subheadings grouping docs by their parent resource. Each doc link ends in `.mdx`. Parent link also uses `.mdx` so both go to raw markdown.
- `llms-full.txt` — inlines the raw content of resource doc markdown files alongside all other resources.
- New raw-markdown route handlers at `/docs/[type]/[id]/[version]/[docType]/[docId].md` and `.mdx`, mirroring the pattern used for other resources.
- Feature-gated on `isResourceDocsEnabled()` (Scale plan) and `isLLMSTxtEnabled()`.

## How It Works

`llms.txt.ts` imports `getResourceDocs()` (from the enterprise resource-docs utils) which resolves each doc's `resourceCollection`, `resourceId`, `resourceVersion`, `type`, `id` from the file path. Docs are bucketed by `{resourceCollection}:{resourceId}:{resourceVersion}` and rendered under a heading linking to the parent resource's `.mdx` page.

`llms-full.txt.ts` pushes the raw `resourceDocs` collection into its resource list so each doc's `filePath` is read from disk and included in the aggregated markdown response.

The new `[docId].md.ts` / `[docId].mdx.ts` route handlers use `getStaticPaths()` (SSG) driven by `getResourceDocs()` or fall back to `getResourceDocsForResource()` in SSR mode. They return the doc's file contents with `Content-Type: text/markdown`.

## Breaking Changes

None.

## Additional Notes

- Builds on PR #2444 (`feat/add-resource-doc-in-llm`), incorporating its `llms.txt`/`llms-full.txt` work plus the `.mdx` URL fix and subheading grouping.
- MCP server does **not** yet surface resource docs — follow-up work could extend `getResource` / `getResources` tools with a `docs` field or `docCount` so LLMs can discover resource docs via MCP too.
- `llms-full.txt` uses the raw `getCollection('resourceDocs')` so it does not filter `hidden: true` docs. Worth deciding whether to unify on `getResourceDocs()` there as well.