### PR TITLE
feat(sdk): add flow write methods and FlowBuilder API

### DIFF
--- a/.changeset/flow-sdk-builder.md
+++ b/.changeset/flow-sdk-builder.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/sdk': minor
+---
+
+Add SDK support for writing flow resources and a fluent `FlowBuilder` API for creating flows from code.

--- a/packages/sdk/flow-api-proposal.md
+++ b/packages/sdk/flow-api-proposal.md
@@ -1,0 +1,687 @@
+# Flow SDK API Proposal
+
+## Goal
+
+Add first-class SDK support for creating, updating, versioning, and composing EventCatalog flows.
+
+The SDK already supports reading flows with `getFlow` and `getFlows`, and the catalog already models flows as frontmatter with `steps`. The missing piece is a write API and a nicer authoring API for users who want to generate flows from code.
+
+This proposal has two layers:
+
+- A low-level resource API that mirrors the rest of the SDK.
+- A fluent `FlowBuilder` API for ergonomic flow creation.
+
+## Low-Level SDK API
+
+The SDK should expose flow helpers that match existing resource helpers for events, services, diagrams, data products, and similar resources.
+
+```ts
+const {
+  getFlow,
+  getFlows,
+  writeFlow,
+  writeVersionedFlow,
+  writeFlowToDomain,
+  writeFlowToService,
+  versionFlow,
+  rmFlow,
+  rmFlowById,
+  flowHasVersion,
+  addFileToFlow,
+} = utils('./catalog');
+```
+
+### Proposed Methods
+
+```ts
+getFlow(id: string, version?: string): Promise<Flow | undefined>
+
+getFlows(options?: { latestOnly?: boolean }): Promise<Flow[] | undefined>
+
+writeFlow(
+  flow: Flow,
+  options?: {
+    path?: string;
+    override?: boolean;
+    versionExistingContent?: boolean;
+    format?: 'md' | 'mdx';
+  }
+): Promise<void>
+
+writeVersionedFlow(flow: Flow): Promise<void>
+
+writeFlowToDomain(
+  flow: Flow,
+  domain: { id: string; version?: string },
+  options?: { path?: string; override?: boolean; format?: 'md' | 'mdx' }
+): Promise<void>
+
+writeFlowToService(
+  flow: Flow,
+  service: { id: string; version?: string },
+  options?: { path?: string; override?: boolean; format?: 'md' | 'mdx' }
+): Promise<void>
+
+versionFlow(id: string): Promise<void>
+
+rmFlow(path: string): Promise<void>
+
+rmFlowById(id: string, version?: string, persistFiles?: boolean): Promise<void>
+
+flowHasVersion(id: string, version?: string): Promise<boolean>
+
+addFileToFlow(
+  id: string,
+  file: { content: string; fileName: string },
+  version?: string
+): Promise<void>
+```
+
+## Fluent Builder API Options
+
+Users are asking for a code-first API that lets them describe flows in a readable, chained form. Any builder API should build the existing `Flow` shape rather than introducing a second model.
+
+Below are three possible fluent APIs. Option 1 is the selected MVP because it is expressive and maps cleanly to the current `FlowStep` model.
+
+Current scope:
+
+- Include Option 1 typed step methods.
+- Do not include `.connect()` yet.
+- Do not include generated catalog type support yet.
+
+## Option 1: Typed Step Builder
+
+This option exposes explicit methods for each step type: `.addStep()`, `.addMessageStep()`, `.addServiceStep()`, `.addActorStep()`, `.addExternalSystemStep()`, `.addFlowStep()`, and `.addCustomStep()`.
+
+It reads close to the current YAML/frontmatter model while giving users autocomplete and type safety for known message ids.
+
+```ts
+import utils, { FlowBuilder } from '@eventcatalog/sdk';
+
+enum ApplicationEventType {
+  HourlyCurtailmentCalculated = 'HourlyCurtailmentCalculated',
+  DailyCurtailmentCalculated = 'DailyCurtailmentCalculated',
+  MonthlyCurtailmentCalculated = 'MonthlyCurtailmentCalculated',
+}
+
+const flow = FlowBuilder.create<ApplicationEventType>({
+  id: 'CurtailmentCalculation',
+  name: 'Curtailment Calculation',
+  version: '1.0.0',
+  summary: 'Flow for calculating hourly curtailment for a customer',
+  markdown: '## Curtailment calculation\n\nGenerated from the application flow definition.',
+})
+  .addStep({
+    id: 'Calculate',
+    title: 'Calculate Hourly Curtailment',
+    summary: 'Hourly curtailment calculation is triggered by a scheduled event',
+    nextSteps: [
+      {
+        id: ApplicationEventType.HourlyCurtailmentCalculated,
+        label: 'Hourly curtailment calculated',
+      },
+    ],
+  })
+  .addMessageStep({
+    id: ApplicationEventType.HourlyCurtailmentCalculated,
+    title: 'Hourly Curtailment Calculated',
+    message: { id: ApplicationEventType.HourlyCurtailmentCalculated },
+    nextSteps: [
+      {
+        id: ApplicationEventType.DailyCurtailmentCalculated,
+        label: 'Daily curtailment recalculated',
+      },
+      {
+        id: 'SAP',
+        label: 'Send curtailment period to SAP',
+      },
+    ],
+  })
+  .addMessageStep({
+    id: ApplicationEventType.DailyCurtailmentCalculated,
+    title: 'Daily Curtailment Calculated',
+    message: { id: ApplicationEventType.DailyCurtailmentCalculated },
+    nextSteps: [
+      {
+        id: ApplicationEventType.MonthlyCurtailmentCalculated,
+        label: 'Monthly curtailment recalculated',
+      },
+    ],
+  })
+  .addMessageStep({
+    id: ApplicationEventType.MonthlyCurtailmentCalculated,
+    title: 'Monthly Curtailment Calculated',
+    message: { id: ApplicationEventType.MonthlyCurtailmentCalculated },
+  })
+  .addExternalSystemStep({
+    id: 'SAP',
+    title: 'Curtailment period registered in SAP',
+    externalSystem: {
+      name: 'SAP',
+      summary: 'SAP processed the curtailment period asynchronously.',
+    },
+    nextSteps: [{ id: 'Curtailment Rewarding' }],
+  })
+  .addStep({
+    id: 'Curtailment Rewarding',
+    title: 'Curtailment Rewarding',
+  })
+  .build();
+
+const { writeFlow } = utils('./catalog');
+
+await writeFlow(flow);
+```
+
+### Why This Option Works
+
+- Clear mapping to EventCatalog's current `FlowStep` shape.
+- Good TypeScript ergonomics with enum-backed message ids.
+- Easy to add optional metadata per step.
+- Easy to normalize `nextSteps` into `next_step` or `next_steps`.
+- Explicit method names make the flow readable in editor autocomplete.
+
+### Tradeoffs
+
+- Slightly more verbose than a pure chain API.
+- Users need to understand which step type they are adding.
+
+## Option 2: Graph Connect Builder
+
+This option separates node declaration from edge declaration. Users declare the nodes first, then connect them.
+
+This is useful when a flow is generated from another model, imported from diagrams, or assembled from data where edges are easier to reason about separately.
+
+```ts
+import utils, { FlowBuilder } from '@eventcatalog/sdk';
+
+enum ApplicationEventType {
+  HourlyCurtailmentCalculated = 'HourlyCurtailmentCalculated',
+  DailyCurtailmentCalculated = 'DailyCurtailmentCalculated',
+  MonthlyCurtailmentCalculated = 'MonthlyCurtailmentCalculated',
+}
+
+const flow = FlowBuilder.create<ApplicationEventType>({
+  id: 'CurtailmentCalculation',
+  name: 'Curtailment Calculation',
+  version: '1.0.0',
+  summary: 'Flow for calculating hourly curtailment for a customer',
+  markdown: '## Curtailment calculation',
+})
+  .step('Calculate', {
+    title: 'Calculate Hourly Curtailment',
+    summary: 'Hourly curtailment calculation is triggered by a scheduled event',
+  })
+  .message(ApplicationEventType.HourlyCurtailmentCalculated, {
+    title: 'Hourly Curtailment Calculated',
+  })
+  .message(ApplicationEventType.DailyCurtailmentCalculated, {
+    title: 'Daily Curtailment Calculated',
+  })
+  .message(ApplicationEventType.MonthlyCurtailmentCalculated, {
+    title: 'Monthly Curtailment Calculated',
+  })
+  .externalSystem('SAP', {
+    name: 'Curtailment period registered in SAP',
+    summary: 'SAP processed the curtailment period asynchronously.',
+  })
+  .step('Curtailment Rewarding')
+  .connect('Calculate', ApplicationEventType.HourlyCurtailmentCalculated, {
+    label: 'Hourly curtailment calculated',
+  })
+  .connect(ApplicationEventType.HourlyCurtailmentCalculated, ApplicationEventType.DailyCurtailmentCalculated, {
+    label: 'Daily curtailment recalculated',
+  })
+  .connect(ApplicationEventType.HourlyCurtailmentCalculated, 'SAP', {
+    label: 'Send curtailment period to SAP',
+  })
+  .connect(ApplicationEventType.DailyCurtailmentCalculated, ApplicationEventType.MonthlyCurtailmentCalculated, {
+    label: 'Monthly curtailment recalculated',
+  })
+  .connect('SAP', 'Curtailment Rewarding')
+  .build();
+
+const { writeFlow } = utils('./catalog');
+
+await writeFlow(flow);
+```
+
+### Why This Option Works
+
+- Very natural for graph-shaped data.
+- Makes branching and convergence explicit.
+- Easier to generate programmatically from external tools.
+- `.connect()` can deduplicate edges and keep step definitions focused.
+
+### Tradeoffs
+
+- More lines for hand-written flows.
+- The narrative order is less obvious because nodes and edges are split.
+- Step ids become more important because all connections reference them.
+
+## Option 3: Narrative Chain Builder
+
+This option optimizes for the most readable authoring experience. Each step call returns a chain context, and `.to()` connects the previous step to the next step.
+
+```ts
+import utils, { FlowBuilder } from '@eventcatalog/sdk';
+
+enum ApplicationEventType {
+  HourlyCurtailmentCalculated = 'HourlyCurtailmentCalculated',
+  DailyCurtailmentCalculated = 'DailyCurtailmentCalculated',
+  MonthlyCurtailmentCalculated = 'MonthlyCurtailmentCalculated',
+}
+
+const flow = FlowBuilder.create<ApplicationEventType>({
+  id: 'CurtailmentCalculation',
+  name: 'Curtailment Calculation',
+  version: '1.0.0',
+  summary: 'Flow for calculating hourly curtailment for a customer',
+  markdown: '## Curtailment calculation',
+})
+  .startWith.step('Calculate', {
+    title: 'Calculate Hourly Curtailment',
+    summary: 'Hourly curtailment calculation is triggered by a scheduled event',
+  })
+  .to.message(ApplicationEventType.HourlyCurtailmentCalculated, {
+    title: 'Hourly Curtailment Calculated',
+    label: 'Hourly curtailment calculated',
+  })
+  .branch((flow) =>
+    flow.to
+      .message(ApplicationEventType.DailyCurtailmentCalculated, {
+        title: 'Daily Curtailment Calculated',
+        label: 'Daily curtailment recalculated',
+      })
+      .to.message(ApplicationEventType.MonthlyCurtailmentCalculated, {
+        title: 'Monthly Curtailment Calculated',
+        label: 'Monthly curtailment recalculated',
+      })
+  )
+  .branch((flow) =>
+    flow.to
+      .externalSystem('SAP', {
+        name: 'Curtailment period registered in SAP',
+        summary: 'SAP processed the curtailment period asynchronously.',
+        label: 'Send curtailment period to SAP',
+      })
+      .to.step('Curtailment Rewarding')
+  )
+  .build();
+
+const { writeFlow } = utils('./catalog');
+
+await writeFlow(flow);
+```
+
+### Why This Option Works
+
+- Reads most like a business process.
+- Keeps the "what happens next" relationship close to the step itself.
+- Good for hand-authored flows where the narrative matters.
+
+### Tradeoffs
+
+- More complex to implement and type correctly.
+- Branching and convergence can become awkward for large flows.
+- The API introduces concepts like `startWith`, `to`, and `branch` that do not directly exist in the current SDK.
+
+## Recommendation
+
+Start with Option 1.
+
+That gives users a readable builder for normal hand-authored flows. Option 2 and Option 3 remain useful future ideas, but they add API surface we do not need for the first pass.
+
+## Generated Flow Shape
+
+All three builder options should return the same normal SDK `Flow`.
+
+```ts
+{
+  id: 'CurtailmentCalculation',
+  name: 'Curtailment Calculation',
+  version: '1.0.0',
+  summary: 'Flow for calculating hourly curtailment for a customer',
+  markdown: '## Curtailment calculation\n\nGenerated from the application flow definition.',
+  steps: [
+    {
+      id: 'Calculate',
+      title: 'Calculate Hourly Curtailment',
+      summary: 'Hourly curtailment calculation is triggered by a scheduled event',
+      next_step: {
+        id: 'HourlyCurtailmentCalculated',
+        label: 'Hourly curtailment calculated',
+      },
+    },
+    {
+      id: 'HourlyCurtailmentCalculated',
+      title: 'Hourly Curtailment Calculated',
+      message: {
+        id: 'HourlyCurtailmentCalculated',
+      },
+      next_steps: [
+        {
+          id: 'DailyCurtailmentCalculated',
+          label: 'Daily curtailment recalculated',
+        },
+        {
+          id: 'SAP',
+          label: 'Send curtailment period to SAP',
+        },
+      ],
+    },
+    {
+      id: 'DailyCurtailmentCalculated',
+      title: 'Daily Curtailment Calculated',
+      message: {
+        id: 'DailyCurtailmentCalculated',
+      },
+      next_step: {
+        id: 'MonthlyCurtailmentCalculated',
+        label: 'Monthly curtailment recalculated',
+      },
+    },
+    {
+      id: 'MonthlyCurtailmentCalculated',
+      title: 'Monthly Curtailment Calculated',
+      message: {
+        id: 'MonthlyCurtailmentCalculated',
+      },
+    },
+    {
+      id: 'SAP',
+      title: 'Curtailment period registered in SAP',
+      externalSystem: {
+        name: 'Curtailment period registered in SAP',
+        summary: 'SAP processed the curtailment period asynchronously.',
+      },
+      next_step: {
+        id: 'Curtailment Rewarding',
+      },
+    },
+    {
+      id: 'Curtailment Rewarding',
+      title: 'Curtailment Rewarding',
+    },
+  ],
+}
+```
+
+## Option 1 Builder Surface
+
+If we choose Option 1, the builder should have explicit methods for the flow step types EventCatalog already supports.
+
+```ts
+FlowBuilder.create<TMessageId extends string = string>(flow: FlowBuilderInput)
+
+.addStep(step: StepInput)
+
+.addMessageStep(step: MessageStepInput<TMessageId>)
+
+.addServiceStep(step: ServiceStepInput)
+
+.addActorStep(step: ActorStepInput)
+
+.addExternalSystemStep(step: ExternalSystemStepInput)
+
+.addFlowStep(step: SubFlowStepInput)
+
+.addCustomStep(step: CustomStepInput)
+
+.build(): Flow
+```
+
+## Option 1 Proposed Types
+
+```ts
+type FlowBuilderInput = Omit<Flow, 'steps'> & {
+  steps?: FlowStep[];
+};
+
+type FlowStepPointer = string | number | { id: string | number; label?: string };
+
+type StepInput = {
+  id: string | number;
+  title?: string;
+  summary?: string;
+  nextSteps?: FlowStepPointer[];
+};
+
+type MessageStepInput<TMessageId extends string = string> = StepInput & {
+  message?: { id: TMessageId; version?: string };
+  version?: string;
+};
+
+type ServiceStepInput = StepInput & {
+  service?: { id: string; version?: string };
+  version?: string;
+};
+
+type ActorStepInput = StepInput & {
+  actor?: { name: string; summary?: string };
+  name?: string;
+};
+
+type ExternalSystemStepInput = StepInput & {
+  externalSystem?: { name: string; summary?: string; url?: string };
+  name?: string;
+  url?: string;
+};
+```
+
+## Deferred: Catalog-Aware Type Generation
+
+Option 1 can become much stronger if the SDK or CLI can generate TypeScript types from an existing catalog.
+
+The goal is not runtime lookup like this:
+
+```ts
+const service = await getService('InventoryService');
+```
+
+Instead, the goal is type-level catalog awareness:
+
+```ts
+.addServiceStep({ id: 'InventoryService' })
+.addMessageStep({ id: 'HourlyCurtailmentCalculated' })
+```
+
+Those ids should autocomplete and fail at compile time when they do not exist in the generated catalog types.
+
+## Generated Catalog Types
+
+Add a command that reads the catalog and writes a generated TypeScript file.
+
+```sh
+eventcatalog generate types --output eventcatalog.generated.ts
+```
+
+Example generated file:
+
+```ts
+// eventcatalog.generated.ts
+// Generated by EventCatalog. Do not edit manually.
+
+export type EventId = 'HourlyCurtailmentCalculated' | 'DailyCurtailmentCalculated' | 'MonthlyCurtailmentCalculated';
+
+export type CommandId = 'CalculateCurtailment' | 'RegisterCurtailmentPeriod';
+
+export type QueryId = 'GetCurtailmentPeriod';
+
+export type MessageId = EventId | CommandId | QueryId;
+
+export type ServiceId = 'CurtailmentService' | 'SAP';
+
+export type FlowId = 'CurtailmentCalculation' | 'CurtailmentRewarding';
+
+export type CatalogTypes = {
+  events: EventId;
+  commands: CommandId;
+  queries: QueryId;
+  messages: MessageId;
+  services: ServiceId;
+  flows: FlowId;
+};
+```
+
+Then users can bind the builder to their catalog types:
+
+```ts
+import { FlowBuilder } from '@eventcatalog/sdk';
+import type { CatalogTypes } from './eventcatalog.generated';
+
+const flow = FlowBuilder.forCatalog<CatalogTypes>({
+  id: 'CurtailmentCalculation',
+  name: 'Curtailment Calculation',
+  version: '1.0.0',
+  markdown: '',
+})
+  .addStep({
+    id: 'Calculate',
+    nextSteps: [{ id: 'HourlyCurtailmentCalculated' }],
+  })
+  .addMessageStep({
+    id: 'HourlyCurtailmentCalculated',
+    nextSteps: [{ id: 'DailyCurtailmentCalculated' }, { id: 'SAP', label: 'Send curtailment period to SAP' }],
+  })
+  .addServiceStep({ id: 'SAP' })
+  .build();
+```
+
+This should fail at compile time:
+
+```ts
+FlowBuilder.forCatalog<CatalogTypes>({
+  id: 'CurtailmentCalculation',
+  name: 'Curtailment Calculation',
+  version: '1.0.0',
+  markdown: '',
+})
+  // Typo: not present in CatalogTypes['messages']
+  .addMessageStep({ id: 'HourlyCurtailmentCalcualted' })
+  .build();
+```
+
+## Generated Catalog Refs
+
+For a nicer authoring experience, the generator could also emit a `catalog` object.
+
+```ts
+// eventcatalog.generated.ts
+export const catalog = {
+  events: {
+    HourlyCurtailmentCalculated: 'HourlyCurtailmentCalculated',
+    DailyCurtailmentCalculated: 'DailyCurtailmentCalculated',
+    MonthlyCurtailmentCalculated: 'MonthlyCurtailmentCalculated',
+  },
+  services: {
+    CurtailmentService: 'CurtailmentService',
+    SAP: 'SAP',
+  },
+  flows: {
+    CurtailmentCalculation: 'CurtailmentCalculation',
+    CurtailmentRewarding: 'CurtailmentRewarding',
+  },
+} as const;
+```
+
+Usage:
+
+```ts
+import { FlowBuilder } from '@eventcatalog/sdk';
+import { catalog } from './eventcatalog.generated';
+import type { CatalogTypes } from './eventcatalog.generated';
+
+const flow = FlowBuilder.forCatalog<CatalogTypes>({
+  id: catalog.flows.CurtailmentCalculation,
+  name: 'Curtailment Calculation',
+  version: '1.0.0',
+  markdown: '',
+})
+  .addMessageStep({
+    id: catalog.events.HourlyCurtailmentCalculated,
+    nextSteps: [
+      { id: catalog.events.DailyCurtailmentCalculated },
+      { id: catalog.services.SAP, label: 'Send curtailment period to SAP' },
+    ],
+  })
+  .addServiceStep({ id: catalog.services.SAP })
+  .build();
+```
+
+This gives users autocomplete from real catalog ids without asking the builder to read the catalog at runtime.
+
+## Typed Ref Objects
+
+If we want stricter separation between events, services, flows, and custom steps, the generator could emit typed ref objects instead of plain strings.
+
+```ts
+export const catalog = {
+  events: {
+    HourlyCurtailmentCalculated: {
+      type: 'message',
+      id: 'HourlyCurtailmentCalculated',
+    },
+  },
+  services: {
+    SAP: {
+      type: 'service',
+      id: 'SAP',
+    },
+  },
+} as const;
+```
+
+Usage:
+
+```ts
+const flow = FlowBuilder.forCatalog<CatalogTypes>({
+  id: 'CurtailmentCalculation',
+  name: 'Curtailment Calculation',
+  version: '1.0.0',
+  markdown: '',
+})
+  .addMessageStep({
+    id: catalog.events.HourlyCurtailmentCalculated.id,
+    message: catalog.events.HourlyCurtailmentCalculated,
+    nextSteps: [
+      catalog.events.DailyCurtailmentCalculated,
+      {
+        ...catalog.services.SAP,
+        label: 'Send curtailment period to SAP',
+      },
+    ],
+  })
+  .build();
+```
+
+The builder would serialize these refs back into the existing `FlowStep` shape. No runtime catalog lookup is required.
+
+## Type Generation Design Notes
+
+- Type generation should be optional. Users can still use plain strings.
+- Generated types should be committed by users if they want stable CI type checking.
+- The generated file should include literal unions and optionally a `catalog` value for autocomplete.
+- The first version can use plain string refs. Typed ref objects can come later if we need stronger separation.
+- The builder should never need to read catalog files at runtime just to validate ids.
+- Runtime validation could still be offered separately for users who want it.
+
+## Design Notes
+
+- The builder should output the existing `Flow` type. No new persisted format is needed.
+- `nextSteps` should be the friendly API, normalized internally to `next_step` or `next_steps`.
+- Explicit methods like `.addMessageStep()`, `.addServiceStep()`, and `.addExternalSystemStep()` make the API readable and avoid overloading one generic `.addStep()` method.
+- A generic message id type lets users pass enums and get autocomplete.
+- Generated catalog types can replace hand-written enums for users who want catalog-backed ids.
+- Message steps should accept `{ version }`, but default to EventCatalog's usual latest-version behavior when omitted.
+- `.connect()` is deferred.
+- The builder should validate duplicate step ids and missing `nextSteps` references before returning the flow.
+- Flow writing should use the same `writeResource` internals as other SDK resources.
+
+## Open Questions
+
+- Should `.addMessageStep()` infer `type: 'message'`, or should the current catalog renderer continue to infer from the `message` property alone?
+- Should enum-backed message ids be typed as events only, or should the builder support separate event, command, and query enums?
+- Should `writeFlowToDomain` and `writeFlowToService` also update the parent domain/service `flows` pointer list, or only write into the nested directory?
+- Should the SDK include `flowToDSL()` later, matching the existing `toDSL()` work for other resources?
+- Should the generated `catalog` object use plain string values first, or typed ref objects from day one?

