### PR TITLE
feat(visualiser): enrich custom flow nodes with color, icons, and metadata

### DIFF
--- a/.changeset/bright-pandas-render.md
+++ b/.changeset/bright-pandas-render.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/visualiser": patch
+---
+
+Enhance custom flow nodes with richer styling and metadata: color palettes, icons, type badges, summary text, key/value properties, and optional context menu links.

--- a/examples/default/domains/E-Commerce/subdomains/Payment/flows/PaymentProcessed/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Payment/flows/PaymentProcessed/index.mdx
@@ -41,7 +41,15 @@ steps:
           label: Notify customer
     - id: "payment_failed"
       title: Payment Failed
-      type: node
+      custom:
+        title: Payment Failure
+        color: red
+        icon: ExclamationTriangleIcon
+        type: Exception
+        summary: Payment processor rejected or failed the payment attempt
+        properties:
+          failure_window: 15 minutes
+          retry_policy: Exponential backoff
       next_steps:
         - id: "failure_notification"
           label: Notify customer of failure
@@ -57,16 +65,46 @@ steps:
         label: Complete order
     - id: "send_custom_notification"
       title: Customer Notified of Payment
-      type: node
+      custom:
+        title: Payment Receipt Notification
+        color: green
+        icon: EnvelopeIcon
+        type: Notification
+        summary: Sends the customer a receipt and order confirmation after successful payment
+        properties:
+          channel: Email
+          template: payment-receipt
       next_step:
         id: "payment_complete"
         label: Complete order
     - id: "failure_notification"
       title: Customer Notified of Failure
-      type: node
+      custom:
+        title: Payment Failure Notification
+        color: yellow
+        icon: BellAlertIcon
+        type: Notification
+        summary: Notifies the customer that the payment failed and gives recovery options
+        properties:
+          channel: Email
+          template: payment-failed
     - id: "retry_payment"
       title: Retry Payment
-      type: node
+      custom:
+        title: Retry Orchestration
+        color: orange
+        icon: ArrowPathIcon
+        type: Processor
+        summary: Coordinates retry attempts for transient payment failures
+        url: https://docs.example.com/payments/retry-policy
+        properties:
+          max_attempts: 3
+          retry_delay: 10 minutes
+        menu:
+          - label: View retry policy
+            url: https://docs.example.com/payments/retry-policy
+          - label: Open failed payments dashboard
+            url: https://analytics.example.com/payments/failures
       next_step:
         id: "payment_initiated"
         label: Retry payment process
@@ -79,7 +117,15 @@ steps:
         label: Order completed
     - id: "order-complete"
       title: Order Completed
-      type: node
+      custom:
+        title: Order Fulfillment Trigger
+        color: blue
+        icon: TruckIcon
+        type: Fulfillment
+        summary: Marks payment completion as ready for downstream fulfillment workflows
+        properties:
+          downstream_flow: Shipping
+          fulfillment_sla: 24 hours
 ---
 
 ### Flow of feature

--- a/examples/default/domains/E-Commerce/subdomains/Subscriptions/flows/SubscriptionRenewed/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Subscriptions/flows/SubscriptionRenewed/index.mdx
@@ -18,8 +18,6 @@ steps:
       properties:
         subscription_id: "sub_12345678"
         renewal_type: "Automatic"
-        billing_cycle: "Monthly"
-        next_billing_date: "2024-08-01"
       menu:
         - label: "View scheduler configuration"
           url: "https://docs.example.com/scheduler"
@@ -211,7 +209,6 @@ steps:
       properties:
         max_attempts: 3
         backoff_interval: "24 hours"
-        current_attempt: 1
     next_steps:
       - id: "payment_initiated"
         label: "Retry payment"

--- a/packages/visualiser/src/nodes/Custom.tsx
+++ b/packages/visualiser/src/nodes/Custom.tsx
@@ -1,37 +1,181 @@
-import { Handle } from "@xyflow/react";
-import * as Icons from "@heroicons/react/24/solid";
 import { memo, useMemo, type ComponentType } from "react";
+import { Handle, Position, useNodeConnections } from "@xyflow/react";
+import * as Icons from "@heroicons/react/24/solid";
 import * as ContextMenu from "@radix-ui/react-context-menu";
