### PR TITLE
fix(core): ignore transient .lock files in watcher

### DIFF
--- a/.changeset/quiet-watchers-ignore-lockfiles.md
+++ b/.changeset/quiet-watchers-ignore-lockfiles.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Watcher now ignores transient `.lock` sidecar files and tolerates files that vanish between the event firing and the stat call, preventing ENOENT crashes during SDK atomic writes.

--- a/packages/core/src/watcher.js
+++ b/packages/core/src/watcher.js
@@ -34,6 +34,13 @@ export async function watch(projectDirectory, catalogDirectory, callback = undef
         for (let event of events) {
           const { path: filePath, type } = event;
 
+          // Transient artifacts from atomic writes (e.g. the SDK's `writeService`
+          // creates a sibling `.lock` file that's removed before the watcher
+          // fires). Skip outright — they're gone by the time we try to stat.
+          if (filePath.endsWith('.lock')) {
+            continue;
+          }
+
           // Ignore any file ending with .mdx or .md, as Astro supports this with the new content collections
           // snippets still need to be copied to the astro directory
           if ((filePath.endsWith('.mdx') || filePath.endsWith('.md')) && !filePath.includes('snippets')) {
@@ -49,14 +56,24 @@ export async function watch(projectDirectory, catalogDirectory, callback = undef
           for (const astroPath of astroPaths) {
             switch (type) {
               case 'create':
-              case 'update':
-                // First copy the file
-                if (fs.statSync(filePath).isDirectory()) {
+              case 'update': {
+                // The file may have disappeared between the watcher firing and
+                // this handler running (atomic writes, editor swap files,
+                // rapid rename/delete). Treat ENOENT as "nothing to copy".
+                let stat;
+                try {
+                  stat = fs.statSync(filePath);
+                } catch (err) {
+                  if (err.code === 'ENOENT') break;
+                  throw err;
+                }
+                if (stat.isDirectory()) {
                   fs.mkdirSync(astroPath, { recursive: true });
                 } else {
                   retryEPERM(fs.cpSync)(filePath, astroPath);
                 }
                 break;
+              }
               case 'delete':
                 retryEPERM(rimrafSync)(astroPath);
                 break;


### PR DESCRIPTION
## What This PR Does

Makes the dev-mode file watcher resilient to the transient `.lock` sidecar files the SDK creates during atomic writes (e.g. `writeService`). The watcher was firing events for lock files that no longer existed by the time the handler ran, causing `ENOENT` crashes in `fs.statSync`.

## Changes Overview

### Key Changes

- Skip any watcher event whose path ends in `.lock` before any filesystem work happens.
- Wrap the `statSync` call in the `create`/`update` branch and swallow `ENOENT` — if the file disappeared between event and handler, there's nothing to copy.
- Other error codes still propagate so real problems aren't hidden.

## How It Works

The SDK's atomic write pattern creates a `<file>.lock` next to the target, writes the real file, and removes the lock. The OS watcher queues an event for the lock before we see it, so the handler runs after the lock is already gone. Two defences:

1. **Early filter**: `.lock` files are never relevant to the Astro content mirror, so an `endsWith('.lock')` check drops them immediately.
2. **Defence in depth**: editor swap files, rapid rename/delete, or simply racy filesystems can also produce "file gone" events for non-lock paths. The `statSync` try/catch handles that by treating `ENOENT` as a no-op `break`.

Only change is in `packages/core/src/watcher.js`.

## Breaking Changes

None.

## Additional Notes

No new tests — the behaviour is a race condition against real filesystem events and is hard to reproduce deterministically in unit tests. Manually verified by running `writeService` against a running dev server with the watcher active.