--- a/packages/sdk/src/docs.ts
+++ b/packages/sdk/src/docs.ts
@@ -38,6 +38,7 @@ export * from './eventcatalog';
 export * from './messages';
 export * from './entities';
 export * from './flows';
+export * from './flow-builder';
 export * from './data-stores';
 export * from './data-products';
 export * from './diagrams';

--- a/packages/sdk/src/flow-builder.ts
+++ b/packages/sdk/src/flow-builder.ts
@@ -1,0 +1,548 @@
+import type { Flow, FlowStep } from './types';
+
+type FlowStepId = string | number;
+type FlowStepPointer = FlowStepId | { id: FlowStepId; label?: string };
+
+/**
+ * Input used to create a flow builder.
+ *
+ * This is the normal `Flow` resource shape without requiring `steps` up front.
+ * You can pass existing steps if you want to append to a partially built flow.
+ */
+export type FlowBuilderInput = Omit<Flow, 'steps'> & {
+  steps?: FlowStep[];
+};
+
+/**
+ * Payload for a generic flow step.
+ *
+ * Use generic steps for process milestones that are not messages, services,
+ * actors, external systems, sub-flows, or custom nodes.
+ */
+export type FlowStepInput = {
+  id: FlowStepId;
+  title?: string;
+  summary?: string;
+  nextSteps?: FlowStepPointer[];
+};
+
+/**
+ * Payload for a flow step that references an event, command, or query.
+ */
+export type FlowMessageStepInput<TMessageId extends string = string> = FlowStepInput & {
+  message?: {
+    id: TMessageId;
+    version?: string;
+  };
+  version?: string;
+};
+
+/**
+ * Payload for a flow step that references a service.
+ */
+export type FlowServiceStepInput = FlowStepInput & {
+  service?: {
+    id: string;
+    version?: string;
+  };
+  version?: string;
+};
+
+/**
+ * Payload for a flow step that represents a user or actor.
+ */
+export type FlowActorStepInput = FlowStepInput & {
+  actor?: {
+    name: string;
+    summary?: string;
+  };
+  name?: string;
+};
+
+/**
+ * Payload for a flow step that represents an external system.
+ */
+export type FlowExternalSystemStepInput = FlowStepInput & {
+  externalSystem?: {
+    name: string;
+    summary?: string;
+    url?: string;
+  };
+  name?: string;
+  url?: string;
+};
+
+/**
+ * Payload for a flow step that references another flow.
+ */
+export type FlowSubFlowStepInput = FlowStepInput & {
+  flow?: {
+    id: string;
+    version?: string;
+  };
+  version?: string;
+};
+
+/**
+ * Payload for a custom flow step.
+ */
+export type FlowCustomStepInput = FlowStepInput & {
+  custom?: {
+    title: string;
+    icon?: string;
+    type?: string;
+    summary?: string;
+    url?: string;
+    color?: string;
+    properties?: Record<string, string | number>;
+    height?: number;
+    menu?: { label: string; url?: string }[];
+  };
+  icon?: string;
+  type?: string;
+  url?: string;
+  color?: string;
+  properties?: Record<string, string | number>;
+  height?: number;
+  menu?: { label: string; url?: string }[];
+};
+
+const cloneStep = (step: FlowStep): FlowStep => ({
+  ...step,
+  ...(step.message ? { message: { ...step.message } } : {}),
+  ...(step.service ? { service: { ...step.service } } : {}),
+  ...(step.flow ? { flow: { ...step.flow } } : {}),
+  ...(step.actor ? { actor: { ...step.actor } } : {}),
+  ...(step.custom
+    ? {
+        custom: {
+          ...step.custom,
+          ...(step.custom.properties ? { properties: { ...step.custom.properties } } : {}),
+          ...(step.custom.menu ? { menu: step.custom.menu.map((item) => ({ ...item })) } : {}),
+        },
+      }
+    : {}),
+  ...(step.externalSystem ? { externalSystem: { ...step.externalSystem } } : {}),
+  ...(step.next_step !== undefined
+    ? { next_step: typeof step.next_step === 'object' ? { ...step.next_step } : step.next_step }
+    : {}),
+  ...(step.next_steps ? { next_steps: step.next_steps.map((next) => (typeof next === 'object' ? { ...next } : next)) } : {}),
+});
+
+/**
+ * Build EventCatalog flow resources using a fluent API.
+ *
+ * `FlowBuilder` is useful when you want to define flows in code and then write
+ * the generated `Flow` resource with `writeFlow`. The builder outputs the normal
+ * EventCatalog `Flow` shape, so the persisted catalog remains standard
+ * markdown/frontmatter.
+ *
+ * `nextSteps` is the authoring API. When `build()` is called, a single next step
+ * is normalized to `next_step` and multiple next steps are normalized to
+ * `next_steps`.
+ *
+ * @example
+ * ```ts
+ * import utils, { FlowBuilder } from '@eventcatalog/sdk';
+ *
+ * const { writeFlow } = utils('/path/to/eventcatalog');
+ *
+ * const flow = FlowBuilder.create({
+ *   id: 'PaymentFlow',
+ *   name: 'Payment Flow',
+ *   version: '1.0.0',
+ *   markdown: '# Payment Flow',
+ * })
+ *   .addStep({
+ *     id: 'Customer places order',
+ *     nextSteps: [{ id: 'PlaceOrder', label: 'places order' }],
+ *   })
+ *   .addMessageStep({
+ *     id: 'PlaceOrder',
+ *     message: { id: 'PlaceOrder' },
+ *     nextSteps: [{ id: 'PaymentService', label: 'process payment' }],
+ *   })
+ *   .addServiceStep({
+ *     id: 'PaymentService',
+ *     service: { id: 'PaymentService' },
+ *   })
+ *   .build();
+ *
+ * await writeFlow(flow);
+ * ```
+ *
+ * @example
+ * ```ts
+ * import { FlowBuilder } from '@eventcatalog/sdk';
+ *
+ * type PaymentMessageId = 'PlaceOrder' | 'PaymentProcessed';
+ *
+ * const flow = FlowBuilder.create<PaymentMessageId>({
+ *   id: 'TypedPaymentFlow',
+ *   name: 'Typed Payment Flow',
+ *   version: '1.0.0',
+ *   markdown: '# Typed Payment Flow',
+ * })
+ *   .addMessageStep({
+ *     id: 'PlaceOrder',
+ *     nextSteps: [{ id: 'PaymentProcessed' }],
+ *   })
+ *   .addMessageStep({
+ *     id: 'PaymentProcessed',
+ *   })
+ *   .build();
+ * ```
+ */
+export class FlowBuilder<TMessageId extends string = string> {
+  private readonly flowResource: FlowBuilderInput;
+  private readonly steps = new Map<FlowStepId, FlowStep>();
+  private readonly order: FlowStepId[] = [];
+
+  private constructor(flow: FlowBuilderInput) {
+    this.flowResource = { ...flow };
+
+    for (const step of flow.steps || []) {
+      this.appendStep(cloneStep(step));
+    }
+  }
+
+  /**
+   * Create a flow builder.
+   *
+   * The created builder can add steps and then produce a normal `Flow` resource
+   * with `build()`.
+   *
+   * @example
+   * ```ts
+   * const flow = FlowBuilder.create({
+   *   id: 'PaymentFlow',
+   *   name: 'Payment Flow',
+   *   version: '1.0.0',
+   *   markdown: '# Payment Flow',
+   * }).build();
+   * ```
+   */
+  static create<TMessageId extends string = string>(flow: FlowBuilderInput) {
+    return new FlowBuilder<TMessageId>(flow);
+  }
+
+  /**
+   * Add a generic flow step.
+   *
+   * Generic steps are useful for business process stages that do not map to
+   * another catalog resource.
+   *
+   * @param step - The step payload.
+   *
+   * @example
+   * ```ts
+   * FlowBuilder.create({
+   *   id: 'OrderFlow',
+   *   name: 'Order Flow',
+   *   version: '1.0.0',
+   *   markdown: '',
+   * })
+   *   .addStep({
+   *     id: 'Calculate',
+   *     title: 'Calculate totals',
+   *     nextSteps: [{ id: 'OrderConfirmed' }],
+   *   });
+   * ```
+   */
+  addStep(step: FlowStepInput) {
+    return this.addStepWithNext(
+      {
+        id: step.id,
+        title: step.title || String(step.id),
+        ...(step.summary ? { summary: step.summary } : {}),
+      },
+      step.nextSteps
+    );
+  }
+
+  /**
+   * Add a message step.
+   *
+   * Message steps can reference an event, command, or query id.
+   *
+   * @param step - The message step payload.
+   *
+   * @example
+   * ```ts
+   * FlowBuilder.create({
+   *   id: 'OrderFlow',
+   *   name: 'Order Flow',
+   *   version: '1.0.0',
+   *   markdown: '',
+   * })
+   *   .addMessageStep({
+   *     id: 'OrderConfirmed',
+   *     title: 'Order confirmed',
+   *     message: { id: 'OrderConfirmed', version: '1.0.0' },
+   *   });
+   * ```
+   */
+  addMessageStep(step: FlowMessageStepInput<TMessageId>) {
+    const message = step.message || {
+      id: String(step.id) as TMessageId,
+      ...(step.version ? { version: step.version } : {}),
+    };
+
+    return this.addStepWithNext(
+      {
+        id: step.id,
+        title: step.title || String(step.id),
+        ...(step.summary ? { summary: step.summary } : {}),
+        message: { ...message, ...(step.version && !message.version ? { version: step.version } : {}) },
+      },
+      step.nextSteps
+    );
+  }
+
+  /**
+   * Add a service step.
+   *
+   * @param step - The service step payload.
+   *
+   * @example
+   * ```ts
+   * FlowBuilder.create({
+   *   id: 'OrderFlow',
+   *   name: 'Order Flow',
+   *   version: '1.0.0',
+   *   markdown: '',
+   * })
+   *   .addServiceStep({
+   *     id: 'OrderService',
+   *     service: { id: 'OrderService', version: '1.0.0' },
+   *   });
+   * ```
+   */
+  addServiceStep(step: FlowServiceStepInput) {
+    const service = step.service || {
+      id: String(step.id),
+      ...(step.version ? { version: step.version } : {}),
+    };
+
+    return this.addStepWithNext(
+      {
+        id: step.id,
+        title: step.title || String(step.id),
+        ...(step.summary ? { summary: step.summary } : {}),
+        service: { ...service, ...(step.version && !service.version ? { version: step.version } : {}) },
+      },
+      step.nextSteps
+    );
+  }
+
+  /**
+   * Add an actor step.
+   *
+   * @param step - The actor step payload.
+   *
+   * @example
+   * ```ts
+   * FlowBuilder.create({
+   *   id: 'OrderFlow',
+   *   name: 'Order Flow',
+   *   version: '1.0.0',
+   *   markdown: '',
+   * })
+   *   .addActorStep({
+   *     id: 'Customer',
+   *     actor: { name: 'Customer' },
+   *   });
+   * ```
+   */
+  addActorStep(step: FlowActorStepInput) {
+    const actor = step.actor || {
+      name: step.name || step.title || String(step.id),
+      ...(step.summary ? { summary: step.summary } : {}),
+    };
+
+    return this.addStepWithNext(
+      {
+        id: step.id,
+        title: step.title || actor.name,
+        ...(step.summary ? { summary: step.summary } : {}),
+        actor,
+      },
+      step.nextSteps
+    );
+  }
+
+  /**
+   * Add an external system step.
+   *
+   * @param step - The external system step payload.
+   *
+   * @example
+   * ```ts
+   * FlowBuilder.create({
+   *   id: 'PaymentFlow',
+   *   name: 'Payment Flow',
+   *   version: '1.0.0',
+   *   markdown: '',
+   * })
+   *   .addExternalSystemStep({
+   *     id: 'Stripe',
+   *     externalSystem: {
+   *       name: 'Stripe',
+   *       summary: 'Payment provider',
+   *       url: 'https://stripe.com',
+   *     },
+   *   });
+   * ```
+   */
+  addExternalSystemStep(step: FlowExternalSystemStepInput) {
+    const externalSystem = step.externalSystem || {
+      name: step.name || step.title || String(step.id),
+      ...(step.summary ? { summary: step.summary } : {}),
+      ...(step.url ? { url: step.url } : {}),
+    };
+
+    return this.addStepWithNext(
+      {
+        id: step.id,
+        title: step.title || externalSystem.name,
+        ...(step.summary ? { summary: step.summary } : {}),
+        externalSystem,
+      },
+      step.nextSteps
+    );
+  }
+
+  /**
+   * Add a sub-flow step.
+   *
+   * @param step - The sub-flow step payload.
+   *
+   * @example
+   * ```ts
+   * FlowBuilder.create({
+   *   id: 'OrderFlow',
+   *   name: 'Order Flow',
+   *   version: '1.0.0',
+   *   markdown: '',
+   * })
+   *   .addFlowStep({
+   *     id: 'PaymentFlow',
+   *     flow: { id: 'PaymentFlow', version: '1.0.0' },
+   *   });
+   * ```
+   */
+  addFlowStep(step: FlowSubFlowStepInput) {
+    const flow = step.flow || {
+      id: String(step.id),
+      ...(step.version ? { version: step.version } : {}),
+    };
+
+    return this.addStepWithNext(
+      {
+        id: step.id,
+        title: step.title || String(step.id),
+        ...(step.summary ? { summary: step.summary } : {}),
+        flow: { ...flow, ...(step.version && !flow.version ? { version: step.version } : {}) },
+      },
+      step.nextSteps
+    );
+  }
+
+  /**
+   * Add a custom flow step.
+   *
+   * @param step - The custom step payload.
+   *
+   * @example
+   * ```ts
+   * FlowBuilder.create({
+   *   id: 'PaymentFlow',
+   *   name: 'Payment Flow',
+   *   version: '1.0.0',
+   *   markdown: '',
+   * })
+   *   .addCustomStep({
+   *     id: 'ManualReview',
+   *     custom: {
+   *       title: 'Manual review',
+   *       type: 'manual',
+   *     },
+   *   });
+   * ```
+   */
+  addCustomStep(step: FlowCustomStepInput) {
+    const custom = step.custom || {
+      title: step.title || String(step.id),
+      ...(step.icon ? { icon: step.icon } : {}),
+      ...(step.type ? { type: step.type } : {}),
+      ...(step.summary ? { summary: step.summary } : {}),
+      ...(step.url ? { url: step.url } : {}),
+      ...(step.color ? { color: step.color } : {}),
+      ...(step.properties ? { properties: step.properties } : {}),
+      ...(step.height ? { height: step.height } : {}),
+      ...(step.menu ? { menu: step.menu } : {}),
+    };
+
+    return this.addStepWithNext(
+      {
+        id: step.id,
+        title: step.title || custom.title,
+        ...(step.summary ? { summary: step.summary } : {}),
+        custom,
+      },
+      step.nextSteps
+    );
+  }
+
+  /**
+   * Build the EventCatalog flow resource.
+   *
+   * @returns A `Flow` resource that can be written with `writeFlow`.
+   */
+  build(): Flow {
+    this.validateNextSteps();
+
+    const { steps: _steps, ...flow } = this.flowResource;
+
+    return {
+      ...flow,
+      steps: this.order.map((id) => cloneStep(this.steps.get(id)!)),
+    };
+  }
+
+  private addStepWithNext(step: FlowStep, nextSteps?: FlowStepPointer[]) {
+    const normalizedNextSteps = nextSteps?.map((next) => (typeof next === 'object' ? { ...next } : { id: next })) || [];
+
+    if (normalizedNextSteps.length === 1) {
+      step.next_step = normalizedNextSteps[0];
+    } else if (normalizedNextSteps.length > 1) {
+      step.next_steps = normalizedNextSteps;
+    }
+
+    this.appendStep(step);
+    return this;
+  }
+
+  private appendStep(step: FlowStep) {
+    if (this.steps.has(step.id)) {
+      throw new Error(`Flow step with id "${step.id}" already exists`);
+    }
+
+    this.steps.set(step.id, step);
+    this.order.push(step.id);
+  }
+
+  private validateNextSteps() {
+    for (const step of this.steps.values()) {
+      const nextSteps = step.next_step !== undefined ? [step.next_step] : step.next_steps || [];
+
+      for (const next of nextSteps) {
+        const nextStepId = typeof next === 'object' && next ? next.id : next;
+
+        if (!this.steps.has(nextStepId)) {
+          throw new Error(`Flow step "${step.id}" references missing next step "${nextStepId}"`);
+        }
+      }
+    }
+  }
+}

