### PR TITLE
feat(visualiser): inline expand/collapse for sub-flow references

### DIFF
--- a/.changeset/curious-flows-unfold.md
+++ b/.changeset/curious-flows-unfold.md
@@ -1,0 +1,6 @@
+---
+"@eventcatalog/core": minor
+"@eventcatalog/visualiser": minor
+---
+
+Sub-flow references inside a flow can now be expanded inline. Clicking a sub-flow node in the visualiser inlines the referenced flow's steps in place (mirroring the message-group expand/collapse pattern), with the Collapse button in the header restoring the single-node view. Expanded sub-flow children participate in the business-flow walkthrough, and the graph recentres via `fitView` on both expand and collapse.

--- a/packages/core/eventcatalog/src/utils/__tests__/flows/mocks.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/flows/mocks.ts
@@ -148,6 +148,72 @@ export const mockFlowsWithSubFlow = [
   },
 ];
 
+// Three-level nesting: Outer → Middle → Leaf. Used to verify that a deep
+// sub-flow's precomputed expandedNodes/expandedEdges get their ids prefixed
+// recursively when the graph is inlined under the outer parent.
+export const mockFlowsNested = [
+  {
+    id: 'Outer/index.mdx',
+    slug: 'outer',
+    body: '',
+    collection: 'flows',
+    data: {
+      id: 'OuterFlow',
+      name: 'Outer Flow',
+      version: '1.0.0',
+      steps: [
+        {
+          id: 'outer_mid',
+          title: 'Call Middle',
+          flow: { id: 'MiddleFlow', version: '1.0.0' },
+        },
+      ],
+    },
+  },
+  {
+    id: 'Middle/index.mdx',
+    slug: 'middle',
+    body: '',
+    collection: 'flows',
+    data: {
+      id: 'MiddleFlow',
+      name: 'Middle Flow',
+      version: '1.0.0',
+      steps: [
+        {
+          id: 'middle_leaf',
+          title: 'Call Leaf',
+          flow: { id: 'LeafFlow', version: '1.0.0' },
+        },
+      ],
+    },
+  },
+  {
+    id: 'Leaf/index.mdx',
+    slug: 'leaf',
+    body: '',
+    collection: 'flows',
+    data: {
+      id: 'LeafFlow',
+      name: 'Leaf Flow',
+      version: '1.0.0',
+      steps: [
+        {
+          id: 'leaf_step_1',
+          type: 'node',
+          title: 'Leaf Step 1',
+          next_step: { id: 'leaf_step_2' },
+        },
+        {
+          id: 'leaf_step_2',
+          type: 'node',
+          title: 'Leaf Step 2',
+        },
+      ],
+    },
+  },
+];
+
 // Cycle: A references B, B references A. Expansion must terminate.
 export const mockFlowsWithCycle = [
   {

--- a/packages/core/eventcatalog/src/utils/__tests__/flows/mocks.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/flows/mocks.ts
@@ -86,6 +86,108 @@ export const mockFlow = [
   },
 ];
 
+// Parent flow that references SubFlow as a step, plus the SubFlow itself, for
+// testing inline sub-flow expansion precomputation.
+export const mockFlowsWithSubFlow = [
+  {
+    id: 'Parent/index.mdx',
+    slug: 'parent',
+    body: '',
+    collection: 'flows',
+    data: {
+      id: 'ParentFlow',
+      name: 'Parent Flow',
+      version: '1.0.0',
+      steps: [
+        {
+          id: 'start',
+          type: 'node',
+          title: 'Start',
+          next_step: { id: 'sub', label: 'Run sub-flow' },
+        },
+        {
+          id: 'sub',
+          title: 'Sub Flow Reference',
+          flow: {
+            id: 'SubFlow',
+            version: '1.0.0',
+          },
+          next_step: { id: 'end', label: 'Finish' },
+        },
+        {
+          id: 'end',
+          type: 'node',
+          title: 'End',
+        },
+      ],
+    },
+  },
+  {
+    id: 'Sub/index.mdx',
+    slug: 'sub',
+    body: '',
+    collection: 'flows',
+    data: {
+      id: 'SubFlow',
+      name: 'Sub Flow',
+      version: '1.0.0',
+      steps: [
+        {
+          id: 'inner_1',
+          type: 'node',
+          title: 'Inner Step 1',
+          next_step: { id: 'inner_2' },
+        },
+        {
+          id: 'inner_2',
+          type: 'node',
+          title: 'Inner Step 2',
+        },
+      ],
+    },
+  },
+];
+
+// Cycle: A references B, B references A. Expansion must terminate.
+export const mockFlowsWithCycle = [
+  {
+    id: 'A/index.mdx',
+    slug: 'a',
+    body: '',
+    collection: 'flows',
+    data: {
+      id: 'FlowA',
+      name: 'Flow A',
+      version: '1.0.0',
+      steps: [
+        {
+          id: 'a_call_b',
+          title: 'Call B',
+          flow: { id: 'FlowB', version: '1.0.0' },
+        },
+      ],
+    },
+  },
+  {
+    id: 'B/index.mdx',
+    slug: 'b',
+    body: '',
+    collection: 'flows',
+    data: {
+      id: 'FlowB',
+      name: 'Flow B',
+      version: '1.0.0',
+      steps: [
+        {
+          id: 'b_call_a',
+          title: 'Call A',
+          flow: { id: 'FlowA', version: '1.0.0' },
+        },
+      ],
+    },
+  },
+];
+
 export const mockFlowByIds = [
   {
     id: 'Payment/PaymentProcessed/index.mdx',

--- a/packages/core/eventcatalog/src/utils/__tests__/flows/sub-flow-expansion.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/flows/sub-flow-expansion.spec.ts
@@ -1,0 +1,83 @@
+import { expect, describe, it, vi } from 'vitest';
+import { mockFlowsWithSubFlow, mockFlowsWithCycle } from './mocks';
+
+vi.mock('astro:content', async (importOriginal) => {
+  return {
+    ...(await importOriginal<typeof import('astro:content')>()),
+    getCollection: (key: string) => {
+      if (key === 'flows') {
+        // @ts-expect-error runtime swap via globalThis
+        return Promise.resolve(globalThis.__flowsMock ?? []);
+      }
+      return Promise.resolve([]);
+    },
+  };
+});
+
+// Import after vi.mock so the module picks up the mocked astro:content
+const { getNodesAndEdges } = await import('../../node-graphs/flows-node-graph');
+
+const withFlowsMock = async (mock: any[], run: () => Promise<void>) => {
+  // @ts-expect-error test shim
+  globalThis.__flowsMock = mock;
+  try {
+    await run();
+  } finally {
+    // @ts-expect-error test shim
+    delete globalThis.__flowsMock;
+  }
+};
+
+describe('Flows NodeGraph — sub-flow expansion precompute', () => {
+  it('attaches expandedNodes and expandedEdges to a step that references another flow', async () => {
+    await withFlowsMock(mockFlowsWithSubFlow, async () => {
+      const { nodes } = await getNodesAndEdges({ id: 'ParentFlow', version: '1.0.0' });
+
+      const subNode = nodes.find((n: any) => n.id === 'step-sub');
+      expect(subNode).toBeDefined();
+      expect(subNode?.type).toBe('flows');
+      expect(Array.isArray(subNode?.data.expandedNodes)).toBe(true);
+      expect(Array.isArray(subNode?.data.expandedEdges)).toBe(true);
+      expect(subNode?.data.expandedNodes.length).toBe(2);
+      expect(subNode?.data.expandedEdges.length).toBe(1);
+    });
+  });
+
+  it('namespaces child node ids with the parent step node id', async () => {
+    await withFlowsMock(mockFlowsWithSubFlow, async () => {
+      const { nodes } = await getNodesAndEdges({ id: 'ParentFlow', version: '1.0.0' });
+
+      const subNode = nodes.find((n: any) => n.id === 'step-sub');
+      const childIds = subNode?.data.expandedNodes.map((n: any) => n.id);
+      expect(childIds).toEqual(expect.arrayContaining(['step-sub__step-inner_1', 'step-sub__step-inner_2']));
+    });
+  });
+
+  it('namespaces expanded edges to reference the child node ids', async () => {
+    await withFlowsMock(mockFlowsWithSubFlow, async () => {
+      const { nodes } = await getNodesAndEdges({ id: 'ParentFlow', version: '1.0.0' });
+
+      const subNode = nodes.find((n: any) => n.id === 'step-sub');
+      const edge = subNode?.data.expandedEdges[0];
+      expect(edge.source).toBe('step-sub__step-inner_1');
+      expect(edge.target).toBe('step-sub__step-inner_2');
+    });
+  });
+
+  it('does not infinitely recurse on flow cycles (A → B → A)', async () => {
+    await withFlowsMock(mockFlowsWithCycle, async () => {
+      const { nodes } = await getNodesAndEdges({ id: 'FlowA', version: '1.0.0' });
+
+      const callB = nodes.find((n: any) => n.id === 'step-a_call_b');
+      expect(callB).toBeDefined();
+      // FlowA → FlowB is expanded (one level deep)
+      expect(Array.isArray(callB?.data.expandedNodes)).toBe(true);
+      expect(callB?.data.expandedNodes.length).toBe(1);
+
+      // The nested FlowB → FlowA reference must not re-expand (it's in visited)
+      const innerCallA = callB?.data.expandedNodes[0];
+      expect(innerCallA.id).toBe('step-a_call_b__step-b_call_a');
+      expect(innerCallA.data.expandedNodes).toBeUndefined();
+    });
+  });
+});

--- a/packages/core/eventcatalog/src/utils/__tests__/flows/sub-flow-expansion.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/flows/sub-flow-expansion.spec.ts
@@ -1,5 +1,5 @@
 import { expect, describe, it, vi } from 'vitest';
-import { mockFlowsWithSubFlow, mockFlowsWithCycle } from './mocks';
+import { mockFlowsWithSubFlow, mockFlowsWithCycle, mockFlowsNested } from './mocks';
 
 vi.mock('astro:content', async (importOriginal) => {
   return {
@@ -61,6 +61,32 @@ describe('Flows NodeGraph — sub-flow expansion precompute', () => {
       const edge = subNode?.data.expandedEdges[0];
       expect(edge.source).toBe('step-sub__step-inner_1');
       expect(edge.target).toBe('step-sub__step-inner_2');
+    });
+  });
+
+  it('prefixes nested expandedNodes recursively so deep sub-flows get unique ids', async () => {
+    await withFlowsMock(mockFlowsNested, async () => {
+      const { nodes } = await getNodesAndEdges({ id: 'OuterFlow', version: '1.0.0' });
+
+      const middleRef = nodes.find((n: any) => n.id === 'step-outer_mid');
+      expect(middleRef).toBeDefined();
+
+      const middleChild = middleRef?.data.expandedNodes[0];
+      expect(middleChild.id).toBe('step-outer_mid__step-middle_leaf');
+
+      // The leaf sub-flow's expansion payload, nested inside MiddleFlow, must
+      // also carry the outer prefix so its ids stay unique across parents.
+      const leafChildren = middleChild.data.expandedNodes;
+      const leafIds = leafChildren.map((c: any) => c.id);
+      expect(leafIds).toEqual(
+        expect.arrayContaining([
+          'step-outer_mid__step-middle_leaf__step-leaf_step_1',
+          'step-outer_mid__step-middle_leaf__step-leaf_step_2',
+        ])
+      );
+      const leafEdges = middleChild.data.expandedEdges;
+      expect(leafEdges[0].source).toBe('step-outer_mid__step-middle_leaf__step-leaf_step_1');
+      expect(leafEdges[0].target).toBe('step-outer_mid__step-middle_leaf__step-leaf_step_2');
     });
   });
 

--- a/packages/core/eventcatalog/src/utils/node-graphs/flows-node-graph.ts
+++ b/packages/core/eventcatalog/src/utils/node-graphs/flows-node-graph.ts
@@ -56,10 +56,20 @@ const getMessageNode = (step: any, messageMap: Map<string, any[]>) => {
 };
 
 // Rewrite every id/source/target in a precomputed sub-flow graph with a
-// namespace prefix so inlined copies don't collide with the parent.
+// namespace prefix so inlined copies don't collide with the parent. Nested
+// `data.expandedNodes` / `data.expandedEdges` payloads are rewritten too so
+// the namespace chain stays unique when the same sub-flow is inlined under
+// multiple parents.
 const prefixGraph = (graph: { nodes: any[]; edges: any[] }, prefix: string) => {
   if (!prefix) return graph;
-  const nodes = graph.nodes.map((n) => ({ ...n, id: `${prefix}${n.id}` }));
+  const nodes = graph.nodes.map((n) => {
+    const next: any = { ...n, id: `${prefix}${n.id}` };
+    if (n.data?.expandedNodes || n.data?.expandedEdges) {
+      const nested = prefixGraph({ nodes: n.data.expandedNodes ?? [], edges: n.data.expandedEdges ?? [] }, prefix);
+      next.data = { ...n.data, expandedNodes: nested.nodes, expandedEdges: nested.edges };
+    }
+    return next;
+  });
   const edges = graph.edges.map((e) => ({
     ...e,
     id: `${prefix}${e.id}`,

--- a/packages/core/eventcatalog/src/utils/node-graphs/flows-node-graph.ts
+++ b/packages/core/eventcatalog/src/utils/node-graphs/flows-node-graph.ts
@@ -22,6 +22,12 @@ interface Props {
   renderAllEdges?: boolean;
 }
 
+interface Maps {
+  messageMap: Map<string, any[]>;
+  serviceMap: Map<string, any[]>;
+  flowMap: Map<string, any[]>;
+}
+
 const getServiceNode = (step: any, serviceMap: Map<string, any[]>) => {
   const service = findInMap(serviceMap, step.service.id, step.service.version);
   return {
@@ -49,53 +55,48 @@ const getMessageNode = (step: any, messageMap: Map<string, any[]>) => {
   };
 };
 
-export const getNodesAndEdges = async ({ id, defaultFlow, version, mode = 'simple', renderAllEdges = false }: Props) => {
-  const graph = defaultFlow || createDagreGraph({ ranksep: 360, nodesep: 200 });
-  const nodes = [] as any,
-    edges = [] as any;
+// Rewrite every id/source/target in a precomputed sub-flow graph with a
+// namespace prefix so inlined copies don't collide with the parent.
+const prefixGraph = (graph: { nodes: any[]; edges: any[] }, prefix: string) => {
+  if (!prefix) return graph;
+  const nodes = graph.nodes.map((n) => ({ ...n, id: `${prefix}${n.id}` }));
+  const edges = graph.edges.map((e) => ({
+    ...e,
+    id: `${prefix}${e.id}`,
+    source: `${prefix}${e.source}`,
+    target: `${prefix}${e.target}`,
+  }));
+  return { nodes, edges };
+};
 
-  // Fetch all collections in parallel
-  const [flows, events, commands, queries, services] = await Promise.all([
-    getCollection('flows'),
-    getCollection('events'),
-    getCollection('commands'),
-    getCollection('queries'),
-    getCollection('services'),
-  ]);
+// `subFlowCache` keys each flow's graph by `id@version` so an N-times
+// referenced sub-flow is built once. `visited` short-circuits cycles.
+const buildFlowGraphInternal = (
+  flow: any,
+  maps: Maps,
+  mode: 'simple' | 'full',
+  subFlowCache: Map<string, { nodes: any[]; edges: any[] }>,
+  visited: Set<string>
+) => {
+  const nodes: any[] = [];
+  const edges: any[] = [];
 
-  const flow = flows.find((flow) => flow.data.id === id && flow.data.version === version);
+  const steps = flow?.data?.steps || [];
+  const stepNodeId = (stepId: any) => `step-${stepId}`;
 
-  // Nothing found...
-  if (!flow) {
-    return {
-      nodes: [],
-      edges: [],
-    };
-  }
-
-  // Build maps for O(1) lookups
-  const messages = [...events, ...commands, ...queries];
-  const messageMap = createVersionedMap(messages);
-  const serviceMap = createVersionedMap(services);
-  const flowMap = createVersionedMap(flows);
-
-  const steps = flow?.data.steps || [];
-
-  //  Hydrate the steps with information they may need.
   const hydratedSteps = steps.map((step: any) => {
-    if (step.service) return getServiceNode(step, serviceMap);
-    if (step.flow) return getFlowNode(step, flowMap);
-    if (step.message) return getMessageNode(step, messageMap);
+    if (step.service) return getServiceNode(step, maps.serviceMap);
+    if (step.flow) return getFlowNode(step, maps.flowMap);
+    if (step.message) return getMessageNode(step, maps.messageMap);
     if (step.actor) return { ...step, type: 'actor', actor: step.actor };
     if (step.custom) return { ...step, type: 'custom', custom: step.custom };
     if (step.externalSystem) return { ...step, type: 'externalSystem', externalSystem: step.externalSystem };
     return { ...step, type: 'step' };
   });
 
-  // Create nodes
   hydratedSteps.forEach((step: any, index: number) => {
-    const node = {
-      id: `step-${step.id}`,
+    const node: NodeType = {
+      id: stepNodeId(step.id),
       sourcePosition: 'right',
       targetPosition: 'left',
       data: {
@@ -124,6 +125,21 @@ export const getNodesAndEdges = async ({ id, defaultFlow, version, mode = 'simpl
         id: step.flow.data.id,
         version: step.flow.data.version,
       });
+
+      // Guard cycles; inline the sub-flow's graph so the client can expand on click.
+      const subFlowKey = `${step.flow.data.id}@${step.flow.data.version}`;
+      if (!visited.has(subFlowKey)) {
+        let cached = subFlowCache.get(subFlowKey);
+        if (!cached) {
+          cached = buildFlowGraphInternal(step.flow, maps, mode, subFlowCache, new Set([...visited, subFlowKey]));
+          subFlowCache.set(subFlowKey, cached);
+        }
+        if (cached.nodes.length > 0) {
+          const { nodes: childNodes, edges: childEdges } = prefixGraph(cached, `${node.id}__`);
+          node.data.expandedNodes = childNodes;
+          node.data.expandedEdges = childEdges;
+        }
+      }
     }
     if (step.message) {
       node.data.message = { ...step.message, ...step.message.data };
@@ -142,12 +158,10 @@ export const getNodesAndEdges = async ({ id, defaultFlow, version, mode = 'simpl
     nodes.push(node);
   });
 
-  // Create Edges
-  hydratedSteps.forEach((step: any, index: number) => {
+  hydratedSteps.forEach((step: any) => {
     let paths = step.next_steps || [];
 
     if (step.next_step) {
-      // If its a string or number
       if (!step.next_step?.id) {
         paths = [{ id: step.next_step }];
       } else {
@@ -165,8 +179,8 @@ export const getNodesAndEdges = async ({ id, defaultFlow, version, mode = 'simpl
     paths.forEach((path: any) => {
       edges.push({
         id: `step-${step.id}-step-${path.id}`,
-        source: `step-${step.id}`,
-        target: `step-${path.id}`,
+        source: stepNodeId(step.id),
+        target: stepNodeId(path.id),
         type: 'flow-edge',
         label: path.label,
         animated: true,
@@ -184,6 +198,45 @@ export const getNodesAndEdges = async ({ id, defaultFlow, version, mode = 'simpl
     });
   });
 
+  return { nodes, edges };
+};
+
+export const getNodesAndEdges = async ({ id, defaultFlow, version, mode = 'simple', renderAllEdges = false }: Props) => {
+  const graph = defaultFlow || createDagreGraph({ ranksep: 360, nodesep: 200 });
+
+  const [flows, events, commands, queries, services] = await Promise.all([
+    getCollection('flows'),
+    getCollection('events'),
+    getCollection('commands'),
+    getCollection('queries'),
+    getCollection('services'),
+  ]);
+
+  const flow = flows.find((flow) => flow.data.id === id && flow.data.version === version);
+
+  if (!flow) {
+    return {
+      nodes: [],
+      edges: [],
+    };
+  }
+
+  const messages = [...events, ...commands, ...queries];
+  const maps: Maps = {
+    messageMap: createVersionedMap(messages),
+    serviceMap: createVersionedMap(services),
+    flowMap: createVersionedMap(flows),
+  };
+
+  const subFlowCache = new Map<string, { nodes: any[]; edges: any[] }>();
+  const { nodes, edges } = buildFlowGraphInternal(
+    flow,
+    maps,
+    mode,
+    subFlowCache,
+    new Set([`${flow.data.id}@${flow.data.version}`])
+  );
+
   nodes.forEach((node: any) => {
     graph.setNode(node.id, { width: DEFAULT_NODE_WIDTH, height: DEFAULT_NODE_HEIGHT });
   });
@@ -192,7 +245,6 @@ export const getNodesAndEdges = async ({ id, defaultFlow, version, mode = 'simpl
     graph.setEdge(edge.source, edge.target);
   });
 
-  // Render the diagram in memory getting hte X and Y
   dagre.layout(graph);
 
   return {

--- a/packages/visualiser/src/components/NodeGraph.tsx
+++ b/packages/visualiser/src/components/NodeGraph.tsx
@@ -772,12 +772,12 @@ const NodeGraphBuilder = ({
       const expandedNode = currentNodes.find((n) => n.id === groupNodeId);
       if (!expandedNode || !isExpandedWrapper(expandedNode.type)) return;
 
-      // The wrapper carries the pre-expansion node and its edges — use that
-      // snapshot when present so nested wrappers (created mid-session and
-      // therefore absent from initialNodes) collapse correctly. Fall back to
-      // initialNodes for wrappers expanded on a top-level node.
+      // The wrapper carries a pre-expansion snapshot — use it so nested
+      // wrappers (created mid-session and therefore absent from initialNodes)
+      // collapse correctly. Fall back to initialNodes for wrappers expanded
+      // on a top-level node that was there from page load.
       const stashed = (expandedNode.data as any).__preExpansion as
-        | { node: Node; edges: Edge[] }
+        | { node: Node; edges: Edge[]; nodeIds: string[] }
         | undefined;
       const originalNode =
         stashed?.node ??
@@ -800,13 +800,14 @@ const NodeGraphBuilder = ({
         currentNodes.filter((n) => n.parentId === groupNodeId).map((n) => n.id),
       );
 
-      // Downstream nodes added on expand are ones present in the original
-      // node's expandedNodes that aren't also in the pre-expansion graph.
+      // Downstream nodes added on expand are those in the original node's
+      // expandedNodes that weren't in the graph just before the expand ran.
+      // Use the stashed pre-expansion id snapshot when present (so mid-
+      // session wrappers diff against their own "before"), else fall back
+      // to the initial page-load node set.
       const originalData = originalNode.data as any;
       const preExistingIds = new Set(
-        stashed
-          ? currentNodes.map((n: Node) => n.id)
-          : initialNodes.map((n: Node) => n.id),
+        stashed ? stashed.nodeIds : initialNodes.map((n: Node) => n.id),
       );
       const downstreamNodeIds = new Set(
         ((originalData.expandedNodes as any[]) || [])
@@ -1014,12 +1015,14 @@ const NodeGraphBuilder = ({
         const containerWidth = 380;
         const containerHeight = childCount * 190 + 100; // 190px per child + header + padding
 
-        // Capture the node and its edges as they are right now so collapse can
-        // restore them verbatim, even if this wrapper was itself created mid-
-        // session by an outer expansion (i.e. never lived in `initialNodes`).
+        // Capture the node, its edges, and the set of node ids as they are
+        // right now so collapse can (a) restore the pre-expansion node/edges
+        // verbatim even for wrappers created mid-session, and (b) identify
+        // which downstream nodes were newly introduced by this expansion.
         const preExpansionEdges = edgesRef.current.filter(
           (e) => e.source === groupNodeId || e.target === groupNodeId,
         );
+        const preExpansionNodeIds = nodesRef.current.map((n) => n.id);
 
         const expandedContainerNode: Node = {
           id: groupNodeId,
@@ -1030,7 +1033,11 @@ const NodeGraphBuilder = ({
             direction: groupData.direction,
             messageCount: childCount,
             onCollapse: groupNodeId,
-            __preExpansion: { node, edges: preExpansionEdges },
+            __preExpansion: {
+              node,
+              edges: preExpansionEdges,
+              nodeIds: preExpansionNodeIds,
+            },
           },
           style: {
             width: containerWidth,
@@ -1229,12 +1236,14 @@ const NodeGraphBuilder = ({
           { padding: CHILD_PADDING, headerH: HEADER_H },
         );
 
-        // Capture the node and its edges as they are right now so collapse can
-        // restore them verbatim, even if this wrapper was itself created mid-
-        // session by an outer expansion (i.e. never lived in `initialNodes`).
+        // Capture the node, its edges, and the set of node ids as they are
+        // right now so collapse can (a) restore the pre-expansion node/edges
+        // verbatim even for wrappers created mid-session, and (b) identify
+        // which downstream nodes were newly introduced by this expansion.
         const preExpansionEdges = edgesRef.current.filter(
           (e) => e.source === flowNodeId || e.target === flowNodeId,
         );
+        const preExpansionNodeIds = nodesRef.current.map((n) => n.id);
 
         const expandedContainerNode: Node = {
           id: flowNodeId,
@@ -1243,7 +1252,11 @@ const NodeGraphBuilder = ({
           data: {
             flowName: flowData.flow?.name || flowData.flow?.data?.name,
             version: flowData.flow?.version || flowData.flow?.data?.version,
-            __preExpansion: { node, edges: preExpansionEdges },
+            __preExpansion: {
+              node,
+              edges: preExpansionEdges,
+              nodeIds: preExpansionNodeIds,
+            },
           },
           style: {
             width: containerWidth,

--- a/packages/visualiser/src/components/NodeGraph.tsx
+++ b/packages/visualiser/src/components/NodeGraph.tsx
@@ -772,40 +772,50 @@ const NodeGraphBuilder = ({
       const expandedNode = currentNodes.find((n) => n.id === groupNodeId);
       if (!expandedNode || !isExpandedWrapper(expandedNode.type)) return;
 
-      // Find the original collapsed node (either messageGroup or a flow-type node)
-      const originalNode = initialNodes.find(
-        (n: Node) =>
-          n.id === groupNodeId &&
-          (n.type === "messageGroup" ||
-            n.type === "flows" ||
-            n.type === "flow"),
-      );
+      // The wrapper carries the pre-expansion node and its edges — use that
+      // snapshot when present so nested wrappers (created mid-session and
+      // therefore absent from initialNodes) collapse correctly. Fall back to
+      // initialNodes for wrappers expanded on a top-level node.
+      const stashed = (expandedNode.data as any).__preExpansion as
+        | { node: Node; edges: Edge[] }
+        | undefined;
+      const originalNode =
+        stashed?.node ??
+        initialNodes.find(
+          (n: Node) =>
+            n.id === groupNodeId &&
+            (n.type === "messageGroup" ||
+              n.type === "flows" ||
+              n.type === "flow"),
+        );
       if (!originalNode) return;
+      const originalEdges =
+        stashed?.edges ??
+        initialEdges.filter(
+          (edge: Edge) =>
+            edge.source === groupNodeId || edge.target === groupNodeId,
+        );
 
-      // Find all child nodes belonging to this group
       const childNodeIds = new Set(
         currentNodes.filter((n) => n.parentId === groupNodeId).map((n) => n.id),
       );
 
-      // Collect downstream node IDs that were added on expand,
-      // but only those that didn't already exist in the original graph
+      // Downstream nodes added on expand are ones present in the original
+      // node's expandedNodes that aren't also in the pre-expansion graph.
       const originalData = originalNode.data as any;
-      const initialNodeIds = new Set(initialNodes.map((n: Node) => n.id));
+      const preExistingIds = new Set(
+        stashed
+          ? currentNodes.map((n: Node) => n.id)
+          : initialNodes.map((n: Node) => n.id),
+      );
       const downstreamNodeIds = new Set(
         ((originalData.expandedNodes as any[]) || [])
           .map((n: any) => n.id)
-          .filter((id: string) => !initialNodeIds.has(id)),
+          .filter((id: string) => !preExistingIds.has(id)),
       );
 
-      // Downstream edges are prefixed with groupNodeId__
       const isDownstreamEdge = (edge: Edge) =>
         edge.id.startsWith(`${groupNodeId}__`);
-
-      // Find original edges for the compact node from initialEdges
-      const originalEdges = initialEdges.filter(
-        (edge: Edge) =>
-          edge.source === groupNodeId || edge.target === groupNodeId,
-      );
 
       // Animate the layout transition
       animateLayout();
@@ -1004,16 +1014,23 @@ const NodeGraphBuilder = ({
         const containerWidth = 380;
         const containerHeight = childCount * 190 + 100; // 190px per child + header + padding
 
-        // Build the expanded group container node
+        // Capture the node and its edges as they are right now so collapse can
+        // restore them verbatim, even if this wrapper was itself created mid-
+        // session by an outer expansion (i.e. never lived in `initialNodes`).
+        const preExpansionEdges = edgesRef.current.filter(
+          (e) => e.source === groupNodeId || e.target === groupNodeId,
+        );
+
         const expandedContainerNode: Node = {
-          id: groupNodeId, // reuse the same ID
+          id: groupNodeId,
           type: "messageGroupExpanded",
-          position: node.position, // will be recalculated by dagre
+          position: node.position,
           data: {
             groupName: groupData.groupName,
             direction: groupData.direction,
             messageCount: childCount,
             onCollapse: groupNodeId,
+            __preExpansion: { node, edges: preExpansionEdges },
           },
           style: {
             width: containerWidth,
@@ -1212,6 +1229,13 @@ const NodeGraphBuilder = ({
           { padding: CHILD_PADDING, headerH: HEADER_H },
         );
 
+        // Capture the node and its edges as they are right now so collapse can
+        // restore them verbatim, even if this wrapper was itself created mid-
+        // session by an outer expansion (i.e. never lived in `initialNodes`).
+        const preExpansionEdges = edgesRef.current.filter(
+          (e) => e.source === flowNodeId || e.target === flowNodeId,
+        );
+
         const expandedContainerNode: Node = {
           id: flowNodeId,
           type: "flowExpanded",
@@ -1219,6 +1243,7 @@ const NodeGraphBuilder = ({
           data: {
             flowName: flowData.flow?.name || flowData.flow?.data?.name,
             version: flowData.flow?.version || flowData.flow?.data?.version,
+            __preExpansion: { node, edges: preExpansionEdges },
           },
           style: {
             width: containerWidth,

--- a/packages/visualiser/src/components/NodeGraph.tsx
+++ b/packages/visualiser/src/components/NodeGraph.tsx
@@ -53,6 +53,7 @@ import { Note as NoteNode } from "../nodes/note";
 import { Field as FieldNode } from "../nodes/field";
 // Core nodes (default exports from flat files)
 import FlowNode from "../nodes/Flow";
+import FlowExpandedNode from "../nodes/FlowExpandedNode";
 import EntityNode from "../nodes/Entity";
 import UserNode from "../nodes/User";
 import StepNode from "../nodes/Step";
@@ -101,10 +102,20 @@ const MINIMAP_STYLE = {
 } as const;
 const LAYOUT_CHANGE_PANEL_STYLE_WITH_WALKTHROUGH = {
   marginBottom: "20px",
-  marginLeft: "410px",
+  marginLeft: "420px",
 } as const;
 const LAYOUT_CHANGE_PANEL_STYLE_DEFAULT = { marginLeft: "60px" } as const;
 const LEGEND_PANEL_STYLE_WITH_MINIMAP = { marginRight: "230px" } as const;
+
+// Expanded wrapper containers are structural only — they host grouped/inlined
+// child nodes and never represent a business step themselves. Centralised so
+// the walkthrough, click handler, and collapse handler agree on the set.
+const EXPANDED_WRAPPER_TYPES = new Set([
+  "flowExpanded",
+  "messageGroupExpanded",
+]);
+const isExpandedWrapper = (type: string | undefined) =>
+  type != null && EXPANDED_WRAPPER_TYPES.has(type);
 
 type LegendEntry = { count: number; colorClass: string; groupId?: string };
 
@@ -382,6 +393,7 @@ const NodeGraphBuilder = ({
       field: wrapWithContextMenu(FieldNode),
       messageGroup: MessageGroupNode,
       messageGroupExpanded: MessageGroupExpandedNode,
+      flowExpanded: FlowExpandedNode,
     } as unknown as NodeTypes;
   }, []);
   const edgeTypes = useMemo(
@@ -545,6 +557,35 @@ const NodeGraphBuilder = ({
   const hideChannelsRef = useRef(hideChannels);
   hideChannelsRef.current = hideChannels;
 
+  // The walkthrough treats expanded wrapper containers as structural rather
+  // than walkable steps. Stitched predecessor/successor edges added at expand
+  // time already connect real outer steps to the sub-flow's children, so
+  // dropping wrapper edges doesn't break traversal.
+  const wrapperNodeIds = useMemo(() => {
+    const ids = new Set<string>();
+    nodes.forEach((n) => {
+      if (isExpandedWrapper(n.type)) ids.add(n.id);
+    });
+    return ids;
+  }, [nodes]);
+  const walkthroughNodes = useMemo(
+    () =>
+      wrapperNodeIds.size === 0
+        ? nodes
+        : nodes.filter((n) => !wrapperNodeIds.has(n.id)),
+    [nodes, wrapperNodeIds],
+  );
+  const walkthroughEdges = useMemo(
+    () =>
+      wrapperNodeIds.size === 0
+        ? edges
+        : edges.filter(
+            (e) =>
+              !wrapperNodeIds.has(e.source) && !wrapperNodeIds.has(e.target),
+          ),
+    [edges, wrapperNodeIds],
+  );
+
   const animateLayout = useCallback(() => {
     const wrapper = reactFlowWrapperRef.current;
     if (!wrapper) return;
@@ -598,8 +639,16 @@ const NodeGraphBuilder = ({
     // Apply dagre positions to top-level nodes
     const positioned = nextNodes.map((node) => {
       if (node.parentId) {
-        // Position children centered within their parent container
         const parent = nextNodes.find((n) => n.id === node.parentId);
+
+        // Sub-flow expansion: children keep the LR positions already computed
+        // when the sub-flow was expanded. Leave them alone so the inner graph
+        // renders in true graph order, not a vertical stack.
+        if (parent?.type === "flowExpanded") {
+          return node;
+        }
+
+        // Message groups: simple vertical stack, centred within the container.
         const parentWidth = (parent?.style?.width as number) || 380;
         const childWidth = 240; // initial estimate, refined by post-render measurement
         const xOffset = Math.max(20, (parentWidth - childWidth) / 2);
@@ -623,12 +672,90 @@ const NodeGraphBuilder = ({
     return positioned;
   }, []);
 
+  // Lay a sub-flow's internal nodes out with dagre LR and return positioned
+  // children, a per-id position map, and the tightest container bounding box
+  // so the wrapper can size itself to fit. `sizeOf` supplies per-child width
+  // and height — callers pass either estimated constants (initial layout) or
+  // measured DOM dimensions (post-paint).
+  const layoutSubFlowChildren = useCallback(
+    (
+      children: Node[],
+      edges: Edge[],
+      sizeOf: (n: Node) => { w: number; h: number },
+      opts: {
+        padding: number;
+        headerH: number;
+        fallbackW?: number;
+        fallbackH?: number;
+      },
+    ) => {
+      const { padding, headerH, fallbackW = 240, fallbackH = 120 } = opts;
+
+      const g = new dagre.graphlib.Graph();
+      g.setGraph({ rankdir: "LR", ranksep: 360, nodesep: 200 });
+      g.setDefaultEdgeLabel(() => ({}));
+      const childIds = new Set(children.map((c) => c.id));
+      children.forEach((c) => {
+        const { w, h } = sizeOf(c);
+        g.setNode(c.id, { width: w, height: h });
+      });
+      edges.forEach((e) => {
+        if (childIds.has(e.source) && childIds.has(e.target)) {
+          g.setEdge(e.source, e.target);
+        }
+      });
+      dagre.layout(g);
+
+      let minX = Infinity;
+      let minY = Infinity;
+      let maxX = -Infinity;
+      let maxY = -Infinity;
+      const positions = new Map<string, { x: number; y: number }>();
+      children.forEach((c) => {
+        const pos = g.node(c.id);
+        if (!pos) return;
+        const x = pos.x - pos.width / 2;
+        const y = pos.y - pos.height / 2;
+        positions.set(c.id, { x, y });
+        minX = Math.min(minX, x);
+        minY = Math.min(minY, y);
+        maxX = Math.max(maxX, x + pos.width);
+        maxY = Math.max(maxY, y + pos.height);
+      });
+
+      const offsetX = padding - (Number.isFinite(minX) ? minX : 0);
+      const offsetY = headerH + padding - (Number.isFinite(minY) ? minY : 0);
+      const positioned = children.map((c) => {
+        const p = positions.get(c.id);
+        if (!p) return c;
+        return { ...c, position: { x: p.x + offsetX, y: p.y + offsetY } };
+      });
+      // Translate positions too so callers that read the map see the final coords.
+      const finalPositions = new Map<string, { x: number; y: number }>();
+      positions.forEach((p, id) =>
+        finalPositions.set(id, { x: p.x + offsetX, y: p.y + offsetY }),
+      );
+
+      const width = Number.isFinite(minX)
+        ? maxX - minX + padding * 2
+        : fallbackW + padding * 2;
+      const height = Number.isFinite(minY)
+        ? maxY - minY + headerH + padding * 2
+        : fallbackH + headerH + padding * 2;
+
+      return { positioned, positions: finalPositions, width, height };
+    },
+    [],
+  );
+
   // Read from refs inside the callback to avoid nodes/edges in the dependency array.
   // This prevents the callback from being recreated on every drag tick (Rule 2).
   const handleCollapseGroup = useCallback(
     (e: React.MouseEvent) => {
       const target = e.target as HTMLElement;
-      const collapseBtn = target.closest(".ec-collapse-group-btn");
+      const collapseBtn = target.closest(
+        ".ec-collapse-group-btn, .ec-collapse-flow-btn",
+      );
       if (!collapseBtn) return;
       e.stopPropagation();
 
@@ -643,18 +770,22 @@ const NodeGraphBuilder = ({
 
       // Find the expanded container node to get its data
       const expandedNode = currentNodes.find((n) => n.id === groupNodeId);
-      if (!expandedNode || expandedNode.type !== "messageGroupExpanded") return;
+      if (!expandedNode || !isExpandedWrapper(expandedNode.type)) return;
+
+      // Find the original collapsed node (either messageGroup or a flow-type node)
+      const originalNode = initialNodes.find(
+        (n: Node) =>
+          n.id === groupNodeId &&
+          (n.type === "messageGroup" ||
+            n.type === "flows" ||
+            n.type === "flow"),
+      );
+      if (!originalNode) return;
 
       // Find all child nodes belonging to this group
       const childNodeIds = new Set(
         currentNodes.filter((n) => n.parentId === groupNodeId).map((n) => n.id),
       );
-
-      // Find the original messageGroup data from initialNodes
-      const originalNode = initialNodes.find(
-        (n: Node) => n.id === groupNodeId && n.type === "messageGroup",
-      );
-      if (!originalNode) return;
 
       // Collect downstream node IDs that were added on expand,
       // but only those that didn't already exist in the original graph
@@ -718,6 +849,12 @@ const NodeGraphBuilder = ({
         );
         return [...without, ...originalEdges];
       });
+
+      // Reframe the graph after the layout transition finishes so the user
+      // sees the collapsed result centred.
+      requestAnimationFrame(() => {
+        fitView({ duration: 400, padding: 0.2 });
+      });
     },
     [
       initialNodes,
@@ -726,6 +863,7 @@ const NodeGraphBuilder = ({
       setEdges,
       relayoutGraph,
       animateLayout,
+      fitView,
     ],
   );
 
@@ -836,18 +974,24 @@ const NodeGraphBuilder = ({
         return;
       }
 
-      // Disable focus mode for flow and entity visualizations
+      // Disable focus mode for flow and entity visualizations — but allow
+      // flow-type nodes that carry precomputed expandedNodes to continue
+      // through to the inline expand handler below.
       const isFlow = edgesRef.current.some(
         (edge: Edge) => edge.type === "flow-edge",
       );
       const isEntityVisualizer = nodesRef.current.some(
         (n: Node) => n.type === "entities",
       );
-      if (isFlow || isEntityVisualizer) return;
+      const isExpandableFlow =
+        (node.type === "flows" || node.type === "flow") &&
+        Array.isArray((node.data as any)?.expandedNodes) &&
+        (node.data as any).expandedNodes.length > 0;
+      if ((isFlow || isEntityVisualizer) && !isExpandableFlow) return;
 
       // Disable focus mode for domain and expanded group nodes
       if (node.type === "domain" || node.type === "domains") return;
-      if (node.type === "messageGroupExpanded") return;
+      if (isExpandedWrapper(node.type)) return;
 
       // Handle messageGroup click — expand inline
       if (node.type === "messageGroup") {
@@ -1030,6 +1174,191 @@ const NodeGraphBuilder = ({
               return { ...n, position: { x, y } };
             });
           });
+        });
+
+        requestAnimationFrame(() => {
+          fitView({ duration: 400, padding: 0.2 });
+        });
+
+        return;
+      }
+
+      // Handle flow-reference click — inline-expand the sub-flow
+      if (isExpandableFlow) {
+        const flowData = node.data as any;
+        const flowNodeId = node.id;
+        const subFlowNodes: any[] = flowData.expandedNodes || [];
+        const subFlowEdges: any[] = flowData.expandedEdges || [];
+
+        const initialChildNodes: Node[] = subFlowNodes.map((child) => ({
+          ...child,
+          parentId: flowNodeId,
+          extent: "parent" as const,
+          position: { x: 0, y: 0 },
+        }));
+
+        const CHILD_PADDING = 60;
+        const HEADER_H = 60;
+        const EST_W = 240;
+        const EST_H = 120;
+        const {
+          positioned: childNodes,
+          width: containerWidth,
+          height: containerHeight,
+        } = layoutSubFlowChildren(
+          initialChildNodes,
+          subFlowEdges as Edge[],
+          () => ({ w: EST_W, h: EST_H }),
+          { padding: CHILD_PADDING, headerH: HEADER_H },
+        );
+
+        const expandedContainerNode: Node = {
+          id: flowNodeId,
+          type: "flowExpanded",
+          position: node.position,
+          data: {
+            flowName: flowData.flow?.name || flowData.flow?.data?.name,
+            version: flowData.flow?.version || flowData.flow?.data?.version,
+          },
+          style: {
+            width: containerWidth,
+            height: containerHeight,
+            background: "transparent",
+            border: "none",
+            padding: 0,
+            overflow: "visible",
+          },
+        };
+
+        const childIds = new Set(childNodes.map((n) => n.id));
+        const hasIncoming = new Set<string>();
+        const hasOutgoing = new Set<string>();
+        for (const e of subFlowEdges) {
+          if (childIds.has(e.target)) hasIncoming.add(e.target);
+          if (childIds.has(e.source)) hasOutgoing.add(e.source);
+        }
+        const entryChildIds = childNodes
+          .map((n) => n.id)
+          .filter((id) => !hasIncoming.has(id));
+        const terminalChildIds = childNodes
+          .map((n) => n.id)
+          .filter((id) => !hasOutgoing.has(id));
+
+        // Reroute the parent graph's edges across the sub-flow's boundary:
+        // each predecessor now targets every entry child; each successor
+        // sources from every terminal child.
+        const currentEdges = edgesRef.current;
+        const predecessorEdges = currentEdges.filter(
+          (e: Edge) => e.target === flowNodeId,
+        );
+        const successorEdges = currentEdges.filter(
+          (e: Edge) => e.source === flowNodeId,
+        );
+
+        const stitchedPredecessors: Edge[] = [];
+        for (const e of predecessorEdges) {
+          for (const entryId of entryChildIds.length > 0
+            ? entryChildIds
+            : [flowNodeId]) {
+            stitchedPredecessors.push({
+              ...e,
+              id: `${e.id}__to__${entryId}`,
+              target: entryId,
+            });
+          }
+        }
+        const stitchedSuccessors: Edge[] = [];
+        for (const e of successorEdges) {
+          for (const terminalId of terminalChildIds.length > 0
+            ? terminalChildIds
+            : [flowNodeId]) {
+            stitchedSuccessors.push({
+              ...e,
+              id: `${e.id}__from__${terminalId}`,
+              source: terminalId,
+            });
+          }
+        }
+
+        animateLayout();
+
+        setNodes((prev) => {
+          const without = prev.filter((n) => n.id !== flowNodeId);
+          const next = [...without, expandedContainerNode, ...childNodes];
+          const nextEdges = [
+            ...currentEdges.filter(
+              (e) => e.source !== flowNodeId && e.target !== flowNodeId,
+            ),
+            ...subFlowEdges,
+            ...stitchedPredecessors,
+            ...stitchedSuccessors,
+          ];
+          return relayoutGraph(next, nextEdges);
+        });
+        setEdges((prev) => {
+          const without = prev.filter(
+            (e) => e.source !== flowNodeId && e.target !== flowNodeId,
+          );
+          return [
+            ...without,
+            ...subFlowEdges,
+            ...stitchedPredecessors,
+            ...stitchedSuccessors,
+          ];
+        });
+
+        // Once React has painted, re-run the LR layout with measured node
+        // sizes so the container sizes itself to real content.
+        requestAnimationFrame(() => {
+          const currentChildren = nodesRef.current.filter(
+            (n) => n.parentId === flowNodeId,
+          );
+          if (currentChildren.length === 0) return;
+
+          const measurements = new Map<string, { w: number; h: number }>();
+          currentChildren.forEach((n) => {
+            const el = document.querySelector(
+              `[data-id="${n.id}"]`,
+            ) as HTMLElement | null;
+            measurements.set(n.id, {
+              w: el?.offsetWidth ?? EST_W,
+              h: el?.offsetHeight ?? EST_H,
+            });
+          });
+
+          const {
+            positions,
+            width: actualContainerW,
+            height: actualContainerH,
+          } = layoutSubFlowChildren(
+            currentChildren,
+            subFlowEdges as Edge[],
+            (n) => measurements.get(n.id) ?? { w: EST_W, h: EST_H },
+            { padding: CHILD_PADDING, headerH: HEADER_H },
+          );
+
+          setNodes((prev) =>
+            prev.map((n) => {
+              if (n.id === flowNodeId) {
+                return {
+                  ...n,
+                  style: {
+                    ...n.style,
+                    width: actualContainerW,
+                    height: actualContainerH,
+                  },
+                };
+              }
+              if (n.parentId !== flowNodeId) return n;
+              const p = positions.get(n.id);
+              if (!p) return n;
+              return { ...n, position: { x: p.x, y: p.y } };
+            }),
+          );
+        });
+
+        requestAnimationFrame(() => {
+          fitView({ duration: 400, padding: 0.2 });
         });
 
         return;
@@ -1863,8 +2192,8 @@ const NodeGraphBuilder = ({
             {isFlowVisualization && showFlowWalkthrough && (
               <Panel position="bottom-left">
                 <StepWalkthrough
-                  nodes={nodes}
-                  edges={edges}
+                  nodes={walkthroughNodes}
+                  edges={walkthroughEdges}
                   isFlowVisualization={isFlowVisualization}
                   onStepChange={handleStepChange}
                   mode={mode}

--- a/packages/visualiser/src/components/StepWalkthrough.tsx
+++ b/packages/visualiser/src/components/StepWalkthrough.tsx
@@ -121,7 +121,14 @@ export default memo(function StepWalkthrough({
       const startNodes = nodes.filter(
         (node: CustomNode) => incomingEdgeMap.get(node.id) === 0,
       );
-      if (startNodes.length > 0 && !startNodeId) {
+
+      // Recompute the start node whenever the cached id no longer exists in
+      // the current node set. This happens when the graph structure changes
+      // — for example when a sub-flow is expanded and its wrapper node gets
+      // replaced by children.
+      const cachedStartStillValid =
+        startNodeId && nodes.some((n: CustomNode) => n.id === startNodeId);
+      if (startNodes.length > 0 && !cachedStartStillValid) {
         const firstStartNode = startNodes[0];
         setStartNodeId(firstStartNode.id);
       }
@@ -130,6 +137,20 @@ export default memo(function StepWalkthrough({
 
   useEffect(() => {
     if (currentNodeId) {
+      // If the current node no longer exists (e.g. user expanded a sub-flow
+      // and the wrapper the walkthrough was pointing at just got replaced),
+      // reset so the user can restart from the new start node.
+      const currentExists = nodes.some(
+        (n: CustomNode) => n.id === currentNodeId,
+      );
+      if (!currentExists) {
+        setCurrentNodeId(null);
+        setCurrentStepIndex(-1);
+        setPathHistory([]);
+        setAvailablePaths([]);
+        return;
+      }
+
       // Find available paths from current node
       const outgoingEdges = edges.filter(
         (edge: Edge) => edge.source === currentNodeId,

--- a/packages/visualiser/src/nodes/Flow.tsx
+++ b/packages/visualiser/src/nodes/Flow.tsx
@@ -1,5 +1,6 @@
 import { memo, useMemo } from "react";
 import { Handle } from "@xyflow/react";
+import { Maximize2 } from "lucide-react";
 import * as ContextMenu from "@radix-ui/react-context-menu";
 import { usePortalContainer } from "../context/PortalContainerContext";
 import { buildUrl } from "../utils/url-builder";
@@ -53,6 +54,9 @@ export default memo(function FlowNode({
   targetPosition,
 }: any) {
   const { mode, flow } = data as Data;
+  const canExpand =
+    Array.isArray((data as any)?.expandedNodes) &&
+    (data as any).expandedNodes.length > 0;
 
   const { id, version, owners = EMPTY_ARRAY, name, styles } = flow.data;
   const { node: { color = "teal", label } = {}, icon = "QueueListIcon" } =
@@ -67,70 +71,96 @@ export default memo(function FlowNode({
     <ContextMenu.Root>
       <ContextMenu.Trigger>
         <div
-          className={classNames(
-            `rounded-md border flex justify-start bg-[rgb(var(--ec-card-bg))] text-[rgb(var(--ec-page-text))] border-${color}-400`,
-          )}
-          style={NODE_WIDTH_STYLE}
+          className="relative"
+          style={{ isolation: "isolate", ...NODE_WIDTH_STYLE }}
         >
+          {/* Stacked shadow layers behind the card signal a sub-flow the user can expand. */}
+          {canExpand && (
+            <>
+              <div
+                className={`absolute inset-0 rounded-md border border-${color}-400 bg-[rgb(var(--ec-card-bg))]`}
+                style={{ transform: "translate(6px, 6px)", opacity: 0.5 }}
+                aria-hidden
+              />
+              <div
+                className={`absolute inset-0 rounded-md border border-${color}-400 bg-[rgb(var(--ec-card-bg))]`}
+                style={{ transform: "translate(3px, 3px)", opacity: 0.7 }}
+                aria-hidden
+              />
+            </>
+          )}
           <div
             className={classNames(
-              `bg-gradient-to-b from-${color}-500 to-${color}-700 relative flex flex-col items-center w-5 justify-between rounded-l-sm text-${color}-100`,
-              `border-r-[1px] border-${color}-500`,
+              `relative rounded-md border flex justify-start bg-[rgb(var(--ec-card-bg))] text-[rgb(var(--ec-page-text))] border-${color}-400`,
             )}
+            style={NODE_WIDTH_STYLE}
           >
-            {Icon && <Icon className="w-4 h-4 opacity-90 text-white mt-1" />}
-            {mode === "full" && (
-              <span
-                className={`text-center text-[${fontSize}] text-white font-bold uppercase mb-4`}
-                style={ROTATED_LABEL_STYLE}
-              >
-                {nodeLabel}
-              </span>
-            )}
-          </div>
-          <div className="p-1 flex-1">
-            {targetPosition && (
-              <Handle type="target" position={targetPosition} />
-            )}
-            {sourcePosition && (
-              <Handle type="source" position={sourcePosition} />
-            )}
             <div
               className={classNames(
-                mode === "full"
-                  ? `border-b border-[rgb(var(--ec-page-border))]`
-                  : "",
+                `bg-gradient-to-b from-${color}-500 to-${color}-700 relative flex flex-col items-center w-5 justify-between rounded-l-sm text-${color}-100`,
+                `border-r-[1px] border-${color}-500`,
               )}
             >
-              <span className="text-xs font-bold block pt-0.5 pb-0.5">
-                {name}
-              </span>
-              <div className="flex justify-between">
-                <span className="text-[10px] font-light block pt-0.5 pb-0.5 ">
-                  v{version}
+              {Icon && <Icon className="w-4 h-4 opacity-90 text-white mt-1" />}
+              {mode === "full" && (
+                <span
+                  className={`text-center text-[${fontSize}] text-white font-bold uppercase mb-4`}
+                  style={ROTATED_LABEL_STYLE}
+                >
+                  {nodeLabel}
                 </span>
-                {mode === "simple" && (
-                  <span className="text-[10px] text-[rgb(var(--ec-page-text-muted))] font-light block pt-0.5 pb-0.5 ">
-                    {nodeLabel}
-                  </span>
-                )}
-              </div>
+              )}
             </div>
-            {mode === "full" && (
-              <div className="divide-y divide-[rgb(var(--ec-page-border))] ">
-                <div className="leading-3 py-1">
-                  <span className="text-[8px] font-light">
-                    {flow.data.summary}
+            <div className="p-1 flex-1">
+              {targetPosition && (
+                <Handle type="target" position={targetPosition} />
+              )}
+              {sourcePosition && (
+                <Handle type="source" position={sourcePosition} />
+              )}
+              <div
+                className={classNames(
+                  mode === "full"
+                    ? `border-b border-[rgb(var(--ec-page-border))]`
+                    : "",
+                )}
+              >
+                <span className="text-xs font-bold block pt-0.5 pb-0.5">
+                  {name}
+                </span>
+                <div className="flex justify-between">
+                  <span className="text-[10px] font-light block pt-0.5 pb-0.5 ">
+                    v{version}
                   </span>
-                </div>
-
-                <div className="grid grid-cols-2 gap-x-4 py-1">
-                  <span className="text-xs" style={TINY_FONT_STYLE}>
-                    Owners: {owners.length}
-                  </span>
+                  {mode === "simple" && (
+                    <span className="text-[10px] text-[rgb(var(--ec-page-text-muted))] font-light block pt-0.5 pb-0.5 ">
+                      {nodeLabel}
+                    </span>
+                  )}
                 </div>
               </div>
-            )}
+              {mode === "full" && (
+                <div className="divide-y divide-[rgb(var(--ec-page-border))] ">
+                  <div className="leading-3 py-1">
+                    <span className="text-[8px] font-light">
+                      {flow.data.summary}
+                    </span>
+                  </div>
+
+                  <div className="grid grid-cols-2 gap-x-4 py-1">
+                    <span className="text-xs" style={TINY_FONT_STYLE}>
+                      Owners: {owners.length}
+                    </span>
+                  </div>
+                </div>
+              )}
+              {canExpand && (
+                <div className="mt-1 flex items-center gap-1 text-[8px] text-[rgb(var(--ec-page-text-muted))]">
+                  <Maximize2 className="w-2.5 h-2.5" />
+                  Click to explore
+                </div>
+              )}
+            </div>
           </div>
         </div>
       </ContextMenu.Trigger>

--- a/packages/visualiser/src/nodes/FlowExpandedNode.tsx
+++ b/packages/visualiser/src/nodes/FlowExpandedNode.tsx
@@ -1,0 +1,127 @@
+import { memo } from "react";
+import { Workflow, Minimize2 } from "lucide-react";
+
+export type FlowExpandedNodeData = {
+  flowName?: string;
+  version?: string;
+};
+
+// Container body keeps a visible teal tint that works in both themes — the
+// teal is the sub-flow identity, while theme-aware variables handle text
+// and header colour. The header uses the card-bg variable so it blends
+// naturally over the dotted background in light and dark modes.
+const CONTAINER_STYLE: React.CSSProperties = {
+  width: "100%",
+  height: "100%",
+  borderRadius: 12,
+  border: "2px solid rgba(20, 184, 166, 0.5)",
+  backgroundColor: "rgba(20, 184, 166, 0.08)",
+  boxShadow: "0 2px 12px rgba(20, 184, 166, 0.12)",
+  position: "relative",
+  overflow: "visible",
+};
+
+const HEADER_STYLE: React.CSSProperties = {
+  position: "absolute",
+  top: 0,
+  left: 0,
+  right: 0,
+  height: 44,
+  borderTopLeftRadius: 10,
+  borderTopRightRadius: 10,
+  background: "rgba(20, 184, 166, 0.12)",
+  borderBottom: "1px solid rgba(20, 184, 166, 0.3)",
+  overflow: "visible",
+};
+
+const BADGE_STYLE: React.CSSProperties = {
+  position: "absolute",
+  top: -10,
+  left: 12,
+  display: "inline-flex",
+  alignItems: "center",
+  gap: 3,
+  padding: "2px 8px",
+  borderRadius: 4,
+  background: "#0d9488",
+  boxShadow: "0 1px 3px rgba(0,0,0,0.15)",
+  zIndex: 10,
+  fontSize: 8,
+  fontWeight: 700,
+  letterSpacing: "0.08em",
+  textTransform: "uppercase" as const,
+  color: "white",
+};
+
+const HEADER_CONTENT_STYLE: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  height: "100%",
+  padding: "0 12px 0 14px",
+};
+
+const FLOW_NAME_STYLE: React.CSSProperties = {
+  fontSize: 11,
+  fontWeight: 700,
+  color: "rgb(var(--ec-page-text))",
+  letterSpacing: "0.04em",
+  textTransform: "uppercase",
+  whiteSpace: "nowrap",
+};
+
+const VERSION_STYLE: React.CSSProperties = {
+  fontSize: 10,
+  fontWeight: 500,
+  color: "#5eead4",
+  marginLeft: 8,
+};
+
+const COLLAPSE_BUTTON_STYLE: React.CSSProperties = {
+  background: "#0d9488",
+  border: "1px solid #5eead4",
+  borderRadius: 6,
+  padding: "4px 10px",
+  cursor: "pointer",
+  display: "flex",
+  alignItems: "center",
+  gap: 4,
+  fontSize: 10,
+  fontWeight: 600,
+  color: "white",
+};
+
+export default memo(function FlowExpandedNode({
+  data,
+}: {
+  data: FlowExpandedNodeData;
+}) {
+  const { flowName, version } = data;
+
+  return (
+    <div style={CONTAINER_STYLE}>
+      <div style={HEADER_STYLE}>
+        <div style={BADGE_STYLE}>
+          <Workflow size={10} strokeWidth={2.5} />
+          Sub-flow
+        </div>
+
+        <div style={HEADER_CONTENT_STYLE}>
+          <div style={{ display: "flex", alignItems: "center" }}>
+            <span style={FLOW_NAME_STYLE}>{flowName || "Flow"}</span>
+            {version && <span style={VERSION_STYLE}>v{version}</span>}
+          </div>
+
+          <button
+            style={COLLAPSE_BUTTON_STYLE}
+            className="ec-collapse-flow-btn nodrag nopan"
+            onMouseDown={(e) => e.stopPropagation()}
+          >
+            <Minimize2 size={12} strokeWidth={2.5} />
+            Collapse
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+});

--- a/packages/visualiser/src/nodes/index.ts
+++ b/packages/visualiser/src/nodes/index.ts
@@ -58,6 +58,7 @@ import CustomNode from "./Custom";
 import DomainNode from "./Domain";
 import EntityNode from "./Entity";
 import FlowNode from "./Flow";
+import FlowExpandedNode from "./FlowExpandedNode";
 import GroupNode from "./GroupNode";
 import StepNode from "./Step";
 import UserNode from "./User";
@@ -70,6 +71,7 @@ export {
   DomainNode,
   EntityNode,
   FlowNode,
+  FlowExpandedNode,
   GroupNode,
   StepNode,
   UserNode,
@@ -117,6 +119,7 @@ export const nodeComponents = {
   domain: DomainNode,
   entity: EntityNode,
   flow: FlowNode,
+  flowExpanded: FlowExpandedNode,
   group: GroupNode,
   step: StepNode,
   user: UserNode,


### PR DESCRIPTION
Closes #2445

## What This PR Does

Lets users click a sub-flow reference node in the visualiser to inline the referenced flow's steps in place, rather than navigating away to the sub-flow's dedicated view. The collapsed card shows a stacked-shadow affordance so it's clear the node can be expanded, and the expanded container renders the sub-flow's nodes with its own LR dagre layout inside a bordered region — the same visual pattern as the existing message-group expand/collapse. The business-flow walkthrough treats expanded children as first-class steps, stepping through them in graph order.

## Changes Overview

### Key Changes

- **Server-side sub-flow precompute** (`packages/core/eventcatalog/src/utils/node-graphs/flows-node-graph.ts`) — every flow-reference step now carries a precomputed `expandedNodes`/`expandedEdges` payload ready for client expansion. Sub-flow graphs are memoised by `id@version`, so a flow referenced N times is built once and re-prefixed per parent. Cycles (A → B → A) are guarded via a `visited` set.
- **`FlowExpandedNode` component** (`packages/visualiser/src/nodes/FlowExpandedNode.tsx`) — new structural container node with a header bar ("Sub-flow" badge, flow name, Collapse button) that hosts expanded children.
- **Flow expand/collapse in `NodeGraph`** (`packages/visualiser/src/components/NodeGraph.tsx`) — click handler swaps a `flows`-type node to `flowExpanded`, attaches children with `parentId` + `extent: "parent"`, stitches predecessor/successor edges onto entry/terminal children, and re-runs LR dagre after React paints so the container sizes to real content. Collapse is shared with the existing message-group handler via a combined `.ec-collapse-group-btn, .ec-collapse-flow-btn` selector and type-agnostic wrapper detection.
- **Walkthrough integration** (`packages/visualiser/src/components/StepWalkthrough.tsx`) — walkthrough sees a filtered view that excludes structural wrapper nodes. When the graph structure changes (expand/collapse), any stale cached start/current node is recomputed rather than leaving the walkthrough pointing at a vanished id.
- **FitView on expand and collapse** — both operations call `fitView` once the layout settles so the user doesn't have to pan manually.
- **Collapsed-card affordance** (`packages/visualiser/src/nodes/Flow.tsx`) — stacked shadow layers behind the card plus a "Click to explore" hint when `expandedNodes` is present, matching the message-group treatment.

### Tests

- `packages/core/eventcatalog/src/utils/__tests__/flows/sub-flow-expansion.spec.ts` — four new tests covering: precomputed `expandedNodes`/`expandedEdges` on a flow-reference step, namespaced child ids, namespaced edge endpoints, and cycle truncation.
- Existing flow node-graph tests continue to pass unchanged.

## How It Works

1. At page build, the flow's step graph is constructed. When a step references another flow, the builder recursively builds the referenced flow's graph (memoised), prefixes its ids with `${parentStepId}__`, and stashes the result on the parent node's `data`.
2. When the user clicks a flow-reference node, the client-side handler:
   - Detects the precomputed payload.
   - Swaps the node's type to `flowExpanded` (same id), inserts the precomputed children with `parentId` + `extent: "parent"` so they render inside the container.
   - Finds the sub-flow's entry nodes (no inbound edges in the sub-graph) and terminal nodes (no outbound), then reroutes the parent's incoming/outgoing edges to those children so the outer graph remains traversable.
   - Runs dagre LR to position children, measures the real DOM sizes after paint, and re-runs the layout for pixel-accurate dimensions.
3. Collapse reverses the swap, keeping a downstream node if surviving edges still reference it.
4. The walkthrough filters wrapper containers out of the walkable set; the stitched predecessor/successor edges mean traversal flows naturally from outer → child → outer.

## Breaking Changes

None. Sub-flow references without a precomputed payload (or without a successful cache lookup) still render as the single node they do today.

## Test Plan

- [ ] Open `PaymentFlow v1.0.0` in the visualiser. The first step ("Flow Step") shows the stacked-shadow affordance and "Click to explore" hint.
- [ ] Click the sub-flow card — the sub-flow expands inline inside a teal-bordered container with a "Sub-flow" badge and Collapse button.
- [ ] Graph reframes via fitView; sub-flow's internal children lay out left-to-right like the outer flow.
- [ ] Click Collapse — the container reverts to the single sub-flow card, graph reframes.
- [ ] Start the business-flow walkthrough with the sub-flow expanded. It steps through outer steps, then into the sub-flow's children, then back out to subsequent outer steps.
- [ ] Dark mode: sub-flow container tint and header text remain legible.

## Additional Notes

- Skipped as scope creep: extracting a shared `ExpandedContainerShell` for `FlowExpandedNode` + `MessageGroupExpandedNode`, unifying the two click-handler branches, and typing the `expandedNodes`/`expandedEdges` contract across package boundaries. All three are worth revisiting if a third wrapper type is added.
- The initial dagre pass on expand uses estimated 240×120 node sizes and is immediately superseded by the post-paint re-layout with measured sizes. Keeping both (rather than the visibility:hidden trick) avoids any risk of layout flash if the rAF timing slips on slower devices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)