### PR TITLE
feat(version): Draft can't be the latest adapt query to handle this

### DIFF
--- a/packages/core/eventcatalog/src/utils/collections/commands.ts
+++ b/packages/core/eventcatalog/src/utils/collections/commands.ts
@@ -60,7 +60,7 @@ export const getCommands = async ({ getAllVersions = true, hydrateServices = tru
     targetCommands.map(async (command) => {
       // Version info
       const commandVersions = commandMap.get(command.data.id) || [];
-      const latestVersion = commandVersions[0]?.data.version || command.data.version;
+      const latestVersion = commandVersions.find((v) => !v.data.draft)?.data.version || command.data.version;
       const versions = commandVersions.map((e) => e.data.version);
 
       // Find producers and consumers via reverse index

--- a/packages/core/eventcatalog/src/utils/collections/events.ts
+++ b/packages/core/eventcatalog/src/utils/collections/events.ts
@@ -60,7 +60,7 @@ export const getEvents = async ({ getAllVersions = true, hydrateServices = true 
     targetEvents.map(async (event) => {
       // Version info
       const eventVersions = eventMap.get(event.data.id) || [];
-      const latestVersion = eventVersions[0]?.data.version || event.data.version;
+      const latestVersion = eventVersions.find((v) => !v.data.draft)?.data.version || event.data.version;
       const versions = eventVersions.map((e) => e.data.version);
 
       // Find producers and consumers via reverse index

--- a/packages/core/eventcatalog/src/utils/collections/queries.ts
+++ b/packages/core/eventcatalog/src/utils/collections/queries.ts
@@ -59,7 +59,7 @@ export const getQueries = async ({ getAllVersions = true, hydrateServices = true
     targetQueries.map(async (query) => {
       // Version info
       const queryVersions = queryMap.get(query.data.id) || [];
-      const latestVersion = queryVersions[0]?.data.version || query.data.version;
+      const latestVersion = queryVersions.find((v) => !v.data.draft)?.data.version || query.data.version;
       const versions = queryVersions.map((e) => e.data.version);
 
       // Find producers and consumers via reverse index


### PR DESCRIPTION
## Motivation
Watching beta/staging environment I can have future version inside EventCatalog.
I mark this beta version as draft for now and I'm doing governance and alerting based on this future version.

It's great to have draft displayed on the catalog,  but draft should not be the latest. 
This PR adapts the code to mark non draft as latest.