--- a/packages/sdk/src/flows.ts
+++ b/packages/sdk/src/flows.ts
@@ -1,5 +1,19 @@
 import type { Flow } from './types';
-import { getResource, getResources } from './internal/resources';
+import fs from 'node:fs/promises';
+import { join } from 'node:path';
+import { findFileById, invalidateFileCache } from './internal/utils';
+import {
+  addFileToResource,
+  getResource,
+  getResources,
+  getVersionedDirectory,
+  rmResourceById,
+  versionResource,
+  writeResource,
+} from './internal/resources';
+
+export { FlowBuilder } from './flow-builder';
+export type * from './flow-builder';
 
 /**
  * Returns a flow from EventCatalog.
@@ -48,3 +62,270 @@ export const getFlows =
   (directory: string) =>
   async (options?: { latestOnly?: boolean }): Promise<Flow[]> =>
     getResources(directory, { type: 'flows', latestOnly: options?.latestOnly }) as Promise<Flow[]>;
+
+/**
+ * Write a flow to EventCatalog.
+ *
+ * You can optionally override the path of the flow.
+ *
+ * @example
+ * ```ts
+ * import utils, { FlowBuilder } from '@eventcatalog/utils';
+ *
+ * const { writeFlow } = utils('/path/to/eventcatalog');
+ *
+ * // Build a flow using the fluent builder API
+ * const flow = FlowBuilder.create({
+ *   id: 'PaymentFlow',
+ *   name: 'Payment Flow',
+ *   version: '0.0.1',
+ *   summary: 'Business flow for processing payments',
+ *   markdown: '# Payment Flow',
+ * })
+ *   .addMessageStep({
+ *     id: 'PlaceOrder',
+ *     title: 'Place order',
+ *     message: { id: 'PlaceOrder', version: '0.0.1' },
+ *     nextSteps: [{ id: 'PaymentProcessed', label: 'Payment processed' }],
+ *   })
+ *   .addMessageStep({
+ *     id: 'PaymentProcessed',
+ *     title: 'Payment processed',
+ *     message: { id: 'PaymentProcessed', version: '0.0.1' },
+ *   })
+ *   .build();
+ *
+ * // Flow would be written to flows/PaymentFlow
+ * await writeFlow(flow);
+ *
+ * // You can also write a raw Flow object
+ * await writeFlow({
+ *   id: 'RewardFlow',
+ *   name: 'Reward Flow',
+ *   version: '0.0.1',
+ *   markdown: '# Reward Flow',
+ *   steps: [],
+ * });
+ *
+ * // Write a flow to the catalog but override the path
+ * // Flow would be written to flows/Payments/RewardFlow
+ * await writeFlow({
+ *   id: 'RewardFlow',
+ *   name: 'Reward Flow',
+ *   version: '0.0.1',
+ *   markdown: '# Reward Flow',
+ *   steps: [],
+ * }, { path: '/Payments/RewardFlow' });
+ *
+ * // Write a flow to the catalog and override the existing content
+ * await writeFlow({
+ *   id: 'RewardFlow',
+ *   name: 'Reward Flow',
+ *   version: '0.0.1',
+ *   markdown: '# Reward Flow',
+ *   steps: [],
+ * }, { override: true });
+ * ```
+ */
+export const writeFlow =
+  (directory: string) =>
+  async (
+    flow: Flow,
+    options: { path?: string; override?: boolean; versionExistingContent?: boolean; format?: 'md' | 'mdx' } = {
+      path: '',
+      override: false,
+      format: 'mdx',
+    }
+  ) =>
+    writeResource(directory, { ...flow }, { ...options, type: 'flow' });
+
+/**
+ * Write a versioned flow to EventCatalog.
+ *
+ * @example
+ * ```ts
+ * import utils from '@eventcatalog/utils';
+ *
+ * const { writeVersionedFlow } = utils('/path/to/eventcatalog');
+ *
+ * // Flow would be written to flows/PaymentFlow/versioned/0.0.1
+ * await writeVersionedFlow({
+ *   id: 'PaymentFlow',
+ *   name: 'Payment Flow',
+ *   version: '0.0.1',
+ *   markdown: '# Payment Flow',
+ *   steps: [],
+ * });
+ * ```
+ */
+export const writeVersionedFlow = (directory: string) => async (flow: Flow) => {
+  const path = getVersionedDirectory(flow.id, flow.version);
+
+  return await writeFlow(directory)({ ...flow }, { path });
+};
+
+/**
+ * Write a flow to a domain in EventCatalog.
+ *
+ * @example
+ * ```ts
+ * import utils from '@eventcatalog/utils';
+ *
+ * const { writeFlowToDomain } = utils('/path/to/eventcatalog');
+ *
+ * // Flow would be written to domains/Orders/flows/PaymentFlow
+ * await writeFlowToDomain({
+ *   id: 'PaymentFlow',
+ *   name: 'Payment Flow',
+ *   version: '0.0.1',
+ *   markdown: '# Payment Flow',
+ *   steps: [],
+ * }, { id: 'Orders' });
+ * ```
+ */
+export const writeFlowToDomain =
+  (directory: string) =>
+  async (
+    flow: Flow,
+    domain: { id: string; version?: string },
+    options: { path?: string; format?: 'md' | 'mdx'; override?: boolean } = { path: '', format: 'mdx', override: false }
+  ) => {
+    let pathForFlow =
+      domain.version && domain.version !== 'latest' ? `/${domain.id}/versioned/${domain.version}/flows` : `/${domain.id}/flows`;
+    pathForFlow = join(pathForFlow, flow.id);
+
+    await writeResource(directory, { ...flow }, { ...options, path: pathForFlow, type: 'flow' });
+  };
+
+/**
+ * Write a flow to a service in EventCatalog.
+ *
+ * @example
+ * ```ts
+ * import utils from '@eventcatalog/utils';
+ *
+ * const { writeFlowToService } = utils('/path/to/eventcatalog');
+ *
+ * // Flow would be written to services/PaymentService/flows/PaymentFlow
+ * await writeFlowToService({
+ *   id: 'PaymentFlow',
+ *   name: 'Payment Flow',
+ *   version: '0.0.1',
+ *   markdown: '# Payment Flow',
+ *   steps: [],
+ * }, { id: 'PaymentService' });
+ * ```
+ */
+export const writeFlowToService =
+  (directory: string) =>
+  async (
+    flow: Flow,
+    service: { id: string; version?: string },
+    options: { path?: string; format?: 'md' | 'mdx'; override?: boolean } = { path: '', format: 'mdx', override: false }
+  ) => {
+    let pathForFlow =
+      service.version && service.version !== 'latest'
+        ? `/${service.id}/versioned/${service.version}/flows`
+        : `/${service.id}/flows`;
+    pathForFlow = join(pathForFlow, flow.id);
+
+    await writeResource(directory, { ...flow }, { ...options, path: pathForFlow, type: 'flow' });
+  };
+
+/**
+ * Delete a flow at its given path.
+ *
+ * @example
+ * ```ts
+ * import utils from '@eventcatalog/utils';
+ *
+ * const { rmFlow } = utils('/path/to/eventcatalog');
+ *
+ * // Removes the flow at flows/PaymentFlow
+ * await rmFlow('/PaymentFlow');
+ * ```
+ */
+export const rmFlow = (directory: string) => async (path: string) => {
+  await fs.rm(join(directory, path), { recursive: true });
+  invalidateFileCache();
+};
+
+/**
+ * Delete a flow by its id.
+ *
+ * Optionally specify a version to delete a specific version of the flow.
+ *
+ * @example
+ * ```ts
+ * import utils from '@eventcatalog/utils';
+ *
+ * const { rmFlowById } = utils('/path/to/eventcatalog');
+ *
+ * // deletes the latest PaymentFlow flow
+ * await rmFlowById('PaymentFlow');
+ *
+ * // deletes a specific version of the PaymentFlow flow
+ * await rmFlowById('PaymentFlow', '0.0.1');
+ * ```
+ */
+export const rmFlowById = (directory: string) => async (id: string, version?: string, persistFiles?: boolean) => {
+  await rmResourceById(directory, id, version, { type: 'flow', persistFiles });
+};
+
+/**
+ * Version a flow by its id.
+ *
+ * Takes the latest flow and moves it to a versioned directory.
+ * All files with this flow are also versioned.
+ *
+ * @example
+ * ```ts
+ * import utils from '@eventcatalog/utils';
+ *
+ * const { versionFlow } = utils('/path/to/eventcatalog');
+ *
+ * // moves the latest PaymentFlow flow to a versioned directory
+ * await versionFlow('PaymentFlow');
+ * ```
+ */
+export const versionFlow = (directory: string) => async (id: string) => versionResource(directory, id);
+
+/**
+ * Check to see if the catalog has a version for the given flow.
+ *
+ * @example
+ * ```ts
+ * import utils from '@eventcatalog/utils';
+ *
+ * const { flowHasVersion } = utils('/path/to/eventcatalog');
+ *
+ * await flowHasVersion('PaymentFlow', '0.0.1');
+ * await flowHasVersion('PaymentFlow', 'latest');
+ * await flowHasVersion('PaymentFlow', '0.0.x');
+ * ```
+ */
+export const flowHasVersion = (directory: string) => async (id: string, version?: string) => {
+  const file = await findFileById(directory, id, version);
+  return !!file;
+};
+
+/**
+ * Adds a file to the given flow.
+ *
+ * @example
+ * ```ts
+ * import utils from '@eventcatalog/utils';
+ *
+ * const { addFileToFlow } = utils('/path/to/eventcatalog');
+ *
+ * // adds a file to the latest PaymentFlow flow
+ * await addFileToFlow('PaymentFlow', { content: 'Hello world', fileName: 'notes.md' });
+ *
+ * // adds a file to a specific version of the PaymentFlow flow
+ * await addFileToFlow('PaymentFlow', { content: 'Hello world', fileName: 'notes.md' }, '0.0.1');
+ * ```
+ */
+export const addFileToFlow =
+  (directory: string) =>
+  async (id: string, file: { content: string; fileName: string }, version?: string): Promise<void> =>
+    addFileToResource(directory, id, file, version, { type: 'flow' });

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -112,7 +112,20 @@ import { dumpCatalog, getEventCatalogConfigurationFile } from './eventcatalog';
 import { createSnapshot, diffSnapshots, listSnapshots } from './snapshots';
 import { writeChangelog, appendChangelog, getChangelog, rmChangelog } from './changelogs';
 import { getEntity, getEntities, writeEntity, rmEntity, rmEntityById, versionEntity, entityHasVersion } from './entities';
