### PR TITLE
feat(core): show http path on command and query pages

### DIFF
--- a/.changeset/swift-cobras-display.md
+++ b/.changeset/swift-cobras-display.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Show HTTP method and path on command and query documentation pages when defined via the `operation` frontmatter.

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ packages/core/eventcatalog/public/pagefind
 
 git-push.sh
 
+# local-only Claude skill (Discord webhook automation)
+.claude/skills/release-discord-summary/
+
 /test-results/
 /playwright-report/
 /blob-report/

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/index.astro
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/index.astro
@@ -272,6 +272,20 @@ const nodeGraphPropsForPage = nodeGraphs.find((nodeGraph: any) => nodeGraph.id =
 
 const shouldRenderVersionList =
   shouldRenderSideBarSection(props, 'versions') && props.data.versions && props.data.versions.length > 1;
+const httpOperation =
+  ['commands', 'queries'].includes(props.collection) && props.data.operation?.path ? props.data.operation : undefined;
+const httpMethodColors: Record<string, { background: string; color: string }> = {
+  GET: { background: 'rgba(34,197,94,0.15)', color: '#22c55e' },
+  POST: { background: 'rgba(59,130,246,0.15)', color: '#3b82f6' },
+  PUT: { background: 'rgba(245,158,11,0.15)', color: '#f59e0b' },
+  PATCH: { background: 'rgba(245,158,11,0.15)', color: '#f59e0b' },
+  DELETE: { background: 'rgba(239,68,68,0.15)', color: '#ef4444' },
+  OPTIONS: { background: 'rgba(139,92,246,0.15)', color: '#8b5cf6' },
+  HEAD: { background: 'rgba(107,114,128,0.15)', color: '#6b7280' },
+};
+const httpMethodStyle = httpOperation?.method
+  ? httpMethodColors[httpOperation.method.toUpperCase()] || { background: '#6b7280', color: '#ffffff' }
+  : undefined;
 
 // This will render the graph for this page
 nodeGraphs.push({
@@ -343,6 +357,26 @@ nodeGraphs.push({
             </div>
 
             <h2 class="text-base pt-4 text-[rgb(var(--ec-page-text-muted))] font-light">{props.data.summary}</h2>
+            {
+              httpOperation && (
+                <div class="pt-4">
+                  <div
+                    class="inline-flex max-w-full items-start gap-2 rounded-lg border border-[rgb(var(--ec-page-border))] bg-[rgb(var(--ec-content-hover))] px-3 py-2 text-sm text-[rgb(var(--ec-page-text))]"
+                    aria-label="HTTP path"
+                  >
+                    {httpOperation.method && (
+                      <span
+                        class="mt-0.5 shrink-0 rounded-md px-2 py-0.5 font-mono text-xs font-semibold"
+                        style={`background: ${httpMethodStyle?.background}; color: ${httpMethodStyle?.color};`}
+                      >
+                        {httpOperation.method}
+                      </span>
+                    )}
+                    <code class="break-all font-mono text-[rgb(var(--ec-page-text))]">{httpOperation.path}</code>
+                  </div>
+                </div>
+              )
+            }
             {
               badges && (
                 <div class="flex flex-wrap gap-3 pt-6 pb-2">


### PR DESCRIPTION
Closes #2468

## What This PR Does

Renders the HTTP method and path on the command and query documentation pages whenever an `operation` is defined in the resource's frontmatter. Previously, this information was only visible on the visualiser (and truncated there), forcing users to duplicate the path in narrative documentation if they wanted readers to see it.

## Changes Overview

### Key Changes
- Display a method/path block under the resource summary on `/docs/[type]/[id]/[version]` pages for `commands` and `queries` when `data.operation.path` is set.
- Style the HTTP method as a colored pill (GET/POST/PUT/PATCH/DELETE/OPTIONS/HEAD) with a fallback for unknown methods.
- Render the full path in a monospace `<code>` element that wraps long paths instead of truncating them.

## How It Works

In `packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/index.astro`, when the resource is a command or query and `props.data.operation?.path` exists, we derive a method-specific color style from a lookup map and render a small badge + path block immediately below the resource `summary`. The block uses existing CSS variables (`--ec-page-border`, `--ec-content-hover`, `--ec-page-text`) so it matches both light and dark themes.

## Breaking Changes

None.

## Additional Notes

The visualiser-side improvement requested in the issue (auto-resizing the path label so the full path is always visible) is not part of this PR and can be addressed separately.