### PR TITLE
fix(core): include resourceDocs in llms-full allowed collections type

### DIFF
--- a/.changeset/swift-otters-type-check.md
+++ b/.changeset/swift-otters-type-check.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/core': patch
+---
+
+fix type error for resourceDocs in llms-full.txt route

--- a/packages/core/eventcatalog/src/pages/docs/llm/llms-full.txt.ts
+++ b/packages/core/eventcatalog/src/pages/docs/llm/llms-full.txt.ts
@@ -16,7 +16,8 @@ type AllowedCollections =
   | 'channels'
   | 'entities'
   | 'flows'
-  | 'containers';
+  | 'containers'
+  | 'resourceDocs';
 
 const events = await getCollection('events');
 const commands = await getCollection('commands');


### PR DESCRIPTION
## What This PR Does

Fixes a TypeScript error surfaced by `astro check` in `packages/core`. The `llms-full.txt` API route was casting `resourceDocs` to `CollectionEntry<AllowedCollections>[]`, but `'resourceDocs'` was missing from the `AllowedCollections` union, causing a non-overlapping-types error.

## Changes Overview

### Key Changes
- Added `'resourceDocs'` to the `AllowedCollections` union in `packages/core/eventcatalog/src/pages/docs/llm/llms-full.txt.ts` so the existing cast typechecks.

## How It Works

The route aggregates entries from multiple collections into a single `CollectionEntry<AllowedCollections>[]`. Other optional collections (e.g. `customPages`) were already part of the union; `resourceDocs` was introduced later for the resource-docs feature but never added. Including it in the union lets the existing cast succeed without changing runtime behavior.

## Breaking Changes

None.

## Additional Notes

- `pnpm run check` now reports 0 errors in `@eventcatalog/core`.
- Changeset: patch bump for `@eventcatalog/core`.