-import { getFlow, getFlows } from './flows';
+import {
+  addFileToFlow,
+  flowHasVersion,
+  getFlow,
+  getFlows,
+  rmFlow,
+  rmFlowById,
+  versionFlow,
+  writeFlow,
+  writeFlowToDomain,
+  writeFlowToService,
+  writeVersionedFlow,
+} from './flows';
+export { FlowBuilder } from './flow-builder';
 
 import {
   getDataStore,
@@ -152,6 +165,7 @@ import {
 // Export the types
 export type * from './types';
 export type * from './snapshot-types';
+export type * from './flow-builder';
 
 /**
  * Init the SDK for EventCatalog
@@ -1193,6 +1207,73 @@ export default (path: string) => {
      * @returns Flow[]|Undefined
      */
     getFlows: getFlows(join(path)),
+    /**
+     * Adds a flow to EventCatalog
+     *
+     * @param flow - The flow to write
+     * @param options - Optional options to write the flow
+     *
+     */
+    writeFlow: writeFlow(join(path, 'flows')),
+    /**
+     * Adds a versioned flow to EventCatalog
+     *
+     * @param flow - The flow to write
+     *
+     */
+    writeVersionedFlow: writeVersionedFlow(join(path, 'flows')),
+    /**
+     * Adds a flow to a domain in EventCatalog
+     *
+     * @param flow - The flow to write to the domain
+     * @param domain - The domain and its id to write the flow to
+     * @param options - Optional options to write the flow
+     *
+     */
+    writeFlowToDomain: writeFlowToDomain(join(path, 'domains')),
+    /**
+     * Adds a flow to a service in EventCatalog
+     *
+     * @param flow - The flow to write to the service
+     * @param service - The service and its id to write the flow to
+     * @param options - Optional options to write the flow
+     *
+     */
+    writeFlowToService: writeFlowToService(join(path, 'services')),
+    /**
+     * Remove a flow from EventCatalog (modeled on the standard POSIX rm utility)
+     *
+     * @param path - The path to your flow, e.g. `/PaymentFlow`
+     *
+     */
+    rmFlow: rmFlow(join(path, 'flows')),
+    /**
+     * Remove a flow by a flow id
+     *
+     * @param id - The id of the flow you want to remove
+     *
+     */
+    rmFlowById: rmFlowById(join(path)),
+    /**
+     * Moves a given flow id to the version directory
+     * @param id - The id of the flow to version
+     */
+    versionFlow: versionFlow(join(path)),
+    /**
+     * Check to see if a flow version exists
+     * @param id - The id of the flow
+     * @param version - The version of the flow (supports semver)
+     * @returns
+     */
+    flowHasVersion: flowHasVersion(join(path)),
+    /**
+     * Adds a file to the given flow
+     * @param id - The id of the flow to add the file to
+     * @param file - File contents to add including the content and the file name
+     * @param version - Optional version of the flow to add the file to
+     * @returns
+     */
+    addFileToFlow: addFileToFlow(join(path)),
 
     /**
      * ================================

--- a/packages/sdk/src/test/flows.test.ts
+++ b/packages/sdk/src/test/flows.test.ts
@@ -1,0 +1,1027 @@
+import { expect, it, describe, beforeEach, afterEach } from 'vitest';
+import utils, { FlowBuilder } from '../index';
+import path from 'node:path';
+import fs from 'node:fs';
+
+const CATALOG_PATH = path.join(__dirname, 'catalog-flows');
+
+const {
+  writeFlow,
+  writeVersionedFlow,
+  writeFlowToDomain,
+  writeFlowToService,
+  getFlow,
+  getFlows,
+  rmFlow,
+  rmFlowById,
+  versionFlow,
+  flowHasVersion,
+  addFileToFlow,
+  writeDomain,
+  versionDomain,
+  writeService,
+  versionService,
+} = utils(CATALOG_PATH);
+
+beforeEach(() => {
+  fs.rmSync(CATALOG_PATH, { recursive: true, force: true });
+  fs.mkdirSync(CATALOG_PATH, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(CATALOG_PATH, { recursive: true, force: true });
+});
+
+describe('Flows SDK', () => {
+  describe('getFlow', () => {
+    it('returns the given flow id from EventCatalog and the latest version when no version is given', async () => {
+      await writeFlow({
+        id: 'PaymentFlow',
+        name: 'Payment Flow',
+        version: '0.0.1',
+        summary: 'Business flow for processing payments',
+        markdown: '# Payment Flow',
+        steps: [
+          {
+            id: 'PlaceOrder',
+            title: 'Place order',
+            message: { id: 'PlaceOrder', version: '0.0.1' },
+            next_step: { id: 'PaymentProcessed', label: 'Payment processed' },
+          },
+          {
+            id: 'PaymentProcessed',
+            title: 'Payment processed',
+            message: { id: 'PaymentProcessed', version: '0.0.1' },
+          },
+        ],
+      });
+
+      const flow = await getFlow('PaymentFlow');
+
+      expect(flow).toEqual({
+        id: 'PaymentFlow',
+        name: 'Payment Flow',
+        version: '0.0.1',
+        summary: 'Business flow for processing payments',
+        markdown: '# Payment Flow',
+        steps: [
+          {
+            id: 'PlaceOrder',
+            title: 'Place order',
+            message: { id: 'PlaceOrder', version: '0.0.1' },
+            next_step: { id: 'PaymentProcessed', label: 'Payment processed' },
+          },
+          {
+            id: 'PaymentProcessed',
+            title: 'Payment processed',
+            message: { id: 'PaymentProcessed', version: '0.0.1' },
+          },
+        ],
+      });
+    });
+
+    it('returns the given flow id from EventCatalog and the requested version when a version is given', async () => {
+      await writeFlow({
+        id: 'PaymentFlow',
+        name: 'Payment Flow',
+        version: '0.0.1',
+        summary: 'Payment flow',
+        markdown: '# Payment Flow',
+        steps: [],
+      });
+
+      await versionFlow('PaymentFlow');
+
+      await writeFlow({
+        id: 'PaymentFlow',
+        name: 'Payment Flow',
+        version: '0.0.2',
+        summary: 'Payment flow v2',
+        markdown: '# Payment Flow v2',
+        steps: [],
+      });
+
+      const flow = await getFlow('PaymentFlow', '0.0.1');
+
+      expect(flow).toEqual({
+        id: 'PaymentFlow',
+        name: 'Payment Flow',
+        version: '0.0.1',
+        summary: 'Payment flow',
+        markdown: '# Payment Flow',
+        steps: [],
+      });
+    });
+
+    it('returns undefined when a given flow is not found', async () => {
+      const flow = await getFlow('MissingFlow');
+
+      expect(flow).toEqual(undefined);
+    });
+
+    it('returns a flow from within a domain', async () => {
+      await writeDomain({
+        id: 'Orders',
+        name: 'Orders Domain',
+        version: '0.0.1',
+        summary: 'Orders domain',
+        markdown: '# Orders domain',
+      });
+
+      await writeFlowToDomain(
+        {
+          id: 'OrderFlow',
+          name: 'Order Flow',
+          version: '1.0.0',
+          summary: 'Order flow',
+          markdown: '# Order flow',
+          steps: [],
+        },
+        { id: 'Orders' }
+      );
+
+      const flow = await getFlow('OrderFlow');
+
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Orders/flows/OrderFlow', 'index.mdx'))).toBe(true);
+      expect(flow).toEqual({
+        id: 'OrderFlow',
+        name: 'Order Flow',
+        version: '1.0.0',
+        summary: 'Order flow',
+        markdown: '# Order flow',
+        steps: [],
+      });
+    });
+
+    it('returns a flow from within a service', async () => {
+      await writeService({
+        id: 'OrdersService',
+        name: 'Orders Service',
+        version: '0.0.1',
+        summary: 'Orders service',
+        markdown: '# Orders service',
+      });
+
+      await writeFlowToService(
+        {
+          id: 'OrderFlow',
+          name: 'Order Flow',
+          version: '1.0.0',
+          summary: 'Order flow',
+          markdown: '# Order flow',
+          steps: [],
+        },
+        { id: 'OrdersService' }
+      );
+
+      const flow = await getFlow('OrderFlow');
+
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/OrdersService/flows/OrderFlow', 'index.mdx'))).toBe(true);
+      expect(flow).toEqual({
+        id: 'OrderFlow',
+        name: 'Order Flow',
+        version: '1.0.0',
+        summary: 'Order flow',
+        markdown: '# Order flow',
+        steps: [],
+      });
+    });
+  });
+
+  describe('getFlows', () => {
+    it('returns all flows from the catalog', async () => {
+      await writeFlow({
+        id: 'PaymentFlow',
+        name: 'Payment Flow',
+        version: '0.0.1',
+        summary: 'Payment flow',
+        markdown: '# Payment Flow',
+        steps: [],
+      });
+
+      await writeFlow({
+        id: 'OrderFlow',
+        name: 'Order Flow',
+        version: '0.0.1',
+        summary: 'Order flow',
+        markdown: '# Order Flow',
+        steps: [],
+      });
+
+      const flows = await getFlows();
+
+      expect(flows).toHaveLength(2);
+      expect(flows.map((flow) => flow.id).sort()).toEqual(['OrderFlow', 'PaymentFlow']);
+    });
+
+    it('returns only latest versions when latestOnly is true', async () => {
+      await writeFlow({
+        id: 'PaymentFlow',
+        name: 'Payment Flow',
+        version: '0.0.1',
+        summary: 'Payment flow',
+        markdown: '# Payment Flow',
+        steps: [],
+      });
+
+      await versionFlow('PaymentFlow');
+
+      await writeFlow({
+        id: 'PaymentFlow',
+        name: 'Payment Flow',
+        version: '0.0.2',
+        summary: 'Payment flow v2',
+        markdown: '# Payment Flow v2',
+        steps: [],
+      });
+
+      const flows = await getFlows({ latestOnly: true });
+
+      expect(flows).toHaveLength(1);
+      expect(flows[0].version).toBe('0.0.2');
+    });
+  });
+
+  describe('writeFlow', () => {
+    it('writes the given flow to the file system', async () => {
+      await writeFlow({
+        id: 'PaymentFlow',
+        name: 'Payment Flow',
+        version: '0.0.1',
+        summary: 'Payment flow',
+        markdown: '# Payment Flow',
+        owners: ['payments-team'],
+        steps: [
+          {
+            id: 'Customer',
+            title: 'Customer',
+            actor: { name: 'Customer' },
+            next_step: 'PlaceOrder',
+          },
+          {
+            id: 'PlaceOrder',
+            title: 'Place order',
+            message: { id: 'PlaceOrder', version: '0.0.1' },
+          },
+        ],
+      });
+
+      const flow = await getFlow('PaymentFlow');
+
+      expect(flow).toEqual({
+        id: 'PaymentFlow',
+        name: 'Payment Flow',
+        version: '0.0.1',
+        summary: 'Payment flow',
+        markdown: '# Payment Flow',
+        owners: ['payments-team'],
+        steps: [
+          {
+            id: 'Customer',
+            title: 'Customer',
+            actor: { name: 'Customer' },
+            next_step: 'PlaceOrder',
+          },
+          {
+            id: 'PlaceOrder',
+            title: 'Place order',
+            message: { id: 'PlaceOrder', version: '0.0.1' },
+          },
+        ],
+      });
+    });
+
+    it('writes the flow to a custom path when path is provided', async () => {
+      await writeFlow(
+        {
+          id: 'PaymentFlow',
+          name: 'Payment Flow',
+          version: '0.0.1',
+          summary: 'Payment flow',
+          markdown: '# Payment Flow',
+          steps: [],
+        },
+        { path: '/Payments/PaymentFlow' }
+      );
+
+      const flow = await getFlow('PaymentFlow');
+
+      expect(flow).toEqual({
+        id: 'PaymentFlow',
+        name: 'Payment Flow',
+        version: '0.0.1',
+        summary: 'Payment flow',
+        markdown: '# Payment Flow',
+        steps: [],
+      });
+    });
+
+    it('throws an error when trying to write a flow that already exists', async () => {
+      await writeFlow({
+        id: 'PaymentFlow',
+        name: 'Payment Flow',
+        version: '0.0.1',
+        summary: 'Payment flow',
+        markdown: '# Payment Flow',
+        steps: [],
+      });
+
+      await expect(
+        writeFlow({
+          id: 'PaymentFlow',
+          name: 'Payment Flow',
+          version: '0.0.1',
+          summary: 'Payment flow',
+          markdown: '# Payment Flow',
+          steps: [],
+        })
+      ).rejects.toThrowError('Failed to write PaymentFlow (flow) as the version 0.0.1 already exists');
+    });
+
+    it('overrides the flow when trying to write a flow that already exists and override is true', async () => {
+      await writeFlow({
+        id: 'PaymentFlow',
+        name: 'Payment Flow',
+        version: '0.0.1',
+        summary: 'Payment flow',
+        markdown: '# Payment Flow',
+        steps: [],
+      });
+
+      await writeFlow(
+        {
+          id: 'PaymentFlow',
+          name: 'Payment Flow',
+          version: '0.0.1',
+          summary: 'Payment flow',
+          markdown: 'Overridden content',
+          steps: [],
+        },
+        { override: true }
+      );
+
+      const flow = await getFlow('PaymentFlow');
+
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'flows/PaymentFlow', 'index.mdx'))).toBe(true);
+      expect(flow.markdown).toBe('Overridden content');
+    });
+
+    describe('versionExistingContent', () => {
+      it('versions the previous flow when trying to write a flow that already exists and versionExistingContent is true', async () => {
+        await writeFlow({
+          id: 'PaymentFlow',
+          name: 'Payment Flow',
+          version: '0.0.1',
+          summary: 'Payment flow',
+          markdown: '# Payment Flow',
+          steps: [],
+        });
+
+        await writeFlow(
+          {
+            id: 'PaymentFlow',
+            name: 'Payment Flow',
+            version: '1.0.0',
+            summary: 'Payment flow',
+            markdown: 'New',
+            steps: [],
+          },
+          { versionExistingContent: true }
+        );
+
+        const flow = await getFlow('PaymentFlow');
+
+        expect(flow.version).toBe('1.0.0');
+        expect(flow.markdown).toBe('New');
+        expect(fs.existsSync(path.join(CATALOG_PATH, 'flows/PaymentFlow/versioned/0.0.1', 'index.mdx'))).toBe(true);
+        expect(fs.existsSync(path.join(CATALOG_PATH, 'flows/PaymentFlow', 'index.mdx'))).toBe(true);
+      });
+
+      it('throws an error when trying to write a flow and versionExistingContent is true and the new version is not greater than the previous one', async () => {
+        await writeFlow(
+          {
+            id: 'PaymentFlow',
+            name: 'Payment Flow',
+            version: '1.0.0',
+            summary: 'Payment flow',
+            markdown: 'New',
+            steps: [],
+          },
+          { versionExistingContent: true }
+        );
+
+        await expect(
+          writeFlow(
+            {
+              id: 'PaymentFlow',
+              name: 'Payment Flow',
+              version: '0.0.0',
+              summary: 'Payment flow',
+              markdown: 'New',
+              steps: [],
+            },
+            { versionExistingContent: true }
+          )
+        ).rejects.toThrowError('New version 0.0.0 is not greater than current version 1.0.0');
+      });
+    });
+
+    describe('formats', () => {
+      it('writes the flow as md when format is md', async () => {
+        await writeFlow(
+          {
+            id: 'PaymentFlow',
+            name: 'Payment Flow',
+            version: '0.0.1',
+            summary: 'Payment flow',
+            markdown: '# Payment Flow',
+            steps: [],
+          },
+          { format: 'md' }
+        );
+
+        expect(fs.existsSync(path.join(CATALOG_PATH, 'flows/PaymentFlow', 'index.md'))).toBe(true);
+      });
+
+      it('writes the flow as mdx when format is mdx (default)', async () => {
+        await writeFlow({
+          id: 'PaymentFlow',
+          name: 'Payment Flow',
+          version: '0.0.1',
+          summary: 'Payment flow',
+          markdown: '# Payment Flow',
+          steps: [],
+        });
+
+        expect(fs.existsSync(path.join(CATALOG_PATH, 'flows/PaymentFlow', 'index.mdx'))).toBe(true);
+      });
+    });
+  });
+
+  describe('writeVersionedFlow', () => {
+    it('writes a versioned flow', async () => {
+      await writeVersionedFlow({
+        id: 'PaymentFlow',
+        name: 'Payment Flow',
+        version: '0.0.1',
+        summary: 'Payment flow',
+        markdown: '# Payment Flow',
+        steps: [],
+      });
+
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'flows/PaymentFlow/versioned/0.0.1', 'index.mdx'))).toBe(true);
+    });
+  });
+
+  describe('writeFlowToDomain', () => {
+    it('writes a flow to a domain', async () => {
+      await writeDomain({
+        id: 'Orders',
+        name: 'Orders Domain',
+        version: '0.0.1',
+        summary: 'Orders domain',
+        markdown: '# Orders domain',
+      });
+
+      await writeFlowToDomain(
+        {
+          id: 'OrderFlow',
+          name: 'Order Flow',
+          version: '1.0.0',
+          summary: 'Order flow',
+          markdown: '# Order flow',
+          steps: [],
+        },
+        { id: 'Orders' }
+      );
+
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Orders/flows/OrderFlow', 'index.mdx'))).toBe(true);
+    });
+
+    it('writes a flow to a versioned domain', async () => {
+      await writeDomain({
+        id: 'Orders',
+        name: 'Orders Domain',
+        version: '0.0.1',
+        summary: 'Orders domain',
+        markdown: '# Orders domain',
+      });
+
+      await versionDomain('Orders');
+
+      await writeDomain({
+        id: 'Orders',
+        name: 'Orders Domain',
+        version: '1.0.0',
+        summary: 'Orders domain',
+        markdown: '# Orders domain',
+      });
+
+      await writeFlowToDomain(
+        {
+          id: 'OrderFlow',
+          name: 'Order Flow',
+          version: '1.0.0',
+          summary: 'Order flow',
+          markdown: '# Order flow',
+          steps: [],
+        },
+        { id: 'Orders', version: '0.0.1' }
+      );
+
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Orders/versioned/0.0.1/flows/OrderFlow', 'index.mdx'))).toBe(true);
+    });
+  });
+
+  describe('writeFlowToService', () => {
+    it('writes a flow to a service', async () => {
+      await writeService({
+        id: 'OrdersService',
+        name: 'Orders Service',
+        version: '0.0.1',
+        summary: 'Orders service',
+        markdown: '# Orders service',
+      });
+
+      await writeFlowToService(
+        {
+          id: 'OrderFlow',
+          name: 'Order Flow',
+          version: '1.0.0',
+          summary: 'Order flow',
+          markdown: '# Order flow',
+          steps: [],
+        },
+        { id: 'OrdersService' }
+      );
+
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/OrdersService/flows/OrderFlow', 'index.mdx'))).toBe(true);
+    });
+
+    it('writes a flow to a versioned service', async () => {
+      await writeService({
+        id: 'OrdersService',
+        name: 'Orders Service',
+        version: '0.0.1',
+        summary: 'Orders service',
+        markdown: '# Orders service',
+      });
+
+      await versionService('OrdersService');
+
+      await writeService({
+        id: 'OrdersService',
+        name: 'Orders Service',
+        version: '1.0.0',
+        summary: 'Orders service',
+        markdown: '# Orders service',
+      });
+
+      await writeFlowToService(
+        {
+          id: 'OrderFlow',
+          name: 'Order Flow',
+          version: '1.0.0',
+          summary: 'Order flow',
+          markdown: '# Order flow',
+          steps: [],
+        },
+        { id: 'OrdersService', version: '0.0.1' }
+      );
+
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/OrdersService/versioned/0.0.1/flows/OrderFlow', 'index.mdx'))).toBe(
+        true
+      );
+    });
+  });
+
+  describe('versionFlow', () => {
+    it('versions a flow by moving it to a versioned directory', async () => {
+      await writeFlow({
+        id: 'PaymentFlow',
+        name: 'Payment Flow',
+        version: '0.0.1',
+        summary: 'Payment flow',
+        markdown: '# Payment Flow',
+        steps: [],
+      });
+
+      await versionFlow('PaymentFlow');
+
+      const flow = await getFlow('PaymentFlow', '0.0.1');
+
+      expect(flow).toEqual({
+        id: 'PaymentFlow',
+        name: 'Payment Flow',
+        version: '0.0.1',
+        summary: 'Payment flow',
+        markdown: '# Payment Flow',
+        steps: [],
+      });
+    });
+  });
+
+  describe('rmFlow', () => {
+    it('removes a flow by its path', async () => {
+      await writeFlow({
+        id: 'PaymentFlow',
+        name: 'Payment Flow',
+        version: '0.0.1',
+        summary: 'Payment flow',
+        markdown: '# Payment Flow',
+        steps: [],
+      });
+
+      await rmFlow('/PaymentFlow');
+
+      const flow = await getFlow('PaymentFlow');
+
+      expect(flow).toEqual(undefined);
+    });
+  });
+
+  describe('rmFlowById', () => {
+    it('removes a flow by its id', async () => {
+      await writeFlow({
+        id: 'PaymentFlow',
+        name: 'Payment Flow',
+        version: '0.0.1',
+        summary: 'Payment flow',
+        markdown: '# Payment Flow',
+        steps: [],
+      });
+
+      await rmFlowById('PaymentFlow');
+
+      const flow = await getFlow('PaymentFlow');
+
+      expect(flow).toEqual(undefined);
+    });
+
+    it('removes a specific version of a flow by its id and version', async () => {
+      await writeFlow({
+        id: 'PaymentFlow',
+        name: 'Payment Flow',
+        version: '0.0.1',
+        summary: 'Payment flow',
+        markdown: '# Payment Flow',
+        steps: [],
+      });
+
+      await versionFlow('PaymentFlow');
+
+      await writeFlow({
+        id: 'PaymentFlow',
+        name: 'Payment Flow',
+        version: '0.0.2',
+        summary: 'Payment flow v2',
+        markdown: '# Payment Flow v2',
+        steps: [],
+      });
+
+      await rmFlowById('PaymentFlow', '0.0.1');
+
+      const oldFlow = await getFlow('PaymentFlow', '0.0.1');
+      const newFlow = await getFlow('PaymentFlow', '0.0.2');
+
+      expect(oldFlow).toEqual(undefined);
+      expect(newFlow).toEqual({
+        id: 'PaymentFlow',
+        name: 'Payment Flow',
+        version: '0.0.2',
+        summary: 'Payment flow v2',
+        markdown: '# Payment Flow v2',
+        steps: [],
+      });
+    });
+  });
+
+  describe('flowHasVersion', () => {
+    it('returns true when the given flow version exists', async () => {
+      await writeFlow({
+        id: 'PaymentFlow',
+        name: 'Payment Flow',
+        version: '0.0.1',
+        summary: 'Payment flow',
+        markdown: '# Payment Flow',
+        steps: [],
+      });
+
+      expect(await flowHasVersion('PaymentFlow', '0.0.1')).toBe(true);
+    });
+
+    it('returns false when the given flow version does not exist', async () => {
+      expect(await flowHasVersion('PaymentFlow', '0.0.1')).toBe(false);
+    });
+  });
+
+  describe('addFileToFlow', () => {
+    it('adds a file to the given flow', async () => {
+      await writeFlow({
+        id: 'PaymentFlow',
+        name: 'Payment Flow',
+        version: '0.0.1',
+        summary: 'Payment flow',
+        markdown: '# Payment Flow',
+        steps: [],
+      });
+
+      await addFileToFlow('PaymentFlow', { content: 'Payment notes', fileName: 'notes.md' });
+
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'flows/PaymentFlow', 'notes.md'))).toBe(true);
+      expect(fs.readFileSync(path.join(CATALOG_PATH, 'flows/PaymentFlow', 'notes.md'), 'utf-8')).toBe('Payment notes');
+    });
+  });
+});
+
+describe('FlowBuilder', () => {
+  it('builds a flow with generic, message, service, actor, external system, sub-flow, and custom steps', () => {
+    const flow = FlowBuilder.create({
+      id: 'PaymentFlow',
+      name: 'Payment Flow',
+      version: '1.0.0',
+      summary: 'Payment flow',
+      markdown: '# Payment Flow',
+    })
+      .addActorStep({
+        id: 'Customer',
+        summary: 'Customer placing an order',
+        nextSteps: [{ id: 'PlaceOrder', label: 'Places order' }],
+      })
+      .addMessageStep({
+        id: 'PlaceOrder',
+        version: '0.0.1',
+        nextSteps: [{ id: 'PaymentService', label: 'Process payment' }],
+      })
+      .addServiceStep({
+        id: 'PaymentService',
+        version: '0.0.2',
+        nextSteps: [
+          { id: 'PaymentProcessed', label: 'Payment processed' },
+          { id: 'Stripe', label: 'Authorize payment' },
+        ],
+      })
+      .addMessageStep({
+        id: 'PaymentProcessed',
+        nextSteps: [{ id: 'RewardFlow', label: 'Reward customer' }],
+      })
+      .addExternalSystemStep({
+        id: 'Stripe',
+        summary: 'Payment provider',
+        url: 'https://stripe.com',
+        nextSteps: [{ id: 'ManualReview', label: 'Review failed payments' }],
+      })
+      .addFlowStep({
+        id: 'RewardFlow',
+        version: '1.0.0',
+      })
+      .addCustomStep({
+        id: 'ManualReview',
+        title: 'Manual Review',
+        summary: 'Review the failed payment manually',
+        icon: 'clipboard',
+        type: 'manual',
+        color: '#ff0000',
+      })
+      .build();
+
+    expect(flow).toEqual({
+      id: 'PaymentFlow',
+      name: 'Payment Flow',
+      version: '1.0.0',
+      summary: 'Payment flow',
+      markdown: '# Payment Flow',
+      steps: [
+        {
+          id: 'Customer',
+          title: 'Customer',
+          summary: 'Customer placing an order',
+          actor: { name: 'Customer', summary: 'Customer placing an order' },
+          next_step: { id: 'PlaceOrder', label: 'Places order' },
+        },
+        {
+          id: 'PlaceOrder',
+          title: 'PlaceOrder',
+          message: { id: 'PlaceOrder', version: '0.0.1' },
+          next_step: { id: 'PaymentService', label: 'Process payment' },
+        },
+        {
+          id: 'PaymentService',
+          title: 'PaymentService',
+          service: { id: 'PaymentService', version: '0.0.2' },
+          next_steps: [
+            { id: 'PaymentProcessed', label: 'Payment processed' },
+            { id: 'Stripe', label: 'Authorize payment' },
+          ],
+        },
+        {
+          id: 'PaymentProcessed',
+          title: 'PaymentProcessed',
+          message: { id: 'PaymentProcessed' },
+          next_step: { id: 'RewardFlow', label: 'Reward customer' },
+        },
+        {
+          id: 'Stripe',
+          title: 'Stripe',
+          summary: 'Payment provider',
+          externalSystem: { name: 'Stripe', summary: 'Payment provider', url: 'https://stripe.com' },
+          next_step: { id: 'ManualReview', label: 'Review failed payments' },
+        },
+        {
+          id: 'RewardFlow',
+          title: 'RewardFlow',
+          flow: { id: 'RewardFlow', version: '1.0.0' },
+        },
+        {
+          id: 'ManualReview',
+          title: 'Manual Review',
+          summary: 'Review the failed payment manually',
+          custom: {
+            title: 'Manual Review',
+            summary: 'Review the failed payment manually',
+            icon: 'clipboard',
+            type: 'manual',
+            color: '#ff0000',
+          },
+        },
+      ],
+    });
+  });
+
+  it('uses a generic step title when a title is not provided', () => {
+    const flow = FlowBuilder.create({
+      id: 'OrderFlow',
+      name: 'Order Flow',
+      version: '1.0.0',
+      markdown: '# Order Flow',
+    })
+      .addStep({ id: 'Calculate' })
+      .build();
+
+    expect(flow.steps).toEqual([
+      {
+        id: 'Calculate',
+        title: 'Calculate',
+      },
+    ]);
+  });
+
+  it('starts from existing steps when steps are provided to the builder', () => {
+    const flow = FlowBuilder.create({
+      id: 'OrderFlow',
+      name: 'Order Flow',
+      version: '1.0.0',
+      markdown: '# Order Flow',
+      steps: [
+        {
+          id: 'Start',
+          title: 'Start',
+        },
+      ],
+    })
+      .addStep({ id: 'End' })
+      .build();
+
+    expect(flow.steps).toEqual([
+      {
+        id: 'Start',
+        title: 'Start',
+      },
+      {
+        id: 'End',
+        title: 'End',
+      },
+    ]);
+  });
+
+  it('throws an error when the same step id is added twice', () => {
+    expect(() =>
+      FlowBuilder.create({
+        id: 'OrderFlow',
+        name: 'Order Flow',
+        version: '1.0.0',
+        markdown: '# Order Flow',
+      })
+        .addStep({ id: 'Start' })
+        .addStep({ id: 'Start' })
+    ).toThrowError('Flow step with id "Start" already exists');
+  });
+
+  it('normalizes string and number next steps into step pointers', () => {
+    const flow = FlowBuilder.create({
+      id: 'OrderFlow',
+      name: 'Order Flow',
+      version: '1.0.0',
+      markdown: '# Order Flow',
+    })
+      .addStep({ id: 'Start', nextSteps: ['Middle', 3] })
+      .addStep({ id: 'Middle' })
+      .addStep({ id: 3, title: 'End' })
+      .build();
+
+    expect(flow.steps).toEqual([
+      {
+        id: 'Start',
+        title: 'Start',
+        next_steps: [{ id: 'Middle' }, { id: 3 }],
+      },
+      {
+        id: 'Middle',
+        title: 'Middle',
+      },
+      {
+        id: 3,
+        title: 'End',
+      },
+    ]);
+  });
+
+  it('builds message, service, external system, flow, actor, and custom details from explicit payloads', () => {
+    const flow = FlowBuilder.create({
+      id: 'OrderFlow',
+      name: 'Order Flow',
+      version: '1.0.0',
+      markdown: '# Order Flow',
+    })
+      .addMessageStep({
+        id: 'PlaceOrderStep',
+        title: 'Place Order',
+        message: { id: 'PlaceOrder', version: '1.0.0' },
+      })
+      .addServiceStep({
+        id: 'OrderServiceStep',
+        title: 'Order Service',
+        service: { id: 'OrderService', version: '1.0.0' },
+      })
+      .addExternalSystemStep({
+        id: 'SAPStep',
+        title: 'SAP',
+        externalSystem: { name: 'SAP', summary: 'ERP', url: 'https://example.com/sap' },
+      })
+      .addFlowStep({
+        id: 'RewardStep',
+        title: 'Rewarding',
+        flow: { id: 'RewardFlow', version: '1.0.0' },
+      })
+      .addActorStep({
+        id: 'CustomerStep',
+        title: 'Customer',
+        actor: { name: 'Customer', summary: 'Buyer' },
+      })
+      .addCustomStep({
+        id: 'CustomStep',
+        title: 'Custom',
+        custom: { title: 'Custom Node', type: 'manual' },
+      })
+      .build();
+
+    expect(flow.steps).toEqual([
+      {
+        id: 'PlaceOrderStep',
+        title: 'Place Order',
+        message: { id: 'PlaceOrder', version: '1.0.0' },
+      },
+      {
+        id: 'OrderServiceStep',
+        title: 'Order Service',
+        service: { id: 'OrderService', version: '1.0.0' },
+      },
+      {
+        id: 'SAPStep',
+        title: 'SAP',
+        externalSystem: { name: 'SAP', summary: 'ERP', url: 'https://example.com/sap' },
+      },
+      {
+        id: 'RewardStep',
+        title: 'Rewarding',
+        flow: { id: 'RewardFlow', version: '1.0.0' },
+      },
+      {
+        id: 'CustomerStep',
+        title: 'Customer',
+        actor: { name: 'Customer', summary: 'Buyer' },
+      },
+      {
+        id: 'CustomStep',
+        title: 'Custom',
+        custom: { title: 'Custom Node', type: 'manual' },
+      },
+    ]);
+  });
+
+  it('throws an error when a step references a missing next step', () => {
+    expect(() =>
+      FlowBuilder.create({
+        id: 'OrderFlow',
+        name: 'Order Flow',
+        version: '1.0.0',
+        markdown: '# Order Flow',
+      })
+        .addStep({
+          id: 'Start',
+          nextSteps: [{ id: 'Missing' }],
+        })
+        .build()
+    ).toThrowError('Flow step "Start" references missing next step "Missing"');
+  });
+});


### PR DESCRIPTION
## What This PR Does

Extends `@eventcatalog/sdk` with first-class support for creating and managing flow resources programmatically. Adds write/version/delete helpers for flows (mirroring the patterns already used by other resource types) and introduces a fluent `FlowBuilder` API for assembling flows from code without hand-crafting step arrays.

## Changes Overview

### Key Changes

- New `FlowBuilder` class (`packages/sdk/src/flow-builder.ts`) — fluent API for composing flow steps (message steps, action steps, custom steps) and producing a valid `Flow` object.
- New flow write helpers in `packages/sdk/src/flows.ts`:
  - `writeFlow`, `writeVersionedFlow`, `writeFlowToDomain`, `writeFlowToService`
  - `rmFlow`, `rmFlowById`
  - `versionFlow`, `flowHasVersion`
  - `addFileToFlow`
- SDK entry point (`packages/sdk/src/index.ts`) wires the new helpers onto the default export so `utils('/path')` exposes them.
- `FlowBuilder` and its types are re-exported from both `flows.ts` and the SDK root, plus included in the docs barrel (`docs.ts`).
- New test suite `packages/sdk/src/test/flows.test.ts` covering the new APIs.
- Proposal/design notes captured in `packages/sdk/flow-api-proposal.md` for reference.

## How It Works

The flow write helpers reuse the existing internal resource utilities (`writeResource`, `versionResource`, `addFileToResource`, etc.) so they pick up the same path resolution, formatting, and version handling as the rest of the SDK — they just specialise on `type: 'flow'` and the `flows/` directory layout (including the domain- and service-scoped variants).

`FlowBuilder.create({...})` returns a builder that lets you chain `addMessageStep`, `addActionStep`, and `addCustomStep` calls. Each step accepts an id, title, optional message reference, and `nextSteps` for wiring the graph. Calling `.build()` returns a fully-typed `Flow` you can pass straight into `writeFlow` / `writeVersionedFlow` / `writeFlowToDomain` / `writeFlowToService`.

## Breaking Changes

None — this is purely additive. Existing `getFlow` / `getFlows` behaviour is unchanged.

## Additional Notes

- Bumps `@eventcatalog/sdk` as a `minor` release via the included changeset.
- `packages/sdk/flow-api-proposal.md` is checked in as design context; happy to drop it from the final merge if reviewers would rather keep it out of the package.