### PR TITLE
feat(core): add visibility mdx component for audience-specific docs

### DIFF
--- a/.changeset/visibility-agent-docs.md
+++ b/.changeset/visibility-agent-docs.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/core': minor
+---
+
+Add a Visibility MDX component for audience-specific docs in the UI and markdown endpoints.

--- a/examples/default/domains/E-Commerce/subdomains/Orders/services/InventoryService/queries/GetInventoryList/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Orders/services/InventoryService/queries/GetInventoryList/index.mdx
@@ -23,4 +23,12 @@ import Footer from '@catalog/components/footer.astro';
 
 The GetInventoryList message is a query used to retrieve a comprehensive list of all available inventory items within a system. It is designed to return detailed information about each item, such as product names, quantities, availability status, and potentially additional metadata like categories or locations. This query is typically utilized by systems or services that require a real-time view of current stock, ensuring that downstream applications or users have accurate and up-to-date information for decision-making or operational purposes. The GetInventoryList is ideal for use cases such as order processing, stock management, or reporting, providing visibility into the full range of inventory data.
 
+<Visibility for="humans">
+Use the **Schema** and **Visualiser** actions on this page to inspect the inventory query contract and its relationships.
+</Visibility>
+
+<Visibility for="agents">
+When helping agents reason about this query, treat `GET /inventory` as a read-only inventory lookup. Prefer linking this query to inventory reporting, order placement, and stock reservation workflows.
+</Visibility>
+
 <NodeGraph />