-import * as Tooltip from "@radix-ui/react-tooltip";
+import { HIDDEN_HANDLE_STYLE } from "./OwnerIndicator";
+import { EMPTY_ARRAY, EMPTY_OBJECT, LINE_CLAMP_STYLE } from "./shared-styles";
 import { usePortalContainer } from "../context/PortalContainerContext";
-import {
-  NODE_WIDTH_STYLE,
-  ROTATED_LABEL_STYLE,
-  TINY_FONT_STYLE,
-  EMPTY_OBJECT,
-  EMPTY_ARRAY,
-} from "./shared-styles";
 
 type MenuItem = {
   label: string;
   url?: string;
 };
 
+type CustomColor =
+  | "blue"
+  | "teal"
+  | "red"
+  | "green"
+  | "purple"
+  | "orange"
+  | "pink"
+  | "yellow"
+  | "gray"
+  | "indigo"
+  | "cyan"
+  | "slate"
+  | "amber"
+  | "emerald"
+  | "violet"
+  | "rose";
+
+type CustomPalette = {
+  border: string;
+  badge: string;
+  ring: string;
+  shadow: string;
+  glow: string;
+  pillBorder: string;
+};
+
+const PALETTES: Record<CustomColor, CustomPalette> = {
+  blue: {
+    border: "border-blue-500",
+    badge: "bg-blue-500",
+    ring: "ring-2 ring-blue-400/60 ring-offset-2",
+    shadow: "rgba(59, 130, 246, 0.15)",
+    glow: "linear-gradient(135deg, #3b82f6, #2563eb)",
+    pillBorder: "#3b82f6",
+  },
+  teal: {
+    border: "border-teal-500",
+    badge: "bg-teal-500",
+    ring: "ring-2 ring-teal-400/60 ring-offset-2",
+    shadow: "rgba(20, 184, 166, 0.15)",
+    glow: "linear-gradient(135deg, #14b8a6, #0f766e)",
+    pillBorder: "#14b8a6",
+  },
+  red: {
+    border: "border-red-500",
+    badge: "bg-red-500",
+    ring: "ring-2 ring-red-400/60 ring-offset-2",
+    shadow: "rgba(239, 68, 68, 0.15)",
+    glow: "linear-gradient(135deg, #ef4444, #b91c1c)",
+    pillBorder: "#ef4444",
+  },
+  green: {
+    border: "border-green-500",
+    badge: "bg-green-500",
+    ring: "ring-2 ring-green-400/60 ring-offset-2",
+    shadow: "rgba(34, 197, 94, 0.15)",
+    glow: "linear-gradient(135deg, #22c55e, #15803d)",
+    pillBorder: "#22c55e",
+  },
+  purple: {
+    border: "border-purple-500",
+    badge: "bg-purple-500",
+    ring: "ring-2 ring-purple-400/60 ring-offset-2",
+    shadow: "rgba(168, 85, 247, 0.15)",
+    glow: "linear-gradient(135deg, #a855f7, #7e22ce)",
+    pillBorder: "#a855f7",
+  },
+  orange: {
+    border: "border-orange-500",
+    badge: "bg-orange-500",
+    ring: "ring-2 ring-orange-400/60 ring-offset-2",
+    shadow: "rgba(251, 146, 60, 0.15)",
+    glow: "linear-gradient(135deg, #fb923c, #ea580c)",
+    pillBorder: "#fb923c",
+  },
+  pink: {
+    border: "border-pink-500",
+    badge: "bg-pink-500",
+    ring: "ring-2 ring-pink-400/60 ring-offset-2",
+    shadow: "rgba(236, 72, 153, 0.15)",
+    glow: "linear-gradient(135deg, #ec4899, #be185d)",
+    pillBorder: "#ec4899",
+  },
+  yellow: {
+    border: "border-yellow-500",
+    badge: "bg-yellow-500",
+    ring: "ring-2 ring-yellow-400/60 ring-offset-2",
+    shadow: "rgba(234, 179, 8, 0.15)",
+    glow: "linear-gradient(135deg, #eab308, #a16207)",
+    pillBorder: "#eab308",
+  },
+  gray: {
+    border: "border-gray-500",
+    badge: "bg-gray-500",
+    ring: "ring-2 ring-gray-400/60 ring-offset-2",
+    shadow: "rgba(107, 114, 128, 0.15)",
+    glow: "linear-gradient(135deg, #6b7280, #374151)",
+    pillBorder: "#6b7280",
+  },
+  indigo: {
+    border: "border-indigo-500",
+    badge: "bg-indigo-500",
+    ring: "ring-2 ring-indigo-400/60 ring-offset-2",
+    shadow: "rgba(99, 102, 241, 0.15)",
+    glow: "linear-gradient(135deg, #6366f1, #4338ca)",
+    pillBorder: "#6366f1",
+  },
+  cyan: {
+    border: "border-cyan-500",
+    badge: "bg-cyan-500",
+    ring: "ring-2 ring-cyan-400/60 ring-offset-2",
+    shadow: "rgba(6, 182, 212, 0.15)",
+    glow: "linear-gradient(135deg, #06b6d4, #0e7490)",
+    pillBorder: "#06b6d4",
+  },
+  slate: {
+    border: "border-slate-500",
+    badge: "bg-slate-500",
+    ring: "ring-2 ring-slate-400/60 ring-offset-2",
+    shadow: "rgba(100, 116, 139, 0.15)",
+    glow: "linear-gradient(135deg, #64748b, #334155)",
+    pillBorder: "#64748b",
+  },
+  amber: {
+    border: "border-amber-500",
+    badge: "bg-amber-500",
+    ring: "ring-2 ring-amber-400/60 ring-offset-2",
+    shadow: "rgba(245, 158, 11, 0.15)",
+    glow: "linear-gradient(135deg, #f59e0b, #b45309)",
+    pillBorder: "#f59e0b",
+  },
+  emerald: {
+    border: "border-emerald-500",
+    badge: "bg-emerald-500",
+    ring: "ring-2 ring-emerald-400/60 ring-offset-2",
+    shadow: "rgba(16, 185, 129, 0.15)",
+    glow: "linear-gradient(135deg, #10b981, #047857)",
+    pillBorder: "#10b981",
+  },
+  violet: {
+    border: "border-violet-500",
+    badge: "bg-violet-500",
+    ring: "ring-2 ring-violet-400/60 ring-offset-2",
+    shadow: "rgba(139, 92, 246, 0.15)",
+    glow: "linear-gradient(135deg, #8b5cf6, #6d28d9)",
+    pillBorder: "#8b5cf6",
+  },
+  rose: {
+    border: "border-rose-500",
+    badge: "bg-rose-500",
+    ring: "ring-2 ring-rose-400/60 ring-offset-2",
+    shadow: "rgba(244, 63, 94, 0.15)",
+    glow: "linear-gradient(135deg, #f43f5e, #be123c)",
+    pillBorder: "#f43f5e",
+  },
+};
+
 interface Data {
-  title: string;
-  label: string;
-  bgColor: string;
-  color: string;
   mode: "simple" | "full";
   step: {
     id: string;
     title: string;
-    summary: string;
-    name: string;
-    actor: { name: string };
+    summary?: string;
   };
-  showTarget?: boolean;
-  showSource?: boolean;
   custom: {
     icon?: string;
     type?: string;
@@ -39,173 +183,187 @@ interface Data {
     summary?: string;
     url?: string;
     color?: string;
-    properties?: Record<string, string>;
+    properties?: Record<string, string | number>;
     menu?: MenuItem[];
     height?: number;
   };
 }
 
-function classNames(...classes: any) {
+function classNames(...classes: any[]) {
   return classes.filter(Boolean).join(" ");
 }
 
-export default memo(function UserNode({
-  data,
-  sourcePosition,
-  targetPosition,
-}: any) {
-  const { mode, step, custom: customProps } = data as Data;
+function getPalette(color: string | undefined) {
+  return PALETTES[(color as CustomColor) || "blue"] ?? PALETTES.blue;
+}
 
+function GlowHandle({
+  side,
+  gradient,
+}: {
+  side: "left" | "right";
+  gradient: string;
+}) {
+  return (
+    <div
+      style={{
+        position: "absolute",
+        top: "50%",
+        [side]: -6,
+        transform: "translateY(-50%)",
+        width: 12,
+        height: 12,
+        borderRadius: "50%",
+        background: gradient,
+        border: "2px solid rgb(var(--ec-page-bg))",
+        zIndex: 20,
+        animation: "ec-handle-pulse 2s ease-in-out infinite",
+        pointerEvents: "none",
+      }}
+    />
+  );
+}
+
+export default memo(function CustomNode({ data, selected }: any) {
+  const { mode, custom: customProps, step } = data as Data;
   const {
     color = "blue",
-    title = "Custom",
-    icon = "UserIcon",
-    type = "custom",
-    summary = "",
-    url: _url = "",
+    title = step?.title || "Custom",
+    icon = "CubeIcon",
+    type = "Custom",
+    summary = step?.summary || "",
+    url,
     properties = EMPTY_OBJECT,
     menu = EMPTY_ARRAY,
     height = 5,
   } = customProps;
 
+  const palette = getPalette(color);
   const IconComponent = useMemo<
     ComponentType<{ className?: string }> | undefined
-  >(() => Icons[icon as keyof typeof Icons], [icon]);
-
-  const { actor: { name: _name } = {} } = step;
-
-  const isLongType = type && type.length > 10;
-  const displayType = isLongType ? `${type.substring(0, 10)}...` : type;
+  >(() => Icons[icon as keyof typeof Icons] || Icons.CubeIcon, [icon]);
   const portalContainer = usePortalContainer();
+  const targetConnections = useNodeConnections({ handleType: "target" });
+  const sourceConnections = useNodeConnections({ handleType: "source" });
+  const propertyEntries = Object.entries(properties);
+  const contextMenuItems = url
+    ? [{ label: `Open ${type.toLowerCase()}`, url }, ...menu]
+    : menu;
 
   return (
     <ContextMenu.Root>
       <ContextMenu.Trigger>
         <div
           className={classNames(
-            `rounded-md border flex justify-start bg-[rgb(var(--ec-card-bg))] text-[rgb(var(--ec-page-text))] border-${color}-400`,
+            "relative min-w-48 max-w-60 rounded-xl border-2 overflow-visible",
+            selected ? palette.ring : "",
+            palette.border,
           )}
           style={{
-            minHeight: mode === "full" ? `${height}em` : "2em",
-            ...NODE_WIDTH_STYLE,
+            background: "var(--ec-custom-node-bg, rgb(var(--ec-card-bg)))",
+            boxShadow: `0 2px 12px ${palette.shadow}`,
+            minHeight: mode === "full" ? `${height}em` : undefined,
           }}
         >
-          <div
-            className={classNames(
-              `bg-gradient-to-b from-${color}-400 to-${color}-600 relative flex flex-col items-center w-5 justify-between rounded-l-sm text-orange-100-500`,
-              `border-r-[1px] border-${color}`,
-            )}
-          >
-            {IconComponent && (
-              <IconComponent className="w-4 h-4 opacity-90 text-white mt-1" />
-            )}
-            {mode === "full" && (
-              <Tooltip.Provider>
-                <Tooltip.Root>
-                  <Tooltip.Trigger asChild>
-                    <span
-                      className="text-center text-[9px] text-white font-bold uppercase mb-4"
-                      style={ROTATED_LABEL_STYLE}
-                    >
-                      {displayType}
-                    </span>
-                  </Tooltip.Trigger>
-                  {isLongType && (
-                    <Tooltip.Portal container={portalContainer}>
-                      <Tooltip.Content
-                        className="bg-slate-800 text-white rounded px-2 py-1 text-xs shadow-md z-50"
-                        side="right"
-                        sideOffset={5}
-                      >
-                        {type}
-                        <Tooltip.Arrow className="fill-slate-800" />
-                      </Tooltip.Content>
-                    </Tooltip.Portal>
-                  )}
-                </Tooltip.Root>
-              </Tooltip.Provider>
-            )}
-          </div>
-          <div className="p-1 flex-1">
-            {targetPosition && (
-              <Handle type="target" position={targetPosition} />
-            )}
-            {sourcePosition && (
-              <Handle type="source" position={sourcePosition} />
-            )}
+          <Handle
+            type="target"
+            position={Position.Left}
+            style={HIDDEN_HANDLE_STYLE}
+          />
+          <Handle
+            type="source"
+            position={Position.Right}
+            style={HIDDEN_HANDLE_STYLE}
+          />
+          {targetConnections.length > 0 && (
+            <GlowHandle side="left" gradient={palette.glow} />
+          )}
+          {sourceConnections.length > 0 && (
+            <GlowHandle side="right" gradient={palette.glow} />
+          )}
 
-            {(!summary || mode !== "full") && (
-              <div className="h-full ">
-                <span className="text-sm font-bold block pb-0.5 w-full">
-                  {title}
-                </span>
+          <div className="absolute -top-3 left-2.5 z-10">
+            <span
+              className={classNames(
+                "inline-flex items-center gap-1 text-[7px] font-bold uppercase tracking-widest text-white px-1.5 py-0.5 rounded shadow-sm",
+                palette.badge,
+              )}
+            >
+              {IconComponent && (
+                <IconComponent className="w-2.5 h-2.5" aria-hidden />
+              )}
+              {type}
+            </span>
+          </div>
+
+          <div className="px-3 pt-3.5 pb-2.5">
+            <div className="flex items-center gap-2">
+              <span className="text-[13px] font-semibold leading-snug text-[rgb(var(--ec-page-text))] truncate">
+                {title}
+              </span>
+            </div>
+
+            {mode === "full" && summary && (
+              <div
+                className="mt-1.5 text-[9px] text-[rgb(var(--ec-page-text-muted))] leading-relaxed overflow-hidden"
+                style={LINE_CLAMP_STYLE}
+                title={summary}
+              >
+                {summary}
               </div>
             )}
 
-            {summary && mode === "full" && (
-              <div>
-                <div
-                  className={classNames(
-                    mode === "full"
-                      ? `border-b border-[rgb(var(--ec-page-border))]`
-                      : "",
-                  )}
-                >
-                  <span className="text-xs font-bold block pb-0.5">
-                    {title}
-                  </span>
-                </div>
-                {mode === "full" && (
-                  <div className="divide-y divide-[rgb(var(--ec-page-border))] ">
-                    <div className="leading-3 py-1">
-                      <span className="text-[8px] font-light">{summary}</span>
+            {mode === "full" && propertyEntries.length > 0 && (
+              <div className="mt-2 pt-1.5 border-t border-[rgb(var(--ec-page-border))] grid grid-cols-2 gap-x-2 gap-y-1">
+                {propertyEntries.map(([key, value]) => (
+                  <div key={key} className="min-w-0">
+                    <div className="text-[7px] font-bold uppercase tracking-wide text-[rgb(var(--ec-page-text-muted))] truncate">
+                      {key}
                     </div>
-                    {properties && (
-                      <div className="grid grid-cols-2 gap-x-4 py-1">
-                        {Object.entries(properties).map(([key, value]) => (
-                          <span
-                            key={key}
-                            className="text-xs"
-                            style={TINY_FONT_STYLE}
-                          >
-                            {key}:{" "}
-                            {typeof value === "string" &&
-                            value.startsWith("http") ? (
-                              <a
-                                href={value}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="text-blue-500 underline"
-                              >
-                                {value}
-                              </a>
-                            ) : (
-                              value
-                            )}
-                          </span>
-                        ))}
+                    {typeof value === "string" && value.startsWith("http") ? (
+                      <a
+                        href={value}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="block text-[8px] text-blue-500 underline truncate"
+                        title={value}
+                      >
+                        {value}
+                      </a>
+                    ) : (
+                      <div
+                        className="text-[8px] text-[rgb(var(--ec-page-text))] truncate"
+                        title={String(value)}
+                      >
+                        {value}
                       </div>
                     )}
                   </div>
-                )}
+                ))}
               </div>
             )}
           </div>
         </div>
       </ContextMenu.Trigger>
-      {menu?.length > 0 && (
+      {contextMenuItems.length > 0 && (
         <ContextMenu.Portal container={portalContainer}>
           <ContextMenu.Content className="min-w-[220px] bg-[rgb(var(--ec-card-bg))] rounded-md p-1 shadow-md border border-[rgb(var(--ec-page-border))]">
-            {menu?.map((item) => {
-              return (
-                <ContextMenu.Item
-                  asChild
-                  className="text-sm px-2 py-1.5 outline-none cursor-pointer hover:bg-orange-100 rounded-sm flex items-center"
+            {contextMenuItems.map((item) => (
+              <ContextMenu.Item
+                asChild
+                key={`${item.label}-${item.url || ""}`}
+                className="text-sm px-2 py-1.5 outline-none cursor-pointer hover:bg-orange-100 rounded-sm flex items-center"
+              >
+                <a
+                  href={item.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-[rgb(var(--ec-page-text))] no-underline"
                 >
-                  <a href={item.url}>{item.label}</a>
-                </ContextMenu.Item>
-              );
-            })}
+                  {item.label}
+                </a>
+              </ContextMenu.Item>
+            ))}
           </ContextMenu.Content>
         </ContextMenu.Portal>
       )}

--- a/packages/visualiser/src/styles-core.css
+++ b/packages/visualiser/src/styles-core.css
@@ -113,6 +113,7 @@
   --ec-dp-node-bg: #f7f5ff;
   --ec-external-node-bg: #faf5ff;
   --ec-actor-node-bg: #fffdf5;
+  --ec-custom-node-bg: #f8fbff;
   --ec-message-group-node-bg: #f9f5ff;
   --ec-deprecated-stripe: rgba(239, 68, 68, 0.3);
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
@@ -145,6 +146,7 @@
   --ec-dp-node-bg: rgb(40, 46, 56);
   --ec-external-node-bg: rgb(40, 46, 56);
   --ec-actor-node-bg: rgb(40, 46, 56);
+  --ec-custom-node-bg: rgb(40, 46, 56);
   --ec-message-group-node-bg: rgb(40, 46, 56);
   --ec-deprecated-stripe: rgba(239, 68, 68, 0.25);
   --ec-input-bg: 22, 27, 34;

--- a/packages/visualiser/src/styles.css
+++ b/packages/visualiser/src/styles.css
@@ -113,6 +113,7 @@
   --ec-dp-node-bg: #f7f5ff;
   --ec-external-node-bg: #faf5ff;
   --ec-actor-node-bg: #fffdf5;
+  --ec-custom-node-bg: #f8fbff;
   --ec-message-group-node-bg: #f9f5ff;
   --ec-deprecated-stripe: rgba(239, 68, 68, 0.3);
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
@@ -145,6 +146,7 @@
   --ec-dp-node-bg: rgb(40, 46, 56);
   --ec-external-node-bg: rgb(40, 46, 56);
   --ec-actor-node-bg: rgb(40, 46, 56);
+  --ec-custom-node-bg: rgb(40, 46, 56);
   --ec-message-group-node-bg: rgb(40, 46, 56);
   --ec-deprecated-stripe: rgba(239, 68, 68, 0.25);
   --ec-input-bg: 22, 27, 34;


### PR DESCRIPTION
## What This PR Does

Expands the `custom` node type in the visualiser so flow authors can express richer intent on each step. Custom nodes now support a typed color palette, Heroicons, a type badge, a summary line, a key/value property list, and an optional context menu of links.

## Changes Overview

### Key Changes
- Rewrote `packages/visualiser/src/nodes/Custom.tsx` with a palette-driven design supporting 16 named colors, icon rendering, type pill, summary, properties block, and Radix context menu.
- Added `--ec-custom-node-bg` CSS variable to both `styles.css` and `styles-core.css` for light and dark themes.
- Updated default catalog examples (`PaymentProcessed` and `SubscriptionRenewed` flows) to demonstrate the new custom node capabilities.

## How It Works

Custom step definitions in flow MDX accept a `custom` block with fields like `title`, `color`, `icon`, `type`, `summary`, `properties`, `url`, and `menu`. The node component looks up the chosen color in a `PALETTES` map to drive border, badge, ring, glow, and shadow styling, and resolves icons by name from `@heroicons/react/24/solid`. Connection handles are positioned dynamically based on `useNodeConnections`, and right-click opens a Radix context menu rendered into the portal container.

## Breaking Changes

None. The existing `type: node` form continues to work; the new `custom` block is opt-in.

## Additional Notes

- The two example flows now showcase the new fields and serve as visual regression baselines.
- Follow-up: consider documenting the supported color names and icon set in the website docs.