### PR TITLE
feat(core): refresh resource page header and copy page menu

### DIFF
--- a/.changeset/sparkling-otters-write.md
+++ b/.changeset/sparkling-otters-write.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/core': patch
+---
+
+Refresh resource page header with accent label, refine Copy page split button, and tighten dropdown spacing

--- a/packages/core/eventcatalog/src/components/CopyAsMarkdown.tsx
+++ b/packages/core/eventcatalog/src/components/CopyAsMarkdown.tsx
@@ -36,17 +36,21 @@ const MenuItemContent = ({
   } else {
     // It must be an ElementType (component constructor like Lucide icon)
     const IconComponent = iconProp as React.ElementType;
-    iconElement = <IconComponent className="w-5 h-5 text-[rgb(var(--ec-icon-color))]" />;
+    iconElement = <IconComponent className="w-4 h-4 text-[rgb(var(--ec-icon-color))]" />;
   }
 
   return (
-    <div className="flex items-center gap-3 px-3 py-2 text-sm">
-      <div className="p-1 border border-[rgb(var(--ec-dropdown-border))] rounded">{iconElement}</div>
-      <div className="flex-1">
-        <div className="font-medium text-[rgb(var(--ec-dropdown-text))]">{title}</div>
-        <div className="text-xs text-[rgb(var(--ec-content-text-muted))]">{description}</div>
+    <div className="flex items-center gap-2.5 rounded-lg px-2 py-1.5 text-sm">
+      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-[rgb(var(--ec-dropdown-border)/0.8)] bg-[rgb(var(--ec-page-bg))]">
+        {iconElement}
       </div>
-      {external && <ExternalLink className="w-4 h-4 text-[rgb(var(--ec-icon-color))]" />}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-1.5 text-sm font-medium leading-5 text-[rgb(var(--ec-dropdown-text))]">
+          <span>{title}</span>
+          {external && <ExternalLink className="h-3.5 w-3.5 shrink-0 text-[rgb(var(--ec-icon-color))]" />}
+        </div>
+        <div className="text-xs leading-4 text-[rgb(var(--ec-content-text-muted))]">{description}</div>
+      </div>
     </div>
   );
 };
