### PR TITLE
feat(core): add Prompt MDX component and refresh admonitions

### DIFF
--- a/.changeset/quiet-pandas-write.md
+++ b/.changeset/quiet-pandas-write.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/core': patch
+---
+
+Add `<Prompt />` MDX component and refresh admonition styling for a more compact, modern look.

--- a/.claude/agents/docs.md
+++ b/.claude/agents/docs.md
@@ -37,25 +37,38 @@ never use em-dash.
 
 4. **Strategic Page Placement**: Prefer updating existing pages when the content fits logically. Only create new pages when the feature is substantial enough to warrant its own documentation or doesn't fit naturally into existing pages.
 
+## Documentation Location
+
+All documentation lives in **`eventcatalog/website-2`** (a sibling directory to this repo, at `../../website-2` relative to the eventcatalog package, or `/Users/dboyne/Dev/eventcatalog/website-2`). Docs are Docusaurus markdown/MDX under `website-2/docs/`. **Never edit the legacy `website/` directory.**
+
 ## Workflow
 
-### Step 1: Understand the Changes
+### Step 1: Determine the Release Version
+
+The version that the new feature ships in is required for the `<AddedIn />` component. Resolve it in this order:
+
+1. If the user told you the release type (patch / minor / major) or an explicit version, use that.
+2. Otherwise read the current version from `packages/core/package.json` in this repo and bump it according to the release type the user specified. If the user did not specify, ask before writing docs — do not guess.
+3. Convention: bug fixes = patch, new feature/additive = minor, breaking = major.
+
+### Step 2: Understand the Changes
 - Use `git diff HEAD~1` to see what changed in the most recent commit
 - If more context is needed, examine additional commits with `git log --oneline -10` and `git diff <commit>..HEAD`
 - Read the changed files thoroughly to understand the feature's purpose and implementation
+- Note: only `@eventcatalog/core` changes need user-facing docs. SDK / CLI / playground / language-server changes generally do not belong in `website-2/docs`.
 
-### Step 2: Survey Existing Documentation
-- Explore the `/website` directory to understand the documentation structure
+### Step 3: Survey Existing Documentation
+- Explore `eventcatalog/website-2/docs` to understand the documentation structure
 - Read existing documentation pages to absorb the writing style, tone, and formatting patterns
 - Identify pages that cover related topics where new content might fit
 - Note the markdown conventions, heading structures, and code example patterns used
 
-### Step 3: Plan Documentation Updates
+### Step 4: Plan Documentation Updates
 - List which existing pages should be updated and why
 - Determine if a new page is necessary (only for substantial, standalone features)
 - Outline what content needs to be added or modified
 
-### Step 4: Write Documentation
+### Step 5: Write Documentation
 - Match the existing documentation's:
   - Tone (professional but approachable, clear and concise)
   - Heading hierarchy and structure
@@ -64,11 +77,13 @@ never use em-dash.
 - Include practical code examples when relevant
 - Explain both the 'what' and the 'why' of features
 - Link to related documentation pages when appropriate
+- Apply the `<AddedIn />` component (see section below) to any new or changed feature
 
-### Step 5: Validate Changes
+### Step 6: Validate Changes
 - Ensure new content flows naturally with existing content
 - Verify all code examples are accurate and follow project conventions
 - Check that formatting is consistent with other pages
+- Confirm every documented addition is annotated with the correct `<AddedIn />` version
 
 ## Documentation Location Guidelines
 
@@ -77,6 +92,36 @@ never use em-dash.
 - **New features**: Consider if they extend an existing feature (update that page) or are entirely new (may warrant new page)
 - **Bug fixes**: Usually don't require documentation unless they change behavior
 - **API changes**: Update API reference documentation
