### PR TITLE
chore(core): refresh settings copy and honour ci license keys

### DIFF
--- a/.changeset/calm-pandas-settle.md
+++ b/.changeset/calm-pandas-settle.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/core': patch
+---
+
+Refresh settings copy: simplify the read-only banner guidance, tighten the MCP/Assistant SSR-required messaging, and let `build:cd` honour license keys provided via the environment.

--- a/packages/core/eventcatalog/src/components/Settings/AssistantSettingsForm.tsx
+++ b/packages/core/eventcatalog/src/components/Settings/AssistantSettingsForm.tsx
@@ -152,10 +152,7 @@ const AssistantNeedsSSR = () => (
           </span>
         </div>
         <p className="mt-1 text-[12px] leading-snug text-[rgb(var(--ec-page-text-muted))]">
-          Your catalog needs to run as a live server before the Agent can chat.
-        </p>
-        <p className="mt-1 text-[12px] leading-snug text-[rgb(var(--ec-page-text-muted))]">
-          Switch your catalog to server mode and you’re good to go — the configuration guide walks through it.
+          The Agent requires your catalog to run in server (SSR) mode. Follow the configuration guide to switch.
         </p>
         <div className="mt-3 flex flex-wrap items-center gap-3">
           <a

--- a/packages/core/eventcatalog/src/components/Settings/McpSettingsForm.tsx
+++ b/packages/core/eventcatalog/src/components/Settings/McpSettingsForm.tsx
@@ -72,10 +72,7 @@ const McpNeedsSSR = () => (
           </span>
         </div>
         <p className="mt-1 text-[12px] leading-snug text-[rgb(var(--ec-page-text-muted))]">
-          Your catalog needs to run as a live server before AI agents can connect to it.
-        </p>
-        <p className="mt-1 text-[12px] leading-snug text-[rgb(var(--ec-page-text-muted))]">
-          Switch your catalog to server mode and you’re good to go — the setup guide walks through it.
+          The MCP Server requires your catalog to run in server (SSR) mode. Follow the setup guide to switch.
         </p>
         <div className="mt-3 flex flex-wrap items-center gap-3">
           <a

--- a/packages/core/eventcatalog/src/components/Settings/ReadOnlyBanner.tsx
+++ b/packages/core/eventcatalog/src/components/Settings/ReadOnlyBanner.tsx
@@ -9,8 +9,9 @@ export const ReadOnlyBanner = () => (
     <div className="space-y-1">
       <p className="font-medium">Read-only</p>
       <p className="text-[rgb(var(--ec-page-text-muted))]">
-        Run <code className="rounded bg-[rgb(var(--ec-page-bg)/0.78)] px-1 py-0.5 font-mono text-xs">npx eventcatalog dev</code>{' '}
-        in your catalog directory to edit these settings.
+        To edit these settings, run EventCatalog locally or update them in your{' '}
+        <code className="rounded bg-[rgb(var(--ec-page-bg)/0.78)] px-1 py-0.5 font-mono text-xs">eventcatalog.config.js</code>{' '}
+        file.
       </p>
     </div>
   </div>

--- a/packages/core/scripts/build-ci.js
+++ b/packages/core/scripts/build-ci.js
@@ -84,9 +84,6 @@ const run = async () => {
         NODE_ENV: 'CI',
         PROJECT_DIR: projectDIR,
         CATALOG_DIR: catalogDir,
-        EVENTCATALOG_SCALE_LICENSE_KEY: '',
-        EVENTCATALOG_STARTER_LICENSE_KEY: '',
-        EVENTCATALOG_LICENSE_KEY_BACKSTAGE: '',
         ...env,
       },
     });


### PR DESCRIPTION
## What This PR Does

Tightens the wording on a few settings screens and lets the Vercel/CI build path actually use a license key from the environment instead of stripping it. No behaviour changes for catalogs running unlicensed — they still build exactly as before.

## Changes Overview

### Key Changes
- **Read-only banner copy:** rewrote the guidance to point users at running EventCatalog locally or editing `eventcatalog.config.js`, instead of showing the bare `npx eventcatalog dev` line.
- **MCP / Assistant SSR-required blocks:** collapsed the two-paragraph explanation into a single sentence that names the requirement and points to the relevant guide.
- **`scripts/build-ci.js`:** removed the three lines that overwrote `EVENTCATALOG_SCALE_LICENSE_KEY`, `EVENTCATALOG_STARTER_LICENSE_KEY`, and `EVENTCATALOG_LICENSE_KEY_BACKSTAGE` with empty strings. Whatever the environment provides now flows through to the catalog build.

## How It Works

The build script already spreads \`process.env\` into the child process — the empty-string overrides were silently nullifying any license key configured upstream (e.g. in Vercel project env). Removing them lets \`isEventCatalogScaleEnabled\` hit the online verify path when a key is set, and continue to short-circuit to \`false\` when one isn't.

The settings copy changes are purely text edits inside the existing banner/notice components.

## Breaking Changes

None.

## Additional Notes

- The example-catalog CI build (\`verify-build:catalog\` in GitHub Actions) has no license key configured, so its behaviour is unchanged.
- Contributors who happen to have license keys exported in their shell will now build with them locally via \`build:cd\`. Flag if you'd rather gate this behind an explicit \`USE_LICENSE=true\` flag.