### PR TITLE
feat(core): expand sidebar and search with flows, entities, and data products

### DIFF
--- a/.changeset/swift-otters-explore.md
+++ b/.changeset/swift-otters-explore.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": minor
+---
+
+Expand sidebar and search navigation: link messages and services to the flows they appear in, surface flow steps (messages, services, subflows) on flow pages, add entities to the global sidebar, and include data products, flows, and entities in the search modal with correct icons, filters, and URLs.

--- a/packages/core/eventcatalog/src/components/Search/SearchModal.tsx
+++ b/packages/core/eventcatalog/src/components/Search/SearchModal.tsx
@@ -27,6 +27,7 @@ import { useStore } from '@nanostores/react';
 import { favoritesStore, toggleFavorite as toggleFavoriteAction } from '../../stores/favorites-store';
 import { buildUrl } from '@utils/url-builder';
 import { resolveIconUrl } from '@utils/icon';
+import { getUrlForSearchItem } from './search-utils';
 
 const typeIcons: any = {
   Domain: RectangleGroupIcon,
@@ -43,6 +44,8 @@ const typeIcons: any = {
   AsyncAPI: DocumentTextIcon,
   Design: Square2StackIcon,
   Container: CircleStackIcon,
+  'Data Product': CubeIcon,
+  Flow: QueueListIcon,
   default: DocumentTextIcon,
 };
 
@@ -62,41 +65,14 @@ const typeColors: any = {
   AsyncAPI: 'text-violet-500 dark:text-violet-400 bg-violet-50 dark:bg-violet-500/10 ring-violet-200 dark:ring-violet-500/30',
   Design: 'text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-gray-500/10 ring-gray-200 dark:ring-gray-500/30',
   Container: 'text-indigo-500 dark:text-indigo-400 bg-indigo-50 dark:bg-indigo-500/10 ring-indigo-200 dark:ring-indigo-500/30',
+  'Data Product': 'text-sky-500 dark:text-sky-400 bg-sky-50 dark:bg-sky-500/10 ring-sky-200 dark:ring-sky-500/30',
+  Flow: 'text-fuchsia-500 dark:text-fuchsia-400 bg-fuchsia-50 dark:bg-fuchsia-500/10 ring-fuchsia-200 dark:ring-fuchsia-500/30',
   default: 'text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-gray-500/10 ring-gray-200 dark:ring-gray-500/30',
 };
 
 function classNames(...classes: (string | boolean | undefined)[]) {
   return classes.filter(Boolean).join(' ');
 }
-
-// Helper to construct URL from key if href is missing
-const getUrlForItem = (node: any, key: string) => {
-  const parts = key.split(':');
-  if (parts.length < 2) return null; // Need at least type:id
-
-  const type = parts[0];
-  const id = parts[1];
-  const version = parts[2]; // May be undefined
-
-  // Skip list items and other special keys
-  if (type === 'list') return null;
-
-  // Only show items that have a version to avoid duplicates
-  if (!version) return null;
-
-  // If node has href, use it, otherwise construct from key
-  if (node.href) return node.href;
-
-  // Pluralize type for URL if needed
-  let pluralType = type;
-  if (['event', 'command', 'domain', 'service', 'flow', 'container', 'channel'].includes(type)) {
-    pluralType = type + 's';
-  } else if (type === 'query') {
-    pluralType = 'queries';
-  }
-
-  return buildUrl(`/docs/${pluralType}/${id}/${version}`);
-};
 
 interface SearchNode {
   key: string;
@@ -203,7 +179,7 @@ export default function SearchModal() {
   const items = useMemo(() => {
     return searchNodes
       .map((node) => {
-        const url = getUrlForItem(node as any, node.key);
+        const url = getUrlForSearchItem(node as any, node.key);
         if (!url) return null;
 
         return {
@@ -252,8 +228,11 @@ export default function SearchModal() {
       Message: 0,
       Team: 0,
       Container: 0,
+      Entity: 0,
       Design: 0,
       Channel: 0,
+      Flow: 0,
+      'Data Product': 0,
     };
 
     itemsToCount.forEach((item) => {
@@ -277,8 +256,12 @@ export default function SearchModal() {
     if (counts.Domain > 0) dynamicFilters.push({ id: 'Domain', name: `Domains (${counts.Domain})` });
     if (counts.Service > 0) dynamicFilters.push({ id: 'Service', name: `Services (${counts.Service})` });
     if (counts.Message > 0) dynamicFilters.push({ id: 'Message', name: `Messages (${counts.Message})` });
-    if (counts.Container > 0) dynamicFilters.push({ id: 'Container', name: `Containers (${counts.Container})` });
+    if (counts.Container > 0) dynamicFilters.push({ id: 'Container', name: `Data Stores (${counts.Container})` });
+    if (counts.Entity > 0) dynamicFilters.push({ id: 'Entity', name: `Entities (${counts.Entity})` });
     if (counts.Channel > 0) dynamicFilters.push({ id: 'Channel', name: `Channels (${counts.Channel})` });
+    if (counts.Flow > 0) dynamicFilters.push({ id: 'Flow', name: `Flows (${counts.Flow})` });
+    if (counts['Data Product'] > 0)
+      dynamicFilters.push({ id: 'Data Product', name: `Data Products (${counts['Data Product']})` });
     if (counts.Design > 0) dynamicFilters.push({ id: 'Design', name: `Designs (${counts.Design})` });
     if (counts.Team > 0) dynamicFilters.push({ id: 'Team', name: `Teams & Users (${counts.Team})` });
 
@@ -317,7 +300,7 @@ export default function SearchModal() {
           .slice(0, 5)
           .map((fav) => {
             const node = searchNodeLookup.get(fav.nodeKey);
-            const url = node ? getUrlForItem(node as any, fav.nodeKey) : fav.href;
+            const url = node ? getUrlForSearchItem(node as any, fav.nodeKey) : fav.href;
             if (!url) return null;
 
             return {
@@ -411,7 +394,13 @@ export default function SearchModal() {
                 </div>
 
                 {/* Filter Tabs */}
-                <div className="flex items-center gap-2 px-4 py-3 overflow-x-auto no-scrollbar border-b border-[rgb(var(--ec-page-border))]">
+                <div
+                  className="flex items-center gap-2 px-4 pt-3 pb-3.5 overflow-x-auto overscroll-x-contain border-b border-[rgb(var(--ec-page-border))]"
+                  style={{
+                    scrollbarWidth: 'thin',
+                    scrollbarColor: 'rgb(var(--ec-page-border)) transparent',
+                  }}
+                >
                   {filters.map((tab) => (
                     <button
                       key={tab.id}
@@ -566,7 +555,7 @@ export default function SearchModal() {
                     <MagnifyingGlassIcon className="mx-auto h-6 w-6 text-[rgb(var(--ec-icon-color))]" />
                     <p className="mt-4 font-semibold text-[rgb(var(--ec-page-text))]">Search for anything</p>
                     <p className="mt-2 text-[rgb(var(--ec-page-text-muted))]">
-                      Search for domains, services, events, commands, queries and more.
+                      Search for domains, services, events, commands, queries, data stores, data products, flows and more.
                     </p>
                   </div>
                 )}

--- a/packages/core/eventcatalog/src/components/Search/search-utils.spec.ts
+++ b/packages/core/eventcatalog/src/components/Search/search-utils.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { getUrlForSearchItem } from './search-utils';
+
+declare global {
+  interface Window {
+    __EC_TRAILING_SLASH__: boolean;
+  }
+}
+
+describe('getUrlForSearchItem', () => {
+  beforeEach(() => {
+    // @ts-ignore
+    global.__EC_TRAILING_SLASH__ = false;
+  });
+
+  it.each([
+    ['container:OrdersDatabase:1.0.0', '/docs/containers/OrdersDatabase/1.0.0'],
+    ['data-product:Customer360:1.0.0', '/docs/data-products/Customer360/1.0.0'],
+    ['entity:Order:1.0.0', '/docs/entities/Order/1.0.0'],
+    ['flow:CheckoutFlow:1.0.0', '/docs/flows/CheckoutFlow/1.0.0'],
+  ])('builds a docs URL for %s', (key, expected) => {
+    expect(getUrlForSearchItem({}, key)).toBe(expected);
+  });
+
+  it('uses the explicit node href when provided', () => {
+    expect(getUrlForSearchItem({ href: '/custom/search-result' }, 'data-product:Customer360:1.0.0')).toBe(
+      '/custom/search-result'
+    );
+  });
+
+  it('skips aliases and unsupported keys', () => {
+    expect(getUrlForSearchItem({}, 'data-product:Customer360')).toBeNull();
+    expect(getUrlForSearchItem({}, 'list:data-products')).toBeNull();
+    expect(getUrlForSearchItem({}, 'unknown:Customer360:1.0.0')).toBeNull();
+  });
+});

--- a/packages/core/eventcatalog/src/components/Search/search-utils.ts
+++ b/packages/core/eventcatalog/src/components/Search/search-utils.ts
@@ -1,0 +1,34 @@
+import { buildUrl } from '@utils/url-builder';
+
+const docsPathByType: Record<string, string> = {
+  channel: 'channels',
+  command: 'commands',
+  container: 'containers',
+  'data-product': 'data-products',
+  domain: 'domains',
+  entity: 'entities',
+  event: 'events',
+  flow: 'flows',
+  query: 'queries',
+  service: 'services',
+};
+
+export const getUrlForSearchItem = (node: { href?: string }, key: string) => {
+  const parts = key.split(':');
+  if (parts.length < 2) return null;
+
+  const type = parts[0];
+  const id = parts[1];
+  const version = parts[2];
+
+  if (type === 'list') return null;
+
+  if (!version) return null;
+
+  if (node.href) return node.href;
+
+  const docsPath = docsPathByType[type];
+  if (!docsPath) return null;
+
+  return buildUrl(`/docs/${docsPath}/${id}/${version}`);
+};

--- a/packages/core/eventcatalog/src/components/SideNav/NestedSideBar/SearchBar.tsx
+++ b/packages/core/eventcatalog/src/components/SideNav/NestedSideBar/SearchBar.tsx
@@ -16,6 +16,8 @@ import {
   SquareMousePointer,
   ListOrdered,
   ArrowLeftRight,
+  Package,
+  Box,
 } from 'lucide-react';
 import type { NavNode } from '@stores/sidebar-store/state';
 import { getBadgeClasses } from './utils';
@@ -83,8 +85,10 @@ export default function SearchBar({ nodes, onSelectResult, onSearchChange }: Pro
     { key: 'channel', label: 'Channels', badge: 'Channel', icon: ArrowLeftRight },
     { key: 'command', label: 'Commands', badge: 'Command', icon: MessageSquare },
     { key: 'container', label: 'Data Stores', badge: 'Container', icon: Database },
+    { key: 'data-product', label: 'Data Products', badge: 'Data Product', icon: Package },
     { key: 'design', label: 'Designs', badge: 'Design', icon: SquareMousePointer },
     { key: 'domain', label: 'Domains', badge: 'Domain', icon: Boxes },
+    { key: 'entity', label: 'Entities', badge: 'Entity', icon: Box },
     { key: 'event', label: 'Events', badge: 'Event', icon: Zap },
     { key: 'flow', label: 'Flows', badge: 'Flow', icon: Waypoints },
     { key: 'query', label: 'Queries', badge: 'Query', icon: SearchIcon },
@@ -116,9 +120,11 @@ export default function SearchBar({ nodes, onSelectResult, onSearchChange }: Pro
       Command: 'command',
       Query: 'query',
       Container: 'container',
+      'Data Product': 'data-product',
       Flow: 'flow',
       Design: 'design',
       Channel: 'channel',
+      Entity: 'entity',
     };
 
     // Use the memoized array instead of Object.entries(nodes)
@@ -135,7 +141,7 @@ export default function SearchBar({ nodes, onSelectResult, onSearchChange }: Pro
 
       const keyParts = key.split(':');
       if (keyParts.length >= 3) {
-        const id = keyParts[2].toLowerCase();
+        const id = keyParts[1].toLowerCase();
         if (id.includes(query)) {
           results.push({ nodeKey: key, node, matchType: 'id' });
         }

--- a/packages/core/eventcatalog/src/components/SideNav/NestedSideBar/index.tsx
+++ b/packages/core/eventcatalog/src/components/SideNav/NestedSideBar/index.tsx
@@ -239,6 +239,8 @@ export default function NestedSideBar() {
         // Data Products
         { pattern: /^\/docs\/data-products\/([^/]+)\/([^/]+)/, type: 'data-product' },
         { pattern: /^\/visualiser\/data-products\/([^/]+)\/([^/]+)/, type: 'data-product' },
+        // Entities
+        { pattern: /^\/docs\/entities\/([^/]+)\/([^/]+)/, type: 'entity' },
       ];
 
       // URL patterns without version (language pages, etc)

--- a/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/sidebar-builder.spec.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/sidebar-builder.spec.ts
@@ -239,6 +239,35 @@ describe('getNestedSideBarData', () => {
       const browseNode = getNavigationConfigurationByKey('list:all', navigationData);
       expect(browseNode.pages).toEqual(['list:domains', 'list:services']);
     });
+
+    it('lists entities as searchable browse resources when they are in the catalog', async () => {
+      const { writeEntity } = utils(CATALOG_FOLDER);
+
+      await writeEntity({
+        id: 'Order',
+        name: 'Order',
+        version: '0.0.1',
+        summary: 'Order aggregate',
+        markdown: 'Order',
+      });
+
+      const navigationData = await getNestedSideBarData();
+      const browseNode = getNavigationConfigurationByKey('list:all', navigationData);
+      const entitiesList = getNavigationConfigurationByKey('list:entities', navigationData);
+      const entityNode = getNavigationConfigurationByKey('entity:Order:0.0.1', navigationData);
+
+      expect(browseNode.pages).toContain('list:entities');
+      expect(entitiesList.pages).toEqual(['entity:Order:0.0.1']);
+      expect(entityNode).toEqual(
+        expect.objectContaining({
+          type: 'item',
+          title: 'Order',
+          badge: 'Entity',
+          summary: 'Order aggregate',
+          href: '/docs/entities/Order/0.0.1',
+        })
+      );
+    });
   });
 
   describe('domain navigation item', () => {
@@ -1742,6 +1771,81 @@ describe('getNestedSideBarData', () => {
       });
     });
 
+    describe('flows section', () => {
+      it('is not listed if the service has no flows and no flows reference the service', async () => {
+        const { writeService } = utils(CATALOG_FOLDER);
+        await writeService({
+          id: 'ShippingService',
+          name: 'ShippingService',
+          version: '0.0.1',
+          markdown: 'ShippingService',
+        });
+
+        const navigationData = await getNestedSideBarData();
+        const serviceNode = getNavigationConfigurationByKey('service:ShippingService:0.0.1', navigationData);
+        const flowsSection = getChildNodeByTitle('Flows', serviceNode.pages ?? []);
+        expect(flowsSection).toBeUndefined();
+      });
+
+      it('lists flows that reference the service in flow steps', async () => {
+        const { writeService } = utils(CATALOG_FOLDER);
+        await writeService({
+          id: 'PaymentService',
+          name: 'Payment Service',
+          version: '0.0.1',
+          markdown: 'Payment Service',
+        });
+
+        mockFlows.push({
+          id: 'CheckoutFlow',
+          name: 'Checkout Flow',
+          version: '0.0.1',
+          markdown: 'Checkout Flow',
+          steps: [{ id: 'payment-service', title: 'Payment service', service: { id: 'PaymentService' } }],
+        });
+
+        const navigationData = await getNestedSideBarData();
+        const serviceNode = getNavigationConfigurationByKey('service:PaymentService:0.0.1', navigationData);
+        const flowsSection = getChildNodeByTitle('Flows', serviceNode.pages ?? []);
+
+        expect(flowsSection.pages).toEqual(['flow:CheckoutFlow:0.0.1']);
+      });
+
+      it('merges explicit service flows with flows that reference the service and removes duplicates', async () => {
+        const { writeService } = utils(CATALOG_FOLDER);
+        await writeService({
+          id: 'PaymentService',
+          name: 'Payment Service',
+          version: '0.0.1',
+          markdown: 'Payment Service',
+          flows: [{ id: 'CheckoutFlow', version: '0.0.1' }, { id: 'FraudFlow' }],
+        });
+
+        mockFlows.push(
+          {
+            id: 'CheckoutFlow',
+            name: 'Checkout Flow',
+            version: '0.0.1',
+            markdown: 'Checkout Flow',
+            steps: [{ id: 'payment-service', title: 'Payment service', service: { id: 'PaymentService' } }],
+          },
+          {
+            id: 'FraudFlow',
+            name: 'Fraud Flow',
+            version: '0.0.1',
+            markdown: 'Fraud Flow',
+            steps: [],
+          }
+        );
+
+        const navigationData = await getNestedSideBarData();
+        const serviceNode = getNavigationConfigurationByKey('service:PaymentService:0.0.1', navigationData);
+        const flowsSection = getChildNodeByTitle('Flows', serviceNode.pages ?? []);
+
+        expect(flowsSection.pages).toEqual(['flow:CheckoutFlow:0.0.1', 'flow:FraudFlow:0.0.1']);
+      });
+    });
+
     describe('owners section', () => {
       it('is not listed if the service does not have any owners', async () => {
         const { writeService } = utils(CATALOG_FOLDER);
@@ -2284,6 +2388,95 @@ describe('getNestedSideBarData', () => {
         const messageNode = getNavigationConfigurationByKey('event:PaymentProcessed:0.0.1', navigationData);
         const consumersSection = getChildNodeByTitle('Consumers', messageNode.pages ?? []);
         expect(consumersSection.pages).toEqual(['service:ShippingService:0.0.1']);
+      });
+    });
+
+    describe('flows section', () => {
+      it('is not listed if no flows reference the message', async () => {
+        const { writeEvent } = utils(CATALOG_FOLDER);
+        await writeEvent({
+          id: 'PaymentProcessed',
+          name: 'Payment Processed',
+          version: '0.0.1',
+          markdown: 'Payment Processed',
+        });
+
+        const navigationData = await getNestedSideBarData();
+        const messageNode = getNavigationConfigurationByKey('event:PaymentProcessed:0.0.1', navigationData);
+        const flowsSection = getChildNodeByTitle('Flows', messageNode.pages ?? []);
+        expect(flowsSection).toBeUndefined();
+      });
+
+      it('lists flows that reference event, command, and query messages', async () => {
+        const { writeEvent, writeCommand, writeQuery } = utils(CATALOG_FOLDER);
+
+        await writeEvent({
+          id: 'PaymentProcessed',
+          name: 'Payment Processed',
+          version: '0.0.1',
+          markdown: 'Payment Processed',
+        });
+        await writeCommand({
+          id: 'ReserveInventory',
+          name: 'Reserve Inventory',
+          version: '0.0.1',
+          markdown: 'Reserve Inventory',
+        });
+        await writeQuery({
+          id: 'GetPaymentStatus',
+          name: 'Get Payment Status',
+          version: '0.0.1',
+          markdown: 'Get Payment Status',
+        });
+
+        mockFlows.push({
+          id: 'CheckoutFlow',
+          name: 'Checkout Flow',
+          version: '0.0.1',
+          markdown: 'Checkout Flow',
+          steps: [
+            { id: 'payment-processed', title: 'Payment processed', message: { id: 'PaymentProcessed' } },
+            { id: 'reserve-inventory', title: 'Reserve inventory', message: { id: 'ReserveInventory', version: '0.0.1' } },
+            { id: 'get-payment-status', title: 'Get payment status', message: { id: 'GetPaymentStatus' } },
+          ],
+        });
+
+        const navigationData = await getNestedSideBarData();
+        const eventNode = getNavigationConfigurationByKey('event:PaymentProcessed:0.0.1', navigationData);
+        const commandNode = getNavigationConfigurationByKey('command:ReserveInventory:0.0.1', navigationData);
+        const queryNode = getNavigationConfigurationByKey('query:GetPaymentStatus:0.0.1', navigationData);
+
+        expect(getChildNodeByTitle('Flows', eventNode.pages ?? []).pages).toEqual(['flow:CheckoutFlow:0.0.1']);
+        expect(getChildNodeByTitle('Flows', commandNode.pages ?? []).pages).toEqual(['flow:CheckoutFlow:0.0.1']);
+        expect(getChildNodeByTitle('Flows', queryNode.pages ?? []).pages).toEqual(['flow:CheckoutFlow:0.0.1']);
+      });
+
+      it('deduplicates flows when multiple steps reference the same message', async () => {
+        const { writeEvent } = utils(CATALOG_FOLDER);
+
+        await writeEvent({
+          id: 'PaymentProcessed',
+          name: 'Payment Processed',
+          version: '0.0.1',
+          markdown: 'Payment Processed',
+        });
+
+        mockFlows.push({
+          id: 'CheckoutFlow',
+          name: 'Checkout Flow',
+          version: '0.0.1',
+          markdown: 'Checkout Flow',
+          steps: [
+            { id: 'payment-processed-1', title: 'Payment processed', message: { id: 'PaymentProcessed' } },
+            { id: 'payment-processed-2', title: 'Payment processed again', message: { id: 'PaymentProcessed' } },
+          ],
+        });
+
+        const navigationData = await getNestedSideBarData();
+        const messageNode = getNavigationConfigurationByKey('event:PaymentProcessed:0.0.1', navigationData);
+        const flowsSection = getChildNodeByTitle('Flows', messageNode.pages ?? []);
+
+        expect(flowsSection.pages).toEqual(['flow:CheckoutFlow:0.0.1']);
       });
     });
 
@@ -3101,6 +3294,91 @@ describe('getNestedSideBarData', () => {
         title: 'Changelog',
         href: '/docs/channels/PaymentChannel/0.0.1/changelog',
       });
+    });
+  });
+
+  describe('flow navigation items', () => {
+    it('lists messages, services, and flows referenced by flow steps', async () => {
+      const { writeEvent, writeCommand, writeQuery, writeService } = utils(CATALOG_FOLDER);
+
+      await writeEvent({
+        id: 'PaymentRequested',
+        name: 'Payment Requested',
+        version: '0.0.1',
+        markdown: 'Payment Requested',
+      });
+      await writeCommand({
+        id: 'ReserveInventory',
+        name: 'Reserve Inventory',
+        version: '0.0.1',
+        markdown: 'Reserve Inventory',
+      });
+      await writeQuery({
+        id: 'GetPaymentStatus',
+        name: 'Get Payment Status',
+        version: '0.0.1',
+        markdown: 'Get Payment Status',
+      });
+      await writeService({
+        id: 'PaymentService',
+        name: 'Payment Service',
+        version: '0.0.1',
+        markdown: 'Payment Service',
+      });
+
+      mockFlows.push(
+        {
+          id: 'CheckoutFlow',
+          name: 'Checkout Flow',
+          version: '0.0.1',
+          markdown: 'Checkout Flow',
+          steps: [
+            { id: 'payment-requested', title: 'Payment requested', message: { id: 'PaymentRequested' } },
+            { id: 'reserve-inventory', title: 'Reserve inventory', message: { id: 'ReserveInventory', version: '0.0.1' } },
+            { id: 'get-payment-status', title: 'Get payment status', message: { id: 'GetPaymentStatus' } },
+            { id: 'payment-service', title: 'Payment service', service: { id: 'PaymentService' } },
+            { id: 'fraud-flow', title: 'Fraud flow', flow: { id: 'FraudFlow' } },
+          ],
+        },
+        {
+          id: 'FraudFlow',
+          name: 'Fraud Flow',
+          version: '0.0.1',
+          markdown: 'Fraud Flow',
+          steps: [],
+        }
+      );
+
+      const navigationData = await getNestedSideBarData();
+      const flowNode = getNavigationConfigurationByKey('flow:CheckoutFlow:0.0.1', navigationData);
+      const messagesSection = getChildNodeByTitle('Messages', flowNode.pages ?? []);
+      const servicesSection = getChildNodeByTitle('Services', flowNode.pages ?? []);
+      const subflowsSection = getChildNodeByTitle('Subflows', flowNode.pages ?? []);
+
+      expect(messagesSection.pages).toEqual([
+        'event:PaymentRequested:0.0.1',
+        'command:ReserveInventory:0.0.1',
+        'query:GetPaymentStatus:0.0.1',
+      ]);
+      expect(servicesSection.pages).toEqual(['service:PaymentService:0.0.1']);
+      expect(subflowsSection.pages).toEqual(['flow:FraudFlow:0.0.1']);
+    });
+
+    it('does not list reference sections when a flow has no resource step references', async () => {
+      mockFlows.push({
+        id: 'ManualFlow',
+        name: 'Manual Flow',
+        version: '0.0.1',
+        markdown: 'Manual Flow',
+        steps: [{ id: 'start', title: 'Start' }],
+      });
+
+      const navigationData = await getNestedSideBarData();
+      const flowNode = getNavigationConfigurationByKey('flow:ManualFlow:0.0.1', navigationData);
+
+      expect(getChildNodeByTitle('Messages', flowNode.pages ?? [])).toBeUndefined();
+      expect(getChildNodeByTitle('Services', flowNode.pages ?? [])).toBeUndefined();
+      expect(getChildNodeByTitle('Subflows', flowNode.pages ?? [])).toBeUndefined();
     });
   });
 

--- a/packages/core/eventcatalog/src/stores/sidebar-store/builders/flow.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/builders/flow.ts
@@ -3,6 +3,44 @@ import { buildUrl } from '@utils/url-builder';
 import type { NavNode, ChildRef, ResourceGroupContext } from './shared';
 import { buildQuickReferenceSection, buildResourceDocsSection, shouldRenderSideBarSection } from './shared';
 import { isChangelogEnabled } from '@utils/feature';
+import { createVersionedMap, findInMap } from '@utils/collections/util';
+import { pluralizeMessageType } from '@utils/collections/messages';
+
+type VersionedEntry = { collection?: string; data: { id: string; version: string } };
+type VersionedEntryMap<T extends VersionedEntry> = Map<string, T[]>;
+
+const uniqueRefs = (refs: string[]) => [...new Set(refs)];
+
+const resolvePointer = <T extends VersionedEntry>(
+  map: VersionedEntryMap<T>,
+  pointer: { id: string; version?: string }
+): T | undefined => {
+  return findInMap(map, pointer.id, pointer.version);
+};
+
+const resolveMessageStep = (
+  step: any,
+  maps: {
+    eventMap: VersionedEntryMap<CollectionEntry<'events'>>;
+    commandMap: VersionedEntryMap<CollectionEntry<'commands'>>;
+    queryMap: VersionedEntryMap<CollectionEntry<'queries'>>;
+  }
+): string | null => {
+  if (!step.message) return null;
+
+  const hydratedMessage = Array.isArray(step.message) ? step.message[0] : undefined;
+  if (hydratedMessage?.collection && hydratedMessage?.data) {
+    return `${pluralizeMessageType(hydratedMessage as any)}:${hydratedMessage.data.id}:${hydratedMessage.data.version}`;
+  }
+
+  const pointer = Array.isArray(step.message) ? undefined : step.message;
+  if (!pointer?.id) return null;
+
+  const message =
+    resolvePointer(maps.eventMap, pointer) || resolvePointer(maps.commandMap, pointer) || resolvePointer(maps.queryMap, pointer);
+
+  return message ? `${pluralizeMessageType(message as any)}:${message.data.id}:${message.data.version}` : null;
+};
 
 export const buildFlowNode = (flow: CollectionEntry<'flows'>, context: ResourceGroupContext): NavNode => {
   const docsSection = buildResourceDocsSection(
@@ -11,6 +49,27 @@ export const buildFlowNode = (flow: CollectionEntry<'flows'>, context: ResourceG
     flow.data.version,
     context.resourceDocs,
     context.resourceDocCategories
+  );
+  const steps = flow.data.steps || [];
+  const eventMap = createVersionedMap(context.events);
+  const commandMap = createVersionedMap(context.commands);
+  const queryMap = createVersionedMap(context.queries);
+  const serviceMap = createVersionedMap(context.services);
+  const flowMap = createVersionedMap(context.flows);
+  const messageRefs = uniqueRefs(
+    steps.map((step) => resolveMessageStep(step, { eventMap, commandMap, queryMap })).filter(Boolean) as string[]
+  );
+  const serviceRefs = uniqueRefs(
+    steps
+      .map((step) => (step.service ? resolvePointer(serviceMap, step.service) : undefined))
+      .filter(Boolean)
+      .map((service) => `service:${service!.data.id}:${service!.data.version}`)
+  );
+  const flowRefs = uniqueRefs(
+    steps
+      .map((step) => (step.flow ? resolvePointer(flowMap, step.flow) : undefined))
+      .filter(Boolean)
+      .map((referencedFlow) => `flow:${referencedFlow!.data.id}:${referencedFlow!.data.version}`)
   );
 
   return {
@@ -42,6 +101,24 @@ export const buildFlowNode = (flow: CollectionEntry<'flows'>, context: ResourceG
             href: buildUrl(`/visualiser/flows/${flow.data.id}/${flow.data.version}`),
           },
         ].filter(Boolean) as ChildRef[],
+      },
+      messageRefs.length > 0 && {
+        type: 'group',
+        title: 'Messages',
+        icon: 'Mail',
+        pages: messageRefs,
+      },
+      serviceRefs.length > 0 && {
+        type: 'group',
+        title: 'Services',
+        icon: 'Server',
+        pages: serviceRefs,
+      },
+      flowRefs.length > 0 && {
+        type: 'group',
+        title: 'Subflows',
+        icon: 'Waypoints',
+        pages: flowRefs,
       },
     ].filter(Boolean) as ChildRef[],
   };

--- a/packages/core/eventcatalog/src/stores/sidebar-store/builders/message.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/builders/message.ts
@@ -18,7 +18,8 @@ export const buildMessageNode = (
   message: CollectionEntry<'events' | 'commands' | 'queries'>,
   owners: any[],
   context: ResourceGroupContext,
-  hasFieldUsage: boolean = false
+  hasFieldUsage: boolean = false,
+  flowRefs: string[] = []
 ): NavNode => {
   const producers = message.data.producers || [];
   const consumers = message.data.consumers || [];
@@ -26,6 +27,7 @@ export const buildMessageNode = (
 
   const renderProducers = producers.length > 0 && shouldRenderSideBarSection(message, 'producers');
   const renderConsumers = consumers.length > 0 && shouldRenderSideBarSection(message, 'consumers');
+  const renderFlows = flowRefs.length > 0 && shouldRenderSideBarSection(message, 'flows');
   const renderRepository = message.data.repository && shouldRenderSideBarSection(message, 'repository');
 
   // Determine badge based on collection type
@@ -131,6 +133,13 @@ export const buildMessageNode = (
         icon: 'Server',
         pages: consumers.map((consumer) => `service:${(consumer as any).data.id}:${(consumer as any).data.version}`),
         visible: consumers.length > 0,
+      },
+      renderFlows && {
+        type: 'group',
+        title: 'Flows',
+        icon: 'Waypoints',
+        pages: flowRefs,
+        visible: flowRefs.length > 0,
       },
       renderOwners && buildOwnersSection(owners),
       renderRepository && buildRepositorySection(message.data.repository as { url: string; language: string }),

--- a/packages/core/eventcatalog/src/stores/sidebar-store/builders/service.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/builders/service.ts
@@ -17,11 +17,14 @@ import { isVisualiserEnabled, isChangelogEnabled } from '@utils/feature';
 import { pluralizeMessageType } from '@utils/collections/messages';
 import { iconFieldsForResource } from '@utils/icon';
 
+const uniqueRefs = (refs: string[]) => [...new Set(refs)];
+
 export const buildServiceNode = (
   service: CollectionEntry<'services'>,
   owners: any[],
   context: ResourceGroupContext,
-  serviceChannels: CollectionEntry<'channels'>[] = []
+  serviceChannels: CollectionEntry<'channels'>[] = [],
+  flowRefs: string[] = []
 ): NavNode => {
   const sendsMessages = service.data.sends || [];
   const receivesMessages = service.data.receives || [];
@@ -36,7 +39,11 @@ export const buildServiceNode = (
   const dataStoresInService = uniqueBy([...(service.data.writesTo || []), ...(service.data.readsFrom || [])], 'id');
 
   const serviceFlows = service.data.flows || [];
-  const hasFlows = serviceFlows.length > 0;
+  const serviceFlowRefs = uniqueRefs([
+    ...serviceFlows.map((flow) => `flow:${(flow as any).data.id}:${(flow as any).data.version}`),
+    ...flowRefs,
+  ]);
+  const hasFlows = serviceFlowRefs.length > 0;
 
   const hasAttachments = service.data.attachments && service.data.attachments.length > 0;
 
@@ -197,7 +204,7 @@ export const buildServiceNode = (
         type: 'group',
         title: 'Flows',
         icon: 'Waypoints',
-        pages: serviceFlows.map((flow) => `flow:${(flow as any).data.id}:${(flow as any).data.version}`),
+        pages: serviceFlowRefs,
       },
       renderOwners && buildOwnersSection(owners),
       renderRepository && buildRepositorySection(service.data.repository as { url: string; language: string }),

--- a/packages/core/eventcatalog/src/stores/sidebar-store/state.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/state.ts
@@ -10,6 +10,7 @@ import { getUsers } from '@utils/collections/users';
 import { getTeams } from '@utils/collections/teams';
 import { getDiagrams } from '@utils/collections/diagrams';
 import { getDataProducts } from '@utils/collections/data-products';
+import { getEntities } from '@utils/collections/entities';
 import { getResourceDocCategories, getResourceDocs } from '@utils/collections/resource-docs';
 import { buildUrl } from '@utils/url-builder';
 import type { NavigationData, NavNode, ChildRef } from './builders/shared';
@@ -32,6 +33,92 @@ export type { NavigationData, NavNode, ChildRef };
 const CACHE_ENABLED = process.env.DISABLE_EVENTCATALOG_CACHE !== 'true';
 let memoryCache: NavigationData | null = null;
 
+type MessageEntry = CollectionEntry<'events' | 'commands' | 'queries'>;
+type ServiceEntry = CollectionEntry<'services'>;
+
+const getMessageNodeKey = (message: MessageEntry) =>
+  `${pluralizeMessageType(message)}:${message.data.id}:${message.data.version}`;
+
+const uniqueRefs = (refs: string[]) => [...new Set(refs)];
+
+const buildFlowReferencesByMessage = ({
+  flows,
+  events,
+  commands,
+  queries,
+}: {
+  flows: CollectionEntry<'flows'>[];
+  events: CollectionEntry<'events'>[];
+  commands: CollectionEntry<'commands'>[];
+  queries: CollectionEntry<'queries'>[];
+}) => {
+  const eventMap = createVersionedMap(events);
+  const commandMap = createVersionedMap(commands);
+  const queryMap = createVersionedMap(queries);
+  const flowRefsByMessage = new Map<string, string[]>();
+
+  const addFlowRef = (message: MessageEntry, flow: CollectionEntry<'flows'>) => {
+    const messageKey = getMessageNodeKey(message);
+    const flowKey = `flow:${flow.data.id}:${flow.data.version}`;
+    flowRefsByMessage.set(messageKey, uniqueRefs([...(flowRefsByMessage.get(messageKey) || []), flowKey]));
+  };
+
+  const resolveMessagePointer = (pointer: { id: string; version?: string }): MessageEntry | undefined => {
+    return (
+      findInMap(eventMap, pointer.id, pointer.version) ||
+      findInMap(commandMap, pointer.id, pointer.version) ||
+      findInMap(queryMap, pointer.id, pointer.version)
+    );
+  };
+
+  for (const flow of flows) {
+    for (const step of flow.data.steps || []) {
+      if (!step.message) continue;
+
+      const hydratedMessage = Array.isArray(step.message) ? step.message[0] : undefined;
+      if (hydratedMessage?.collection && hydratedMessage?.data) {
+        addFlowRef(hydratedMessage as MessageEntry, flow);
+        continue;
+      }
+
+      if (Array.isArray(step.message)) continue;
+
+      const message = resolveMessagePointer(step.message);
+      if (message) addFlowRef(message, flow);
+    }
+  }
+
+  return flowRefsByMessage;
+};
+
+const buildFlowReferencesByService = ({
+  flows,
+  services,
+}: {
+  flows: CollectionEntry<'flows'>[];
+  services: CollectionEntry<'services'>[];
+}) => {
+  const serviceMap = createVersionedMap(services);
+  const flowRefsByService = new Map<string, string[]>();
+
+  const addFlowRef = (service: ServiceEntry, flow: CollectionEntry<'flows'>) => {
+    const serviceKey = `service:${service.data.id}:${service.data.version}`;
+    const flowKey = `flow:${flow.data.id}:${flow.data.version}`;
+    flowRefsByService.set(serviceKey, uniqueRefs([...(flowRefsByService.get(serviceKey) || []), flowKey]));
+  };
+
+  for (const flow of flows) {
+    for (const step of flow.data.steps || []) {
+      if (!step.service) continue;
+
+      const service = findInMap(serviceMap, step.service.id, step.service.version);
+      if (service) addFlowRef(service, flow);
+    }
+  }
+
+  return flowRefsByService;
+};
+
 /**
  * Get the navigation data for the sidebar
  */
@@ -52,6 +139,7 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
     channels,
     diagrams,
     dataProducts,
+    entities,
     resourceDocs,
     resourceDocCategories,
   ] = await Promise.all([
@@ -66,6 +154,7 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
     getChannels({ getAllVersions: false }),
     getDiagrams({ getAllVersions: false }),
     getDataProducts({ getAllVersions: false }),
+    getEntities({ getAllVersions: false }),
     getResourceDocs(),
     getResourceDocCategories(),
   ]);
@@ -86,6 +175,7 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
     containers,
     diagrams,
     dataProducts,
+    entities,
     resourceDocs,
     resourceDocCategories,
   };
@@ -190,11 +280,13 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
     }
   }
 
+  const flowRefsByService = buildFlowReferencesByService({ flows, services });
+
   const serviceNodes = servicesWithOwners.reduce(
     (acc, { service, owners }) => {
       const versionedKey = `service:${service.data.id}:${service.data.version}`;
       const serviceChannels = serviceChannelsMap.get(`${service.data.id}:${service.data.version}`) || [];
-      acc[versionedKey] = buildServiceNode(service, owners, context, serviceChannels);
+      acc[versionedKey] = buildServiceNode(service, owners, context, serviceChannels, flowRefsByService.get(versionedKey) || []);
       if (service.data.latestVersion === service.data.version) {
         // Store reference to versioned key instead of duplicating the full node
         acc[`service:${service.data.id}`] = versionedKey;
@@ -217,12 +309,14 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
     }
   }
 
+  const flowRefsByMessage = buildFlowReferencesByMessage({ flows, events, commands, queries });
+
   const messageNodes = messagesWithOwners.reduce(
     (acc, { message, owners }) => {
       const type = pluralizeMessageType(message as any);
       const versionedKey = `${type}:${message.data.id}:${message.data.version}`;
       const hasFieldUsage = messagesWithFieldUsage.has(message.data.id);
-      acc[versionedKey] = buildMessageNode(message, owners, context, hasFieldUsage);
+      acc[versionedKey] = buildMessageNode(message, owners, context, hasFieldUsage, flowRefsByMessage.get(versionedKey) || []);
       if (message.data.latestVersion === message.data.version) {
         // Store reference to versioned key instead of duplicating the full node
         acc[`${type}:${message.data.id}`] = versionedKey;
@@ -270,6 +364,25 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
       acc[versionedKey] = buildDataProductNode(dataProduct, owners, dataProductContext);
       if (dataProduct.data.latestVersion === dataProduct.data.version) {
         acc[`data-product:${dataProduct.data.id}`] = versionedKey;
+      }
+      return acc;
+    },
+    {} as Record<string, NavNode | string>
+  );
+
+  const entityNodes = entities.reduce(
+    (acc, entity) => {
+      const versionedKey = `entity:${entity.data.id}:${entity.data.version}`;
+      acc[versionedKey] = {
+        type: 'item',
+        title: entity.data.name,
+        badge: 'Entity',
+        summary: entity.data.summary,
+        icon: 'Box',
+        href: buildUrl(`/docs/entities/${entity.data.id}/${entity.data.version}`),
+      };
+      if (entity.data.latestVersion === entity.data.version) {
+        acc[`entity:${entity.data.id}`] = versionedKey;
       }
       return acc;
     },
@@ -435,6 +548,13 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
     pages: dataProducts.map((dataProduct) => `data-product:${dataProduct.data.id}:${dataProduct.data.version}`),
   });
 
+  const entitiesList = createLeaf(entities, {
+    type: 'item',
+    title: 'Entities',
+    icon: 'Box',
+    pages: entities.map((entity) => `entity:${entity.data.id}:${entity.data.version}`),
+  });
+
   const designsList = createLeaf(designs, {
     type: 'item',
     title: 'Designs',
@@ -498,6 +618,7 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
     'list:flows',
     'list:containers',
     'list:data-products',
+    'list:entities',
     'list:designs',
     'list:people',
   ];
@@ -510,6 +631,7 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
     flowsList,
     containersList,
     dataProductsList,
+    entitiesList,
     designsList,
     peopleList,
   ];
@@ -537,6 +659,7 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
     ...(flowsList ? { 'list:flows': flowsList } : {}),
     ...(containersList ? { 'list:containers': containersList } : {}),
     ...(dataProductsList ? { 'list:data-products': dataProductsList } : {}),
+    ...(entitiesList ? { 'list:entities': entitiesList } : {}),
     ...(designsList ? { 'list:designs': designsList } : {}),
     ...(teamsList ? { 'list:teams': teamsList } : {}),
     ...(usersList ? { 'list:users': usersList } : {}),
@@ -572,6 +695,7 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
     ...channelNodes,
     ...containerNodes,
     ...dataProductNodes,
+    ...entityNodes,
     ...flowNodes,
     ...userNodes,
     ...teamNodes,

--- a/packages/core/eventcatalog/src/utils/collections/flows.ts
+++ b/packages/core/eventcatalog/src/utils/collections/flows.ts
@@ -24,13 +24,14 @@ export const getFlows = async ({ getAllVersions = true }: Props = {}): Promise<F
   }
 
   // 1. Fetch collections in parallel
-  const [allFlows, allEvents, allCommands] = await Promise.all([
+  const [allFlows, allEvents, allCommands, allQueries] = await Promise.all([
     getCollection('flows'),
     getCollection('events'),
     getCollection('commands'),
+    getCollection('queries'),
   ]);
 
-  const allMessages = [...allEvents, ...allCommands];
+  const allMessages = [...allEvents, ...allCommands, ...allQueries];
 
   // 2. Build optimized maps
   const flowMap = createVersionedMap(allFlows);


### PR DESCRIPTION
## What This PR Does

Broadens navigation across EventCatalog so that flows, entities, and data products are first-class citizens in both the sidebar and the global search. Service and message pages now show the flows they participate in, flow pages now list their referenced messages, services, and subflows, and entities now have their own top-level sidebar group and search results.

Closes: https://github.com/event-catalog/eventcatalog/issues/2416

## Changes Overview

### Key Changes
- Sidebar: messages now show a "Flows" group listing each flow that references them via `flow.steps[].message`.
- Sidebar: services now merge `service.data.flows` with flows discovered through `flow.steps[].service`, so flows referencing a service are surfaced even without an explicit pointer.
- Sidebar: flow pages now expose "Messages", "Services", and "Subflows" groups, resolved from each step.
- Sidebar: a new top-level "Entities" group lists all entities, and each entity gets a navigation node with an Entity badge.
- Search modal: adds Data Product and Flow type icons, colors, filter chips, and counts; renames Container chip to "Data Stores"; adds an Entity counter.
- Search modal: extracts URL resolution into `search-utils.ts` with a typed `docsPathByType` map covering containers, data products, entities, and flows.
- Nested sidebar search: adds Data Product and Entity badges, maps them to filter keys, and fixes an off-by-one when searching by id (`keyParts[1]` instead of `keyParts[2]`).
- Flows collection: `getFlows` now also loads `queries`, so flow step pointers to queries hydrate correctly.

## How It Works

`state.ts` builds two new lookup maps before constructing service and message nodes:

- `buildFlowReferencesByMessage` walks every flow's steps and indexes the flows that reference each message (by `event/command/query` pluralized key + versioned id).
- `buildFlowReferencesByService` does the same for services referenced via `step.service`.

These maps are passed into `buildServiceNode` and `buildMessageNode` so each resource can render a "Flows" group with deduped versioned references.

In `builders/flow.ts`, each flow step is resolved against `events`, `commands`, `queries`, `services`, and `flows` versioned maps via `createVersionedMap` / `findInMap`. Steps that arrive already hydrated (Astro reference arrays) are handled directly; pointer-only steps fall back to map lookups. The resulting refs feed three new sidebar groups under each flow.

Search URL construction was duplicated and missing type handling for containers, data products, entities, and flows. It is now centralized in `search-utils.ts` with a `docsPathByType` map and covered by `search-utils.spec.ts`.

## Breaking Changes

None. All additions are backwards compatible: missing flow references degrade to the previous (no group) behavior, and the new entity sidebar group only renders when entities exist.

## Additional Notes

- New unit tests: `search-utils.spec.ts` covers URL building for the new resource types, alias keys, and explicit `href` overrides.
- Sidebar builder spec was expanded with coverage for the new flow/service/message linking behavior.
- Reviewer note: the `SearchBar.tsx` `keyParts[1]` change is a bug fix — the previous code read the version segment when matching by id.