### PR TITLE
chore(create-eventcatalog): simplify e-commerce domain template

### DIFF
--- a/.changeset/clever-pandas-dance.md
+++ b/.changeset/clever-pandas-dance.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/create-eventcatalog": patch
+---
+
+Simplify E-Commerce domain template by removing target architecture section

--- a/packages/create-eventcatalog/templates/default/domains/E-Commerce/index.mdx
+++ b/packages/create-eventcatalog/templates/default/domains/E-Commerce/index.mdx
@@ -68,13 +68,7 @@ The E-Commerce domain is built on the following sub domains:
   </ResourceLink>
   - Generic subscription domain handling users subscriptions
 
-## Target Architecture (Event Storming Results)
-
-Our target architecture was defined through collaborative event storming sessions with product, engineering, and business stakeholders. This represents our vision for FlowMart's commerce capabilities.
-
-<Miro boardId="uXjVIHCImos=/" moveToWidget="3074457347671667709" edit={false} />
-
-## Current Production Architecture
+## Architecture
 
 Our current event-driven architecture powering FlowMart's shopping experience:
 


### PR DESCRIPTION
## What This PR Does

Cleans up the default E-Commerce domain template shipped by `create-eventcatalog` by removing the "Target Architecture (Event Storming Results)" section (including its embedded Miro board) and renaming "Current Production Architecture" to simply "Architecture". The template now lands new users with a leaner, more focused starting point.

## Changes Overview

### Key Changes
- Remove "Target Architecture" heading, intro paragraph, and embedded `<Miro />` board from the default E-Commerce domain template
- Rename "Current Production Architecture" to "Architecture"

## How It Works

The change is to a single MDX template file consumed by `create-eventcatalog` when scaffolding the default catalog. No code or runtime behaviour changes — new projects generated from the default template just get the simplified copy.

## Breaking Changes

None.

## Additional Notes

Patch release for `@eventcatalog/create-eventcatalog`. Existing catalogs are unaffected.