### PR TITLE
feat(core): default to dark theme and use sunset theme in templates

### DIFF
--- a/.changeset/sunset-dark-default.md
+++ b/.changeset/sunset-dark-default.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/core': patch
+---
+
+Default theme to dark when the user has no system preference set.

--- a/.changeset/sunset-template-theme.md
+++ b/.changeset/sunset-template-theme.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/create-eventcatalog': patch
+---
+
+Set `theme: 'sunset'` as the default theme across all project templates.

--- a/packages/core/eventcatalog/src/layouts/BaseLayout.astro
+++ b/packages/core/eventcatalog/src/layouts/BaseLayout.astro
@@ -20,22 +20,14 @@ const catalogTheme = config.theme || 'default';
     <!-- Inline script to prevent flash of wrong theme -->
     <script is:inline define:vars={{ catalogTheme }}>
       (function () {
-        function getSystemTheme() {
-          if (window.matchMedia) {
-            if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-              return 'dark';
-            }
-            if (window.matchMedia('(prefers-color-scheme: light)').matches) {
-              return 'light';
-            }
-          }
+        function getDefaultTheme() {
           return 'dark';
         }
 
         function applyTheme() {
-          // Check localStorage first, fall back to system preference
+          // Check localStorage first, fall back to dark mode
           const stored = localStorage.getItem('eventcatalog-theme');
-          const theme = stored === 'light' || stored === 'dark' ? stored : getSystemTheme();
+          const theme = stored === 'light' || stored === 'dark' ? stored : getDefaultTheme();
           document.documentElement.setAttribute('data-theme', theme);
           // Also ensure catalog theme is set (for page transitions)
           document.documentElement.setAttribute('data-catalog-theme', catalogTheme);

--- a/packages/core/eventcatalog/src/layouts/BaseLayout.astro
+++ b/packages/core/eventcatalog/src/layouts/BaseLayout.astro
@@ -21,10 +21,15 @@ const catalogTheme = config.theme || 'default';
     <script is:inline define:vars={{ catalogTheme }}>
       (function () {
         function getSystemTheme() {
-          if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
-            return 'dark';
+          if (window.matchMedia) {
+            if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+              return 'dark';
+            }
+            if (window.matchMedia('(prefers-color-scheme: light)').matches) {
+              return 'light';
+            }
           }
-          return 'light';
+          return 'dark';
         }
 
         function applyTheme() {

--- a/packages/core/eventcatalog/src/stores/theme-store.ts
+++ b/packages/core/eventcatalog/src/stores/theme-store.ts
@@ -6,16 +6,8 @@ export type Theme = 'light' | 'dark';
 
 export const themeStore = atom<Theme>('dark');
 
-// Get system preference
-const getSystemTheme = (): Theme => {
-  if (typeof window !== 'undefined' && window.matchMedia) {
-    if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-      return 'dark';
-    }
-    if (window.matchMedia('(prefers-color-scheme: light)').matches) {
-      return 'light';
-    }
-  }
+// Default theme when the user has not explicitly chosen one.
+const getDefaultTheme = (): Theme => {
   return 'dark';
 };
 
@@ -36,15 +28,14 @@ const initStore = () => {
         themeStore.set(stored);
         applyTheme(stored);
       } else {
-        // No stored preference, use system preference
-        const systemTheme = getSystemTheme();
-        themeStore.set(systemTheme);
-        applyTheme(systemTheme);
+        // No stored preference, use the catalog default
+        const defaultTheme = getDefaultTheme();
+        themeStore.set(defaultTheme);
+        applyTheme(defaultTheme);
       }
     } catch (e) {
       console.warn('Failed to load theme:', e);
-      const systemTheme = getSystemTheme();
-      applyTheme(systemTheme);
+      applyTheme(getDefaultTheme());
     }
   }
 };

--- a/packages/core/eventcatalog/src/stores/theme-store.ts
+++ b/packages/core/eventcatalog/src/stores/theme-store.ts
@@ -4,14 +4,19 @@ const THEME_KEY = 'eventcatalog-theme';
 
 export type Theme = 'light' | 'dark';
 
-export const themeStore = atom<Theme>('light');
+export const themeStore = atom<Theme>('dark');
 
 // Get system preference
 const getSystemTheme = (): Theme => {
   if (typeof window !== 'undefined' && window.matchMedia) {
-    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      return 'dark';
+    }
+    if (window.matchMedia('(prefers-color-scheme: light)').matches) {
+      return 'light';
+    }
   }
-  return 'light';
+  return 'dark';
 };
 
 // Apply theme to document via data-theme attribute

--- a/packages/core/src/eventcatalog.config.ts
+++ b/packages/core/src/eventcatalog.config.ts
@@ -76,6 +76,8 @@ type IntegrationsConfig = {
   debug?: boolean;
 };
 
+type CatalogTheme = 'default' | 'ocean' | 'sapphire' | 'sunset' | 'forest' | (string & {});
+
 // Any Scalar Configuration for the OpenAPI Component.
 type ScalarConfiguration = any;
 
@@ -96,9 +98,12 @@ export interface Config {
    * Theme for the catalog UI.
    * - 'default': Default purple/slate theme
    * - 'ocean': Deep blue/teal ocean-inspired theme
+   * - 'sapphire': Blue/violet theme
+   * - 'sunset': Orange/pink sunset-inspired theme
+   * - 'forest': Green forest-inspired theme
    * @default 'default'
    */
-  theme?: 'default' | 'ocean';
+  theme?: CatalogTheme;
   auth?: AuthConfig;
   rss?: {
     enabled: boolean;

--- a/packages/create-eventcatalog/templates/amazon-api-gateway/eventcatalog.config.js
+++ b/packages/create-eventcatalog/templates/amazon-api-gateway/eventcatalog.config.js
@@ -4,6 +4,7 @@ export default {
   tagline:
     'This internal platform provides a comprehensive view of our event-driven architecture across all systems. Use this portal to discover EventBridge schemas, services and domains, and understand the message contracts that connect our infrastructure',
   organizationName: '<organizationName>',
+  theme: 'sunset',
   homepageLink: 'https://eventcatalog.dev/',
   editUrl: 'https://github.com/boyney123/eventcatalog-demo/edit/master',
   // Supports static or server. Static renders a static site, server renders a server side rendered site

--- a/packages/create-eventcatalog/templates/asyncapi/eventcatalog.config.js
+++ b/packages/create-eventcatalog/templates/asyncapi/eventcatalog.config.js
@@ -9,6 +9,7 @@ export default {
   tagline:
     'This internal platform provides a comprehensive view of our event-driven architecture across all systems. Use this portal to discover existing domains, explore services and their dependencies, and understand the message contracts that connect our infrastructure',
   organizationName: '<organizationName>',
+  theme: 'sunset',
   homepageLink: 'https://eventcatalog.dev/',
   editUrl: 'https://github.com/boyney123/eventcatalog-demo/edit/master',
   // Supports static or server. Static renders a static site, server renders a server side rendered site

--- a/packages/create-eventcatalog/templates/confluent/eventcatalog.config.js
+++ b/packages/create-eventcatalog/templates/confluent/eventcatalog.config.js
@@ -4,6 +4,7 @@ export default {
   tagline:
     'This internal platform provides a comprehensive view of our event-driven architecture across all systems. Use this portal to discover kafka schemas, topics, services and domains, and understand the message contracts that connect our infrastructure',
   organizationName: '<organizationName>',
+  theme: 'sunset',
   homepageLink: 'https://eventcatalog.dev/',
   editUrl: 'https://github.com/boyney123/eventcatalog-demo/edit/master',
   // Supports static or server. Static renders a static site, server renders a server side rendered site

--- a/packages/create-eventcatalog/templates/default/eventcatalog.config.js
+++ b/packages/create-eventcatalog/templates/default/eventcatalog.config.js
@@ -4,6 +4,7 @@ export default {
   tagline:
     'This internal platform provides a comprehensive view of our event-driven architecture across all systems. Use this portal to discover existing domains, explore services and their dependencies, and understand the message contracts that connect our infrastructure',
   organizationName: '<organizationName>',
+  theme: 'sunset',
   homepageLink: 'https://eventcatalog.dev/',
   editUrl: 'https://github.com/boyney123/eventcatalog-demo/edit/master',
   // Supports static or server. Static renders a static site, server renders a server side rendered site

--- a/packages/create-eventcatalog/templates/empty/eventcatalog.config.js
+++ b/packages/create-eventcatalog/templates/empty/eventcatalog.config.js
@@ -4,6 +4,7 @@ export default {
   tagline:
     'This internal platform provides a comprehensive view of our event-driven architecture across all systems. Use this portal to discover existing domains, explore services and their dependencies, and understand the message contracts that connect our infrastructure',
   organizationName: '<organizationName>',
+  theme: 'sunset',
   homepageLink: 'https://eventcatalog.dev/',
   editUrl: 'https://github.com/boyney123/eventcatalog-demo/edit/master',
   // Supports static or server. Static renders a static site, server renders a server side rendered site

--- a/packages/create-eventcatalog/templates/eventbridge/eventcatalog.config.js
+++ b/packages/create-eventcatalog/templates/eventbridge/eventcatalog.config.js
@@ -4,6 +4,7 @@ export default {
   tagline:
     'This internal platform provides a comprehensive view of our event-driven architecture across all systems. Use this portal to discover EventBridge schemas, services and domains, and understand the message contracts that connect our infrastructure',
   organizationName: '<organizationName>',
+  theme: 'sunset',
   homepageLink: 'https://eventcatalog.dev/',
   editUrl: 'https://github.com/boyney123/eventcatalog-demo/edit/master',
   // Supports static or server. Static renders a static site, server renders a server side rendered site

--- a/packages/create-eventcatalog/templates/graphql/eventcatalog.config.js
+++ b/packages/create-eventcatalog/templates/graphql/eventcatalog.config.js
@@ -9,6 +9,7 @@ export default {
   tagline:
     'This internal platform provides a comprehensive view of our event-driven architecture across all systems. Use this portal to discover existing domains, explore services and their dependencies, and understand the message contracts that connect our infrastructure',
   organizationName: '<organizationName>',
+  theme: 'sunset',
   homepageLink: 'https://eventcatalog.dev/',
   editUrl: 'https://github.com/boyney123/eventcatalog-demo/edit/master',
   // Supports static or server. Static renders a static site, server renders a server side rendered site

--- a/packages/create-eventcatalog/templates/openapi/eventcatalog.config.js
+++ b/packages/create-eventcatalog/templates/openapi/eventcatalog.config.js
@@ -9,6 +9,7 @@ export default {
   tagline:
     'This internal platform provides a comprehensive view of our event-driven architecture across all systems. Use this portal to discover existing domains, explore services and their dependencies, and understand the message contracts that connect our infrastructure',
   organizationName: '<organizationName>',
+  theme: 'sunset',
   homepageLink: 'https://eventcatalog.dev/',
   editUrl: 'https://github.com/boyney123/eventcatalog-demo/edit/master',
   // Supports static or server. Static renders a static site, server renders a server side rendered site


### PR DESCRIPTION
## What This PR Does

Switches the EventCatalog default theme to `dark` when a visitor has no system colour preference set, and updates every `create-eventcatalog` template so new projects opt in to the `sunset` theme out of the box. Visitors who explicitly prefer light mode still get light mode; only the "no preference" fallback changed.

## Changes Overview

### Key Changes
- `BaseLayout.astro` inline theme bootstrap now explicitly checks for `prefers-color-scheme: light` before falling back to `dark` (previously fell back to `light`).
- `theme-store.ts` mirrors the same logic and defaults the atom to `dark`.
- All nine `create-eventcatalog` templates (default, asyncapi, openapi, graphql, eventbridge, confluent, amazon-api-gateway, empty, and so on) now set `theme: 'sunset'` in their `eventcatalog.config.js`.

## How It Works

The pre-hydration script in `BaseLayout.astro` runs before paint. It now distinguishes three cases: explicit dark preference, explicit light preference, and no preference — the last of which now resolves to dark to match the new brand direction. The nanostore in `theme-store.ts` uses the same resolution so SSR/client agree.

For new catalogs, scaffolding via `create-eventcatalog` produces a config that pins the `sunset` theme, so users see the intended branded look immediately without needing to edit config.

## Breaking Changes

None for existing catalogs — users with a configured `theme` in their `eventcatalog.config.js` are unaffected, and users with an explicit system colour preference continue to get that preference honoured. Visitors with no preference set will now see dark mode by default.

## Additional Notes

Newly scaffolded projects from any template will start on the `sunset` theme; users can change this by editing `theme` in `eventcatalog.config.js`.