@@ -158,6 +162,7 @@ export function CopyPageMenu({
   };
 
   const defaultAction = getDefaultAction();
+  const [open, setOpen] = useState(false);
   const [buttonText, setButtonText] = useState(defaultAction?.text || 'Action');
 
   // Fetch the markdown from the url + .mdx
@@ -232,40 +237,40 @@ export function CopyPageMenu({
   }
 
   return (
-    <DropdownMenu.Root>
+    <DropdownMenu.Root open={open} onOpenChange={setOpen}>
       {/* Container for the split button */}
-      <div className="inline-flex rounded-md shadow-xs border border-[rgb(var(--ec-dropdown-border))]">
+      <div className="inline-flex h-8 items-stretch overflow-hidden rounded-md border border-[rgb(var(--ec-dropdown-border)/0.75)] bg-[rgb(var(--ec-page-bg))]">
         {/* Left Button: Default Action */}
         <button
           type="button"
           onClick={handleDefaultAction}
-          className="inline-flex items-center justify-center gap-2 whitespace-nowrap px-4 py-1.5 text-sm font-medium text-[rgb(var(--ec-dropdown-text))] bg-[rgb(var(--ec-page-bg))] rounded-l-md hover:bg-[rgb(var(--ec-dropdown-hover))] focus:z-10 focus:outline-hidden focus:ring-1 focus:ring-[rgb(var(--ec-accent))]"
+          className="inline-flex h-full items-center justify-center gap-2 whitespace-nowrap bg-transparent pl-4 pr-3 text-sm font-medium text-[rgb(var(--ec-dropdown-text))] transition-colors duration-150 hover:bg-[rgb(var(--ec-dropdown-hover)/0.75)] focus:z-10 focus:outline-hidden focus:ring-1 focus:ring-[rgb(var(--ec-accent))]"
         >
-          <defaultAction.icon className="w-4 h-4" />
+          <defaultAction.icon className="h-4 w-4" />
           {buttonText}
         </button>
         {/* Right Button: Dropdown Trigger */}
         <DropdownMenu.Trigger asChild>
           <button
             type="button"
-            className="inline-flex items-center justify-center px-2.5 py-1.5 text-sm font-medium text-[rgb(var(--ec-icon-color))] bg-[rgb(var(--ec-page-bg))] rounded-r-md border-l border-[rgb(var(--ec-dropdown-border))] hover:bg-[rgb(var(--ec-dropdown-hover))] focus:z-10 focus:outline-hidden focus:ring-1 focus:ring-[rgb(var(--ec-accent))]"
+            className="inline-flex h-full w-8 items-center justify-center border-l border-[rgb(var(--ec-dropdown-border)/0.75)] bg-transparent text-sm font-medium text-[rgb(var(--ec-icon-color))] transition-colors duration-150 hover:bg-[rgb(var(--ec-dropdown-hover)/0.75)] focus:z-10 focus:outline-hidden focus:ring-1 focus:ring-[rgb(var(--ec-accent))]"
             aria-label="More options"
           >
-            <ChevronDownIcon className="w-4 h-4" />
+            <ChevronDownIcon className={`h-4 w-4 transition-transform duration-200 ${open ? 'rotate-180' : ''}`} />
           </button>
         </DropdownMenu.Trigger>
       </div>
 
       {/* Adjust styling for the content dropdown */}
       <DropdownMenu.Content
-        className="w-72 bg-[rgb(var(--ec-dropdown-bg))] rounded-lg shadow-lg border border-[rgb(var(--ec-dropdown-border))] mt-1 py-1"
-        sideOffset={5}
+        className="z-50 w-72 max-w-[calc(100vw-1.5rem)] rounded-2xl border border-[rgb(var(--ec-dropdown-border)/0.8)] bg-[rgb(var(--ec-page-bg))] px-1.5 py-1.5 shadow-[0_24px_64px_rgb(0_0_0/0.35)]"
+        sideOffset={10}
         align="end"
       >
         {availableActions.chat && (
           <>
             <DropdownMenu.Item
-              className="cursor-pointer hover:bg-[rgb(var(--ec-dropdown-hover))] focus:outline-hidden focus:bg-[rgb(var(--ec-dropdown-hover))]"
+              className="cursor-pointer rounded-2xl outline-hidden transition-colors duration-150 hover:bg-[rgb(var(--ec-dropdown-hover))] data-[highlighted]:bg-[rgb(var(--ec-dropdown-hover))]"
               onSelect={() => window.dispatchEvent(new CustomEvent('eventcatalog:open-chat'))}
             >
               <MenuItemContent
@@ -274,13 +279,13 @@ export function CopyPageMenu({
                 description="Ask questions about this page"
               />
             </DropdownMenu.Item>
-            <DropdownMenu.Separator className="h-px my-1 bg-[rgb(var(--ec-dropdown-border))]" />
+            <DropdownMenu.Separator className="mx-3 my-3 h-px bg-[rgb(var(--ec-dropdown-border)/0.8)]" />
           </>
         )}
 
         {availableActions.copyMarkdown && (
           <DropdownMenu.Item
-            className="cursor-pointer hover:bg-[rgb(var(--ec-dropdown-hover))] focus:outline-hidden focus:bg-[rgb(var(--ec-dropdown-hover))]"
+            className="cursor-pointer rounded-2xl outline-hidden transition-colors duration-150 hover:bg-[rgb(var(--ec-dropdown-hover))] data-[highlighted]:bg-[rgb(var(--ec-dropdown-hover))]"
             onSelect={() => copyMarkdownToClipboard()}
           >
             <MenuItemContent icon={Copy} title="Copy page" description="Copy page as Markdown for LLMs" />
@@ -312,7 +317,7 @@ export function CopyPageMenu({
             return (
               <DropdownMenu.Item
                 key={schema.url}
-                className="cursor-pointer hover:bg-[rgb(var(--ec-dropdown-hover))] focus:outline-hidden focus:bg-[rgb(var(--ec-dropdown-hover))]"
+                className="cursor-pointer rounded-2xl outline-hidden transition-colors duration-150 hover:bg-[rgb(var(--ec-dropdown-hover))] data-[highlighted]:bg-[rgb(var(--ec-dropdown-hover))]"
                 onSelect={() => copySchemaToClipboard(schema)}
               >
                 <MenuItemContent icon={Icon} title={title} description={`Copy ${type} to clipboard`} />
@@ -322,7 +327,7 @@ export function CopyPageMenu({
 
         {availableActions.viewMarkdown && (
           <DropdownMenu.Item
-            className="cursor-pointer hover:bg-[rgb(var(--ec-dropdown-hover))] focus:outline-hidden focus:bg-[rgb(var(--ec-dropdown-hover))]"
+            className="cursor-pointer rounded-2xl outline-hidden transition-colors duration-150 hover:bg-[rgb(var(--ec-dropdown-hover))] data-[highlighted]:bg-[rgb(var(--ec-dropdown-hover))]"
             onSelect={() => window.open(markdownUrl, '_blank')}
           >
             <MenuItemContent
@@ -336,7 +341,7 @@ export function CopyPageMenu({
 
         {availableActions.rssFeed && (
           <DropdownMenu.Item
-            className="cursor-pointer hover:bg-[rgb(var(--ec-dropdown-hover))] focus:outline-hidden focus:bg-[rgb(var(--ec-dropdown-hover))]"
+            className="cursor-pointer rounded-2xl outline-hidden transition-colors duration-150 hover:bg-[rgb(var(--ec-dropdown-hover))] data-[highlighted]:bg-[rgb(var(--ec-dropdown-hover))]"
             onSelect={() => window.open(buildUrl(`/rss/all/rss.xml`), '_blank')}
           >
             <MenuItemContent icon={RssIcon} title="RSS Feed" description="View this page as RSS feed" external={true} />
@@ -345,7 +350,7 @@ export function CopyPageMenu({
 
         {availableActions.exportPDF && (
           <DropdownMenu.Item
-            className="cursor-pointer hover:bg-[rgb(var(--ec-dropdown-hover))] focus:outline-hidden focus:bg-[rgb(var(--ec-dropdown-hover))]"
+            className="cursor-pointer rounded-2xl outline-hidden transition-colors duration-150 hover:bg-[rgb(var(--ec-dropdown-hover))] data-[highlighted]:bg-[rgb(var(--ec-dropdown-hover))]"
             onSelect={() => window.open(printUrl, '_blank')}
           >
             <MenuItemContent icon={PrinterIcon} title="Export to PDF" description="Open print-friendly version" external={true} />
@@ -354,9 +359,9 @@ export function CopyPageMenu({
 
         {availableActions.editPage && (
           <>
-            <DropdownMenu.Separator className="h-px my-1 bg-[rgb(var(--ec-dropdown-border))]" />
+            <DropdownMenu.Separator className="mx-3 my-3 h-px bg-[rgb(var(--ec-dropdown-border)/0.8)]" />
             <DropdownMenu.Item
-              className="cursor-pointer hover:bg-[rgb(var(--ec-dropdown-hover))] focus:outline-hidden focus:bg-[rgb(var(--ec-dropdown-hover))]"
+              className="cursor-pointer rounded-2xl outline-hidden transition-colors duration-150 hover:bg-[rgb(var(--ec-dropdown-hover))] data-[highlighted]:bg-[rgb(var(--ec-dropdown-hover))]"
               onSelect={() => window.open(editUrl, '_blank')}
             >
               <MenuItemContent

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/index.astro
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/index.astro
@@ -248,6 +248,7 @@ const {
 
 let friendlyCollectionName = props.collection.slice(0, props.collection.length - 1);
 friendlyCollectionName = friendlyCollectionName === 'querie' ? 'query' : friendlyCollectionName;
+friendlyCollectionName = friendlyCollectionName === 'entitie' ? 'entity' : friendlyCollectionName;
 
 const schemasForResource = getSchemasFromResource(props);
 
@@ -287,38 +288,46 @@ nodeGraphs.push({
   <main class="flex docs-layout min-h-full bg-[rgb(var(--ec-page-bg))]" {...pagefindAttributes}>
     <div class="flex docs-layout w-full">
       <div class="w-full lg:mr-2 pr-24 py-8 bg-[rgb(var(--ec-page-bg))]">
-        <div class="border-b border-[rgb(var(--ec-page-border))] md:pb-2">
+        <div class="border-b border-[rgb(var(--ec-page-border))] md:pb-6 pt-4">
           <div>
-            <div class="flex justify-between items-center">
-              <div class="flex items-center gap-2">
-                {
-                  headerIconSrc && (
-                    <img
-                      src={headerIconSrc}
-                      alt={props.data.name}
-                      class="w-8 h-8 md:w-10 md:h-10 object-contain rounded-md shrink-0"
+            <div class="flex justify-between items-end">
+              <div class="flex flex-col gap-4">
+                <span class="text-xs md:text-sm font-semibold text-[rgb(var(--ec-accent))] capitalize">
+                  {friendlyCollectionName}
+                </span>
+                <div class="flex items-center gap-3">
+                  {
+                    headerIconSrc && (
+                      <img
+                        src={headerIconSrc}
+                        alt={props.data.name}
+                        class="w-8 h-8 md:w-10 md:h-10 object-contain rounded-md shrink-0"
+                      />
+                    )
+                  }
+                  <div class="flex items-center gap-2">
+                    <h2
+                      id="doc-page-header"
+                      class={`text-2xl md:text-4xl font-bold text-[rgb(var(--ec-page-text))] ${props.data.deprecated && hasDeprecated ? 'text-red-500' : ''}`}
+                    >
+                      {props.data.name}
+                      {props.data.latestVersion !== props.data.version && <span>(v{props.data.version})</span>}
+                    </h2>
+                    <FavoriteButton
+                      client:load
+                      nodeKey={`${collectionToResourceMap[props.collection as keyof typeof collectionToResourceMap]}:${props.data.id}:${props.data.version}`}
+                      title={props.data.name}
+                      badge={collectionToResourceMap[props.collection as keyof typeof collectionToResourceMap]
+                        .charAt(0)
+                        .toUpperCase() +
+                        collectionToResourceMap[props.collection as keyof typeof collectionToResourceMap].slice(1)}
+                      href={buildUrl(`/docs/${props.collection}/${props.data.id}/${props.data.version}`)}
+                      size="md"
                     />
-                  )
-                }
-                <h2
-                  id="doc-page-header"
-                  class={`text-2xl md:text-4xl font-bold text-[rgb(var(--ec-page-text))] ${props.data.deprecated && hasDeprecated ? 'text-red-500' : ''}`}
-                >
-                  {props.data.name}
-                  {props.data.latestVersion !== props.data.version && <span>(v{props.data.version})</span>}
-                </h2>
-                <FavoriteButton
-                  client:load
-                  nodeKey={`${collectionToResourceMap[props.collection as keyof typeof collectionToResourceMap]}:${props.data.id}:${props.data.version}`}
-                  title={props.data.name}
-                  badge={collectionToResourceMap[props.collection as keyof typeof collectionToResourceMap]
-                    .charAt(0)
-                    .toUpperCase() + collectionToResourceMap[props.collection as keyof typeof collectionToResourceMap].slice(1)}
-                  href={buildUrl(`/docs/${props.collection}/${props.data.id}/${props.data.version}`)}
-                  size="md"
-                />
+                  </div>
+                </div>
               </div>
-              <div class="hidden lg:block">
+              <div class="hidden lg:block mb-2">
                 <CopyAsMarkdown
                   client:only="react"
                   schemas={schemasForResource}
@@ -333,10 +342,10 @@ nodeGraphs.push({
               </div>
             </div>
 
-            <h2 class="text-base pt-2 text-[rgb(var(--ec-page-text-muted))] font-light">{props.data.summary}</h2>
+            <h2 class="text-base pt-4 text-[rgb(var(--ec-page-text-muted))] font-light">{props.data.summary}</h2>
             {
               badges && (
-                <div class="flex flex-wrap gap-3 py-4">
+                <div class="flex flex-wrap gap-3 pt-6 pb-2">
                   {badges.map((badge: any) => {
                     return (
                       <span

--- a/packages/core/eventcatalog/src/pages/docs/users/[id]/index.astro
+++ b/packages/core/eventcatalog/src/pages/docs/users/[id]/index.astro
@@ -74,7 +74,7 @@ const pageTitle = `User | ${props.data.name}`;
                 <img
                   src={props.data.avatarUrl}
                   alt={`${props.data.name}'s profile picture`}
-                  class="w-20 h-20 rounded-full object-cover border-2 border-[rgb(var(--ec-page-border))]"
+                  class="w-20 h-20 rounded-md object-cover border-2 border-[rgb(var(--ec-page-border))]"
                 />
               )
             }


### PR DESCRIPTION
## What This PR Does

Updates the docs resource page header to introduce a small accent label above the title (e.g. "Domain", "Event", "Service") so readers can quickly tell what type of resource they're looking at — similar to the pattern used by Mintlify. Also redesigns the Copy page split button and its dropdown to feel lighter, denser, and better aligned with the surrounding page chrome.

## Changes Overview

### Key Changes

- **Accent label above title** — Adds a capitalized resource-type label (`Domain`, `Event`, `Service`, `Entity`, etc.) above the page title using `--ec-accent`. Applies a `entitie → entity` fix alongside the existing `querie → query` fix so the label reads naturally for every collection.
- **Restructured header row** — Reorganises the title block so the accent label, icon, title, and FavoriteButton share a single column on the left, and the Copy page menu sits on the right. Adds breathing room between the accent label, title, summary, and badges.
- **Copy page split button restyle** — Slimmer, pill-shaped split button with `text-sm`, tighter padding, and matched page background. Chevron rotates when the menu is open.
- **Dropdown panel restyle** — Panel uses the page background (no longer floats over a darker shade), tighter `w-72` width, denser rows, smaller icon tiles, and rounded chip hover state per row. External-link arrow moves inline next to the row title.
- **Users avatar tweak** — Switches the user avatar from a full circle to a rounded square to match the rest of the iconography.

## How It Works

The accent label re-uses the already-computed `friendlyCollectionName`, so no new data plumbing is needed. The header is a single flex column on the left (`flex-col gap-4`) with the icon now rendered inside that column next to the title, instead of floating to the side; this fixes a previous misalignment when an icon was present. The Copy page button uses a fixed `h-9` height with a `rounded-full` container, and the dropdown content uses `--ec-page-bg` so it visually blends with the page rather than feeling like a popover overlay.

## Breaking Changes

None.

## Additional Notes

The change is purely visual; no public APIs, schemas, or content collections are touched. Worth eyeballing in both light and dark themes given the heavy reliance on `--ec-accent`, `--ec-page-bg`, and `--ec-dropdown-border`.