### PR TITLE
fix(core): render json schema array-valued type correctly in SchemaViewer

### DIFF
--- a/.changeset/schema-viewer-array-types.md
+++ b/.changeset/schema-viewer-array-types.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix: render JSON Schema array-valued `type` correctly in `SchemaViewer`. Types declared as arrays (e.g. `["object", "null"]`) now display as `object | null` instead of `objectnull`, and nested properties/array items are still traversable when the type is a union.

--- a/examples/default/domains/E-Commerce/subdomains/Orders/services/OrdersService/events/OrderAmended/schema.json
+++ b/examples/default/domains/E-Commerce/subdomains/Orders/services/OrdersService/events/OrderAmended/schema.json
@@ -1,7 +1,7 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "title": "OrderAmendedEvent",
-    "type": "object",
+    "type": ["object", "null"],
     "properties": {
       "orderId": {
         "type": "string",
@@ -9,9 +9,24 @@
         "description": "The unique identifier of the order that was amended."
       },
       "userId": {
-        "type": "string",
+        "type": ["string", "null"],
         "format": "uuid",
         "description": "The unique identifier of the user who placed the order."
+      },
+      "customer": {
+        "type": ["object", "null"],
+        "description": "The customer details associated with the amended order. May be null for guest checkouts.",
+        "properties": {
+          "name": {
+            "type": ["string", "null"],
+            "description": "The customer's full name."
+          },
+          "id": {
+            "type": ["string", "null"],
+            "format": "uuid",
+            "description": "The customer's unique identifier."
+          }
+        }
       },
       "amendedItems": {
         "type": "array",
@@ -68,4 +83,3 @@
     "required": ["orderId", "userId", "amendedItems", "orderStatus", "totalAmount", "timestamp"],
     "additionalProperties": false
   }
-  

--- a/packages/core/eventcatalog/src/components/SchemaExplorer/JSONSchemaViewer.tsx
+++ b/packages/core/eventcatalog/src/components/SchemaExplorer/JSONSchemaViewer.tsx
@@ -19,6 +19,18 @@ interface SchemaPropertyProps {
   expand: boolean;
 }
 
+// JSON Schema allows `type` to be a string or an array of strings (e.g. ["object", "null"]).
+// These helpers normalise both forms so the rest of the viewer can treat type checks uniformly.
+function hasType(type: any, candidate: string): boolean {
+  if (Array.isArray(type)) return type.includes(candidate);
+  return type === candidate;
+}
+
+function formatType(type: any): string {
+  if (Array.isArray(type)) return type.join(' | ');
+  return type ?? '';
+}
+
 // Helper function to count properties recursively
 function countProperties(obj: any): number {
   if (!obj || typeof obj !== 'object') return 0;
@@ -196,7 +208,7 @@ function processSchema(schema: any, rootSchema?: any): any {
   }
 
   // Process array items
-  if (schema.type === 'array' && schema.items) {
+  if (hasType(schema.type, 'array') && schema.items) {
     schema = { ...schema, items: processSchema(schema.items, root) };
   }
 
@@ -269,11 +281,11 @@ const SchemaProperty = ({ name, details, isRequired, level, isListItem = false, 
     setIsExpanded(expand);
   }, [expand]);
 
-  const hasNestedProperties = details.type === 'object' && details.properties && Object.keys(details.properties).length > 0;
-  const hasArrayItems = details.type === 'array' && details.items;
+  const hasNestedProperties = hasType(details.type, 'object') && details.properties && Object.keys(details.properties).length > 0;
+  const hasArrayItems = hasType(details.type, 'array') && details.items;
   const hasArrayItemProperties =
     hasArrayItems &&
-    ((details.items.type === 'object' && details.items.properties) ||
+    ((hasType(details.items.type, 'object') && details.items.properties) ||
       details.items.allOf ||
       details.items.oneOf ||
       details.items.anyOf ||
@@ -307,8 +319,8 @@ const SchemaProperty = ({ name, details, isRequired, level, isListItem = false, 
             <div>
               <span className="font-semibold text-[rgb(var(--ec-page-text))] text-sm">{name}</span>
               <span className="ml-1.5 text-[rgb(var(--ec-accent))] font-mono text-xs">
-                {hasVariants ? (details.variantType === 'anyOf' ? 'anyOf' : 'oneOf') : details.type}
-                {details.type === 'array' && details.items?.type ? `[${details.items.type}]` : ''}
+                {hasVariants ? (details.variantType === 'anyOf' ? 'anyOf' : 'oneOf') : formatType(details.type)}
+                {hasType(details.type, 'array') && details.items?.type ? `[${formatType(details.items.type)}]` : ''}
                 {details.format ? `<${details.format}>` : ''}
                 {details._refPath && (
                   <span className="text-blue-600 dark:text-blue-400 ml-1">→ {details._refName || details._refPath}</span>
@@ -513,9 +525,9 @@ export default function JSONSchemaViewer({
     let display = processedSchema;
     let isArray = false;
 
-    if (processedSchema.type === 'array' && processedSchema.items) {
+    if (hasType(processedSchema.type, 'array') && processedSchema.items) {
       isArray = true;
-      if (processedSchema.items.type === 'object' && processedSchema.items.properties) {
+      if (hasType(processedSchema.items.type, 'object') && processedSchema.items.properties) {
         display = {
           ...processedSchema.items,
           description: processedSchema.description || processedSchema.items.description,
@@ -838,7 +850,9 @@ export default function JSONSchemaViewer({
             <div className="text-[rgb(var(--ec-page-text-muted))] text-sm">
               <p>
                 This array contains items of type:{' '}
-                <span className="font-mono text-blue-600 dark:text-blue-400">{processedSchema.items?.type || 'unknown'}</span>
+                <span className="font-mono text-blue-600 dark:text-blue-400">
+                  {processedSchema.items?.type ? formatType(processedSchema.items.type) : 'unknown'}
+                </span>
               </p>
               {processedSchema.items?.description && (
                 <p className="text-xs mt-2 text-[rgb(var(--ec-page-text-muted))]">{processedSchema.items.description}</p>


### PR DESCRIPTION
Closes #2446

## What This PR Does

Fixes a rendering bug in `JSONSchemaViewer` when a property declares `type` as an array of strings (e.g. `["object", "null"]`) — a valid JSON Schema construct used to express nullable types. Previously those types rendered concatenated (`objectnull`) and the property became non-expandable, hiding child properties.

## Changes Overview

### Key Changes
- Added `hasType()` and `formatType()` helpers in `JSONSchemaViewer.tsx` to normalise both string and array forms of `type`.
- Updated `processSchema` so it recurses into `items` when the type array includes `"array"`.
- Updated `SchemaProperty` expand/collapse detection (`hasNestedProperties`, `hasArrayItems`, `hasArrayItemProperties`) to use `hasType()`, so properties with union types remain expandable.
- Updated the rendered type label to join array types with ` | ` (e.g. `object | null`), including array item types.
- Updated root-level array-schema handling and the "array contains items of type" banner to handle array-valued `type`.
- Updated the `OrderAmended` example schema in `examples/default` to exercise the array-type pattern (nullable root, nullable nested `customer` object with nullable string fields) so the fix is visible when running the example catalog.

## How It Works

JSON Schema permits `type` to be a single string or an array of strings. The viewer previously assumed a string, which broke in two ways:

1. The label `{details.type}` coerced the array to the string `"objectnull"`.
2. Checks like `details.type === 'object'` returned false for `["object", "null"]`, so the component skipped traversal into `properties` and the collapse button.

The fix normalises both cases. `hasType(type, 'object')` returns true for both `"object"` and `["object", "null"]`, and `formatType(type)` produces a human-readable `object | null`. All call sites that previously tested `type === 'array'` or `type === 'object'` now go through these helpers.

## Breaking Changes

None.

## Additional Notes

- Verify by running `pnpm run start:catalog` and opening the `OrderAmended` event — the `customer` property should render as `object | null` and expand to show `name` and `id`.