+
+## The `<AddedIn />` Component
+
+Every new feature or notable change you document **must** be marked with `<AddedIn />` so readers know which release introduced it.
+
+### Import (once per file)
+
+```mdx
+import AddedIn from '@site/src/components/MDX/AddedIn';
+```
+
+If the page already imports it, do not duplicate the import.
+
+### Usage
+
+Place the tag directly under the feature heading it applies to, before any prose:
+
+```mdx
+## Customize the landing page
+
+<AddedIn version="2.37.1" />
+
+EventCatalog provides a landing page for...
+```
+
+- Use the full release version (e.g. `2.37.1`, `3.15.0`), never `latest` or a range.
+- For a brand new page, place a single `<AddedIn />` near the top, under the page title intro.
+- For an existing page that gains a new section/option, scope the `<AddedIn />` to that section only — do not bump the page-level marker.
+- A single page can contain multiple `<AddedIn />` tags at different versions; that is expected and correct.
+- Bug fixes generally do not need `<AddedIn />` (and usually don't need docs).
 
 ## IMAGES
 

--- a/.claude/commands/update-docs.md
+++ b/.claude/commands/update-docs.md
@@ -1,0 +1,57 @@
+---
+description: Update EventCatalog docs in website-2 based on uncommitted changes (or the previous commit) using the docs-updater agent
+allowed-tools: Bash(git status:*), Bash(git diff:*), Bash(git diff --staged:*), Bash(git log:*), Bash(git show:*), Bash(git rev-parse:*), Bash(git branch:*), Read, Agent
+---
+
+You are coordinating a documentation update for EventCatalog. The actual writing is delegated to the `docs-updater` agent (defined in `.claude/agents/docs.md`). Your job is to gather change context, then dispatch that agent with a complete brief.
+
+User hint (may be empty, may contain release type like "minor" / "patch" / "major" or an explicit version): $ARGUMENTS
+
+## Workflow
+
+### 1) Decide which changes to document
+
+Run `git status` and `git diff --stat` first.
+
+- If there are **uncommitted changes** (staged or unstaged) → document those.
+- If the working tree is clean → document the **previous commit** (`HEAD`). Use `git show HEAD` and `git log -1`.
+- If both apply (uncommitted + the user clearly meant the last commit), ask the user which to use before proceeding.
+
+Capture the actual diff with one of:
+- `git diff` and `git diff --staged` (uncommitted)
+- `git show HEAD` (previous commit)
+
+Only `@eventcatalog/core` (under `packages/core/`) changes need user-facing docs. If the diff is purely SDK / CLI / playground / language-server / tests / formatting, tell the user there's nothing to document and stop.
+
+### 2) Resolve the release version
+
+The `docs-updater` agent will tag new content with `<AddedIn version="..." />`, so it needs an exact version.
+
+- Read the current version from `packages/core/package.json`.
+- If the user passed a release type in `$ARGUMENTS` (patch / minor / major) or an explicit version, compute / use that.
+- If no release type was given, **ask the user** which bump to use before dispatching the agent. Do not guess.
+
+### 3) Dispatch the docs-updater agent
+
+Launch a single `Agent` call with `subagent_type: "docs-updater"`. The agent has no memory of this conversation — your prompt must be self-contained. Include:
+
+- The resolved target version (e.g. `3.33.0`) and the release type.
+- A summary of what changed (feature description, not a raw diff dump) — point at file paths and line numbers so the agent can read them itself.
+- Whether you're documenting uncommitted changes or `HEAD`, and how to reproduce the diff (the exact `git` command).
+- A reminder that docs live in `eventcatalog/website-2/docs` (never `/website`) and that every new/changed feature must carry an `<AddedIn />` marker with the resolved version.
+- Any user hint from `$ARGUMENTS` that's relevant (e.g. "this is a paid feature", "ship under the Scale plan section").
+
+Keep the brief tight — the agent will do its own exploration of `website-2`.
+
+### 4) Report back
+
+After the agent returns, summarise to the user in 2–3 lines:
+- Which doc files were created or updated.
+- The version stamped via `<AddedIn />`.
+- Anything the agent flagged as unresolved (missing screenshots, ambiguous placement, etc.).
+
+## Constraints
+
+- Never edit docs yourself in this command — always delegate to the agent so its conventions (tone, headings, `<AddedIn />` rules) are applied.
+- Never invent a version. If unsure, ask.
+- If the diff has no user-facing impact (refactor, internal tests, formatting), say so and skip the agent dispatch.

--- a/packages/core/eventcatalog/src/components/MDX/Prompt/Prompt.astro
+++ b/packages/core/eventcatalog/src/components/MDX/Prompt/Prompt.astro
@@ -1,0 +1,181 @@
+---
+import * as LucideIcons from 'lucide-react';
+
+type ActionType = 'copy' | 'cursor';
+
+interface Props {
+  description: string;
+  actions?: ActionType[];
+  icon?: string;
+}
+
+const { description, actions = ['copy'], icon } = Astro.props;
+
+const showCopy = actions.includes('copy');
+const showCursor = actions.includes('cursor');
+
+const toPascalCase = (input: string): string =>
+  input
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join('');
+
+const Icon = (() => {
+  if (!icon) return null;
+  const pascal = toPascalCase(icon);
+  const found = (LucideIcons as Record<string, unknown>)[pascal];
+  if (typeof found === 'function' || (typeof found === 'object' && found !== null)) {
+    return found as any;
+  }
+  return null;
+})();
+
+// Render the slotted content to a string so we can use it as the prompt text
+// (for clipboard + the Cursor deep link).
+const slotHtml = await Astro.slots.render('default');
+const promptText = (slotHtml ?? '')
+  .replace(/<[^>]+>/g, '')
+  .replace(/&nbsp;/g, ' ')
+  .replace(/&amp;/g, '&')
+  .replace(/&lt;/g, '<')
+  .replace(/&gt;/g, '>')
+  .replace(/&quot;/g, '"')
+  .replace(/&#39;/g, "'")
+  .trim();
+
+const cursorUrl = `https://cursor.com/link/prompt?text=${encodeURIComponent(promptText)}`;
+---
+
+<ec-prompt
+  class="not-prose my-4 block rounded-xl border border-[rgb(var(--ec-page-border))] bg-gray-50 dark:bg-[rgb(var(--ec-rail-bg))]"
+  data-prompt-text={promptText}
+>
+  <div class="flex items-center gap-2.5 px-4 py-3">
+    {Icon && <Icon className="w-4 h-4 shrink-0 text-[rgb(var(--ec-page-text-muted))]" />}
+    <div class="flex-1 min-w-0">
+      <div class="text-sm font-medium text-[rgb(var(--ec-page-text))] leading-snug">{description}</div>
+    </div>
+    <div class="flex items-center gap-1.5 shrink-0">
+      {
+        showCopy && (
+          <button
+            type="button"
+            data-prompt-copy
+            data-copied="false"
+            aria-label="Copy prompt"
+            aria-live="polite"
+            class="ec-prompt-copy inline-flex items-center gap-1.5 px-2 py-1 text-xs font-medium rounded-md border transition-all duration-150 border-[rgb(var(--ec-page-border))] bg-[rgb(var(--ec-page-bg))] text-[rgb(var(--ec-page-text))] hover:bg-[rgb(var(--ec-content-hover))] data-[copied=true]:border-emerald-500/70 data-[copied=true]:bg-emerald-50 data-[copied=true]:text-emerald-700 dark:data-[copied=true]:bg-emerald-950/50 dark:data-[copied=true]:text-emerald-300 dark:data-[copied=true]:border-emerald-500/60"
+          >
+            <span data-prompt-copy-idle class="inline-flex items-center gap-1.5">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+              </svg>
+              <span>Copy</span>
+            </span>
+            <span data-prompt-copy-done class="inline-flex items-center gap-1.5" style="display:none;">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2.5"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <polyline points="20 6 9 17 4 12" />
+              </svg>
+              <span>Copied!</span>
+            </span>
+          </button>
+        )
+      }
+      {
+        showCursor && (
+          <a
+            href={cursorUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Open in Cursor"
+            class="inline-flex items-center gap-1.5 px-2 py-1 text-xs font-medium rounded-md border border-black bg-black !text-white hover:bg-black/85 transition-colors no-underline"
+          >
+            <svg
+              height="1em"
+              width="1em"
+              viewBox="0 0 16 16"
+              xmlns="http://www.w3.org/2000/svg"
+              aria-hidden="true"
+              class="w-3 h-3 shrink-0"
+            >
+              <path
+                fill="currentColor"
+                d="M14.4734 3.9527L8.31773 0.398522C8.22052 0.342485 8.11029 0.312988 7.99809 0.312988C7.88589 0.312988 7.77566 0.342485 7.67846 0.398522L1.52355 3.9527C1.44182 3.99989 1.37394 4.06773 1.32671 4.14942C1.27948 4.23112 1.25457 4.32379 1.25446 4.41816V11.584C1.25457 11.6783 1.27948 11.771 1.32671 11.8527C1.37394 11.9344 1.44182 12.0022 1.52355 12.0494L7.67918 15.6036C7.77636 15.6597 7.8866 15.6893 7.99882 15.6893C8.11103 15.6893 8.22127 15.6597 8.31846 15.6036L14.4741 12.0502C14.5558 12.003 14.6237 11.9351 14.6709 11.8534C14.7182 11.7717 14.7431 11.6791 14.7432 11.5847V4.41743C14.7431 4.32307 14.7182 4.23039 14.6709 4.14869C14.6237 4.067 14.5558 3.99916 14.4741 3.95198L14.4734 3.9527ZM14.0872 4.70543L8.14464 14.9978C8.10464 15.0669 7.99846 15.0385 7.99846 14.9578V8.21889C7.99841 8.15254 7.98092 8.08738 7.94773 8.02993C7.91454 7.97249 7.86682 7.92478 7.80936 7.89161L1.97373 4.52361C1.90391 4.48289 1.93227 4.3767 2.013 4.3767H13.8966C14.0661 4.3767 14.1715 4.55925 14.0872 4.70543Z"
+              />
+            </svg>
+            <span>Open in Cursor</span>
+          </a>
+        )
+      }
+    </div>
+  </div>
+  <div hidden><slot /></div>
+</ec-prompt>
+
+<script>
+  if (!customElements.get('ec-prompt')) {
+    class ECPromptElement extends HTMLElement {
+      private resetTimer: number | null = null;
+      private button: HTMLButtonElement | null = null;
+      private boundHandler = this.handleCopy.bind(this);
+
+      connectedCallback() {
+        this.button = this.querySelector<HTMLButtonElement>('[data-prompt-copy]');
+        this.button?.addEventListener('click', this.boundHandler);
+      }
+
+      disconnectedCallback() {
+        this.button?.removeEventListener('click', this.boundHandler);
+        if (this.resetTimer != null) {
+          window.clearTimeout(this.resetTimer);
+          this.resetTimer = null;
+        }
+      }
+
+      private async handleCopy() {
+        const text = this.dataset.promptText ?? '';
+        try {
+          await navigator.clipboard.writeText(text);
+        } catch {
+          return;
+        }
+        this.setCopied(true);
+        if (this.resetTimer != null) window.clearTimeout(this.resetTimer);
+        this.resetTimer = window.setTimeout(() => this.setCopied(false), 1500);
+      }
+
+      private setCopied(copied: boolean) {
+        if (!this.button) return;
+        this.button.dataset.copied = copied ? 'true' : 'false';
+        this.button.setAttribute('aria-label', copied ? 'Copied to clipboard' : 'Copy prompt');
+        const idle = this.button.querySelector<HTMLElement>('[data-prompt-copy-idle]');
+        const done = this.button.querySelector<HTMLElement>('[data-prompt-copy-done]');
+        if (idle) idle.style.display = copied ? 'none' : '';
+        if (done) done.style.display = copied ? '' : 'none';
+      }
+    }
+    customElements.define('ec-prompt', ECPromptElement);
+  }
+</script>

--- a/packages/core/eventcatalog/src/components/MDX/Prompt/Prompt.astro
+++ b/packages/core/eventcatalog/src/components/MDX/Prompt/Prompt.astro
@@ -1,5 +1,5 @@
 ---
-import * as LucideIcons from 'lucide-react';
+import { LUCIDE_ICON_MAP } from '@utils/icon-map';
 
 type ActionType = 'copy' | 'cursor';
 
@@ -21,15 +21,7 @@ const toPascalCase = (input: string): string =>
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join('');
 
-const Icon = (() => {
-  if (!icon) return null;
-  const pascal = toPascalCase(icon);
-  const found = (LucideIcons as Record<string, unknown>)[pascal];
-  if (typeof found === 'function' || (typeof found === 'object' && found !== null)) {
-    return found as any;
-  }
-  return null;
-})();
+const Icon = icon ? (LUCIDE_ICON_MAP[toPascalCase(icon)] ?? null) : null;
 
 // Render the slotted content to a string so we can use it as the prompt text
 // (for clipboard + the Cursor deep link).

--- a/packages/core/eventcatalog/src/components/MDX/components.tsx
+++ b/packages/core/eventcatalog/src/components/MDX/components.tsx
@@ -10,6 +10,7 @@ import Tile from '@components/MDX/Tiles/Tile.astro';
 import Steps from '@components/MDX/Steps/Steps.astro';
 import Step from '@components/MDX/Steps/Step.astro';
 import Admonition from '@components/MDX/Admonition';
+import Prompt from '@components/MDX/Prompt/Prompt.astro';
 import OpenAPI from '@components/MDX/OpenAPI/OpenAPI.astro';
 import AsyncAPI from '@components/MDX/AsyncAPI/AsyncAPI.astro';
 import ChannelInformation from '@components/MDX/ChannelInformation/ChannelInformation';
@@ -53,6 +54,7 @@ const components = (props: any) => {
     NodeGraph: (mdxProp: any) => jsx(NodeGraphPortal, { ...props.data, ...mdxProp, props, mdxProp }),
     EntityMap: (mdxProp: any) => jsx(EntityMap, { ...props, ...mdxProp }),
     OpenAPI,
+    Prompt: (mdxProp: any) => jsx(Prompt, { ...props, ...mdxProp }),
     ResourceGroupTable: (mdxProp: any) => jsx(ResourceGroupTable, { ...props, ...mdxProp }),
     ResourceLink: (mdxProp: any) => jsx(ResourceLink, { ...props, ...mdxProp }),
     ResourceRef: (mdxProp: any) => jsx(ResourceRef, { ...props, ...mdxProp }),

--- a/packages/core/eventcatalog/src/remark-plugins/directives.ts
+++ b/packages/core/eventcatalog/src/remark-plugins/directives.ts
@@ -5,29 +5,48 @@ export function remarkDirectives() {
   return (tree: any) => {
     visit(tree, (node) => {
       if (node.type === 'containerDirective') {
+        // Subtle, tinted backgrounds with a coloured left bar and icon.
+        // Body text inherits the page's normal text colour for readability.
         const blockTypes = {
-          info: 'bg-blue-50 dark:bg-blue-950/50 border-l-4 border-blue-500 text-blue-700 dark:text-blue-200',
-          warning: 'bg-yellow-50 dark:bg-yellow-950/50 border-l-4 border-yellow-500 text-yellow-700 dark:text-yellow-200',
-          danger: 'bg-red-50 dark:bg-red-950/50 border-l-4 border-red-500 text-red-700 dark:text-red-200',
-          tip: 'bg-green-50 dark:bg-green-950/50 border-l-4 border-green-500 text-green-700 dark:text-green-200',
-          note: 'bg-gray-50 dark:bg-gray-950/50 border-l-4 border-gray-500 text-gray-700 dark:text-gray-200',
+          info: 'ec-admonition ec-admonition--info bg-blue-50/60 dark:bg-blue-950/30 border border-blue-200/70 dark:border-blue-900/60',
+          warning:
+            'ec-admonition ec-admonition--warning bg-amber-50/60 dark:bg-amber-950/30 border border-amber-200/70 dark:border-amber-900/60',
+          danger:
+            'ec-admonition ec-admonition--danger bg-red-50/60 dark:bg-red-950/30 border border-red-200/70 dark:border-red-900/60',
+          tip: 'ec-admonition ec-admonition--tip bg-emerald-50/60 dark:bg-emerald-900/40 border border-emerald-200/70 dark:border-emerald-700/80',
+          note: 'ec-admonition ec-admonition--note bg-slate-50/70 dark:bg-slate-900/40 border border-slate-200/70 dark:border-slate-700/60',
         };
 
-        // Lucide icon paths
+        // Distinct Lucide icons per intent (warning vs danger no longer share).
         const iconPaths = {
-          info: 'M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z',
-          warning:
-            'M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z',
-          danger:
-            'M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z',
-          tip: 'M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z',
-          note: 'M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z',
+          // Info — circle with "i"
+          info: 'M12 2a10 10 0 100 20 10 10 0 000-20zM12 8h.01M11 12h1v4h1',
+          // Warning — triangle with !
+          warning: 'M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0zM12 9v4 M12 17h.01',
+          // Danger — octagon with !
+          danger: 'M7.86 2h8.28L22 7.86v8.28L16.14 22H7.86L2 16.14V7.86L7.86 2z M12 8v4 M12 16h.01',
+          // Tip — lightbulb
+          tip: 'M9 18h6 M10 22h4 M12 2a7 7 0 0 0-4 12.74V17h8v-2.26A7 7 0 0 0 12 2z',
+          // Note — pencil-line
+          note: 'M12 20h9 M16.5 3.5a2.121 2.121 0 1 1 3 3L7 19l-4 1 1-4 12.5-12.5z',
         };
+
+        // Coloured icon + title classes (intent accent colours).
+        const accentTextClasses = {
+          info: 'text-blue-700 dark:text-blue-300',
+          warning: 'text-amber-700 dark:text-amber-300',
+          danger: 'text-red-700 dark:text-red-300',
+          tip: 'text-emerald-700 dark:text-emerald-300',
+          note: 'text-slate-600 dark:text-slate-300',
+        };
+
+        const intent = node.name as keyof typeof blockTypes;
+        const accentClass = accentTextClasses[intent] || accentTextClasses.note;
 
         node.data = node.data || {};
         node.data.hName = 'div';
         node.data.hProperties = {
-          class: `rounded-lg p-4 my-4 ${blockTypes[node.name as keyof typeof blockTypes] || ''}`,
+          class: `rounded-md px-3 py-2.5 my-4 text-[0.85rem] leading-relaxed ${blockTypes[intent] || ''}`,
         };
 
         // Check if there's a custom title (label) provided via :::note[Custom Title]
@@ -62,26 +81,26 @@ export function remarkDirectives() {
           data: {
             hName: 'div',
             hProperties: {
-              class: 'flex items-center gap-2 font-semibold mb-2',
+              class: `flex items-center gap-1.5 mb-1 ${accentClass}`,
             },
           },
           children: [
-            // Lucide Icon SVG
+            // Lucide Icon SVG (smaller, accent-coloured)
             {
               type: 'element',
               data: {
                 hName: 'svg',
                 hProperties: {
                   xmlns: 'http://www.w3.org/2000/svg',
-                  width: '26',
-                  height: '26',
+                  width: '14',
+                  height: '14',
                   viewBox: '0 0 24 24',
                   fill: 'none',
                   stroke: 'currentColor',
-                  strokeWidth: '2',
+                  strokeWidth: '2.25',
                   strokeLinecap: 'round',
                   strokeLinejoin: 'round',
-                  class: 'lucide',
+                  class: 'lucide shrink-0',
                 },
               },
               children: [
@@ -96,13 +115,13 @@ export function remarkDirectives() {
                 },
               ],
             },
-            // Title (with support for markdown)
+            // Title — small, uppercase, tracked
             {
               type: 'element',
               data: {
                 hName: 'span',
                 hProperties: {
-                  class: '',
+                  class: 'text-[0.7rem] font-semibold uppercase tracking-wider',
                 },
               },
               children: titleChildren,
@@ -116,7 +135,8 @@ export function remarkDirectives() {
           data: {
             hName: 'div',
             hProperties: {
-              class: 'prose prose-md dark:prose-invert w-full max-w-none! prose-p:my-1 prose-p:text-inherit',
+              class:
+                'prose prose-sm dark:prose-invert w-full max-w-none! prose-p:my-0.5 prose-p:text-inherit prose-p:text-[0.85rem] prose-p:leading-relaxed prose-code:text-[0.8rem]',
             },
           },
           children: contentChildren,

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -13,7 +13,6 @@
 - 8f724a7: feat: add `externalSystem` flag to services for modelling third-party integrations
 
   Services can now set `externalSystem: true` in their frontmatter to be rendered as external systems. This changes their presentation without changing their capabilities — they still send and receive messages, have owners, and support specifications like any other service.
-
   - Visualiser: external services render purple with a Globe icon and an "External System" badge
   - Sidebar (root): a dedicated "External Systems" section lists externals; the regular "Services" section excludes them
   - Sidebar (domain): externals appear under a new "External Integrations" group, separate from "Services In Domain"


### PR DESCRIPTION
## What This PR Does

Introduces a new `<Prompt />` MDX component that authors can drop into catalog pages, and gives the existing `:::info` / `:::warning` / `:::danger` / `:::tip` / `:::note` admonitions a visual refresh. The admonitions are now more compact with subtler tinted backgrounds, distinct icons per intent (warning vs danger no longer share), and a small uppercase label so they sit alongside body copy without dominating the page.

## Changes Overview

### Key Changes

- **New `<Prompt />` MDX component** at `packages/core/eventcatalog/src/components/MDX/Prompt/Prompt.astro`, registered in the MDX components map so it can be used directly in `.mdx` files.
- **Refreshed admonition styling** in `packages/core/eventcatalog/src/remark-plugins/directives.ts`:
  - Tighter padding, smaller text, subtler tinted backgrounds with light borders.
  - Distinct Lucide icons for each intent (info / warning / danger / tip / note).
  - Smaller, uppercase, tracked title; body inherits the page text colour for readability.
- **Internal tooling updates** to `.claude/agents/docs.md` and a new `.claude/commands/update-docs.md` (not shipped to users).

## How It Works

The remark directive plugin maps each container directive (`:::info` etc.) to an `ec-admonition` div with intent-specific Tailwind classes. The accent colour is now applied only to the icon and title row (via an `accentTextClasses` map) while the body uses the default page text colour, which improves contrast in both light and dark themes. Icon SVGs are inlined in the AST as `hast` nodes, with one Lucide path per intent.

The new `Prompt` component is a regular Astro component registered alongside other MDX components in `components.tsx`, so it works wherever the EventCatalog MDX renderer is used.

## Breaking Changes

None. Admonition syntax is unchanged; only the rendered output is restyled.

## Test plan

- [ ] Visual check of admonitions (`:::info`, `:::warning`, `:::danger`, `:::tip`, `:::note`) in light theme
- [ ] Visual check of admonitions in dark theme
- [ ] Render a page using the new `<Prompt />` component