### PR TITLE
feat(core): add env var to disable channel migration

### DIFF
--- a/.changeset/quiet-otters-skip.md
+++ b/.changeset/quiet-otters-skip.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Add `EVENTCATALOG_DISABLE_CHANNEL_MIGRATION` env var to opt out of the message → service channel migration on startup.

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,8 @@ examples/e-commerce
 .claude/agents/eventcatalog-blog-writer.md
 pr-descriptions/
 .claude/commands/ship.md
+.claude/skills/release-discord-summary/SKILL.md
+.claude/skills/release-discord-summary/scripts/post-to-discord.sh
 
 
 PRD.md

--- a/packages/core/src/__tests__/migrations/message-channels-to-service-channels.spec.ts
+++ b/packages/core/src/__tests__/migrations/message-channels-to-service-channels.spec.ts
@@ -11,11 +11,38 @@ import matter from 'gray-matter';
 
 describe('message-channels-to-service-channels', () => {
   beforeEach(() => {
+    delete process.env.EVENTCATALOG_DISABLE_CHANNEL_MIGRATION;
     process.env.PROJECT_DIR = path.join(__dirname, 'catalog');
     // Clear the catalog directory
     fs.rmSync(path.join(process.env.PROJECT_DIR!), { recursive: true });
     // Copy test data from previous version of the catalog to a new catalog
     fs.cpSync(path.join(__dirname, 'message-channels-examples'), path.join(process.env.PROJECT_DIR!), { recursive: true });
+  });
+
+  it('does not update catalog files when EVENTCATALOG_DISABLE_CHANNEL_MIGRATION is true', async () => {
+    process.env.EVENTCATALOG_DISABLE_CHANNEL_MIGRATION = 'true';
+
+    const servicePath = path.join(process.env.PROJECT_DIR!, 'services', 'InventoryService', 'index.mdx');
+    const messagePath = path.join(
+      process.env.PROJECT_DIR!,
+      'services',
+      'InventoryService',
+      'events',
+      'OrderAmended',
+      'index.mdx'
+    );
+
+    const serviceBeforeMigration = fs.readFileSync(servicePath, 'utf8');
+    const messageBeforeMigration = fs.readFileSync(messagePath, 'utf8');
+
+    const result = await messageChannelsToServiceChannels();
+
+    expect(result).toEqual({
+      status: 'skipped',
+      message: 'Channel migration disabled by EVENTCATALOG_DISABLE_CHANNEL_MIGRATION',
+    });
+    expect(fs.readFileSync(servicePath, 'utf8')).toBe(serviceBeforeMigration);
+    expect(fs.readFileSync(messagePath, 'utf8')).toBe(messageBeforeMigration);
   });
 
   it('if messages are found in the catalog that use channels, the migration script will move the channel configuration to the service that sends (to) or receives (from) the message', async () => {

--- a/packages/core/src/migrations/message-channels-to-service-channels.ts
+++ b/packages/core/src/migrations/message-channels-to-service-channels.ts
@@ -4,7 +4,17 @@ import os from 'node:os';
 import matter from 'gray-matter';
 import path from 'node:path';
 
+const DISABLE_CHANNEL_MIGRATION_ENV = 'EVENTCATALOG_DISABLE_CHANNEL_MIGRATION';
+
+const isChannelMigrationDisabled = () => {
+  return ['true', '1', 'yes'].includes((process.env[DISABLE_CHANNEL_MIGRATION_ENV] ?? '').toLowerCase());
+};
+
 export default async (dir?: string) => {
+  if (isChannelMigrationDisabled()) {
+    return { status: 'skipped', message: `Channel migration disabled by ${DISABLE_CHANNEL_MIGRATION_ENV}` };
+  }
+
   const PROJECT_DIR = path.join(dir || process.env.PROJECT_DIR!);
 
   const messages = await glob(


### PR DESCRIPTION
## What This PR Does

Adds an `EVENTCATALOG_DISABLE_CHANNEL_MIGRATION` environment variable that lets users opt out of the automatic "message channels → service channels" migration that runs on startup. Useful for catalogs that have intentionally kept the legacy shape, or for users who need to pin behaviour while debugging.

## Changes Overview

### Key Changes
- Migration short-circuits with `{ status: 'skipped', message: ... }` when `EVENTCATALOG_DISABLE_CHANNEL_MIGRATION` is set to `true`, `1`, or `yes` (case-insensitive).
- New test covers the disabled path: ensures service and message MDX files are not modified when the env var is on.

## How It Works

`packages/core/src/migrations/message-channels-to-service-channels.ts` checks the env var at the top of the exported migration function and returns early before scanning the catalog. The check is case-insensitive and accepts the common truthy strings (`true`, `1`, `yes`). The existing test suite resets the env var in `beforeEach` so other cases aren't affected.

## Breaking Changes

None. Default behaviour is unchanged — the migration still runs unless the user explicitly sets the env var.

## Additional Notes

The `.gitignore` change just hides two local-only Claude skill files; no runtime impact.