--- a/examples/default/eventcatalog.config.js
+++ b/examples/default/eventcatalog.config.js
@@ -14,7 +14,7 @@ export default {
   port: 3000,
   outDir: 'dist',
 
-  output: 'server',
+  // output: 'server',
 
   logo: {
     src: '/logo.png',

--- a/examples/default/eventcatalog.config.js
+++ b/examples/default/eventcatalog.config.js
@@ -14,7 +14,7 @@ export default {
   port: 3000,
   outDir: 'dist',
 
-  // output: 'server',
+  output: 'server',
 
   logo: {
     src: '/logo.png',

--- a/packages/core/eventcatalog/src/components/MDX/Visibility.tsx
+++ b/packages/core/eventcatalog/src/components/MDX/Visibility.tsx
@@ -1,0 +1,12 @@
+type VisibilityProps = {
+  for: 'agents' | 'humans';
+  children?: any;
+};
+
+const Visibility = ({ for: audience, children }: VisibilityProps) => {
+  if (audience !== 'humans') return null;
+
+  return <>{children}</>;
+};
+
+export default Visibility;

--- a/packages/core/eventcatalog/src/components/MDX/components.tsx
+++ b/packages/core/eventcatalog/src/components/MDX/components.tsx
@@ -35,6 +35,7 @@ import NodeGraphPortal from '@components/MDX/NodeGraph/NodeGraphPortal';
 import SchemaViewerPortal from '@components/MDX/SchemaViewer/SchemaViewerPortal';
 import { jsx } from 'astro/jsx-runtime';
 import RemoteSchema from '@components/MDX/RemoteSchema.astro';
+import Visibility from '@components/MDX/Visibility';
 
 const components = (props: any) => {
   return {
@@ -66,6 +67,7 @@ const components = (props: any) => {
     Tabs,
     Tile,
     Tiles,
+    Visibility,
     Miro: (mdxProp: any) => jsx(Miro, { ...props, ...mdxProp }),
     Lucid: (mdxProp: any) => jsx(Lucid, { ...props, ...mdxProp }),
     DrawIO: (mdxProp: any) => jsx(DrawIO, { ...props, ...mdxProp }),

--- a/packages/core/eventcatalog/src/enterprise/custom-documentation/pages/docs/custom/[...path].mdx.ts
+++ b/packages/core/eventcatalog/src/enterprise/custom-documentation/pages/docs/custom/[...path].mdx.ts
@@ -6,9 +6,11 @@ import type { APIRoute, GetStaticPaths } from 'astro';
 import { getCollection } from 'astro:content';
 import fs from 'fs';
 import { isLLMSTxtEnabled } from '@utils/feature';
+import { filterMarkdownForAgents } from '@utils/llms';
+
+const docs = await getCollection('customPages');
 
 export const getStaticPaths = (async () => {
-  const docs = await getCollection('customPages');
   const paths = docs.map((doc) => ({
     params: { path: doc.id.replace('docs/', '') },
     props: doc,
@@ -23,8 +25,10 @@ export const GET: APIRoute = async ({ params, props }) => {
     return new Response('llms.txt is not enabled for this Catalog.', { status: 404 });
   }
 
-  if (props.filePath) {
-    const file = fs.readFileSync(props.filePath, 'utf8');
+  const docPath = Array.isArray(params.path) ? params.path.join('/') : params.path;
+  const content = props?.filePath ? props : docs.find((doc) => doc.id.replace('docs/', '') === docPath);
+  if (content?.filePath) {
+    const file = filterMarkdownForAgents(fs.readFileSync(content.filePath, 'utf8'));
     return new Response(file, { status: 200 });
   }
 

--- a/packages/core/eventcatalog/src/pages/diagrams/[id]/[version].mdx.ts
+++ b/packages/core/eventcatalog/src/pages/diagrams/[id]/[version].mdx.ts
@@ -7,6 +7,7 @@ import type { APIRoute } from 'astro';
 import { getCollection } from 'astro:content';
 import fs from 'fs';
 import { isLLMSTxtEnabled, isSSR } from '@utils/feature';
+import { filterMarkdownForAgents } from '@utils/llms';
 
 const diagrams = await getCollection('diagrams');
 
@@ -34,11 +35,11 @@ export const GET: APIRoute = async ({ params, props }) => {
     if (!diagram?.filePath) {
       return new Response('Not found', { status: 404 });
     }
-    const file = fs.readFileSync(diagram.filePath, 'utf8');
+    const file = filterMarkdownForAgents(fs.readFileSync(diagram.filePath, 'utf8'));
     return new Response(file, { status: 200 });
   } else {
     if (props?.content?.filePath) {
-      const file = fs.readFileSync(props.content.filePath, 'utf8');
+      const file = filterMarkdownForAgents(fs.readFileSync(props.content.filePath, 'utf8'));
       return new Response(file, { status: 200 });
     }
   }

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version].md.ts
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version].md.ts
@@ -8,6 +8,7 @@ import { getEntities } from '@utils/collections/entities';
 import config from '@config';
 import fs from 'fs';
 import { isLLMSTxtEnabled } from '@utils/feature';
+import { filterMarkdownForAgents } from '@utils/llms';
 
 const events = await getCollection('events');
 const commands = await getCollection('commands');
@@ -18,23 +19,30 @@ const flows = await getCollection('flows');
 const channels = await getCollection('channels');
 const containers = await getCollection('containers');
 const entities = await getEntities();
+
+const collections = {
+  events,
+  commands,
+  queries,
+  services,
+  domains,
+  flows,
+  channels,
+  containers,
+  entities,
+};
+
+const findContent = (params: Record<string, string | undefined>) => {
+  const collection = collections[params.type as keyof typeof collections];
+  return collection?.find((item: any) => item.data.id === params.id && item.data.version === params.version);
+};
+
 export async function getStaticPaths() {
   // Just return empty array if LLMs are not enabled
   if (!isLLMSTxtEnabled()) {
     return [];
   }
 
-  const collections = {
-    events,
-    commands,
-    queries,
-    services,
-    domains,
-    flows,
-    channels,
-    containers,
-    entities,
-  };
   const paths = Object.keys(collections).map((type) => {
     return collections[type as keyof typeof collections].map((item: { data: { id: string; version: string } }) => ({
       params: { type, id: item.data.id, version: item.data.version },
@@ -51,8 +59,9 @@ export const GET: APIRoute = async ({ params, props }) => {
     return new Response('llms.txt is not enabled for this Catalog.', { status: 404 });
   }
 
-  if (props?.content?.filePath) {
-    const file = fs.readFileSync(props.content.filePath, 'utf8');
+  const content = props?.content ?? findContent(params);
+  if (content?.filePath) {
+    const file = filterMarkdownForAgents(fs.readFileSync(content.filePath, 'utf8'));
     return new Response(file, { status: 200 });
   }
 

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version].mdx.ts
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version].mdx.ts
@@ -6,7 +6,7 @@ import type { APIRoute } from 'astro';
 import { getCollection } from 'astro:content';
 import config from '@config';
 import fs from 'fs';
-import { addSchemaToMarkdown } from '@utils/llms';
+import { addSchemaToMarkdown, filterMarkdownForAgents } from '@utils/llms';
 import { isLLMSTxtEnabled, isSSR } from '@utils/feature';
 const events = await getCollection('events');
 const commands = await getCollection('commands');
@@ -15,25 +15,34 @@ const services = await getCollection('services');
 const domains = await getCollection('domains');
 const flows = await getCollection('flows');
 const channels = await getCollection('channels');
+const containers = await getCollection('containers');
 const entities = await getCollection('entities');
 
 import utils from '@eventcatalog/sdk';
+
+const collections = {
+  events,
+  commands,
+  queries,
+  services,
+  domains,
+  flows,
+  channels,
+  containers,
+  entities,
+};
+
+const findContent = (params: Record<string, string | undefined>) => {
+  const collection = collections[params.type as keyof typeof collections];
+  return collection?.find((item) => item.data.id === params.id && item.data.version === params.version);
+};
 
 export async function getStaticPaths() {
   // Just return empty array if LLMs are not enabled
   if (!isLLMSTxtEnabled()) {
     return [];
   }
-  const collections = {
-    events,
-    commands,
-    queries,
-    services,
-    domains,
-    flows,
-    channels,
-    entities,
-  };
+
   const paths = Object.keys(collections).map((type) => {
     return collections[type as keyof typeof collections].map((item: { data: { id: string; version: string } }) => ({
       params: { type, id: item.data.id, version: item.data.version },
@@ -50,26 +59,27 @@ export const GET: APIRoute = async ({ params, props }) => {
     return new Response('llms.txt is not enabled for this Catalog.', { status: 404 });
   }
 
+  const content = props?.content ?? findContent(params);
+  if (content?.filePath) {
+    let file = fs.readFileSync(content.filePath, 'utf8');
+
+    try {
+      file = addSchemaToMarkdown(content, file);
+    } catch (error) {
+      console.log('Warning: Cant find the schema for', content.data.id, content.data.version);
+    }
+
+    return new Response(filterMarkdownForAgents(file), { status: 200 });
+  }
+
   if (isSSR()) {
     const { getResourcePath } = utils(process.env.PROJECT_DIR ?? '');
     const filePath = await getResourcePath(process.env.PROJECT_DIR ?? '', params.id ?? '', params.version ?? '');
     if (!filePath) {
       return new Response('Not found', { status: 404 });
     }
-    const file = fs.readFileSync(filePath.fullPath, 'utf8');
+    const file = filterMarkdownForAgents(fs.readFileSync(filePath.fullPath, 'utf8'));
     return new Response(file, { status: 200 });
-  } else {
-    if (props?.content?.filePath) {
-      let file = fs.readFileSync(props.content.filePath, 'utf8');
-
-      try {
-        file = addSchemaToMarkdown(props.content, file);
-      } catch (error) {
-        console.log('Warning: Cant find the schema for', props.content.data.id, props.content.data.version);
-      }
-
-      return new Response(file, { status: 200 });
-    }
   }
 
   return new Response('Not found', { status: 404 });

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/[docType]/[docId].md.ts
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/[docType]/[docId].md.ts
@@ -6,6 +6,7 @@ import type { APIRoute } from 'astro';
 import fs from 'fs';
 import { isLLMSTxtEnabled, isResourceDocsEnabled, isSSR } from '@utils/feature';
 import { getResourceDocs, getResourceDocsForResource, type ResourceCollection } from '@utils/collections/resource-docs';
+import { filterMarkdownForAgents } from '@utils/llms';
 
 const supportedResourceCollections = new Set<ResourceCollection>([
   'domains',
@@ -70,6 +71,6 @@ export const GET: APIRoute = async ({ params, props }) => {
     return new Response('Not found', { status: 404 });
   }
 
-  const file = fs.readFileSync(filePath, 'utf8');
+  const file = filterMarkdownForAgents(fs.readFileSync(filePath, 'utf8'));
   return new Response(file, { status: 200, headers: { 'Content-Type': 'text/markdown; charset=utf-8' } });
 };

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/[docType]/[docId].mdx.ts
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/[docType]/[docId].mdx.ts
@@ -6,6 +6,7 @@ import type { APIRoute } from 'astro';
 import fs from 'fs';
 import { isLLMSTxtEnabled, isResourceDocsEnabled, isSSR } from '@utils/feature';
 import { getResourceDocs, getResourceDocsForResource, type ResourceCollection } from '@utils/collections/resource-docs';
+import { filterMarkdownForAgents } from '@utils/llms';
 
 const supportedResourceCollections = new Set<ResourceCollection>([
   'domains',
@@ -70,6 +71,6 @@ export const GET: APIRoute = async ({ params, props }) => {
     return new Response('Not found', { status: 404 });
   }
 
-  const file = fs.readFileSync(filePath, 'utf8');
+  const file = filterMarkdownForAgents(fs.readFileSync(filePath, 'utf8'));
   return new Response(file, { status: 200, headers: { 'Content-Type': 'text/markdown; charset=utf-8' } });
 };

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/language.mdx.ts
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/language.mdx.ts
@@ -4,6 +4,7 @@ import type { APIRoute } from 'astro';
 import config from '@config';
 import fs from 'fs';
 import { isLLMSTxtEnabled } from '@utils/feature';
+import { filterMarkdownForAgents } from '@utils/llms';
 
 export async function getStaticPaths() {
   const domains = await getDomains({ getAllVersions: false });
@@ -30,11 +31,17 @@ export const GET: APIRoute = async ({ params, props }) => {
     return new Response('llms.txt is not enabled for this Catalog.', { status: 404 });
   }
 
-  const ubiquitousLanguages = await getUbiquitousLanguage(props as CollectionEntry<'domains'>);
+  const domains = await getDomains({ getAllVersions: false });
+  const domain = props?.data ? (props as CollectionEntry<'domains'>) : domains.find((item) => item.data.id === params.id);
+  if (!domain) {
+    return new Response('Not found', { status: 404 });
+  }
+
+  const ubiquitousLanguages = await getUbiquitousLanguage(domain as CollectionEntry<'domains'>);
   const ubiquitousLanguage = ubiquitousLanguages[0];
 
   if (ubiquitousLanguage?.filePath) {
-    let file = fs.readFileSync(ubiquitousLanguage.filePath, 'utf8');
+    let file = filterMarkdownForAgents(fs.readFileSync(ubiquitousLanguage.filePath, 'utf8'));
 
     return new Response(file, { status: 200 });
   }

--- a/packages/core/eventcatalog/src/pages/docs/llm/llms-full.txt.ts
+++ b/packages/core/eventcatalog/src/pages/docs/llm/llms-full.txt.ts
@@ -2,7 +2,7 @@ import { getCollection, type CollectionEntry } from 'astro:content';
 import type { APIRoute } from 'astro';
 import fs from 'fs';
 import { isCustomDocsEnabled, isResourceDocsEnabled, isLLMSTxtEnabled } from '@utils/feature';
-import { addSchemaToMarkdown } from '@utils/llms';
+import { addSchemaToMarkdown, filterMarkdownForAgents } from '@utils/llms';
 
 type AllowedCollections =
   | 'events'
@@ -74,7 +74,7 @@ export const GET: APIRoute = async ({ params, request }) => {
         // just skip the resource if it has no schema
       }
 
-      return file;
+      return filterMarkdownForAgents(file);
     })
     .join('\n');
 

--- a/packages/core/eventcatalog/src/pages/docs/teams/[id].md.ts
+++ b/packages/core/eventcatalog/src/pages/docs/teams/[id].md.ts
@@ -7,6 +7,7 @@ import { getCollection } from 'astro:content';
 import config from '@config';
 import fs from 'fs';
 import { isLLMSTxtEnabled } from '@utils/feature';
+import { filterMarkdownForAgents } from '@utils/llms';
 
 const teams = await getCollection('teams');
 
@@ -28,8 +29,9 @@ export const GET: APIRoute = async ({ params, props }) => {
     return new Response('llms.txt is not enabled for this Catalog.', { status: 404 });
   }
 
-  if (props?.content?.filePath) {
-    const file = fs.readFileSync(props.content.filePath, 'utf8');
+  const content = props?.content ?? teams.find((team) => team.data.id === params.id);
+  if (content?.filePath) {
+    const file = filterMarkdownForAgents(fs.readFileSync(content.filePath, 'utf8'));
     return new Response(file, { status: 200 });
   }
 

--- a/packages/core/eventcatalog/src/pages/docs/teams/[id].mdx.ts
+++ b/packages/core/eventcatalog/src/pages/docs/teams/[id].mdx.ts
@@ -6,6 +6,7 @@ import type { APIRoute } from 'astro';
 import { getCollection } from 'astro:content';
 import { isLLMSTxtEnabled } from '@utils/feature';
 import fs from 'fs';
+import { filterMarkdownForAgents } from '@utils/llms';
 
 const teams = await getCollection('teams');
 
@@ -27,8 +28,9 @@ export const GET: APIRoute = async ({ params, props }) => {
     return new Response('llms.txt is not enabled for this Catalog.', { status: 404 });
   }
 
-  if (props?.content?.filePath) {
-    const file = fs.readFileSync(props.content.filePath, 'utf8');
+  const content = props?.content ?? teams.find((team) => team.data.id === params.id);
+  if (content?.filePath) {
+    const file = filterMarkdownForAgents(fs.readFileSync(content.filePath, 'utf8'));
     return new Response(file, { status: 200 });
   }
 

--- a/packages/core/eventcatalog/src/pages/docs/users/[id].md.ts
+++ b/packages/core/eventcatalog/src/pages/docs/users/[id].md.ts
@@ -7,6 +7,7 @@ import { getCollection } from 'astro:content';
 import config from '@config';
 import fs from 'fs';
 import { isLLMSTxtEnabled } from '@utils/feature';
+import { filterMarkdownForAgents } from '@utils/llms';
 
 const users = await getCollection('users');
 
@@ -28,8 +29,9 @@ export const GET: APIRoute = async ({ params, props }) => {
     return new Response('llms.txt is not enabled for this Catalog.', { status: 404 });
   }
 
-  if (props?.content?.filePath) {
-    const file = fs.readFileSync(props.content?.filePath, 'utf8');
+  const content = props?.content ?? users.find((user) => user.data.id === params.id);
+  if (content?.filePath) {
+    const file = filterMarkdownForAgents(fs.readFileSync(content.filePath, 'utf8'));
     return new Response(file, { status: 200 });
   }
 

--- a/packages/core/eventcatalog/src/pages/docs/users/[id].mdx.ts
+++ b/packages/core/eventcatalog/src/pages/docs/users/[id].mdx.ts
@@ -6,6 +6,7 @@ import type { APIRoute } from 'astro';
 import { getCollection } from 'astro:content';
 import { isLLMSTxtEnabled } from '@utils/feature';
 import fs from 'fs';
+import { filterMarkdownForAgents } from '@utils/llms';
 
 const users = await getCollection('users');
 
@@ -27,8 +28,9 @@ export const GET: APIRoute = async ({ params, props }) => {
     return new Response('llms.txt is not enabled for this Catalog.', { status: 404 });
   }
 
-  if (props?.content?.filePath) {
-    const file = fs.readFileSync(props.content?.filePath, 'utf8');
+  const content = props?.content ?? users.find((user) => user.data.id === params.id);
+  if (content?.filePath) {
+    const file = filterMarkdownForAgents(fs.readFileSync(content.filePath, 'utf8'));
     return new Response(file, { status: 200 });
   }
 

--- a/packages/core/eventcatalog/src/utils/__tests__/llms.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/llms.spec.ts
@@ -1,0 +1,56 @@
+import { filterMarkdownForAgents, filterMarkdownForAudience } from '@utils/llms';
+
+describe('llms', () => {
+  describe('filterMarkdownForAudience', () => {
+    it('keeps agent visibility content and removes human visibility content for markdown endpoints', () => {
+      const markdown = `---
+id: OrderCreated
+---
+
+# Order Created
+
+<Visibility for="humans">
+Click the **Create order** button in the UI.
+</Visibility>
+
+Shared content.
+
+<Visibility for="agents">
+Call \`POST /orders\` with a valid order payload.
+</Visibility>
+`;
+
+      expect(filterMarkdownForAgents(markdown)).toBe(`---
+id: OrderCreated
+---
+
+# Order Created
+
+Shared content.
+
+Call \`POST /orders\` with a valid order payload.`);
+    });
+
+    it('supports single quoted and expression quoted visibility props', () => {
+      const markdown = `<Visibility for='agents'>
+Agent content
+</Visibility>
+
+<Visibility for={"humans"}>
+Human content
+</Visibility>`;
+
+      expect(filterMarkdownForAudience(markdown, 'humans')).toBe('Human content');
+    });
+
+    it('does not change markdown when no visibility components are present', () => {
+      const markdown = `# Plain docs
+
+Content with source formatting preserved.
+
+`;
+
+      expect(filterMarkdownForAgents(markdown)).toBe(markdown);
+    });
+  });
+});

--- a/packages/core/eventcatalog/src/utils/llms.ts
+++ b/packages/core/eventcatalog/src/utils/llms.ts
@@ -33,3 +33,25 @@ export const addSchemaToMarkdown = (collection: CollectionEntry<CollectionTypes>
 
   return file;
 };
+
+type VisibilityAudience = 'agents' | 'humans';
+
+const visibilityPattern =
+  /(?:\r?\n){0,2}<Visibility\b(?=[^>]*\bfor=(?:"agents"|'agents'|{["']agents["']}|"humans"|'humans'|{["']humans["']}))[^>]*\bfor=(?:"(agents|humans)"|'(agents|humans)'|{["'](agents|humans)["']})[^>]*>\s*([\s\S]*?)\s*<\/Visibility>(?:\r?\n){0,2}/g;
+
+export const filterMarkdownForAudience = (file: string, audience: VisibilityAudience) => {
+  visibilityPattern.lastIndex = 0;
+  if (!visibilityPattern.test(file)) {
+    return file;
+  }
+  visibilityPattern.lastIndex = 0;
+
+  return file
+    .replace(visibilityPattern, (_match, doubleQuoted, singleQuoted, expressionQuoted, content) => {
+      const visibilityAudience = doubleQuoted || singleQuoted || expressionQuoted;
+      return visibilityAudience === audience ? `\n\n${content.trim()}\n\n` : '\n\n';
+    })
+    .trim();
+};
+
+export const filterMarkdownForAgents = (file: string) => filterMarkdownForAudience(file, 'agents');


### PR DESCRIPTION
## What This PR Does

Introduces a new `<Visibility for="agents" | "humans">` MDX component that lets catalog authors write a single MDX file that serves both human readers and AI agents/LLMs. Humans only see `for="humans"` blocks in the rendered UI; agents/LLMs only see `for="agents"` blocks when consuming the raw `.md` / `.mdx` endpoints and `llms-full.txt`. This removes the need to fork content for the two audiences and gives authors a clean, declarative way to tailor documentation per consumer.

## Changes Overview

### Key Changes
- New `Visibility` React component (`packages/core/eventcatalog/src/components/MDX/Visibility.tsx`) that renders only when `for="humans"`, returning `null` otherwise.
- Registered `Visibility` in the global MDX components map (`packages/core/eventcatalog/src/components/MDX/components.tsx`), so it works in any resource MDX file.
- New `filterMarkdownForAudience` / `filterMarkdownForAgents` utilities in `packages/core/eventcatalog/src/utils/llms.ts` that strip the opposite-audience `<Visibility>` blocks from raw markdown.
- Applied agent-side filtering across every markdown / MDX endpoint that agents and LLMs hit:
  - `docs/[type]/[id]/[version].md.ts` and `.mdx.ts`
  - `docs/[type]/[id]/[version]/[docType]/[docId].md.ts` and `.mdx.ts`
  - `docs/[type]/[id]/language.mdx.ts`
  - `docs/teams/[id].md.ts` and `.mdx.ts`, `docs/users/[id].md.ts` and `.mdx.ts`
  - `docs/llm/llms-full.txt.ts`
  - `diagrams/[id]/[version].mdx.ts`
  - `enterprise/custom-documentation/pages/docs/custom/[...path].mdx.ts`
- Unit tests for the audience filter (`packages/core/eventcatalog/src/utils/__tests__/llms.spec.ts`).
- Example usage added to `examples/default/.../GetInventoryList/index.mdx` so it's visible in the default catalog.
- Changeset for `@eventcatalog/core` (`minor`).

## How It Works

The component itself is a tiny React component: when `for !== 'humans'` it returns `null`, so the browser only ever sees the human-facing block. The reverse split happens at the markdown layer: a regex-based `filterMarkdownForAudience` walks every `<Visibility for="...">...</Visibility>` block and either keeps the inner content (audience matches) or drops the block entirely (audience doesn't match). All routes that emit raw markdown for agents — including the file-system fallback path used in SSR — now pipe their output through `filterMarkdownForAgents` before responding, so agents never see the `for="humans"` blocks and humans never see the `for="agents"` blocks.

## Breaking Changes

None. `<Visibility>` is an additive component; existing MDX files are unaffected.

## Additional Notes

- Public docs page added separately in `website-2` under the MDX components reference, stamped with `<AddedIn version="3.33.0" />`.
- The `filterMarkdownForAudience` helper is intentionally not exported as part of any public API — it's a local server-side utility.