### PR TITLE
feat(visualiser): expandable message groups and improved search

### DIFF
--- a/.changeset/swift-otters-grouping.md
+++ b/.changeset/swift-otters-grouping.md
@@ -1,0 +1,8 @@
+---
+"@eventcatalog/visualiser": minor
+"@eventcatalog/core": minor
+---
+
+feat(visualiser): expandable message groups and improved search for large catalogs
+
+Visualiser now supports expanding grouped message nodes inline so producers/consumers with many messages stay readable on domain and service diagrams. Surrounding nodes are packed around the expanded group so they no longer overlap, and search has been overhauled with icons, resource-type filtering, and better keyboard navigation. Addresses #2079.

--- a/packages/core/eventcatalog/src/components/MDX/EntityMap/EntityMap.astro
+++ b/packages/core/eventcatalog/src/components/MDX/EntityMap/EntityMap.astro
@@ -61,7 +61,7 @@ const nodesWithLayout = applyLayoutToNodes(nodes as any[], savedLayout);
 }
 
 <div
-  class="h-[30em] my-6 mb-12 w-full relative border border-gray-200 rounded-md"
+  class="h-[30em] my-6 mb-12 w-full relative border border-[rgb(var(--ec-page-border))] rounded-md"
   id={`${id}-entity-map-portal`}
   style={{
     maxHeight: maxHeight ? `${maxHeight}em` : `30em`,

--- a/packages/visualiser/package.json
+++ b/packages/visualiser/package.json
@@ -25,6 +25,8 @@
     "dev": "tsup --watch --onSuccess \"pnpm build:css\"",
     "playground": "vite playground --config playground/vite.config.ts",
     "clean": "rimraf dist",
+    "test": "vitest --run",
+    "test:ci": "vitest --run",
     "typecheck": "tsc --noEmit",
     "format": "prettier --write \"src/**/*.{ts,tsx}\"",
     "format:diff": "prettier --check \"src/**/*.{ts,tsx}\""
@@ -72,7 +74,8 @@
     "tailwindcss": "^4.1.5",
     "tsup": "^8.5.0",
     "typescript": "^5.8.2",
-    "vite": "^7.1.9"
+    "vite": "^7.1.9",
+    "vitest": "^3.2.4"
   },
   "peerDependencies": {
     "react": ">=18.0.0",

--- a/packages/visualiser/src/components/NodeGraph.tsx
+++ b/packages/visualiser/src/components/NodeGraph.tsx
@@ -81,6 +81,11 @@ import NodeContextMenu from "./NodeContextMenu";
 import { convertToMermaid } from "../utils/export-mermaid";
 import { copyToClipboard } from "../utils/clipboard";
 import { layoutGraph } from "../utils/layout";
+import { packNodesAroundBounds } from "../utils/local-packing";
+import {
+  buildMessageGroupExpansionNodes,
+  getExpandedMessageGroupNode,
+} from "../utils/message-group-expansion";
 import { AllNotesModal, getNotesFromNode } from "./NotesToolbarButton";
 import { setBuildUrlFn } from "../utils/url-builder";
 import { PortalContainerProvider } from "../context/PortalContainerContext";
@@ -407,7 +412,8 @@ const NodeGraphBuilder = ({
   );
   const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
   const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
-  const { fitView, getNodes } = useReactFlow();
+  const { fitView, getNodes, getIntersectingNodes, getZoom, setCenter } =
+    useReactFlow();
 
   // Sync when parent passes new nodes/edges (e.g. playground re-parse)
   useEffect(() => {
@@ -593,84 +599,150 @@ const NodeGraphBuilder = ({
     setTimeout(() => wrapper.classList.remove("ec-animating-layout"), 400);
   }, []);
 
-  const relayoutGraph = useCallback((nextNodes: Node[], nextEdges: Edge[]) => {
-    const g = new dagre.graphlib.Graph({ compound: true });
-    g.setGraph({ rankdir: "LR", ranksep: 300, nodesep: 50 });
-    g.setDefaultEdgeLabel(() => ({}));
+  const relayoutGraph = useCallback(
+    (
+      nextNodes: Node[],
+      nextEdges: Edge[],
+      anchor?: { id: string; position: { x: number; y: number } },
+    ) => {
+      const g = new dagre.graphlib.Graph({ compound: true });
+      g.setGraph({ rankdir: "LR", ranksep: 300, nodesep: 50 });
+      g.setDefaultEdgeLabel(() => ({}));
 
-    // Add nodes to dagre — skip children (they're positioned relative to parent)
-    nextNodes.forEach((node) => {
-      if (node.parentId) return;
-      const w =
-        (node.style?.width as number) ||
-        (node.type === "messageGroupExpanded" ? 380 : 150);
-      const h =
-        (node.style?.height as number) ||
-        (node.type === "messageGroupExpanded" ? 0 : 120);
+      // Add nodes to dagre — skip children (they're positioned relative to parent)
+      nextNodes.forEach((node) => {
+        if (node.parentId) return;
+        const w =
+          (node.style?.width as number) ||
+          (node.type === "messageGroupExpanded" ? 380 : 150);
+        const h =
+          (node.style?.height as number) ||
+          (node.type === "messageGroupExpanded" ? 0 : 120);
 
-      // For expanded groups, calculate height from child count
-      if (node.type === "messageGroupExpanded") {
-        const children = nextNodes.filter((n) => n.parentId === node.id);
-        const childHeight = children.length * 190 + 100; // 190px per child + padding
-        g.setNode(node.id, { width: w, height: childHeight });
-      } else {
-        g.setNode(node.id, { width: w, height: h });
-      }
-    });
+        // For expanded groups, calculate height from child count
+        if (node.type === "messageGroupExpanded") {
+          const children = nextNodes.filter((n) => n.parentId === node.id);
+          const childHeight = children.length * 190 + 100; // 190px per child + padding
+          g.setNode(node.id, { width: w, height: childHeight });
+        } else {
+          g.setNode(node.id, { width: w, height: h });
+        }
+      });
 
-    // Add edges — only between top-level nodes or from top-level to parent of child
-    nextEdges.forEach((edge) => {
-      const sourceNode = nextNodes.find((n) => n.id === edge.source);
-      const targetNode = nextNodes.find((n) => n.id === edge.target);
-      const sourceTop = sourceNode?.parentId || edge.source;
-      const targetTop = targetNode?.parentId || edge.target;
-      // Only add edge if both endpoints are in the dagre graph
-      if (
-        g.hasNode(sourceTop) &&
-        g.hasNode(targetTop) &&
-        sourceTop !== targetTop
-      ) {
-        g.setEdge(sourceTop, targetTop);
-      }
-    });
+      // Add edges — only between top-level nodes or from top-level to parent of child
+      nextEdges.forEach((edge) => {
+        const sourceNode = nextNodes.find((n) => n.id === edge.source);
+        const targetNode = nextNodes.find((n) => n.id === edge.target);
+        const sourceTop = sourceNode?.parentId || edge.source;
+        const targetTop = targetNode?.parentId || edge.target;
+        // Only add edge if both endpoints are in the dagre graph
+        if (
+          g.hasNode(sourceTop) &&
+          g.hasNode(targetTop) &&
+          sourceTop !== targetTop
+        ) {
+          g.setEdge(sourceTop, targetTop);
+        }
+      });
 
-    dagre.layout(g);
+      dagre.layout(g);
 
-    // Apply dagre positions to top-level nodes
-    const positioned = nextNodes.map((node) => {
-      if (node.parentId) {
-        const parent = nextNodes.find((n) => n.id === node.parentId);
+      // Apply dagre positions to top-level nodes
+      const positioned = nextNodes.map((node) => {
+        if (node.parentId) {
+          const parent = nextNodes.find((n) => n.id === node.parentId);
 
-        // Sub-flow expansion: children keep the LR positions already computed
-        // when the sub-flow was expanded. Leave them alone so the inner graph
-        // renders in true graph order, not a vertical stack.
-        if (parent?.type === "flowExpanded") {
-          return node;
+          // Sub-flow expansion: children keep the LR positions already computed
+          // when the sub-flow was expanded. Leave them alone so the inner graph
+          // renders in true graph order, not a vertical stack.
+          if (parent?.type === "flowExpanded") {
+            return node;
+          }
+
+          // Message groups: simple vertical stack, centred within the container.
+          const parentWidth = (parent?.style?.width as number) || 380;
+          const childWidth = 240; // initial estimate, refined by post-render measurement
+          const xOffset = Math.max(20, (parentWidth - childWidth) / 2);
+          const siblings = nextNodes.filter(
+            (n) => n.parentId === node.parentId,
+          );
+          const index = siblings.indexOf(node);
+          return {
+            ...node,
+            position: { x: xOffset, y: 70 + index * 190 },
+          };
         }
 
-        // Message groups: simple vertical stack, centred within the container.
-        const parentWidth = (parent?.style?.width as number) || 380;
-        const childWidth = 240; // initial estimate, refined by post-render measurement
-        const xOffset = Math.max(20, (parentWidth - childWidth) / 2);
-        const siblings = nextNodes.filter((n) => n.parentId === node.parentId);
-        const index = siblings.indexOf(node);
+        const pos = g.node(node.id);
+        if (!pos) return node;
+        // dagre returns center positions — convert to top-left for ReactFlow
         return {
           ...node,
-          position: { x: xOffset, y: 70 + index * 190 },
+          position: { x: pos.x - pos.width / 2, y: pos.y - pos.height / 2 },
         };
-      }
+      });
 
-      const pos = g.node(node.id);
-      if (!pos) return node;
-      // dagre returns center positions — convert to top-left for ReactFlow
-      return {
-        ...node,
-        position: { x: pos.x - pos.width / 2, y: pos.y - pos.height / 2 },
+      if (!anchor) return positioned;
+
+      const positionedAnchor = positioned.find((node) => node.id === anchor.id);
+      if (!positionedAnchor) return positioned;
+
+      const offset = {
+        x: anchor.position.x - positionedAnchor.position.x,
+        y: anchor.position.y - positionedAnchor.position.y,
       };
-    });
 
-    return positioned;
-  }, []);
+      return positioned.map((node) => {
+        if (node.parentId) return node;
+        return {
+          ...node,
+          position: {
+            x: node.position.x + offset.x,
+            y: node.position.y + offset.y,
+          },
+        };
+      });
+    },
+    [],
+  );
+
+  const makeRoomForRenderedExpandedGroup = useCallback(
+    (
+      groupNodeId: string,
+      groupBounds: { x: number; y: number; width: number; height: number },
+    ) => {
+      const padding = 80;
+      const protectedBounds = {
+        x: groupBounds.x - padding,
+        y: groupBounds.y - padding,
+        width: groupBounds.width + padding * 2,
+        height: groupBounds.height + padding * 2,
+      };
+      const intersectingIds = new Set(
+        getIntersectingNodes(protectedBounds, true)
+          .filter((node) => node.id !== groupNodeId && !node.parentId)
+          .map((node) => node.id),
+      );
+
+      if (intersectingIds.size === 0) return;
+
+      setNodes((currentNodes) => {
+        const plannedPositions = packNodesAroundBounds({
+          nodes: currentNodes,
+          movableNodeIds: intersectingIds,
+          protectedBounds,
+          groupNodeId,
+        });
+
+        return currentNodes.map((node) => {
+          const plannedPosition = plannedPositions.get(node.id);
+          if (!plannedPosition) return node;
+          return { ...node, position: plannedPosition };
+        });
+      });
+    },
+    [getIntersectingNodes, setNodes],
+  );
 
   // Lay a sub-flow's internal nodes out with dagre LR and return positioned
   // children, a per-id position map, and the tightest container bounding box
@@ -777,7 +849,12 @@ const NodeGraphBuilder = ({
       // collapse correctly. Fall back to initialNodes for wrappers expanded
       // on a top-level node that was there from page load.
       const stashed = (expandedNode.data as any).__preExpansion as
-        | { node: Node; edges: Edge[]; nodeIds: string[] }
+        | {
+            node: Node;
+            edges: Edge[];
+            nodeIds: string[];
+            nodePositions?: Record<string, { x: number; y: number }>;
+          }
         | undefined;
       const originalNode =
         stashed?.node ??
@@ -842,14 +919,27 @@ const NodeGraphBuilder = ({
           referencedByEdges.add(edge.target);
         }
 
-        const without = prev.filter(
-          (n) =>
-            n.id !== groupNodeId &&
-            !childNodeIds.has(n.id) &&
-            !(downstreamNodeIds.has(n.id) && !referencedByEdges.has(n.id)),
-        );
-        const next = [...without, originalNode];
-        return relayoutGraph(next, nextEdges);
+        const without = prev
+          .filter(
+            (n) =>
+              n.id !== groupNodeId &&
+              !childNodeIds.has(n.id) &&
+              !(downstreamNodeIds.has(n.id) && !referencedByEdges.has(n.id)),
+          )
+          .map((n) => {
+            const stashedPosition = stashed?.nodePositions?.[n.id];
+            if (!stashedPosition || n.parentId) return n;
+            return { ...n, position: stashedPosition };
+          });
+        const next = [
+          ...without,
+          {
+            ...originalNode,
+            position:
+              stashed?.nodePositions?.[groupNodeId] ?? expandedNode.position,
+          },
+        ];
+        return next;
       });
       setEdges((prev) => {
         const without = prev.filter(
@@ -860,12 +950,6 @@ const NodeGraphBuilder = ({
         );
         return [...without, ...originalEdges];
       });
-
-      // Reframe the graph after the layout transition finishes so the user
-      // sees the collapsed result centred.
-      requestAnimationFrame(() => {
-        fitView({ duration: 400, padding: 0.2 });
-      });
     },
     [
       initialNodes,
@@ -874,7 +958,6 @@ const NodeGraphBuilder = ({
       setEdges,
       relayoutGraph,
       animateLayout,
-      fitView,
     ],
   );
 
@@ -979,12 +1062,6 @@ const NodeGraphBuilder = ({
         return;
       }
 
-      // Legacy behavior for linksToVisualiser (deprecated - use onNodeClick instead)
-      if (linksToVisualiser && onNavigate) {
-        // Consumer should handle navigation - but onNodeClick wasn't provided
-        return;
-      }
-
       // Disable focus mode for flow and entity visualizations — but allow
       // flow-type nodes that carry precomputed expandedNodes to continue
       // through to the inline expand handler below.
@@ -1008,6 +1085,32 @@ const NodeGraphBuilder = ({
       if (node.type === "messageGroup") {
         const groupData = node.data as any;
         const groupNodeId = node.id;
+        const currentGroupNode = getExpandedMessageGroupNode(
+          nodesRef.current,
+          groupNodeId,
+        );
+        if (currentGroupNode?.type === "messageGroupExpanded") {
+          const measured = (currentGroupNode as any)?.measured;
+          const width =
+            measured?.width ??
+            (currentGroupNode.style?.width as number | undefined) ??
+            380;
+          const height =
+            measured?.height ??
+            (currentGroupNode.style?.height as number | undefined) ??
+            300;
+
+          setCenter(
+            currentGroupNode.position.x + width / 2,
+            currentGroupNode.position.y + height / 2,
+            {
+              duration: 300,
+              zoom: Math.min(Math.max(getZoom(), 0.55), 1),
+            },
+          );
+          return;
+        }
+
         const serviceNodeId = `${groupData.service.id}-${groupData.service.version}`;
 
         // Calculate expanded container dimensions based on message count
@@ -1023,6 +1126,9 @@ const NodeGraphBuilder = ({
           (e) => e.source === groupNodeId || e.target === groupNodeId,
         );
         const preExpansionNodeIds = nodesRef.current.map((n) => n.id);
+        const preExpansionNodePositions = Object.fromEntries(
+          nodesRef.current.map((n) => [n.id, { ...n.position }]),
+        );
 
         const expandedContainerNode: Node = {
           id: groupNodeId,
@@ -1037,6 +1143,7 @@ const NodeGraphBuilder = ({
               node,
               edges: preExpansionEdges,
               nodeIds: preExpansionNodeIds,
+              nodePositions: preExpansionNodePositions,
             },
           },
           style: {
@@ -1124,25 +1231,22 @@ const NodeGraphBuilder = ({
 
         // Swap: remove compact node + its edge, add expanded container + children + downstream + edges
         setNodes((prev) => {
-          const without = prev.filter((n) => n.id !== groupNodeId);
-          // Deduplicate: downstream nodes that already exist in the graph should not be added again
-          const existingIds = new Set(without.map((n) => n.id));
-          const newDownstream = downstreamNodes.filter(
-            (n) => !existingIds.has(n.id),
-          );
-          const next = [
-            ...without,
+          const downstreamX =
+            groupData.direction === "sends"
+              ? node.position.x + containerWidth + 260
+              : node.position.x - 420;
+          const downstreamY = node.position.y + 40;
+          return buildMessageGroupExpansionNodes({
+            currentNodes: prev,
+            groupNodeId,
             expandedContainerNode,
-            ...childNodes,
-            ...newDownstream,
-          ];
-          return relayoutGraph(next, [
-            ...edgesRef.current.filter(
-              (e) => e.source !== groupNodeId && e.target !== groupNodeId,
-            ),
-            ...childEdges,
-            ...downstreamEdges,
-          ]);
+            childNodes,
+            downstreamNodes,
+            getDownstreamPosition: (_downstreamNode, index) => ({
+              x: downstreamX,
+              y: downstreamY + index * 190,
+            }),
+          }) as Node[];
         });
         setEdges((prev) => {
           const without = prev.filter(
@@ -1153,6 +1257,13 @@ const NodeGraphBuilder = ({
 
         // After React renders the new nodes, measure actual sizes, resize container, and distribute evenly
         requestAnimationFrame(() => {
+          let actualContainerBounds = {
+            x: node.position.x,
+            y: node.position.y,
+            width: containerWidth,
+            height: containerHeight,
+          };
+
           setNodes((prev) => {
             const children = prev.filter((n) => n.parentId === groupNodeId);
             if (children.length === 0) return prev;
@@ -1178,9 +1289,22 @@ const NodeGraphBuilder = ({
             const actualContainerH = headerH + totalChildH + padding * 2;
 
             let currentY = headerH + padding;
+            actualContainerBounds = {
+              x: node.position.x,
+              y: node.position.y,
+              width: containerWidth,
+              height: actualContainerH,
+            };
+
             return prev.map((n) => {
               // Resize the container to fit actual content
               if (n.id === groupNodeId) {
+                actualContainerBounds = {
+                  x: n.position.x,
+                  y: n.position.y,
+                  width: containerWidth,
+                  height: actualContainerH,
+                };
                 return {
                   ...n,
                   style: {
@@ -1198,10 +1322,31 @@ const NodeGraphBuilder = ({
               return { ...n, position: { x, y } };
             });
           });
-        });
 
-        requestAnimationFrame(() => {
-          fitView({ duration: 400, padding: 0.2 });
+          requestAnimationFrame(() => {
+            const groupNode = getNodes().find((n) => n.id === groupNodeId);
+            const measured = (groupNode as any)?.measured;
+            const width =
+              measured?.width ??
+              (groupNode?.style?.width as number | undefined) ??
+              containerWidth;
+            const height =
+              measured?.height ??
+              (groupNode?.style?.height as number | undefined) ??
+              actualContainerBounds.height;
+            const bounds = {
+              x: groupNode?.position.x ?? actualContainerBounds.x,
+              y: groupNode?.position.y ?? actualContainerBounds.y,
+              width,
+              height,
+            };
+
+            makeRoomForRenderedExpandedGroup(groupNodeId, bounds);
+            setCenter(bounds.x + width / 2, bounds.y + height / 2, {
+              duration: 450,
+              zoom: Math.min(Math.max(getZoom(), 0.55), 1),
+            });
+          });
         });
 
         return;
@@ -1402,11 +1547,26 @@ const NodeGraphBuilder = ({
         return;
       }
 
+      // Legacy behavior for linksToVisualiser (deprecated - use onNodeClick instead).
+      // Keep this after inline expand handlers so embedded overview graphs can
+      // still expand message groups/sub-flows without opening focus mode.
+      if (linksToVisualiser && onNavigate) {
+        return;
+      }
+
       // Open focus mode modal
       setFocusedNodeId(node.id);
       setFocusModeOpen(true);
     },
-    [onNodeClick, linksToVisualiser, onNavigate],
+    [
+      onNodeClick,
+      linksToVisualiser,
+      onNavigate,
+      makeRoomForRenderedExpandedGroup,
+      getNodes,
+      getZoom,
+      setCenter,
+    ],
   );
 
   const toggleAnimateMessages = useCallback(() => {
@@ -1701,14 +1861,16 @@ const NodeGraphBuilder = ({
 
   const handleLegendClick = useCallback(
     (collectionType: string, groupId?: string) => {
+      const isLegendTarget = (node: Node<any>) => {
+        if (groupId) {
+          return node.data.group && node.data.group?.id === groupId;
+        }
+        return node.type === collectionType;
+      };
+
       const updatedNodes = nodes.map((node: Node<any>) => {
-        // Check if the groupId is set first
-        if (groupId && node.data.group && node.data.group?.id === groupId) {
+        if (isLegendTarget(node)) {
           return { ...node, style: { ...node.style, opacity: 1 } };
-        } else {
-          if (node.type === collectionType) {
-            return { ...node, style: { ...node.style, opacity: 1 } };
-          }
         }
         return { ...node, style: { ...node.style, opacity: 0.1 } };
       });
@@ -1726,10 +1888,13 @@ const NodeGraphBuilder = ({
       setNodes(updatedNodes);
       setEdges(updatedEdges);
 
+      const targetNodes = updatedNodes.filter(isLegendTarget);
+      if (targetNodes.length === 0) return;
+
       fitView({
         padding: 0.2,
         duration: 800,
-        nodes: updatedNodes.filter((node) => node.type === collectionType),
+        nodes: targetNodes,
       });
     },
     [nodes, edges, setNodes, setEdges, fitView],

--- a/packages/visualiser/src/components/VisualiserSearch.tsx
+++ b/packages/visualiser/src/components/VisualiserSearch.tsx
@@ -8,47 +8,155 @@ import {
   memo,
 } from "react";
 import type { Node } from "@xyflow/react";
+import {
+  Blocks,
+  Database,
+  Layers,
+  ListTree,
+  MessageSquare,
+  Search as SearchIcon,
+  Server,
+  User,
+  Workflow,
+  Zap,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 
 // Define interfaces for different node data structures
-interface MessageData {
-  name: string;
-  version?: string;
-}
-
-interface ServiceData {
-  name: string;
-  version?: string;
-}
-
-interface DomainData {
-  name: string;
-  version?: string;
-}
-
-interface EntityData {
-  name: string;
-  version?: string;
-}
-
-interface NodeDataContent extends Record<string, unknown> {
-  message?: {
-    data: MessageData;
-  };
-  service?: {
-    data: ServiceData;
-  };
-  domain?: {
-    data: DomainData;
-  };
-  entity?: {
-    data: EntityData;
-  };
+interface ResourceData {
+  id?: string;
   name?: string;
   version?: string;
 }
 
+type MessageData = ResourceData;
+
+type ServiceData = ResourceData;
+
+type DomainData = ResourceData;
+
+type EntityData = ResourceData;
+
+interface NodeDataContent extends Record<string, unknown> {
+  message?: { data?: MessageData } & MessageData;
+  service?: { data?: ServiceData } & ServiceData;
+  domain?: { data?: DomainData } & DomainData;
+  entity?: { data?: EntityData } & EntityData;
+  channel?: { data?: ResourceData } & ResourceData;
+  dataProduct?: { data?: ResourceData } & ResourceData;
+  data?: ResourceData;
+  name?: string;
+  version?: string;
+  groupName?: string;
+  messages?: Array<{
+    message?: {
+      collection?: string;
+      data?: MessageData & { id?: string };
+    };
+  }>;
+}
+
 // Extend the Node type with our custom data structure
 type CustomNode = Node<NodeDataContent>;
+
+type SearchSuggestion = {
+  key: string;
+  node: CustomNode;
+  label: string;
+  searchText: string;
+  type: string;
+  resourceKey: string;
+  groupName?: string;
+  isGroupedMessage?: boolean;
+};
+
+type NodeTypeMeta = {
+  label: string;
+  Icon: LucideIcon;
+  iconClass: string;
+  badgeClass: string;
+};
+
+const formatVersionedName = (name: string, version?: string) => {
+  if (version) {
+    const nameWithoutVersion = name.replace(
+      new RegExp(`-v?${version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`),
+      "",
+    );
+    return `${nameWithoutVersion} (v${version})`;
+  }
+
+  const versionMatch = name.match(
+    /^(.+)-v?(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)$/,
+  );
+  if (!versionMatch) return name;
+
+  return `${versionMatch[1]} (v${versionMatch[2]})`;
+};
+
+const normalizeCollectionType = (type: string) => {
+  const aliases: Record<string, string> = {
+    event: "events",
+    command: "commands",
+    query: "queries",
+    service: "services",
+    domain: "domains",
+    channel: "channels",
+    entity: "entities",
+  };
+
+  return aliases[type] || type;
+};
+
+const splitVersionedName = (name: string, version?: string) => {
+  if (version) {
+    return {
+      id: name.replace(
+        new RegExp(`-v?${version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`),
+        "",
+      ),
+      version,
+    };
+  }
+
+  const versionMatch = name.match(
+    /^(.+)-v?(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)$/,
+  );
+  if (!versionMatch) return { id: name, version: undefined };
+
+  return { id: versionMatch[1], version: versionMatch[2] };
+};
+
+const getResourceKey = ({
+  type,
+  id,
+  name,
+  version,
+}: {
+  type: string;
+  id?: string;
+  name: string;
+  version?: string;
+}) => {
+  const parsed = splitVersionedName(id || name, version);
+  return `${normalizeCollectionType(type)}:${parsed.id}:${parsed.version || ""}`.toLowerCase();
+};
+
+const getNodeResourceData = (
+  data: NodeDataContent,
+  key:
+    | "message"
+    | "service"
+    | "domain"
+    | "entity"
+    | "channel"
+    | "dataProduct"
+    | "data",
+) => {
+  const resource = data?.[key];
+  if (!resource || typeof resource !== "object") return undefined;
+  return "data" in resource && resource.data ? resource.data : resource;
+};
 
 interface VisualiserSearchProps {
   nodes: CustomNode[];
@@ -66,13 +174,15 @@ const VisualiserSearch = memo(
     ({ nodes, onNodeSelect, onClear, onPaneClick: _onPaneClick }, ref) => {
       const [searchQuery, setSearchQuery] = useState("");
       const [filteredSuggestions, setFilteredSuggestions] = useState<
-        CustomNode[]
+        SearchSuggestion[]
       >([]);
       const [showSuggestions, setShowSuggestions] = useState(false);
       const [selectedSuggestionIndex, setSelectedSuggestionIndex] =
         useState(-1);
       const searchInputRef = useRef<HTMLInputElement>(null);
       const containerRef = useRef<HTMLDivElement>(null);
+      const suggestionsListRef = useRef<HTMLDivElement>(null);
+      const suggestionItemRefs = useRef<Array<HTMLDivElement | null>>([]);
 
       const hideSuggestions = useCallback(() => {
         setShowSuggestions(false);
@@ -94,41 +204,291 @@ const VisualiserSearch = memo(
         if (node.type === "messageGroupExpanded") {
           return (node.data as any)?.groupName || node.id;
         }
+        const message = getNodeResourceData(node.data, "message");
+        const service = getNodeResourceData(node.data, "service");
+        const domain = getNodeResourceData(node.data, "domain");
+        const entity = getNodeResourceData(node.data, "entity");
+        const channel = getNodeResourceData(node.data, "channel");
+        const dataProduct = getNodeResourceData(node.data, "dataProduct");
+        const data = getNodeResourceData(node.data, "data");
         const name =
-          node.data?.message?.data?.name ||
-          node.data?.service?.data?.name ||
-          node.data?.domain?.data?.name ||
-          node.data?.entity?.data?.name ||
+          message?.name ||
+          message?.id ||
+          service?.name ||
+          service?.id ||
+          domain?.name ||
+          domain?.id ||
+          entity?.name ||
+          entity?.id ||
+          channel?.name ||
+          channel?.id ||
+          dataProduct?.name ||
+          dataProduct?.id ||
+          data?.name ||
+          data?.id ||
           node.data?.name ||
           node.id;
         const version =
-          node.data?.message?.data?.version ||
-          node.data?.service?.data?.version ||
-          node.data?.domain?.data?.version ||
-          node.data?.entity?.data?.version ||
+          message?.version ||
+          service?.version ||
+          domain?.version ||
+          entity?.version ||
+          channel?.version ||
+          dataProduct?.version ||
+          data?.version ||
           node.data?.version;
-        return version ? `${name} (v${version})` : name;
+        return formatVersionedName(name, version);
       }, []);
 
-      const getNodeTypeColorClass = useCallback((nodeType: string) => {
-        const colorClasses: { [key: string]: string } = {
-          events: "bg-orange-600 text-white",
-          services: "bg-pink-600 text-white",
-          flows: "bg-teal-600 text-white",
-          commands: "bg-blue-600 text-white",
-          queries: "bg-green-600 text-white",
-          channels: "bg-gray-600 text-white",
-          domains: "bg-yellow-500 text-white",
-          externalSystem: "bg-pink-600 text-white",
-          actor: "bg-yellow-500 text-white",
-          step: "bg-gray-700 text-white",
-          user: "bg-yellow-500 text-white",
-          custom: "bg-gray-500 text-white",
-          field: "bg-cyan-600 text-white",
-          messageGroup: "bg-violet-600 text-white",
-          messageGroupExpanded: "bg-violet-600 text-white",
+      const getNodeResourceKey = useCallback(
+        (node: CustomNode, label: string) => {
+          if (
+            node.type === "messageGroup" ||
+            node.type === "messageGroupExpanded"
+          ) {
+            return `${node.type}:${node.id}`.toLowerCase();
+          }
+
+          const data = node.data as any;
+          const resource =
+            getNodeResourceData(data, "message") ||
+            getNodeResourceData(data, "service") ||
+            getNodeResourceData(data, "domain") ||
+            getNodeResourceData(data, "entity") ||
+            getNodeResourceData(data, "channel") ||
+            getNodeResourceData(data, "dataProduct") ||
+            data?.data ||
+            data;
+
+          return getResourceKey({
+            type: node.type || "unknown",
+            id: resource?.id,
+            name: resource?.name || resource?.id || label || node.id,
+            version: resource?.version || data?.version,
+          });
+        },
+        [],
+      );
+
+      const dedupeSearchSuggestions = useCallback(
+        (suggestions: SearchSuggestion[]) => {
+          const uniqueSuggestions: SearchSuggestion[] = [];
+          const indexByResourceKey = new Map<string, number>();
+
+          suggestions.forEach((suggestion) => {
+            const existingIndex = indexByResourceKey.get(
+              suggestion.resourceKey,
+            );
+
+            if (existingIndex === undefined) {
+              indexByResourceKey.set(
+                suggestion.resourceKey,
+                uniqueSuggestions.length,
+              );
+              uniqueSuggestions.push(suggestion);
+              return;
+            }
+
+            if (
+              suggestion.isGroupedMessage &&
+              !uniqueSuggestions[existingIndex].isGroupedMessage
+            ) {
+              uniqueSuggestions[existingIndex] = suggestion;
+            }
+          });
+
+          return uniqueSuggestions;
+        },
+        [],
+      );
+
+      const getSearchSuggestions = useCallback(
+        (nodesToIndex: CustomNode[]): SearchSuggestion[] => {
+          const suggestions = nodesToIndex.flatMap((node) => {
+            const nodeName = getNodeDisplayName(node);
+            const suggestions: SearchSuggestion[] = [
+              {
+                key: node.id,
+                node,
+                label: nodeName,
+                searchText: nodeName,
+                type: node.type || "unknown",
+                resourceKey: getNodeResourceKey(node, nodeName),
+              },
+            ];
+
+            if (node.type !== "messageGroup") return suggestions;
+
+            const groupName = node.data?.groupName || nodeName;
+            const groupedMessages = node.data?.messages || [];
+            groupedMessages.forEach((item, index) => {
+              const message = item.message;
+              const messageName = message?.data?.name || message?.data?.id;
+              if (!messageName) return;
+
+              const version = message?.data?.version;
+              const label = formatVersionedName(messageName, version);
+
+              suggestions.push({
+                key: `${node.id}:${message?.data?.id || messageName}:${version || index}`,
+                node,
+                label,
+                searchText: `${label} ${groupName}`,
+                type: message?.collection || "message",
+                resourceKey: getResourceKey({
+                  type: message?.collection || "message",
+                  id: message?.data?.id,
+                  name: messageName,
+                  version,
+                }),
+                groupName,
+                isGroupedMessage: true,
+              });
+            });
+
+            return suggestions;
+          });
+
+          return dedupeSearchSuggestions(suggestions);
+        },
+        [dedupeSearchSuggestions, getNodeDisplayName, getNodeResourceKey],
+      );
+
+      const getNodeTypeMeta = useCallback((nodeType: string): NodeTypeMeta => {
+        const meta: Record<string, NodeTypeMeta> = {
+          events: {
+            label: "Event",
+            Icon: Zap,
+            iconClass: "border-orange-500/25 bg-orange-500/10 text-orange-500",
+            badgeClass:
+              "border-orange-500/25 bg-orange-500/10 text-orange-700 dark:text-orange-300",
+          },
+          event: {
+            label: "Event",
+            Icon: Zap,
+            iconClass: "border-orange-500/25 bg-orange-500/10 text-orange-500",
+            badgeClass:
+              "border-orange-500/25 bg-orange-500/10 text-orange-700 dark:text-orange-300",
+          },
+          commands: {
+            label: "Command",
+            Icon: MessageSquare,
+            iconClass: "border-blue-500/25 bg-blue-500/10 text-blue-500",
+            badgeClass:
+              "border-blue-500/25 bg-blue-500/10 text-blue-700 dark:text-blue-300",
+          },
+          command: {
+            label: "Command",
+            Icon: MessageSquare,
+            iconClass: "border-blue-500/25 bg-blue-500/10 text-blue-500",
+            badgeClass:
+              "border-blue-500/25 bg-blue-500/10 text-blue-700 dark:text-blue-300",
+          },
+          queries: {
+            label: "Query",
+            Icon: SearchIcon,
+            iconClass: "border-green-500/25 bg-green-500/10 text-green-500",
+            badgeClass:
+              "border-green-500/25 bg-green-500/10 text-green-700 dark:text-green-300",
+          },
+          query: {
+            label: "Query",
+            Icon: SearchIcon,
+            iconClass: "border-green-500/25 bg-green-500/10 text-green-500",
+            badgeClass:
+              "border-green-500/25 bg-green-500/10 text-green-700 dark:text-green-300",
+          },
+          services: {
+            label: "Service",
+            Icon: Server,
+            iconClass: "border-pink-500/25 bg-pink-500/10 text-pink-500",
+            badgeClass:
+              "border-pink-500/25 bg-pink-500/10 text-pink-700 dark:text-pink-300",
+          },
+          domains: {
+            label: "Domain",
+            Icon: Blocks,
+            iconClass:
+              "border-yellow-500/25 bg-yellow-500/10 text-yellow-600 dark:text-yellow-400",
+            badgeClass:
+              "border-yellow-500/25 bg-yellow-500/10 text-yellow-700 dark:text-yellow-300",
+          },
+          flows: {
+            label: "Flow",
+            Icon: Workflow,
+            iconClass: "border-teal-500/25 bg-teal-500/10 text-teal-500",
+            badgeClass:
+              "border-teal-500/25 bg-teal-500/10 text-teal-700 dark:text-teal-300",
+          },
+          channels: {
+            label: "Channel",
+            Icon: ListTree,
+            iconClass: "border-gray-500/25 bg-gray-500/10 text-gray-500",
+            badgeClass:
+              "border-gray-500/25 bg-gray-500/10 text-gray-700 dark:text-gray-300",
+          },
+          data: {
+            label: "Data",
+            Icon: Database,
+            iconClass: "border-blue-500/25 bg-blue-500/10 text-blue-500",
+            badgeClass:
+              "border-blue-500/25 bg-blue-500/10 text-blue-700 dark:text-blue-300",
+          },
+          entities: {
+            label: "Entity",
+            Icon: Database,
+            iconClass: "border-blue-500/25 bg-blue-500/10 text-blue-500",
+            badgeClass:
+              "border-blue-500/25 bg-blue-500/10 text-blue-700 dark:text-blue-300",
+          },
+          externalSystem: {
+            label: "External",
+            Icon: Server,
+            iconClass: "border-pink-500/25 bg-pink-500/10 text-pink-500",
+            badgeClass:
+              "border-pink-500/25 bg-pink-500/10 text-pink-700 dark:text-pink-300",
+          },
+          actor: {
+            label: "Actor",
+            Icon: User,
+            iconClass:
+              "border-yellow-500/25 bg-yellow-500/10 text-yellow-600 dark:text-yellow-400",
+            badgeClass:
+              "border-yellow-500/25 bg-yellow-500/10 text-yellow-700 dark:text-yellow-300",
+          },
+          user: {
+            label: "User",
+            Icon: User,
+            iconClass:
+              "border-yellow-500/25 bg-yellow-500/10 text-yellow-600 dark:text-yellow-400",
+            badgeClass:
+              "border-yellow-500/25 bg-yellow-500/10 text-yellow-700 dark:text-yellow-300",
+          },
+          messageGroup: {
+            label: "Group",
+            Icon: Layers,
+            iconClass: "border-violet-500/25 bg-violet-500/10 text-violet-500",
+            badgeClass:
+              "border-violet-500/25 bg-violet-500/10 text-violet-700 dark:text-violet-300",
+          },
+          messageGroupExpanded: {
+            label: "Group",
+            Icon: Layers,
+            iconClass: "border-violet-500/25 bg-violet-500/10 text-violet-500",
+            badgeClass:
+              "border-violet-500/25 bg-violet-500/10 text-violet-700 dark:text-violet-300",
+          },
         };
-        return colorClasses[nodeType] || "bg-gray-100 text-gray-700";
+
+        return (
+          meta[nodeType] || {
+            label: nodeType,
+            Icon: Layers,
+            iconClass: "border-gray-500/25 bg-gray-500/10 text-gray-500",
+            badgeClass:
+              "border-gray-500/25 bg-gray-500/10 text-gray-700 dark:text-gray-300",
+          }
+        );
       }, []);
 
       const handleSearchChange = useCallback(
@@ -137,59 +497,73 @@ const VisualiserSearch = memo(
           setSearchQuery(query);
 
           if (query.length > 0) {
-            const filtered = nodes.filter((node) => {
-              const nodeName = getNodeDisplayName(node);
-              return nodeName.toLowerCase().includes(query.toLowerCase());
-            });
+            const search = query.toLowerCase();
+            const filtered = getSearchSuggestions(nodes).filter((suggestion) =>
+              suggestion.searchText.toLowerCase().includes(search),
+            );
             setFilteredSuggestions(filtered);
             setShowSuggestions(true);
             setSelectedSuggestionIndex(-1);
           } else {
-            setFilteredSuggestions(nodes);
+            setFilteredSuggestions(getSearchSuggestions(nodes));
             setShowSuggestions(true);
             setSelectedSuggestionIndex(-1);
           }
         },
-        [nodes, getNodeDisplayName],
+        [nodes, getSearchSuggestions],
       );
 
       const handleSearchFocus = useCallback(() => {
-        if (searchQuery.length === 0) {
-          setFilteredSuggestions(nodes);
-        }
+        const suggestions = getSearchSuggestions(nodes);
+        const search = searchQuery.toLowerCase();
+        setFilteredSuggestions(
+          searchQuery.length === 0
+            ? suggestions
+            : suggestions.filter((suggestion) =>
+                suggestion.searchText.toLowerCase().includes(search),
+              ),
+        );
         setShowSuggestions(true);
         setSelectedSuggestionIndex(-1);
-      }, [nodes, searchQuery]);
+      }, [nodes, searchQuery, getSearchSuggestions]);
 
       const handleSuggestionClick = useCallback(
-        (node: CustomNode) => {
-          setSearchQuery(getNodeDisplayName(node));
+        (suggestion: SearchSuggestion) => {
+          setSearchQuery("");
+          setFilteredSuggestions([]);
           setShowSuggestions(false);
-          onNodeSelect(node);
+          setSelectedSuggestionIndex(-1);
+          onNodeSelect(suggestion.node);
         },
-        [onNodeSelect, getNodeDisplayName],
+        [onNodeSelect],
       );
 
       const handleSearchKeyDown = useCallback(
         (event: React.KeyboardEvent<HTMLInputElement>) => {
-          if (!showSuggestions || filteredSuggestions.length === 0) return;
-
           switch (event.key) {
             case "ArrowDown":
               event.preventDefault();
+              if (filteredSuggestions.length === 0) return;
+              setShowSuggestions(true);
               setSelectedSuggestionIndex((prev) =>
                 prev < filteredSuggestions.length - 1 ? prev + 1 : 0,
               );
               break;
             case "ArrowUp":
               event.preventDefault();
+              if (filteredSuggestions.length === 0) return;
+              setShowSuggestions(true);
               setSelectedSuggestionIndex((prev) =>
                 prev > 0 ? prev - 1 : filteredSuggestions.length - 1,
               );
               break;
             case "Enter":
               event.preventDefault();
-              if (selectedSuggestionIndex >= 0) {
+              if (
+                showSuggestions &&
+                selectedSuggestionIndex >= 0 &&
+                selectedSuggestionIndex < filteredSuggestions.length
+              ) {
                 handleSuggestionClick(
                   filteredSuggestions[selectedSuggestionIndex],
                 );
@@ -219,6 +593,36 @@ const VisualiserSearch = memo(
           searchInputRef.current.focus();
         }
       }, [onClear]);
+
+      useEffect(() => {
+        suggestionItemRefs.current = suggestionItemRefs.current.slice(
+          0,
+          filteredSuggestions.length,
+        );
+      }, [filteredSuggestions.length]);
+
+      useEffect(() => {
+        if (!showSuggestions || selectedSuggestionIndex < 0) return;
+
+        const list = suggestionsListRef.current;
+        const item = suggestionItemRefs.current[selectedSuggestionIndex];
+        if (!list || !item) return;
+
+        const itemTop = item.offsetTop;
+        const itemBottom = itemTop + item.offsetHeight;
+        const visibleTop = list.scrollTop;
+        const visibleBottom = visibleTop + list.clientHeight;
+
+        if (itemTop < visibleTop) {
+          list.scrollTop = itemTop;
+        } else if (itemBottom > visibleBottom) {
+          list.scrollTop = itemBottom - list.clientHeight;
+        }
+      }, [
+        showSuggestions,
+        selectedSuggestionIndex,
+        filteredSuggestions.length,
+      ]);
 
       // Close suggestions when clicking outside
       useEffect(() => {
@@ -274,27 +678,47 @@ const VisualiserSearch = memo(
             )}
           </div>
           {showSuggestions && filteredSuggestions.length > 0 && (
-            <div className="absolute top-full left-0 right-0 mt-1 bg-[rgb(var(--ec-card-bg))] border border-[rgb(var(--ec-page-border))] rounded-md shadow-lg z-50 max-h-60 overflow-y-auto">
-              {filteredSuggestions.map((node, index) => {
-                const nodeName = getNodeDisplayName(node);
-                const nodeType = node.type || "unknown";
+            <div
+              ref={suggestionsListRef}
+              className="absolute top-full left-0 right-0 mt-1 bg-[rgb(var(--ec-card-bg))] border border-[rgb(var(--ec-page-border))] rounded-md shadow-lg z-50 max-h-60 overflow-y-auto"
+            >
+              {filteredSuggestions.map((suggestion, index) => {
+                const nodeTypeMeta = getNodeTypeMeta(suggestion.type);
+                const Icon = nodeTypeMeta.Icon;
+                const isSelected = index === selectedSuggestionIndex;
                 return (
                   <div
-                    key={node.id}
-                    onClick={() => handleSuggestionClick(node)}
-                    className={`px-4 py-2 cursor-pointer flex items-center justify-between hover:bg-[rgb(var(--ec-page-border)/0.5)] ${
-                      index === selectedSuggestionIndex
-                        ? "bg-[rgb(var(--ec-accent-subtle))]"
-                        : ""
+                    key={`${suggestion.key}:${index}`}
+                    ref={(element) => {
+                      suggestionItemRefs.current[index] = element;
+                    }}
+                    onClick={() => handleSuggestionClick(suggestion)}
+                    onMouseEnter={() => setSelectedSuggestionIndex(index)}
+                    className={`px-3 py-2 cursor-pointer flex items-start gap-3 ${
+                      isSelected
+                        ? "bg-[rgb(var(--ec-accent-subtle))] outline outline-1 -outline-offset-1 outline-[rgb(var(--ec-accent))]"
+                        : "hover:bg-[rgb(var(--ec-page-border)/0.5)]"
                     }`}
                   >
-                    <span className="text-sm font-medium text-[rgb(var(--ec-page-text))]">
-                      {nodeName}
+                    <span
+                      className={`mt-0.5 flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-md border ${nodeTypeMeta.iconClass}`}
+                    >
+                      <Icon className="h-3.5 w-3.5" />
+                    </span>
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate text-sm font-medium text-[rgb(var(--ec-page-text))]">
+                        {suggestion.label}
+                      </span>
+                      {suggestion.isGroupedMessage && suggestion.groupName && (
+                        <span className="mt-0.5 block truncate text-xs text-[rgb(var(--ec-page-text-muted))]">
+                          in {suggestion.groupName}
+                        </span>
+                      )}
                     </span>
                     <span
-                      className={`text-xs capitalize px-2 py-1 rounded ${getNodeTypeColorClass(nodeType)}`}
+                      className={`mt-0.5 flex-shrink-0 rounded border px-2 py-0.5 text-xs font-medium ${nodeTypeMeta.badgeClass}`}
                     >
-                      {nodeType}
+                      {nodeTypeMeta.label}
                     </span>
                   </div>
                 );

--- a/packages/visualiser/src/utils/local-packing.test.ts
+++ b/packages/visualiser/src/utils/local-packing.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import {
+  packNodesAroundBounds,
+  rectsIntersect,
+  type PackableNode,
+} from "./local-packing";
+
+const node = (
+  id: string,
+  x: number,
+  y: number,
+  width = 100,
+  height = 100,
+): PackableNode => ({
+  id,
+  position: { x, y },
+  measured: { width, height },
+});
+
+describe("packNodesAroundBounds", () => {
+  it("moves intersecting nodes into the nearest non-overlapping slot", () => {
+    const nodes = [
+      node("group", 0, 0, 300, 300),
+      node("move", 40, 180),
+      node("occupied", 40, 360),
+    ];
+    const positions = packNodesAroundBounds({
+      nodes,
+      movableNodeIds: new Set(["move"]),
+      protectedBounds: { x: 0, y: 0, width: 300, height: 300 },
+      groupNodeId: "group",
+      gap: 40,
+    });
+
+    expect(positions.get("move")).toEqual({ x: 40, y: 500 });
+  });
+
+  it("keeps moved nodes from colliding with existing nodes and each other", () => {
+    const nodes = [
+      node("group", 0, 0, 300, 300),
+      node("move-a", 40, 180),
+      node("move-b", 40, 220),
+      node("occupied", 40, 360),
+    ];
+    const positions = packNodesAroundBounds({
+      nodes,
+      movableNodeIds: new Set(["move-a", "move-b"]),
+      protectedBounds: { x: 0, y: 0, width: 300, height: 300 },
+      groupNodeId: "group",
+      gap: 40,
+    });
+    const movedRects = ["move-a", "move-b"].map((id) => {
+      const moved = nodes.find((n) => n.id === id)!;
+      const position = positions.get(id)!;
+      return {
+        ...position,
+        width: moved.measured!.width!,
+        height: moved.measured!.height!,
+      };
+    });
+
+    expect(rectsIntersect(movedRects[0], movedRects[1], 40)).toBe(false);
+    expect(movedRects.map((rect) => rect.y)).toEqual([500, 640]);
+  });
+
+  it("moves nodes above the protected bounds when they start above the group center", () => {
+    const nodes = [node("group", 0, 0, 300, 300), node("move", 40, 20)];
+    const positions = packNodesAroundBounds({
+      nodes,
+      movableNodeIds: new Set(["move"]),
+      protectedBounds: { x: 0, y: 0, width: 300, height: 300 },
+      groupNodeId: "group",
+      gap: 40,
+    });
+
+    expect(positions.get("move")).toEqual({ x: 40, y: -140 });
+  });
+});

--- a/packages/visualiser/src/utils/local-packing.ts
+++ b/packages/visualiser/src/utils/local-packing.ts
@@ -1,0 +1,150 @@
+export type Position = {
+  x: number;
+  y: number;
+};
+
+export type Rect = Position & {
+  width: number;
+  height: number;
+};
+
+export type PackableNode = {
+  id: string;
+  parentId?: string;
+  position: Position;
+  style?: {
+    width?: number | string;
+    height?: number | string;
+  };
+  measured?: {
+    width?: number;
+    height?: number;
+  };
+  width?: number;
+  height?: number;
+};
+
+const toNumber = (value: unknown) => {
+  if (typeof value === "number") return value;
+  if (typeof value === "string") {
+    const parsed = Number.parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+};
+
+export const getPackableNodeSize = (node: PackableNode) => ({
+  width:
+    toNumber(node.measured?.width) ??
+    toNumber(node.width) ??
+    toNumber(node.style?.width) ??
+    260,
+  height:
+    toNumber(node.measured?.height) ??
+    toNumber(node.height) ??
+    toNumber(node.style?.height) ??
+    140,
+});
+
+export const rectsIntersect = (a: Rect, b: Rect, gap = 0) =>
+  a.x < b.x + b.width + gap &&
+  a.x + a.width + gap > b.x &&
+  a.y < b.y + b.height + gap &&
+  a.y + a.height + gap > b.y;
+
+const toRect = (node: PackableNode, y = node.position.y): Rect => {
+  const size = getPackableNodeSize(node);
+  return {
+    x: node.position.x,
+    y,
+    width: size.width,
+    height: size.height,
+  };
+};
+
+export const packNodesAroundBounds = ({
+  nodes,
+  movableNodeIds,
+  protectedBounds,
+  groupNodeId,
+  gap = 40,
+}: {
+  nodes: PackableNode[];
+  movableNodeIds: Set<string>;
+  protectedBounds: Rect;
+  groupNodeId: string;
+  gap?: number;
+}) => {
+  const movableNodes = nodes
+    .filter((node) => movableNodeIds.has(node.id))
+    .sort((a, b) => a.position.y - b.position.y);
+  const movableIds = new Set(movableNodes.map((node) => node.id));
+  const occupiedRects: Rect[] = [
+    protectedBounds,
+    ...nodes
+      .filter(
+        (node) =>
+          !node.parentId && node.id !== groupNodeId && !movableIds.has(node.id),
+      )
+      .map((node) => toRect(node)),
+  ];
+  const plannedPositions = new Map<string, Position>();
+  const groupCenterY = protectedBounds.y + protectedBounds.height / 2;
+
+  const placeNode = (node: PackableNode) => {
+    const size = getPackableNodeSize(node);
+    const nodeCenterY = node.position.y + size.height / 2;
+    const moveDirection = nodeCenterY >= groupCenterY ? 1 : -1;
+    let y =
+      moveDirection > 0
+        ? Math.max(
+            node.position.y,
+            protectedBounds.y + protectedBounds.height + gap,
+          )
+        : Math.min(node.position.y, protectedBounds.y - size.height - gap);
+    let attempts = 0;
+
+    while (attempts < occupiedRects.length + 8) {
+      const rect = {
+        x: node.position.x,
+        y,
+        width: size.width,
+        height: size.height,
+      };
+      const collision = occupiedRects.find((occupied) =>
+        rectsIntersect(rect, occupied, gap),
+      );
+      if (!collision) {
+        occupiedRects.push(rect);
+        plannedPositions.set(node.id, { ...node.position, y });
+        return;
+      }
+
+      y =
+        moveDirection > 0
+          ? collision.y + collision.height + gap
+          : collision.y - size.height - gap;
+      attempts += 1;
+    }
+
+    occupiedRects.push({
+      x: node.position.x,
+      y,
+      width: size.width,
+      height: size.height,
+    });
+    plannedPositions.set(node.id, { ...node.position, y });
+  };
+
+  const below = movableNodes.filter((node) => {
+    const size = getPackableNodeSize(node);
+    return node.position.y + size.height / 2 >= groupCenterY;
+  });
+  const belowIds = new Set(below.map((node) => node.id));
+  const above = movableNodes.filter((node) => !belowIds.has(node.id)).reverse();
+
+  below.forEach(placeNode);
+  above.forEach(placeNode);
+
+  return plannedPositions;
+};

--- a/packages/visualiser/src/utils/message-group-expansion.test.ts
+++ b/packages/visualiser/src/utils/message-group-expansion.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildMessageGroupExpansionNodes,
+  getExpandedMessageGroupNode,
+  type GraphNode,
+} from "./message-group-expansion";
+
+const node = (
+  id: string,
+  type: string,
+  x = 0,
+  y = 0,
+  parentId?: string,
+): GraphNode => ({
+  id,
+  type,
+  parentId,
+  position: { x, y },
+});
+
+describe("message group expansion helpers", () => {
+  it("detects when a message group is already expanded", () => {
+    const nodes = [
+      node("message-group-orders-sends-Updates", "messageGroupExpanded"),
+      node("OrderCreated-1.0.0", "events"),
+    ];
+
+    expect(
+      getExpandedMessageGroupNode(nodes, "message-group-orders-sends-Updates"),
+    ).toBe(nodes[0]);
+  });
+
+  it("replaces an existing expanded group and children instead of appending duplicates", () => {
+    const groupNodeId = "message-group-orders-sends-Updates";
+    const expandedContainer = node(groupNodeId, "messageGroupExpanded", 10, 20);
+    const child = node(
+      `${groupNodeId}__OrderCreated-1.0.0`,
+      "events",
+      70,
+      70,
+      groupNodeId,
+    );
+    const existingExpandedChild = node(
+      `${groupNodeId}__OrderCreated-1.0.0`,
+      "events",
+      70,
+      260,
+      groupNodeId,
+    );
+    const downstream = node("NotificationsService-1.0.0", "services", 0, 0);
+
+    const nextNodes = buildMessageGroupExpansionNodes({
+      currentNodes: [
+        node("OrdersService-1.0.0", "services"),
+        node(groupNodeId, "messageGroupExpanded", 10, 20),
+        existingExpandedChild,
+        downstream,
+      ],
+      groupNodeId,
+      expandedContainerNode: expandedContainer,
+      childNodes: [child],
+      downstreamNodes: [downstream],
+      getDownstreamPosition: (_node, index) => ({
+        x: 650,
+        y: 60 + index * 190,
+      }),
+    });
+
+    expect(nextNodes.filter((n) => n.id === groupNodeId)).toHaveLength(1);
+    expect(nextNodes.filter((n) => n.parentId === groupNodeId)).toHaveLength(1);
+    expect(nextNodes.filter((n) => n.id === downstream.id)).toHaveLength(1);
+  });
+});

--- a/packages/visualiser/src/utils/message-group-expansion.ts
+++ b/packages/visualiser/src/utils/message-group-expansion.ts
@@ -1,0 +1,59 @@
+export type GraphNode = {
+  id: string;
+  type?: string;
+  parentId?: string;
+  position: {
+    x: number;
+    y: number;
+  };
+  style?: {
+    width?: number | string;
+    height?: number | string;
+  };
+  [key: string]: unknown;
+};
+
+export const getExpandedMessageGroupNode = (
+  nodes: GraphNode[],
+  groupNodeId: string,
+) =>
+  nodes.find(
+    (node) => node.id === groupNodeId && node.type === "messageGroupExpanded",
+  );
+
+export const buildMessageGroupExpansionNodes = ({
+  currentNodes,
+  groupNodeId,
+  expandedContainerNode,
+  childNodes,
+  downstreamNodes,
+  getDownstreamPosition,
+}: {
+  currentNodes: GraphNode[];
+  groupNodeId: string;
+  expandedContainerNode: GraphNode;
+  childNodes: GraphNode[];
+  downstreamNodes: GraphNode[];
+  getDownstreamPosition: (
+    node: GraphNode,
+    index: number,
+  ) => GraphNode["position"];
+}) => {
+  const withoutExistingGroup = currentNodes.filter(
+    (node) => node.id !== groupNodeId && node.parentId !== groupNodeId,
+  );
+  const existingIds = new Set(withoutExistingGroup.map((node) => node.id));
+  const newDownstream = downstreamNodes
+    .filter((node) => !existingIds.has(node.id))
+    .map((node, index) => ({
+      ...node,
+      position: getDownstreamPosition(node, index),
+    }));
+
+  return [
+    ...withoutExistingGroup,
+    expandedContainerNode,
+    ...childNodes,
+    ...newDownstream,
+  ];
+};

--- a/packages/visualiser/src/vite-env.d.ts
+++ b/packages/visualiser/src/vite-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="vite/client" />
+
+declare module "*.svg?raw" {
+  const content: string;
+  export default content;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -802,6 +802,9 @@ importers:
       vite:
         specifier: ^7.1.9
         version: 7.1.9(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@25.0.3)(jiti@2.6.1)(jsdom@27.0.0(postcss@8.5.6))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/vscode-extension:
     dependencies:
@@ -8134,9 +8137,6 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
-  std-env@3.9.0:
-    resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
-
   stdin-discarder@0.2.2:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
     engines: {node: '>=18'}
@@ -10304,6 +10304,11 @@ snapshots:
   '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
     dependencies:
       '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-syntax-patches-for-csstree@1.0.14(postcss@8.5.6)':
+    dependencies:
+      postcss: 8.5.6
+    optional: true
 
   '@csstools/css-syntax-patches-for-csstree@1.0.14(postcss@8.5.9)':
     dependencies:
@@ -14575,6 +14580,15 @@ snapshots:
     dependencies:
       css-tree: 2.2.1
 
+  cssstyle@5.3.1(postcss@8.5.6):
+    dependencies:
+      '@asamuzakjp/css-color': 4.0.5
+      '@csstools/css-syntax-patches-for-csstree': 1.0.14(postcss@8.5.6)
+      css-tree: 3.1.0
+    transitivePeerDependencies:
+      - postcss
+    optional: true
+
   cssstyle@5.3.1(postcss@8.5.9):
     dependencies:
       '@asamuzakjp/css-color': 4.0.5
@@ -16208,6 +16222,35 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@27.0.0(postcss@8.5.6):
+    dependencies:
+      '@asamuzakjp/dom-selector': 6.6.1
+      cssstyle: 5.3.1(postcss@8.5.6)
+      data-urls: 6.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      parse5: 7.3.0
+      rrweb-cssom: 0.8.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 15.1.0
+      ws: 8.18.3
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - postcss
+      - supports-color
+      - utf-8-validate
+    optional: true
 
   jsdom@27.0.0(postcss@8.5.9):
     dependencies:
@@ -18745,8 +18788,6 @@ snapshots:
 
   std-env@3.10.0: {}
 
-  std-env@3.9.0: {}
-
   stdin-discarder@0.2.2: {}
 
   stop-iteration-iterator@1.1.0:
@@ -19560,8 +19601,8 @@ snapshots:
       expect-type: 1.2.2
       magic-string: 0.30.21
       pathe: 2.0.3
-      picomatch: 4.0.3
-      std-env: 3.9.0
+      picomatch: 4.0.4
+      std-env: 3.10.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
       tinyglobby: 0.2.15
@@ -19574,6 +19615,49 @@ snapshots:
       '@types/debug': 4.1.12
       '@types/node': 20.19.19
       jsdom: 27.0.0(postcss@8.5.9)
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@25.0.3)(jiti@2.6.1)(jsdom@27.0.0(postcss@8.5.6))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.2.2
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite-node: 3.2.4(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.12
+      '@types/node': 25.0.3
+      jsdom: 27.0.0(postcss@8.5.6)
     transitivePeerDependencies:
       - jiti
       - less
@@ -19603,8 +19687,8 @@ snapshots:
       expect-type: 1.2.2
       magic-string: 0.30.21
       pathe: 2.0.3
-      picomatch: 4.0.3
-      std-env: 3.9.0
+      picomatch: 4.0.4
+      std-env: 3.10.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
       tinyglobby: 0.2.15


### PR DESCRIPTION
Closes #2079

## What This PR Does

Makes the visualiser usable for services and domains that produce or consume large numbers of messages. Grouped message nodes can now be expanded inline to reveal their children, and the rest of the graph is repacked around the expanded bounds so nothing overlaps. The search panel has been rewritten with icons, type filters, and better keyboard navigation so users can quickly jump to a specific resource in a busy diagram.

## Changes Overview

### Key Changes
- Add `messageGroupExpanded` handling in `NodeGraph` so clicking a message group swaps it for a container node with its children laid out inside, while keeping the surrounding graph stable.
- Add `local-packing` utility that packs sibling nodes around protected bounds without re-running a full dagre layout — keeps the user's mental model intact when expanding/collapsing groups.
- Add `message-group-expansion` utility that builds the next node set when a group is opened (filters out the collapsed group, inserts the expanded container + children, places downstream nodes).
- Rewrite `VisualiserSearch` with lucide icons per resource type, grouped/filterable results, and improved keyboard navigation.
- Theme `EntityMap.astro` border to `--ec-page-border` so it follows the active theme instead of being hardcoded gray.
- Add `vitest` to the visualiser package and wire `test` / `test:ci` scripts; ship 5 unit tests covering the new utilities.

## How It Works

When a user clicks an aggregated message group, `NodeGraphBuilder` looks up the children for that group, builds an `messageGroupExpanded` container node, and uses `buildMessageGroupExpansionNodes` to splice the new nodes into the current graph. Because re-running dagre on every expansion would jump the camera and reshuffle unrelated nodes, `packNodesAroundBounds` instead treats the expanded group as a protected rectangle and slides only its overlapping siblings up or down by the minimum amount needed to avoid collisions. The expansion is anchored on the original group's center so the user stays oriented.

The search panel groups results by resource type (services, messages, domains, entities, etc.), shows a lucide icon and version next to each result, and supports arrow-key navigation plus type filtering. The data shape was unified into a single `ResourceData` type to remove duplicated interface definitions.

## Breaking Changes

None.

## Additional Notes

- The collapsed-group flow is unchanged; only the expanded path is new.
- The new layout helper is intentionally local — full layout is still done by dagre on initial render and on explicit relayout.
- Follow-up: consider exposing the pack/expand utilities for FocusMode if we want consistent behavior there too.