### PR TITLE
feat(flows): add container and data product steps

### DIFF
--- a/.changeset/swift-flows-container-steps.md
+++ b/.changeset/swift-flows-container-steps.md
@@ -1,0 +1,7 @@
+---
+'@eventcatalog/core': patch
+'@eventcatalog/sdk': patch
+'@eventcatalog/visualiser': patch
+---
+
+Add support for `container` and `dataProduct` steps in flows. Flows can now reference data stores (containers) and data products directly as steps, rendered in the flow node graph and sidebar. SDK adds `addDataStoreStep`, `addContainerStep`, and `addDataProductStep` builders.

--- a/examples/default/domains/E-Commerce/subdomains/Orders/flows/InventoryReservation/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Orders/flows/InventoryReservation/index.mdx
@@ -1,0 +1,128 @@
+---
+id: InventoryReservationFlow
+name: "Inventory Reservation Flow"
+version: "1.0.0"
+summary: "Flow for reserving stock after an order has been confirmed"
+owners:
+  - inventory-team
+steps:
+  - id: "order_confirmed"
+    title: "Order confirmed event"
+    message:
+      id: "OrderConfirmed"
+      version: "0.0.1"
+    next_step:
+      id: "inventory_service"
+      label: "Reserve stock"
+
+  - id: "inventory_service"
+    title: "Inventory Service"
+    service:
+      id: "InventoryService"
+    next_step:
+      id: "inventory_status_query"
+      label: "Check available stock"
+
+  - id: "inventory_status_query"
+    title: "Get inventory status query"
+    message:
+      id: "GetInventoryStatus"
+      version: "0.0.1"
+    next_step:
+      id: "inventory_readmodel"
+      label: "Read stock projection"
+
+  - id: "inventory_readmodel"
+    title: "Inventory Read Model"
+    container:
+      id: "inventory-readmodel"
+    next_steps:
+      - id: "reservation_policy"
+        label: "Stock available"
+      - id: "out_of_stock"
+        label: "Insufficient stock"
+
+  - id: "reservation_policy"
+    title: "Reservation policy"
+    custom:
+      title: "Reservation Policy"
+      color: "purple"
+      icon: "QueueListIcon"
+      type: "Decision"
+      summary: "Allocates stock by warehouse, channel priority, and promised delivery date"
+      properties:
+        hold_duration: "15 minutes"
+        allocation_strategy: "nearest warehouse first"
+    next_step:
+      id: "update_inventory"
+      label: "Reserve units"
+
+  - id: "update_inventory"
+    title: "Update inventory command"
+    message:
+      id: "UpdateInventory"
+      version: "0.0.3"
+    next_step:
+      id: "inventory_db"
+      label: "Persist reservation"
+
+  - id: "inventory_db"
+    title: "Inventory DB"
+    container:
+      id: "inventory-db"
+    next_step:
+      id: "inventory_adjusted"
+      label: "Publish adjustment"
+
+  - id: "inventory_adjusted"
+    title: "Inventory adjusted event"
+    message:
+      id: "InventoryAdjusted"
+      version: "1.0.1"
+    next_step:
+      id: "reservation_complete"
+      label: "Reservation complete"
+
+  - id: "reservation_complete"
+    title: "Reservation complete"
+    custom:
+      title: "Stock Reserved"
+      color: "green"
+      icon: "CheckCircleIcon"
+      type: "Business Milestone"
+      summary: "Stock is held for the order and downstream fulfillment can continue"
+      properties:
+        reservation_status: "held"
+        expiry_policy: "release on payment timeout"
+
+  - id: "out_of_stock"
+    title: "Out of stock event"
+    message:
+      id: "OutOfStock"
+    next_step:
+      id: "reorder_policy"
+      label: "Evaluate recovery"
+
+  - id: "reorder_policy"
+    title: "Reorder policy"
+    custom:
+      title: "Out-of-stock Recovery"
+      color: "yellow"
+      icon: "ArrowPathIcon"
+      type: "Policy"
+      summary: "Decides whether to split shipment, backorder, substitute, or cancel"
+      properties:
+        backorder_window: "3 days"
+        owner: "Inventory operations"
+    next_step:
+      id: "notify_customer"
+      label: "Notify customer"
+
+  - id: "notify_customer"
+    title: "Notification Service"
+    service:
+      id: "NotificationService"
+      version: "0.0.2"
+---
+
+<NodeGraph />

--- a/examples/default/domains/E-Commerce/subdomains/Orders/flows/PlaceOrder/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Orders/flows/PlaceOrder/index.mdx
@@ -1,0 +1,137 @@
+---
+id: PlaceOrderFlow
+name: "Place Order Flow"
+version: "1.0.0"
+summary: "End-to-end flow for accepting a customer order and preparing downstream fulfillment"
+owners:
+  - orders-team
+steps:
+  - id: "customer_submits_order"
+    title: "Customer submits order"
+    actor:
+      name: "Customer"
+      summary: "Customer confirms basket, delivery address, and payment intent"
+    next_step:
+      id: "place_order_command"
+      label: "Submit order"
+
+  - id: "place_order_command"
+    title: "Place order command"
+    message:
+      id: "PlaceOrder"
+      version: "0.0.1"
+    next_step:
+      id: "orders_service"
+      label: "Validate order"
+
+  - id: "orders_service"
+    title: "Orders Service"
+    service:
+      id: "OrdersService"
+    next_steps:
+      - id: "order_validation"
+        label: "Run business validation"
+      - id: "order_rejected"
+        label: "Reject invalid order"
+
+  - id: "order_validation"
+    title: "Order validation"
+    custom:
+      title: "Order Policy Check"
+      color: "blue"
+      icon: "ClipboardDocumentCheckIcon"
+      type: "Policy"
+      summary: "Checks basket totals, address coverage, fraud flags, and customer eligibility"
+      properties:
+        checks: "pricing, address, stock, payment intent"
+        owner: "Orders platform"
+    next_step:
+      id: "orders_db"
+      label: "Persist accepted order"
+
+  - id: "orders_db"
+    title: "Orders DB"
+    container:
+      id: "orders-db"
+    next_step:
+      id: "order_metadata_store"
+      label: "Store derived metadata"
+
+  - id: "order_metadata_store"
+    title: "Order Metadata Store"
+    container:
+      id: "order-metadata-store"
+    next_step:
+      id: "order_confirmed"
+      label: "Publish order confirmation"
+
+  - id: "order_confirmed"
+    title: "Order confirmed event"
+    message:
+      id: "OrderConfirmed"
+      version: "0.0.1"
+    next_steps:
+      - id: "inventory_reservation"
+        label: "Reserve inventory"
+      - id: "payment_flow"
+        label: "Collect payment"
+      - id: "order_analytics"
+        label: "Update order analytics"
+
+  - id: "order_analytics"
+    title: "Order Analytics"
+    dataProduct:
+      id: "order-analytics"
+    next_step:
+      id: "order_fulfillment_metrics"
+      label: "Prepare fulfillment KPIs"
+
+  - id: "order_fulfillment_metrics"
+    title: "Order Fulfillment Metrics"
+    dataProduct:
+      id: "order-fulfillment-metrics"
+
+  - id: "inventory_reservation"
+    title: "Inventory reservation flow"
+    flow:
+      id: "InventoryReservationFlow"
+    next_step:
+      id: "order_accepted_notification"
+      label: "Inventory flow started"
+
+  - id: "payment_flow"
+    title: "Payment flow"
+    flow:
+      id: "PaymentFlow"
+    next_step:
+      id: "order_accepted_notification"
+      label: "Payment flow started"
+
+  - id: "order_accepted_notification"
+    title: "Order accepted notification"
+    container:
+      id: "notifications-queue"
+    next_step:
+      id: "notification_service"
+      label: "Notify customer"
+
+  - id: "notification_service"
+    title: "Notification Service"
+    service:
+      id: "NotificationService"
+      version: "0.0.2"
+
+  - id: "order_rejected"
+    title: "Order rejected"
+    custom:
+      title: "Order Rejected"
+      color: "red"
+      icon: "ExclamationTriangleIcon"
+      type: "Exception"
+      summary: "The order could not be accepted and the customer needs a corrective action"
+      properties:
+        common_causes: "invalid address, price mismatch, unavailable item"
+        next_action: "show checkout error"
+---
+
+<NodeGraph />

--- a/examples/default/domains/E-Commerce/subdomains/Orders/flows/ShipmentCreation/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Orders/flows/ShipmentCreation/index.mdx
@@ -1,0 +1,164 @@
+---
+id: ShipmentCreationFlow
+name: "Shipment Creation Flow"
+version: "1.0.0"
+summary: "Flow for creating a shipment once payment and inventory reservation are complete"
+owners:
+  - fulfillment-team
+steps:
+  - id: "payment_complete"
+    title: "Payment complete event"
+    message:
+      id: "PaymentComplete"
+    next_step:
+      id: "create_shipment"
+      label: "Create shipment"
+
+  - id: "create_shipment"
+    title: "Create shipment command"
+    message:
+      id: "CreateShipment"
+      version: "0.0.1"
+    next_step:
+      id: "shipping_service"
+      label: "Prepare fulfillment"
+
+  - id: "shipping_service"
+    title: "Shipping Service"
+    service:
+      id: "ShippingService"
+      version: "0.0.1"
+    next_step:
+      id: "carrier_selection"
+      label: "Select carrier"
+
+  - id: "carrier_selection"
+    title: "Carrier selection"
+    custom:
+      title: "Carrier Selection"
+      color: "blue"
+      icon: "TruckIcon"
+      type: "Decision"
+      summary: "Chooses the carrier based on destination, SLA, item size, and cost"
+      properties:
+        default_sla: "2 days"
+        fallback_carrier: "Royal Mail"
+    next_step:
+      id: "carrier_api"
+      label: "Book shipment"
+
+  - id: "carrier_api"
+    title: "Carrier API"
+    externalSystem:
+      name: "Carrier API"
+      summary: "External parcel carrier integration"
+      url: "https://carrier.example.com/"
+    next_steps:
+      - id: "shipment_created"
+        label: "Shipment booked"
+      - id: "shipment_booking_failed"
+        label: "Booking failed"
+
+  - id: "shipment_created"
+    title: "Shipment created event"
+    message:
+      id: "ShipmentCreated"
+      version: "0.0.1"
+    next_step:
+      id: "tracking_notification_queue"
+      label: "Queue tracking email"
+
+  - id: "tracking_notification_queue"
+    title: "Notifications Queue"
+    container:
+      id: "notifications-queue"
+    next_step:
+      id: "notification_service"
+      label: "Send tracking notification"
+
+  - id: "notification_service"
+    title: "Notification Service"
+    service:
+      id: "NotificationService"
+      version: "0.0.2"
+    next_step:
+      id: "shipment_dispatched"
+      label: "Dispatch parcel"
+
+  - id: "shipment_dispatched"
+    title: "Shipment dispatched event"
+    message:
+      id: "ShipmentDispatched"
+      version: "0.0.1"
+    next_step:
+      id: "update_shipment_status"
+      label: "Track shipment"
+
+  - id: "update_shipment_status"
+    title: "Update shipment status command"
+    message:
+      id: "UpdateShipmentStatus"
+      version: "0.0.1"
+    next_steps:
+      - id: "shipment_in_transit"
+        label: "Carrier scan received"
+      - id: "delivery_failed"
+        label: "Delivery failed"
+
+  - id: "shipment_in_transit"
+    title: "Shipment in transit event"
+    message:
+      id: "ShipmentInTransit"
+      version: "0.0.1"
+    next_step:
+      id: "shipment_delivered"
+      label: "Delivered"
+
+  - id: "shipment_delivered"
+    title: "Shipment delivered event"
+    message:
+      id: "ShipmentDelivered"
+      version: "0.0.1"
+    next_step:
+      id: "order_fulfillment_metrics"
+      label: "Update fulfillment KPIs"
+
+  - id: "order_fulfillment_metrics"
+    title: "Order Fulfillment Metrics"
+    dataProduct:
+      id: "order-fulfillment-metrics"
+
+  - id: "delivery_failed"
+    title: "Delivery failed event"
+    message:
+      id: "DeliveryFailed"
+    next_step:
+      id: "delivery_exception"
+      label: "Handle exception"
+
+  - id: "delivery_exception"
+    title: "Delivery exception"
+    custom:
+      title: "Delivery Exception"
+      color: "red"
+      icon: "ExclamationTriangleIcon"
+      type: "Exception"
+      summary: "Support or carrier operations must resolve a failed delivery attempt"
+      properties:
+        owner: "Fulfillment operations"
+        customer_visible: "true"
+
+  - id: "shipment_booking_failed"
+    title: "Shipment booking failed"
+    custom:
+      title: "Carrier Booking Failed"
+      color: "orange"
+      icon: "ArrowPathIcon"
+      type: "Retry"
+      summary: "Carrier booking failed and the shipment must be retried or moved to another carrier"
+      properties:
+        retry_attempts: 3
+        fallback: "manual fulfillment"
+---
+
+<NodeGraph />

--- a/examples/default/domains/E-Commerce/subdomains/Payment/flows/PaymentProcessed/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Payment/flows/PaymentProcessed/index.mdx
@@ -4,129 +4,261 @@ name: Payment Flow for customers
 version: 1.0.0
 summary: Business flow for processing payments in an e-commerce platform
 owners:
-    - dboyne
+  - dboyne
 steps:
-    - id: "flow_step"
-      title: "Flow Step"
-      flow:
-        id: SubscriptionRenewed
-      next_step: 
-        id: "place_order_request"  
-        label: "Subscription Renewed, New Order Placed"
-    - id: "place_order_request"
-      title: Place order
-      message:
-        id: PlaceOrder
-        version: 0.0.1
-      next_step:
-        id: "payment_initiated"
-        label: Initiate payment
-    - id: "payment_initiated"
-      title: Payment Initiated
-      message:
-        id: PaymentInitiated
-        version: 0.0.1
-      next_steps:
-        - "payment_processed"
-        - "payment_failed"
-    - id: "payment_processed"
-      title: Payment Processed
-      message:
-        id: PaymentProcessed
-        version: 0.0.1
-      next_steps:
-        - id: "adjust_inventory"
-          label: Adjust inventory
-        - id: "send_custom_notification"
-          label: Notify customer
-    - id: "payment_failed"
-      title: Payment Failed
-      custom:
-        title: Payment Failure
-        color: red
-        icon: ExclamationTriangleIcon
-        type: Exception
-        summary: Payment processor rejected or failed the payment attempt
-        properties:
-          failure_window: 15 minutes
-          retry_policy: Exponential backoff
-      next_steps:
-        - id: "failure_notification"
-          label: Notify customer of failure
-        - id: "retry_payment"
-          label: Retry payment
-    - id: "adjust_inventory"
-      title: Inventory Adjusted
-      message:
-        id: InventoryAdjusted
-        version: 1.0.1
-      next_step:
-        id: "payment_complete"
-        label: Complete order
-    - id: "send_custom_notification"
-      title: Customer Notified of Payment
-      custom:
-        title: Payment Receipt Notification
-        color: green
-        icon: EnvelopeIcon
-        type: Notification
-        summary: Sends the customer a receipt and order confirmation after successful payment
-        properties:
-          channel: Email
-          template: payment-receipt
-      next_step:
-        id: "payment_complete"
-        label: Complete order
-    - id: "failure_notification"
-      title: Customer Notified of Failure
-      custom:
-        title: Payment Failure Notification
-        color: yellow
-        icon: BellAlertIcon
-        type: Notification
-        summary: Notifies the customer that the payment failed and gives recovery options
-        properties:
-          channel: Email
-          template: payment-failed
-    - id: "retry_payment"
-      title: Retry Payment
-      custom:
-        title: Retry Orchestration
-        color: orange
-        icon: ArrowPathIcon
-        type: Processor
-        summary: Coordinates retry attempts for transient payment failures
-        url: https://docs.example.com/payments/retry-policy
-        properties:
-          max_attempts: 3
-          retry_delay: 10 minutes
-        menu:
-          - label: View retry policy
-            url: https://docs.example.com/payments/retry-policy
-          - label: Open failed payments dashboard
-            url: https://analytics.example.com/payments/failures
-      next_step:
-        id: "payment_initiated"
-        label: Retry payment process
-    - id: "payment_complete"
-      title: Payment Complete
-      message:
-        id: PaymentComplete
-      next_step:
-        id: "order-complete"
-        label: Order completed
-    - id: "order-complete"
-      title: Order Completed
-      custom:
-        title: Order Fulfillment Trigger
-        color: blue
-        icon: TruckIcon
-        type: Fulfillment
-        summary: Marks payment completion as ready for downstream fulfillment workflows
-        properties:
-          downstream_flow: Shipping
-          fulfillment_sla: 24 hours
+  - id: "checkout_customer"
+    title: "Customer checks out"
+    actor:
+      name: "Customer"
+      summary: "Customer confirms the basket and starts payment"
+    next_step:
+      id: "place_order_request"
+      label: "Place order"
+
+  - id: "place_order_request"
+    title: "Place order command"
+    message:
+      id: "PlaceOrder"
+      version: "0.0.1"
+    next_step:
+      id: "orders_service"
+      label: "Validate order"
+
+  - id: "orders_service"
+    title: "Orders Service"
+    service:
+      id: "OrdersService"
+    next_steps:
+      - id: "orders_db"
+        label: "Persist order intent"
+      - id: "subscription_renewal_context"
+        label: "Order came from renewal"
+
+  - id: "subscription_renewal_context"
+    title: "Subscription renewal context"
+    flow:
+      id: "SubscriptionRenewed"
+    next_step:
+      id: "payment_initiated"
+      label: "Continue payment"
+
+  - id: "orders_db"
+    title: "Orders DB"
+    container:
+      id: "orders-db"
+    next_step:
+      id: "payment_initiated"
+      label: "Start payment"
+
+  - id: "payment_initiated"
+    title: "Payment initiated event"
+    message:
+      id: "PaymentInitiated"
+      version: "0.0.1"
+    next_step:
+      id: "payment_cache"
+      label: "Create payment session"
+
+  - id: "payment_cache"
+    title: "Payment session cache"
+    container:
+      id: "payment-cache"
+    next_step:
+      id: "fraud_detection_service"
+      label: "Check payment risk"
+
+  - id: "fraud_detection_service"
+    title: "Fraud Detection Service"
+    service:
+      id: "FraudDetectionService"
+      version: "0.0.1"
+    next_steps:
+      - id: "risk_score_calculated"
+        label: "Risk score accepted"
+      - id: "fraud_detected"
+        label: "Fraud suspected"
+
+  - id: "risk_score_calculated"
+    title: "Risk score calculated"
+    message:
+      id: "RiskScoreCalculated"
+      version: "0.0.1"
+    next_step:
+      id: "fraud_analytics_db"
+      label: "Store risk signal"
+
+  - id: "fraud_analytics_db"
+    title: "Fraud Analytics DB"
+    container:
+      id: "fraud-analytics-db"
+    next_step:
+      id: "process_payment_command"
+      label: "Proceed to payment gateway"
+
+  - id: "process_payment_command"
+    title: "Process payment command"
+    message:
+      id: "ProcessPayment"
+      version: "0.0.1"
+    next_step:
+      id: "payment_gateway_service"
+      label: "Authorize card"
+
+  - id: "payment_gateway_service"
+    title: "Payment Gateway Service"
+    service:
+      id: "PaymentGatewayService"
+      version: "0.0.1"
+    next_step:
+      id: "stripe"
+      label: "Charge customer"
+
+  - id: "stripe"
+    title: "Stripe"
+    externalSystem:
+      name: "Stripe"
+      summary: "External card processor"
+      url: "https://stripe.com/"
+    next_steps:
+      - id: "stripe_charge_succeeded"
+        label: "Charge succeeded"
+      - id: "stripe_charge_failed"
+        label: "Charge failed"
+
+  - id: "stripe_charge_succeeded"
+    title: "Stripe charge succeeded"
+    message:
+      id: "StripeChargeSucceeded"
+      version: "0.0.1"
+    next_step:
+      id: "payments_db"
+      label: "Record transaction"
+
+  - id: "payments_db"
+    title: "Payments DB"
+    container:
+      id: "payments-db"
+    next_step:
+      id: "payment_processed"
+      label: "Publish success"
+
+  - id: "payment_processed"
+    title: "Payment processed event"
+    message:
+      id: "PaymentProcessed"
+    next_steps:
+      - id: "adjust_inventory"
+        label: "Reserve stock"
+      - id: "payment_receipt"
+        label: "Send receipt"
+
+  - id: "adjust_inventory"
+    title: "Inventory adjusted event"
+    message:
+      id: "InventoryAdjusted"
+      version: "1.0.1"
+    next_step:
+      id: "payment_complete"
+      label: "Complete payment"
+
+  - id: "payment_receipt"
+    title: "Payment receipt"
+    custom:
+      title: "Receipt Notification"
+      color: "green"
+      icon: "EnvelopeIcon"
+      type: "Notification"
+      summary: "Sends the customer a receipt after payment settlement"
+      properties:
+        channel: "email"
+        template: "payment-receipt"
+    next_step:
+      id: "payment_complete"
+      label: "Receipt sent"
+
+  - id: "payment_complete"
+    title: "Payment complete event"
+    message:
+      id: "PaymentComplete"
+    next_step:
+      id: "fulfillment_ready"
+      label: "Ready for fulfillment"
+
+  - id: "fulfillment_ready"
+    title: "Fulfillment trigger"
+    custom:
+      title: "Fulfillment Trigger"
+      color: "blue"
+      icon: "TruckIcon"
+      type: "Business Milestone"
+      summary: "Signals that the order can be packed and shipped"
+      properties:
+        downstream_flow: "Shipping"
+        fulfillment_sla: "24 hours"
+
+  - id: "stripe_charge_failed"
+    title: "Stripe charge failed"
+    message:
+      id: "StripeChargeFailed"
+      version: "0.0.1"
+    next_step:
+      id: "payment_failed"
+      label: "Publish failure"
+
+  - id: "payment_failed"
+    title: "Payment failed event"
+    message:
+      id: "PaymentFailed"
+      version: "0.0.1"
+    next_step:
+      id: "retry_policy"
+      label: "Evaluate retry"
+
+  - id: "retry_policy"
+    title: "Retry policy"
+    custom:
+      title: "Retry Orchestration"
+      color: "orange"
+      icon: "ArrowPathIcon"
+      type: "Processor"
+      summary: "Coordinates retry attempts for transient payment failures"
+      properties:
+        max_attempts: 3
+        retry_delay: "10 minutes"
+    next_steps:
+      - id: "process_payment_command"
+        label: "Retry payment"
+      - id: "payment_failure_notification"
+        label: "Retries exhausted"
+
+  - id: "payment_failure_notification"
+    title: "Payment failure notification"
+    service:
+      id: "NotificationService"
+      version: "0.0.2"
+
+  - id: "fraud_detected"
+    title: "Fraud detected event"
+    message:
+      id: "FraudDetected"
+      version: "0.0.1"
+    next_step:
+      id: "manual_review"
+      label: "Hold payment"
+
+  - id: "manual_review"
+    title: "Manual review"
+    custom:
+      title: "Fraud Review Queue"
+      color: "red"
+      icon: "ShieldExclamationIcon"
+      type: "Human Review"
+      summary: "Operations team reviews high-risk payments before capture"
+      properties:
+        sla: "30 minutes"
+        team: "Risk operations"
 ---
 
 ### Flow of feature
+
 <NodeGraph />

--- a/examples/default/domains/E-Commerce/subdomains/Payment/flows/PaymentRefund/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Payment/flows/PaymentRefund/index.mdx
@@ -1,0 +1,134 @@
+---
+id: PaymentRefundFlow
+name: "Payment Refund Flow"
+version: "1.0.0"
+summary: "Flow for refunding a captured payment and notifying the customer"
+owners:
+  - payments-team
+steps:
+  - id: "support_requests_refund"
+    title: "Support requests refund"
+    actor:
+      name: "Support agent"
+      summary: "Support reviews a customer request and starts the refund"
+    next_step:
+      id: "refund_policy"
+      label: "Check refund eligibility"
+
+  - id: "refund_policy"
+    title: "Refund policy"
+    custom:
+      title: "Refund Eligibility"
+      color: "purple"
+      icon: "ClipboardDocumentCheckIcon"
+      type: "Policy"
+      summary: "Checks order status, refund window, payment capture state, and fraud signals"
+      properties:
+        refund_window: "30 days"
+        approval_threshold: "500 GBP"
+    next_steps:
+      - id: "get_payment_status"
+        label: "Eligible refund"
+      - id: "refund_rejected"
+        label: "Refund rejected"
+
+  - id: "get_payment_status"
+    title: "Get payment status query"
+    message:
+      id: "GetPaymentStatus"
+      version: "0.0.1"
+    next_step:
+      id: "payment_service"
+      label: "Validate transaction"
+
+  - id: "payment_service"
+    title: "Payment Service"
+    service:
+      id: "PaymentService"
+      version: "0.0.1"
+    next_step:
+      id: "payments_db"
+      label: "Load payment record"
+
+  - id: "payments_db"
+    title: "Payments DB"
+    container:
+      id: "payments-db"
+    next_step:
+      id: "stripe_refund"
+      label: "Refund via processor"
+
+  - id: "stripe_refund"
+    title: "Stripe"
+    externalSystem:
+      name: "Stripe"
+      summary: "External payment processor used to issue the refund"
+      url: "https://stripe.com/"
+    next_steps:
+      - id: "refund_recorded"
+        label: "Refund accepted"
+      - id: "refund_failed"
+        label: "Refund failed"
+
+  - id: "refund_recorded"
+    title: "Refund recorded"
+    custom:
+      title: "Refund Recorded"
+      color: "green"
+      icon: "BanknotesIcon"
+      type: "Business Milestone"
+      summary: "The refund has been accepted by the processor and recorded for reconciliation"
+      properties:
+        ledger: "payments-db"
+        reconciliation_status: "pending settlement"
+    next_step:
+      id: "payment_analytics"
+      label: "Update reporting"
+
+  - id: "payment_analytics"
+    title: "Payment Analytics"
+    dataProduct:
+      id: "payment-analytics"
+    next_step:
+      id: "notification_queue"
+      label: "Notify customer"
+
+  - id: "notification_queue"
+    title: "Notifications Queue"
+    container:
+      id: "notifications-queue"
+    next_step:
+      id: "notification_service"
+      label: "Send refund email"
+
+  - id: "notification_service"
+    title: "Notification Service"
+    service:
+      id: "NotificationService"
+      version: "0.0.2"
+
+  - id: "refund_failed"
+    title: "Refund failed"
+    custom:
+      title: "Refund Provider Failure"
+      color: "red"
+      icon: "ExclamationTriangleIcon"
+      type: "Exception"
+      summary: "The payment provider rejected or failed the refund request"
+      properties:
+        owner: "Payments operations"
+        next_action: "manual processor review"
+
+  - id: "refund_rejected"
+    title: "Refund rejected"
+    custom:
+      title: "Refund Rejected"
+      color: "yellow"
+      icon: "NoSymbolIcon"
+      type: "Policy"
+      summary: "Refund policy rejected the request before processor submission"
+      properties:
+        reason_examples: "outside refund window, already refunded, fraud hold"
+---
+
+<NodeGraph />

--- a/examples/default/domains/E-Commerce/subdomains/Subscriptions/flows/CancelSubscription/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Subscriptions/flows/CancelSubscription/index.mdx
@@ -6,33 +6,23 @@ summary: "Flow for when a user has cancelled a subscription"
 owners:
   - subscriptions-management
 steps:
-  - id: "cancel_subscription_initiated"
-    title: "Cancels Subscription"
-    summary: "User cancels their subscription"
+  - id: "customer_requests_cancellation"
+    title: "Customer requests cancellation"
     actor:
-      name: "User"
+      name: "Customer"
+      summary: "Customer opens account settings and asks to cancel"
     next_step:
       id: "cancel_subscription_request"
-      label: "Initiate subscription cancellation"
+      label: "Submit cancellation"
 
   - id: "cancel_subscription_request"
-    title: "Cancel Subscription"
+    title: "Cancel subscription command"
     message:
       id: "CancelSubscription"
       version: "0.0.1"
     next_step:
       id: "subscription_service"
-      label: "Proceed to subscription service"
-
-  - id: "stripe_integration"
-    title: "Stripe"
-    externalSystem:
-      name: "Stripe"
-      summary: "3rd party payment system"
-      url: "https://stripe.com/"
-    next_step:
-      id: "subscription_service"
-      label: "Return to subscription service"
+      label: "Validate cancellation"
 
   - id: "subscription_service"
     title: "Subscription Service"
@@ -40,31 +30,168 @@ steps:
       id: "SubscriptionService"
       version: "0.0.1"
     next_steps:
-      - id: "stripe_integration"
-        label: "Cancel subscription via Stripe"
-      - id: "subscription_cancelled"
-        label: "Successful cancellation"
+      - id: "subscriptions_db"
+        label: "Load subscription state"
+      - id: "retention_offer"
+        label: "Eligible for retention offer"
       - id: "subscription_rejected"
-        label: "Failed cancellation"
+        label: "Cancellation not allowed"
+
+  - id: "subscriptions_db"
+    title: "Subscriptions DB"
+    container:
+      id: "subscriptions-db"
+    next_step:
+      id: "billing_service"
+      label: "Stop future billing"
+
+  - id: "retention_offer"
+    title: "Retention offer"
+    custom:
+      title: "Save Offer Decision"
+      color: "purple"
+      icon: "SparklesIcon"
+      type: "Decision"
+      summary: "Decides whether to offer a discount, pause, or support handoff"
+      properties:
+        offer_window: "7 days"
+        max_discount: "25 percent"
+    next_steps:
+      - id: "customer_accepts_offer"
+        label: "Customer accepts offer"
+      - id: "billing_service"
+        label: "Customer still cancels"
+
+  - id: "customer_accepts_offer"
+    title: "Customer accepts save offer"
+    actor:
+      name: "Customer"
+      summary: "Customer keeps the subscription after reviewing the offer"
+    next_step:
+      id: "save_offer_applied"
+      label: "Keep subscription active"
+
+  - id: "save_offer_applied"
+    title: "Save offer applied"
+    custom:
+      title: "Retention Offer Applied"
+      color: "green"
+      icon: "CheckCircleIcon"
+      type: "Business Milestone"
+      summary: "The customer accepted the retention offer and the subscription remains active"
+      properties:
+        outcome: "retained"
+        billing_change: "discount applied"
+
+  - id: "billing_service"
+    title: "Billing Service"
+    service:
+      id: "BillingService"
+      version: "0.0.1"
+    next_step:
+      id: "stripe_integration"
+      label: "Cancel processor agreement"
+
+  - id: "stripe_integration"
+    title: "Stripe"
+    externalSystem:
+      name: "Stripe"
+      summary: "External billing and payment processor"
+      url: "https://stripe.com/"
+    next_steps:
+      - id: "processor_cancellation_confirmed"
+        label: "Processor cancelled"
+      - id: "processor_cancellation_failed"
+        label: "Processor failed"
+
+  - id: "processor_cancellation_confirmed"
+    title: "Processor cancellation confirmed"
+    custom:
+      title: "Billing Agreement Closed"
+      color: "green"
+      icon: "CheckCircleIcon"
+      type: "Checkpoint"
+      summary: "Stripe has stopped future subscription charges"
+      properties:
+        provider: "Stripe"
+        action: "cancel_at_period_end"
+    next_step:
+      id: "subscription_cancelled"
+      label: "Publish cancellation"
 
   - id: "subscription_cancelled"
-    title: "Subscription has been Cancelled"
+    title: "Subscription cancelled event"
     message:
       id: "UserSubscriptionCancelled"
       version: "0.0.1"
     next_step:
-      id: "notification_service"
-      label: "Email customer"
+      id: "notifications_queue"
+      label: "Queue customer notification"
 
-  - id: "subscription_rejected"
-    title: "Subscription cancellation has been rejected"
+  - id: "notifications_queue"
+    title: "Notifications Queue"
+    container:
+      id: "notifications-queue"
+    next_step:
+      id: "notification_service"
+      label: "Send confirmation"
 
   - id: "notification_service"
     title: "Notifications Service"
     service:
       id: "NotificationService"
       version: "0.0.2"
+    next_step:
+      id: "cancellation_complete"
+      label: "Customer notified"
 
+  - id: "cancellation_complete"
+    title: "Cancellation complete"
+    custom:
+      title: "Customer Access Updated"
+      color: "blue"
+      icon: "ArchiveBoxIcon"
+      type: "Business Milestone"
+      summary: "Subscription is cancelled and access is aligned to the entitlement policy"
+      properties:
+        access_until: "period end"
+        audit_event: "subscription.cancelled"
+
+  - id: "processor_cancellation_failed"
+    title: "Processor cancellation failed"
+    custom:
+      title: "Billing Provider Error"
+      color: "red"
+      icon: "ExclamationTriangleIcon"
+      type: "Exception"
+      summary: "Cancellation could not be confirmed with the payment provider"
+      properties:
+        retry_policy: "manual review"
+        severity: "high"
+    next_step:
+      id: "subscription_rejected"
+      label: "Reject request"
+
+  - id: "subscription_rejected"
+    title: "Subscription cancellation rejected"
+    custom:
+      title: "Cancellation Rejected"
+      color: "yellow"
+      icon: "NoSymbolIcon"
+      type: "Policy"
+      summary: "The request cannot be completed because the account is locked or billing state is inconsistent"
+      properties:
+        owner: "Customer support"
+        next_action: "contact customer"
+    next_step:
+      id: "rejection_notification"
+      label: "Notify customer"
+
+  - id: "rejection_notification"
+    title: "Cancellation rejected notification"
+    service:
+      id: "NotificationService"
+      version: "0.0.2"
 ---
 
 <NodeGraph />

--- a/examples/default/domains/E-Commerce/subdomains/Subscriptions/flows/CancelSubscription/versioned/0.0.1/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Subscriptions/flows/CancelSubscription/versioned/0.0.1/index.mdx
@@ -7,22 +7,41 @@ owners:
   - subscriptions-management
 steps:
   - id: "cancel_subscription_initiated"
-    title: "Cancels Subscription"
-    summary: "User cancels their subscription"
+    title: "Customer starts cancellation"
     actor:
-      name: "User"
+      name: "Customer"
+      summary: "Customer requests cancellation from account settings"
     next_step:
       id: "cancel_subscription_request"
       label: "Initiate subscription cancellation"
 
   - id: "cancel_subscription_request"
-    title: "Cancel Subscription"
+    title: "Cancel subscription command"
     message:
       id: "CancelSubscription"
       version: "0.0.1"
     next_step:
       id: "subscription_service"
       label: "Proceed to subscription service"
+
+  - id: "subscription_service"
+    title: "Subscription Service"
+    service:
+      id: "SubscriptionService"
+      version: "0.0.1"
+    next_step:
+      id: "subscriptions_db"
+      label: "Load subscription"
+
+  - id: "subscriptions_db"
+    title: "Subscriptions DB"
+    container:
+      id: "subscriptions-db"
+    next_steps:
+      - id: "stripe_integration"
+        label: "Cancel subscription via Stripe"
+      - id: "subscription_rejected"
+        label: "Subscription cannot be cancelled"
 
   - id: "stripe_integration"
     title: "Stripe"
@@ -31,21 +50,43 @@ steps:
       summary: "3rd party payment system"
       url: "https://stripe.com/"
     next_step:
-      id: "subscription_service"
-      label: "Return to subscription service"
+      id: "subscription_cancelled"
+      label: "Return cancellation confirmation"
 
-  - id: "subscription_service"
-    title: "Subscription Service"
-    service:
-      id: "SubscriptionService"
+  - id: "subscription_cancelled"
+    title: "Subscription cancelled event"
+    message:
+      id: "UserSubscriptionCancelled"
       version: "0.0.1"
-    next_steps:
-      - id: "stripe_integration"
-        label: "Cancel subscription via Stripe"
-      - id: "subscription_cancelled"
-        label: "Successful cancellation"
-      - id: "subscription_rejected"
-        label: "Failed cancellation"
+    next_step:
+      id: "notifications_queue"
+      label: "Queue notification"
+
+  - id: "notifications_queue"
+    title: "Notifications Queue"
+    container:
+      id: "notifications-queue"
+    next_step:
+      id: "notification_service"
+      label: "Notify customer"
+
+  - id: "notification_service"
+    title: "Notification Service"
+    service:
+      id: "NotificationService"
+      version: "0.0.2"
+
+  - id: "subscription_rejected"
+    title: "Cancellation rejected"
+    custom:
+      title: "Cancellation Rejected"
+      color: "yellow"
+      icon: "NoSymbolIcon"
+      type: "Policy"
+      summary: "Cancellation could not be completed because billing state needs review"
+      properties:
+        owner: "Customer support"
+        next_action: "manual review"
 ---
 
 <NodeGraph />

--- a/examples/default/domains/E-Commerce/subdomains/Subscriptions/flows/SubscriptionPaymentFailure/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Subscriptions/flows/SubscriptionPaymentFailure/index.mdx
@@ -1,0 +1,205 @@
+---
+id: SubscriptionPaymentFailureFlow
+name: "Subscription Payment Failure Flow"
+version: "1.0.0"
+summary: "Flow for handling failed recurring subscription payments and recovery"
+owners:
+  - subscriptions-management
+steps:
+  - id: "subscription_payment_due"
+    title: "Subscription payment due event"
+    message:
+      id: "SubscriptionPaymentDue"
+      version: "0.0.1"
+    next_step:
+      id: "billing_service"
+      label: "Attempt renewal charge"
+
+  - id: "billing_service"
+    title: "Billing Service"
+    service:
+      id: "BillingService"
+      version: "0.0.1"
+    next_step:
+      id: "process_payment"
+      label: "Process recurring payment"
+
+  - id: "process_payment"
+    title: "Process payment command"
+    message:
+      id: "ProcessPayment"
+      version: "0.0.1"
+    next_step:
+      id: "payment_gateway_service"
+      label: "Authorize payment"
+
+  - id: "payment_gateway_service"
+    title: "Payment Gateway Service"
+    service:
+      id: "PaymentGatewayService"
+      version: "0.0.1"
+    next_step:
+      id: "stripe"
+      label: "Charge saved payment method"
+
+  - id: "stripe"
+    title: "Stripe"
+    externalSystem:
+      name: "Stripe"
+      summary: "External payment processor for recurring card charges"
+      url: "https://stripe.com/"
+    next_steps:
+      - id: "payment_processed"
+        label: "Payment succeeds"
+      - id: "payment_failed"
+        label: "Payment fails"
+
+  - id: "payment_processed"
+    title: "Payment processed event"
+    message:
+      id: "PaymentProcessed"
+      version: "1.0.0"
+    next_step:
+      id: "invoice_generated"
+      label: "Generate invoice"
+
+  - id: "invoice_generated"
+    title: "Invoice generated event"
+    message:
+      id: "InvoiceGenerated"
+      version: "0.0.1"
+    next_step:
+      id: "subscriptions_db_success"
+      label: "Mark billing cycle paid"
+
+  - id: "subscriptions_db_success"
+    title: "Subscriptions DB"
+    container:
+      id: "subscriptions-db"
+    next_step:
+      id: "payment_recovered"
+      label: "Complete renewal"
+
+  - id: "payment_recovered"
+    title: "Subscription payment recovered"
+    custom:
+      title: "Renewal Paid"
+      color: "green"
+      icon: "CheckCircleIcon"
+      type: "Business Milestone"
+      summary: "The billing cycle is paid and subscription access remains active"
+      properties:
+        subscription_status: "active"
+        entitlement_change: "none"
+    next_step:
+      id: "subscription_metrics"
+      label: "Update subscription KPIs"
+
+  - id: "payment_failed"
+    title: "Payment failed event"
+    message:
+      id: "PaymentFailed"
+      version: "0.0.1"
+    next_step:
+      id: "retry_policy"
+      label: "Start dunning"
+
+  - id: "retry_policy"
+    title: "Retry policy"
+    custom:
+      title: "Dunning Retry Policy"
+      color: "orange"
+      icon: "ArrowPathIcon"
+      type: "Timer"
+      summary: "Schedules payment retries and controls when the subscription enters grace period"
+      properties:
+        attempts: 3
+        cadence: "1 day, 3 days, 7 days"
+    next_steps:
+      - id: "process_payment"
+        label: "Retry payment"
+      - id: "grace_period"
+        label: "Retries exhausted"
+
+  - id: "grace_period"
+    title: "Grace period"
+    custom:
+      title: "Subscription Grace Period"
+      color: "yellow"
+      icon: "ShieldExclamationIcon"
+      type: "Policy"
+      summary: "Keeps access active for a short period while the customer updates payment details"
+      properties:
+        duration: "7 days"
+        access_level: "limited"
+    next_step:
+      id: "notification_queue"
+      label: "Ask customer to update payment"
+
+  - id: "notification_queue"
+    title: "Notifications Queue"
+    container:
+      id: "notifications-queue"
+    next_step:
+      id: "notification_service"
+      label: "Send dunning notification"
+
+  - id: "notification_service"
+    title: "Notification Service"
+    service:
+      id: "NotificationService"
+      version: "0.0.2"
+    next_step:
+      id: "customer_updates_payment"
+      label: "Wait for customer action"
+
+  - id: "customer_updates_payment"
+    title: "Customer updates payment"
+    actor:
+      name: "Customer"
+      summary: "Customer updates or replaces their payment method"
+    next_steps:
+      - id: "process_payment"
+        label: "Retry with new payment method"
+      - id: "suspend_subscription"
+        label: "No payment update"
+
+  - id: "suspend_subscription"
+    title: "Suspend subscription"
+    service:
+      id: "SubscriptionService"
+      version: "0.0.1"
+    next_step:
+      id: "subscriptions_db_failed"
+      label: "Persist suspension"
+
+  - id: "subscriptions_db_failed"
+    title: "Subscriptions DB"
+    container:
+      id: "subscriptions-db"
+    next_step:
+      id: "subscription_suspended"
+      label: "Access suspended"
+
+  - id: "subscription_suspended"
+    title: "Subscription suspended"
+    custom:
+      title: "Subscription Suspended"
+      color: "red"
+      icon: "PauseCircleIcon"
+      type: "Business Milestone"
+      summary: "The subscription is suspended after failed payment recovery attempts"
+      properties:
+        subscription_status: "suspended"
+        access_level: "restricted"
+    next_step:
+      id: "subscription_metrics"
+      label: "Update churn metrics"
+
+  - id: "subscription_metrics"
+    title: "Subscription Metrics"
+    dataProduct:
+      id: "subscription-metrics"
+---
+
+<NodeGraph />

--- a/examples/default/domains/E-Commerce/subdomains/Subscriptions/flows/SubscriptionRenewed/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Subscriptions/flows/SubscriptionRenewed/index.mdx
@@ -24,14 +24,30 @@ steps:
         - label: "Subscription timing documentation"
           url: "https://docs.example.com/subscription-timing"
     next_step:
+      id: "get_subscription_status"
+      label: "Load renewal candidate"
+
+  - id: "get_subscription_status"
+    title: "Get subscription status query"
+    message:
+      id: "GetSubscriptionStatus"
+    next_step:
       id: "check_subscription_status"
-      label: "Verify subscription status"
+      label: "Evaluate subscription"
 
   - id: "check_subscription_status"
     title: "Check Subscription Status"
     service:
       id: "SubscriptionService"
       version: "0.0.1"
+    next_step:
+      id: "subscriptions_db"
+      label: "Read subscription state"
+
+  - id: "subscriptions_db"
+    title: "Subscriptions DB"
+    container:
+      id: "subscriptions-db"
     next_steps:
       - id: "payment_approval_check"
         label: "Subscription active, proceed to payment"
@@ -56,6 +72,14 @@ steps:
 
   - id: "send_renewal_notification"
     title: "Send Renewal Notification"
+    container:
+      id: "notifications-queue"
+    next_step:
+      id: "notification_service_renewal"
+      label: "Queue renewal email"
+
+  - id: "notification_service_renewal"
+    title: "Notification Service"
     service:
       id: "NotificationService"
       version: "0.0.2"
@@ -176,11 +200,37 @@ steps:
       id: "PaymentInitiated"
       version: "0.0.1"
     next_step:
+      id: "payment_cache"
+      label: "Create idempotent payment session"
+
+  - id: "payment_cache"
+    title: "Payment Cache"
+    container:
+      id: "payment-cache"
+    next_step:
+      id: "process_payment"
+      label: "Prepare charge"
+
+  - id: "process_payment"
+    title: "Process payment command"
+    message:
+      id: "ProcessPayment"
+      version: "0.0.1"
+    next_step:
+      id: "payment_gateway_service"
+      label: "Authorize recurring charge"
+
+  - id: "payment_gateway_service"
+    title: "Payment Gateway Service"
+    service:
+      id: "PaymentGatewayService"
+      version: "0.0.1"
+    next_step:
       id: "payment_gateway"
-      label: "Send to payment gateway"
+      label: "Send to payment provider"
 
   - id: "payment_gateway"
-    title: "Payment Gateway"
+    title: "Stripe"
     externalSystem:
       name: "Stripe"
       summary: "3rd party payment processor"
@@ -193,7 +243,9 @@ steps:
 
   - id: "payment_failed"
     title: "Payment Failed"
-    type: "node"
+    message:
+      id: "PaymentFailed"
+      version: "0.0.1"
     next_step:
       id: "retry_payment"
       label: "Retry payment"
@@ -221,6 +273,14 @@ steps:
       id: "PaymentProcessed"
       version: "1.0.0"
     next_step:
+      id: "payments_db"
+      label: "Persist renewal payment"
+
+  - id: "payments_db"
+    title: "Payments DB"
+    container:
+      id: "payments-db"
+    next_step:
       id: "update_subscription_status"
       label: "Update subscription"
 
@@ -235,6 +295,14 @@ steps:
 
   - id: "send_renewal_confirmation"
     title: "Send Renewal Confirmation"
+    container:
+      id: "notifications-queue"
+    next_step:
+      id: "notification_service_confirmation"
+      label: "Queue renewal confirmation"
+
+  - id: "notification_service_confirmation"
+    title: "Notification Service"
     service:
       id: "NotificationService"
       version: "0.0.2"
@@ -276,7 +344,6 @@ steps:
   - id: "flow_ends"
     title: "Flow Completed"
     type: "node"
-
 ---
 
 ## Subscription Renewal Flow
@@ -287,11 +354,11 @@ This flow documents the process of automatic subscription renewals, including ha
 
 ### Key Components
 
-* **Automatic Renewal Process**: Triggered by a scheduled timer when the subscription renewal period is reached
-* **Payment Processing**: Integration with payment gateway and handling of payment failures
-* **Customer Notifications**: Various notifications sent throughout the process
-* **Grace Period Handling**: Special handling when payments fail with a grace period before subscription suspension
-* **Usage Analytics**: Analysis of customer usage patterns to identify upgrade opportunities
+- **Automatic Renewal Process**: Triggered by a scheduled timer when the subscription renewal period is reached
+- **Payment Processing**: Integration with payment gateway and handling of payment failures
+- **Customer Notifications**: Various notifications sent throughout the process
+- **Grace Period Handling**: Special handling when payments fail with a grace period before subscription suspension
+- **Usage Analytics**: Analysis of customer usage patterns to identify upgrade opportunities
 
 ### Business Rules
 

--- a/packages/core/eventcatalog/src/content.config.ts
+++ b/packages/core/eventcatalog/src/content.config.ts
@@ -266,6 +266,8 @@ const flows = defineCollection({
             message: pointer.optional(),
             service: pointer.optional(),
             flow: pointer.optional(),
+            container: pointer.optional(),
+            dataProduct: pointer.optional(),
 
             actor: z
               .object({
@@ -308,7 +310,15 @@ const flows = defineCollection({
             if (data.next_step && data.next_steps) return false;
 
             // Either one or non types can be present
-            const typesUsed = [data.message, data.service, data.flow, data.actor, data.custom].filter((v) => v).length;
+            const typesUsed = [
+              data.message,
+              data.service,
+              data.flow,
+              data.container,
+              data.dataProduct,
+              data.actor,
+              data.custom,
+            ].filter((v) => v).length;
             return typesUsed === 0 || typesUsed === 1;
           })
       ),
@@ -425,6 +435,18 @@ const dataProducts = defineCollection({
     .object({
       inputs: z.array(pointer).optional(),
       outputs: z.array(dataProductOutputPointer).optional(),
+      detailsPanel: z
+        .object({
+          domains: detailPanelPropertySchema.optional(),
+          inputs: detailPanelPropertySchema.optional(),
+          outputs: detailPanelPropertySchema.optional(),
+          versions: detailPanelPropertySchema.optional(),
+          repository: detailPanelPropertySchema.optional(),
+          owners: detailPanelPropertySchema.optional(),
+          changelog: detailPanelPropertySchema.optional(),
+          flows: detailPanelPropertySchema.optional(),
+        })
+        .optional(),
     })
     .extend(baseSchema.shape),
 });
@@ -517,6 +539,7 @@ const containers = defineCollection({
           changelog: detailPanelPropertySchema.optional(),
           attachments: detailPanelPropertySchema.optional(),
           services: detailPanelPropertySchema.optional(),
+          flows: detailPanelPropertySchema.optional(),
         })
         .optional(),
       services: z.array(reference('services')).optional(),

--- a/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/data-product-builder.spec.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/data-product-builder.spec.ts
@@ -467,6 +467,46 @@ describe('buildDataProductNode', () => {
     });
   });
 
+  describe('flows section', () => {
+    it('renders Flows section when flow references are provided', () => {
+      const dataProduct = createMockDataProduct();
+
+      const result = buildDataProductNode(dataProduct, [], emptyContext, ['flow:CheckoutFlow:1.0.0']);
+      const flowsSection = (result.pages as any[])?.find((p: any) => p.title === 'Flows');
+
+      expect(flowsSection).toMatchObject({
+        type: 'group',
+        title: 'Flows',
+        icon: 'Waypoints',
+        pages: ['flow:CheckoutFlow:1.0.0'],
+      });
+    });
+
+    it('does not render Flows section when no flow references are provided', () => {
+      const dataProduct = createMockDataProduct();
+
+      const result = buildDataProductNode(dataProduct, [], emptyContext);
+      const flowsSection = (result.pages as any[])?.find((p: any) => p.title === 'Flows');
+
+      expect(flowsSection).toBeUndefined();
+    });
+
+    it('does not render Flows section when the data product details panel hides it', () => {
+      const dataProduct = createMockDataProduct({
+        detailsPanel: {
+          flows: {
+            visible: false,
+          },
+        },
+      });
+
+      const result = buildDataProductNode(dataProduct, [], emptyContext, ['flow:CheckoutFlow:1.0.0']);
+      const flowsSection = (result.pages as any[])?.find((p: any) => p.title === 'Flows');
+
+      expect(flowsSection).toBeUndefined();
+    });
+  });
+
   describe('owners', () => {
     it('includes Owners section when owners are provided', () => {
       const dataProduct = createMockDataProduct({ owners: [{ id: 'user1' }] });

--- a/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/sidebar-builder.spec.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/sidebar-builder.spec.ts
@@ -3041,6 +3041,107 @@ describe('getNestedSideBarData', () => {
       });
     });
 
+    describe('flows section', () => {
+      it('is not listed if no flows reference the container', async () => {
+        const { writeDataStore } = utils(CATALOG_FOLDER);
+        await writeDataStore({
+          id: 'PaymentDataStore',
+          name: 'Payment DataStore',
+          version: '0.0.1',
+          markdown: 'Payment DataStore',
+          container_type: 'database',
+        });
+
+        const navigationData = await getNestedSideBarData();
+        const containerNode = getNavigationConfigurationByKey('container:PaymentDataStore:0.0.1', navigationData);
+        const flowsSection = getChildNodeByTitle('Flows', containerNode.pages ?? []);
+        expect(flowsSection).toBeUndefined();
+      });
+
+      it('lists flows that reference the container in flow steps', async () => {
+        const { writeDataStore } = utils(CATALOG_FOLDER);
+        await writeDataStore({
+          id: 'PaymentDataStore',
+          name: 'Payment DataStore',
+          version: '0.0.1',
+          markdown: 'Payment DataStore',
+          container_type: 'database',
+        });
+
+        mockFlows.push({
+          id: 'CheckoutFlow',
+          name: 'Checkout Flow',
+          version: '0.0.1',
+          markdown: 'Checkout Flow',
+          steps: [{ id: 'payments-db', title: 'Payments DB', container: { id: 'PaymentDataStore' } }],
+        });
+
+        const navigationData = await getNestedSideBarData();
+        const containerNode = getNavigationConfigurationByKey('container:PaymentDataStore:0.0.1', navigationData);
+        const flowsSection = getChildNodeByTitle('Flows', containerNode.pages ?? []);
+
+        expect(flowsSection.pages).toEqual(['flow:CheckoutFlow:0.0.1']);
+      });
+
+      it('deduplicates flows when multiple steps reference the same container', async () => {
+        const { writeDataStore } = utils(CATALOG_FOLDER);
+        await writeDataStore({
+          id: 'PaymentDataStore',
+          name: 'Payment DataStore',
+          version: '0.0.1',
+          markdown: 'Payment DataStore',
+          container_type: 'database',
+        });
+
+        mockFlows.push({
+          id: 'CheckoutFlow',
+          name: 'Checkout Flow',
+          version: '0.0.1',
+          markdown: 'Checkout Flow',
+          steps: [
+            { id: 'payments-db-read', title: 'Read Payments DB', container: { id: 'PaymentDataStore' } },
+            { id: 'payments-db-write', title: 'Write Payments DB', container: { id: 'PaymentDataStore', version: '0.0.1' } },
+          ],
+        });
+
+        const navigationData = await getNestedSideBarData();
+        const containerNode = getNavigationConfigurationByKey('container:PaymentDataStore:0.0.1', navigationData);
+        const flowsSection = getChildNodeByTitle('Flows', containerNode.pages ?? []);
+
+        expect(flowsSection.pages).toEqual(['flow:CheckoutFlow:0.0.1']);
+      });
+
+      it('is not listed if the container is configured not to render the section', async () => {
+        const { writeDataStore } = utils(CATALOG_FOLDER);
+        await writeDataStore({
+          id: 'PaymentDataStore',
+          name: 'Payment DataStore',
+          version: '0.0.1',
+          markdown: 'Payment DataStore',
+          container_type: 'database',
+          detailsPanel: {
+            // @ts-ignore
+            flows: {
+              visible: false,
+            },
+          },
+        });
+
+        mockFlows.push({
+          id: 'CheckoutFlow',
+          name: 'Checkout Flow',
+          version: '0.0.1',
+          markdown: 'Checkout Flow',
+          steps: [{ id: 'payments-db', title: 'Payments DB', container: { id: 'PaymentDataStore' } }],
+        });
+
+        const navigationData = await getNestedSideBarData();
+        const containerNode = getNavigationConfigurationByKey('container:PaymentDataStore:0.0.1', navigationData);
+        const flowsSection = getChildNodeByTitle('Flows', containerNode.pages ?? []);
+        expect(flowsSection).toBeUndefined();
+      });
+    });
+
     describe('owners section', () => {
       it('is not listed if the container does not have any owners', async () => {
         const { writeDataStore } = utils(CATALOG_FOLDER);
@@ -3297,9 +3398,111 @@ describe('getNestedSideBarData', () => {
     });
   });
 
+  describe('data product navigation items', () => {
+    describe('flows section', () => {
+      it('is not listed if no flows reference the data product', async () => {
+        const { writeDataProduct } = utils(CATALOG_FOLDER);
+        await writeDataProduct({
+          id: 'PaymentAnalytics',
+          name: 'Payment Analytics',
+          version: '0.0.1',
+          markdown: 'Payment Analytics',
+        });
+
+        const navigationData = await getNestedSideBarData();
+        const dataProductNode = getNavigationConfigurationByKey('data-product:PaymentAnalytics:0.0.1', navigationData);
+        const flowsSection = getChildNodeByTitle('Flows', dataProductNode.pages ?? []);
+        expect(flowsSection).toBeUndefined();
+      });
+
+      it('lists flows that reference the data product in flow steps', async () => {
+        const { writeDataProduct } = utils(CATALOG_FOLDER);
+        await writeDataProduct({
+          id: 'PaymentAnalytics',
+          name: 'Payment Analytics',
+          version: '0.0.1',
+          markdown: 'Payment Analytics',
+        });
+
+        mockFlows.push({
+          id: 'CheckoutFlow',
+          name: 'Checkout Flow',
+          version: '0.0.1',
+          markdown: 'Checkout Flow',
+          steps: [{ id: 'payment-analytics', title: 'Payment Analytics', dataProduct: { id: 'PaymentAnalytics' } }],
+        });
+
+        const navigationData = await getNestedSideBarData();
+        const dataProductNode = getNavigationConfigurationByKey('data-product:PaymentAnalytics:0.0.1', navigationData);
+        const flowsSection = getChildNodeByTitle('Flows', dataProductNode.pages ?? []);
+
+        expect(flowsSection.pages).toEqual(['flow:CheckoutFlow:0.0.1']);
+      });
+
+      it('deduplicates flows when multiple steps reference the same data product', async () => {
+        const { writeDataProduct } = utils(CATALOG_FOLDER);
+        await writeDataProduct({
+          id: 'PaymentAnalytics',
+          name: 'Payment Analytics',
+          version: '0.0.1',
+          markdown: 'Payment Analytics',
+        });
+
+        mockFlows.push({
+          id: 'CheckoutFlow',
+          name: 'Checkout Flow',
+          version: '0.0.1',
+          markdown: 'Checkout Flow',
+          steps: [
+            { id: 'payment-analytics-ingest', title: 'Ingest Payment Analytics', dataProduct: { id: 'PaymentAnalytics' } },
+            {
+              id: 'payment-analytics-read',
+              title: 'Read Payment Analytics',
+              dataProduct: { id: 'PaymentAnalytics', version: '0.0.1' },
+            },
+          ],
+        });
+
+        const navigationData = await getNestedSideBarData();
+        const dataProductNode = getNavigationConfigurationByKey('data-product:PaymentAnalytics:0.0.1', navigationData);
+        const flowsSection = getChildNodeByTitle('Flows', dataProductNode.pages ?? []);
+
+        expect(flowsSection.pages).toEqual(['flow:CheckoutFlow:0.0.1']);
+      });
+
+      it('is not listed if the data product is configured not to render the section', async () => {
+        const { writeDataProduct } = utils(CATALOG_FOLDER);
+        await writeDataProduct({
+          id: 'PaymentAnalytics',
+          name: 'Payment Analytics',
+          version: '0.0.1',
+          markdown: 'Payment Analytics',
+          detailsPanel: {
+            flows: {
+              visible: false,
+            },
+          },
+        });
+
+        mockFlows.push({
+          id: 'CheckoutFlow',
+          name: 'Checkout Flow',
+          version: '0.0.1',
+          markdown: 'Checkout Flow',
+          steps: [{ id: 'payment-analytics', title: 'Payment Analytics', dataProduct: { id: 'PaymentAnalytics' } }],
+        });
+
+        const navigationData = await getNestedSideBarData();
+        const dataProductNode = getNavigationConfigurationByKey('data-product:PaymentAnalytics:0.0.1', navigationData);
+        const flowsSection = getChildNodeByTitle('Flows', dataProductNode.pages ?? []);
+        expect(flowsSection).toBeUndefined();
+      });
+    });
+  });
+
   describe('flow navigation items', () => {
-    it('lists messages, services, and flows referenced by flow steps', async () => {
-      const { writeEvent, writeCommand, writeQuery, writeService } = utils(CATALOG_FOLDER);
+    it('lists messages, services, flows, data stores, and data products referenced by flow steps', async () => {
+      const { writeEvent, writeCommand, writeQuery, writeService, writeDataStore, writeDataProduct } = utils(CATALOG_FOLDER);
 
       await writeEvent({
         id: 'PaymentRequested',
@@ -3325,6 +3528,19 @@ describe('getNestedSideBarData', () => {
         version: '0.0.1',
         markdown: 'Payment Service',
       });
+      await writeDataStore({
+        id: 'PaymentsDB',
+        name: 'Payments DB',
+        version: '0.0.1',
+        markdown: 'Payments DB',
+        container_type: 'database',
+      });
+      await writeDataProduct({
+        id: 'PaymentAnalytics',
+        name: 'Payment Analytics',
+        version: '0.0.1',
+        markdown: 'Payment Analytics',
+      });
 
       mockFlows.push(
         {
@@ -3338,6 +3554,8 @@ describe('getNestedSideBarData', () => {
             { id: 'get-payment-status', title: 'Get payment status', message: { id: 'GetPaymentStatus' } },
             { id: 'payment-service', title: 'Payment service', service: { id: 'PaymentService' } },
             { id: 'fraud-flow', title: 'Fraud flow', flow: { id: 'FraudFlow' } },
+            { id: 'payments-db', title: 'Payments DB', container: { id: 'PaymentsDB' } },
+            { id: 'payment-analytics', title: 'Payment Analytics', dataProduct: { id: 'PaymentAnalytics' } },
           ],
         },
         {
@@ -3354,6 +3572,8 @@ describe('getNestedSideBarData', () => {
       const messagesSection = getChildNodeByTitle('Messages', flowNode.pages ?? []);
       const servicesSection = getChildNodeByTitle('Services', flowNode.pages ?? []);
       const subflowsSection = getChildNodeByTitle('Subflows', flowNode.pages ?? []);
+      const dataStoresSection = getChildNodeByTitle('Data Stores', flowNode.pages ?? []);
+      const dataProductsSection = getChildNodeByTitle('Data Products', flowNode.pages ?? []);
 
       expect(messagesSection.pages).toEqual([
         'event:PaymentRequested:0.0.1',
@@ -3362,6 +3582,8 @@ describe('getNestedSideBarData', () => {
       ]);
       expect(servicesSection.pages).toEqual(['service:PaymentService:0.0.1']);
       expect(subflowsSection.pages).toEqual(['flow:FraudFlow:0.0.1']);
+      expect(dataStoresSection.pages).toEqual(['container:PaymentsDB:0.0.1']);
+      expect(dataProductsSection.pages).toEqual(['data-product:PaymentAnalytics:0.0.1']);
     });
 
     it('does not list reference sections when a flow has no resource step references', async () => {
@@ -3379,6 +3601,8 @@ describe('getNestedSideBarData', () => {
       expect(getChildNodeByTitle('Messages', flowNode.pages ?? [])).toBeUndefined();
       expect(getChildNodeByTitle('Services', flowNode.pages ?? [])).toBeUndefined();
       expect(getChildNodeByTitle('Subflows', flowNode.pages ?? [])).toBeUndefined();
+      expect(getChildNodeByTitle('Data Stores', flowNode.pages ?? [])).toBeUndefined();
+      expect(getChildNodeByTitle('Data Products', flowNode.pages ?? [])).toBeUndefined();
     });
   });
 

--- a/packages/core/eventcatalog/src/stores/sidebar-store/builders/container.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/builders/container.ts
@@ -16,7 +16,8 @@ import { iconFieldsForResource } from '@utils/icon';
 export const buildContainerNode = (
   container: CollectionEntry<'containers'>,
   owners: any[],
-  context: ResourceGroupContext
+  context: ResourceGroupContext,
+  flowRefs: string[] = []
 ): NavNode => {
   const servicesWritingToContainer = container.data.servicesThatWriteToContainer || [];
   const servicesReadingFromContainer = container.data.servicesThatReadFromContainer || [];
@@ -36,6 +37,7 @@ export const buildContainerNode = (
     ...dataProductsReadingFromContainer.map((dp: any) => `data-product:${dp.data.id}:${dp.data.version}`),
   ];
   const renderReads = allReads.length > 0 && shouldRenderSideBarSection(container, 'services');
+  const renderFlows = flowRefs.length > 0 && shouldRenderSideBarSection(container, 'flows');
 
   const renderVisualiser = isVisualiserEnabled();
 
@@ -107,6 +109,13 @@ export const buildContainerNode = (
         title: 'Reads',
         icon: 'ArrowDownToLine',
         pages: allReads,
+      },
+      renderFlows && {
+        type: 'group',
+        title: 'Flows',
+        icon: 'Waypoints',
+        pages: flowRefs,
+        visible: flowRefs.length > 0,
       },
       renderOwners && buildOwnersSection(owners),
       renderRepository && buildRepositorySection(container.data.repository as { url: string; language: string }),

--- a/packages/core/eventcatalog/src/stores/sidebar-store/builders/data-product.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/builders/data-product.ts
@@ -60,13 +60,15 @@ const resolvePointerToRef = (pointer: { id: string; version?: string }, context:
 export const buildDataProductNode = (
   dataProduct: CollectionEntry<'data-products'>,
   owners: any[],
-  context: DataProductContext
+  context: DataProductContext,
+  flowRefs: string[] = []
 ): NavNode => {
   const inputs = dataProduct.data.inputs || [];
   const outputs = dataProduct.data.outputs || [];
 
   const renderVisualiser = isVisualiserEnabled();
   const renderOwners = owners.length > 0 && shouldRenderSideBarSection(dataProduct, 'owners');
+  const renderFlows = flowRefs.length > 0 && shouldRenderSideBarSection(dataProduct, 'flows');
   const docsSection = buildResourceDocsSection(
     'data-products',
     dataProduct.data.id,
@@ -138,6 +140,13 @@ export const buildDataProductNode = (
         title: 'Data Contracts',
         icon: 'FileCheck',
         pages: dataContracts,
+      },
+      renderFlows && {
+        type: 'group',
+        title: 'Flows',
+        icon: 'Waypoints',
+        pages: flowRefs,
+        visible: flowRefs.length > 0,
       },
       renderOwners && buildOwnersSection(owners),
     ].filter(Boolean) as ChildRef[],

--- a/packages/core/eventcatalog/src/stores/sidebar-store/builders/flow.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/builders/flow.ts
@@ -56,6 +56,8 @@ export const buildFlowNode = (flow: CollectionEntry<'flows'>, context: ResourceG
   const queryMap = createVersionedMap(context.queries);
   const serviceMap = createVersionedMap(context.services);
   const flowMap = createVersionedMap(context.flows);
+  const containerMap = createVersionedMap(context.containers);
+  const dataProductMap = createVersionedMap(context.dataProducts);
   const messageRefs = uniqueRefs(
     steps.map((step) => resolveMessageStep(step, { eventMap, commandMap, queryMap })).filter(Boolean) as string[]
   );
@@ -70,6 +72,30 @@ export const buildFlowNode = (flow: CollectionEntry<'flows'>, context: ResourceG
       .map((step) => (step.flow ? resolvePointer(flowMap, step.flow) : undefined))
       .filter(Boolean)
       .map((referencedFlow) => `flow:${referencedFlow!.data.id}:${referencedFlow!.data.version}`)
+  );
+  const containerRefs = uniqueRefs(
+    steps
+      .map((step: any) => {
+        const hydratedContainer = Array.isArray(step.container) ? step.container[0] : undefined;
+        if (hydratedContainer?.collection && hydratedContainer?.data) return hydratedContainer;
+
+        const pointer = Array.isArray(step.container) ? undefined : step.container;
+        return pointer ? resolvePointer(containerMap, pointer) : undefined;
+      })
+      .filter(Boolean)
+      .map((container) => `container:${container!.data.id}:${container!.data.version}`)
+  );
+  const dataProductRefs = uniqueRefs(
+    steps
+      .map((step: any) => {
+        const hydratedDataProduct = Array.isArray(step.dataProduct) ? step.dataProduct[0] : undefined;
+        if (hydratedDataProduct?.collection && hydratedDataProduct?.data) return hydratedDataProduct;
+
+        const pointer = Array.isArray(step.dataProduct) ? undefined : step.dataProduct;
+        return pointer ? resolvePointer(dataProductMap, pointer) : undefined;
+      })
+      .filter(Boolean)
+      .map((dataProduct) => `data-product:${dataProduct!.data.id}:${dataProduct!.data.version}`)
   );
 
   return {
@@ -119,6 +145,18 @@ export const buildFlowNode = (flow: CollectionEntry<'flows'>, context: ResourceG
         title: 'Subflows',
         icon: 'Waypoints',
         pages: flowRefs,
+      },
+      containerRefs.length > 0 && {
+        type: 'group',
+        title: 'Data Stores',
+        icon: 'Database',
+        pages: containerRefs,
+      },
+      dataProductRefs.length > 0 && {
+        type: 'group',
+        title: 'Data Products',
+        icon: 'Package',
+        pages: dataProductRefs,
       },
     ].filter(Boolean) as ChildRef[],
   };

--- a/packages/core/eventcatalog/src/stores/sidebar-store/builders/shared.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/builders/shared.ts
@@ -61,6 +61,7 @@ export type ResourceGroupContext = {
   queries: CollectionEntry<'queries'>[];
   flows: CollectionEntry<'flows'>[];
   containers: CollectionEntry<'containers'>[];
+  dataProducts: CollectionEntry<'data-products'>[];
   diagrams: CollectionEntry<'diagrams'>[];
   resourceDocs: ResourceDocEntry[];
   resourceDocCategories: ResourceDocCategoryEntry[];

--- a/packages/core/eventcatalog/src/stores/sidebar-store/state.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/state.ts
@@ -35,6 +35,8 @@ let memoryCache: NavigationData | null = null;
 
 type MessageEntry = CollectionEntry<'events' | 'commands' | 'queries'>;
 type ServiceEntry = CollectionEntry<'services'>;
+type ContainerEntry = CollectionEntry<'containers'>;
+type DataProductEntry = CollectionEntry<'data-products'>;
 
 const getMessageNodeKey = (message: MessageEntry) =>
   `${pluralizeMessageType(message)}:${message.data.id}:${message.data.version}`;
@@ -117,6 +119,78 @@ const buildFlowReferencesByService = ({
   }
 
   return flowRefsByService;
+};
+
+const buildFlowReferencesByContainer = ({
+  flows,
+  containers,
+}: {
+  flows: CollectionEntry<'flows'>[];
+  containers: CollectionEntry<'containers'>[];
+}) => {
+  const containerMap = createVersionedMap(containers);
+  const flowRefsByContainer = new Map<string, string[]>();
+
+  const addFlowRef = (container: ContainerEntry, flow: CollectionEntry<'flows'>) => {
+    const containerKey = `container:${container.data.id}:${container.data.version}`;
+    const flowKey = `flow:${flow.data.id}:${flow.data.version}`;
+    flowRefsByContainer.set(containerKey, uniqueRefs([...(flowRefsByContainer.get(containerKey) || []), flowKey]));
+  };
+
+  for (const flow of flows) {
+    for (const step of flow.data.steps || []) {
+      if (!step.container) continue;
+
+      const hydratedContainer = Array.isArray(step.container) ? step.container[0] : undefined;
+      if (hydratedContainer?.collection && hydratedContainer?.data) {
+        addFlowRef(hydratedContainer as ContainerEntry, flow);
+        continue;
+      }
+
+      if (Array.isArray(step.container)) continue;
+
+      const container = findInMap(containerMap, step.container.id, step.container.version);
+      if (container) addFlowRef(container as ContainerEntry, flow);
+    }
+  }
+
+  return flowRefsByContainer;
+};
+
+const buildFlowReferencesByDataProduct = ({
+  flows,
+  dataProducts,
+}: {
+  flows: CollectionEntry<'flows'>[];
+  dataProducts: CollectionEntry<'data-products'>[];
+}) => {
+  const dataProductMap = createVersionedMap(dataProducts);
+  const flowRefsByDataProduct = new Map<string, string[]>();
+
+  const addFlowRef = (dataProduct: DataProductEntry, flow: CollectionEntry<'flows'>) => {
+    const dataProductKey = `data-product:${dataProduct.data.id}:${dataProduct.data.version}`;
+    const flowKey = `flow:${flow.data.id}:${flow.data.version}`;
+    flowRefsByDataProduct.set(dataProductKey, uniqueRefs([...(flowRefsByDataProduct.get(dataProductKey) || []), flowKey]));
+  };
+
+  for (const flow of flows) {
+    for (const step of flow.data.steps || []) {
+      if (!step.dataProduct) continue;
+
+      const hydratedDataProduct = Array.isArray(step.dataProduct) ? step.dataProduct[0] : undefined;
+      if (hydratedDataProduct?.collection && hydratedDataProduct?.data) {
+        addFlowRef(hydratedDataProduct as DataProductEntry, flow);
+        continue;
+      }
+
+      if (Array.isArray(step.dataProduct)) continue;
+
+      const dataProduct = findInMap(dataProductMap, step.dataProduct.id, step.dataProduct.version);
+      if (dataProduct) addFlowRef(dataProduct as DataProductEntry, flow);
+    }
+  }
+
+  return flowRefsByDataProduct;
 };
 
 /**
@@ -326,10 +400,12 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
     {} as Record<string, NavNode | string>
   );
 
+  const flowRefsByContainer = buildFlowReferencesByContainer({ flows, containers });
+
   const containerNodes = containerWithOwners.reduce(
     (acc, { container, owners }) => {
       const versionedKey = `container:${container.data.id}:${container.data.version}`;
-      acc[versionedKey] = buildContainerNode(container, owners, context);
+      acc[versionedKey] = buildContainerNode(container, owners, context, flowRefsByContainer.get(versionedKey) || []);
       if (container.data.latestVersion === container.data.version) {
         // Store reference to versioned key instead of duplicating the full node
         acc[`container:${container.data.id}`] = versionedKey;
@@ -358,10 +434,17 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
     resourceDocCategories,
   };
 
+  const flowRefsByDataProduct = buildFlowReferencesByDataProduct({ flows, dataProducts });
+
   const dataProductNodes = dataProductWithOwners.reduce(
     (acc, { dataProduct, owners }) => {
       const versionedKey = `data-product:${dataProduct.data.id}:${dataProduct.data.version}`;
-      acc[versionedKey] = buildDataProductNode(dataProduct, owners, dataProductContext);
+      acc[versionedKey] = buildDataProductNode(
+        dataProduct,
+        owners,
+        dataProductContext,
+        flowRefsByDataProduct.get(versionedKey) || []
+      );
       if (dataProduct.data.latestVersion === dataProduct.data.version) {
         acc[`data-product:${dataProduct.data.id}`] = versionedKey;
       }

--- a/packages/core/eventcatalog/src/utils/__tests__/flows/mocks.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/flows/mocks.ts
@@ -28,6 +28,50 @@ export const mockServices = [
   },
 ];
 
+export const mockContainers = [
+  {
+    slug: 'orders-db',
+    collection: 'containers',
+    data: {
+      id: 'OrdersDB',
+      name: 'Orders DB',
+      version: '1.0.0',
+      container_type: 'database',
+    },
+  },
+  {
+    slug: 'orders-db/versioned/0.0.1',
+    collection: 'containers',
+    data: {
+      id: 'OrdersDB',
+      name: 'Orders DB',
+      version: '0.0.1',
+      container_type: 'database',
+    },
+  },
+];
+
+export const mockDataProducts = [
+  {
+    slug: 'order-analytics',
+    collection: 'data-products',
+    data: {
+      id: 'OrderAnalytics',
+      name: 'Order Analytics',
+      version: '1.0.0',
+    },
+  },
+  {
+    slug: 'order-analytics/versioned/0.0.1',
+    collection: 'data-products',
+    data: {
+      id: 'OrderAnalytics',
+      name: 'Order Analytics',
+      version: '0.0.1',
+    },
+  },
+];
+
 export const mockFlow = [
   {
     id: 'Payment/PaymentProcessed/index.mdx',
@@ -82,6 +126,72 @@ export const mockFlow = [
       summary: 'Business flow for processing payments in an e-commerce platform',
       version: '1.0.0',
       type: 'node',
+    },
+  },
+  {
+    id: 'Orders/DataStoreFlow/index.mdx',
+    slug: 'orders/datastoreflow',
+    body: '',
+    collection: 'flows',
+    data: {
+      steps: [
+        {
+          id: 'orders-service',
+          title: 'Orders Service',
+          service: {
+            id: 'SubscriptionService',
+            version: 'latest',
+          },
+          next_step: {
+            id: 'orders-db',
+            label: 'Stores order data',
+          },
+        },
+        {
+          id: 'orders-db',
+          title: 'Orders DB',
+          container: {
+            id: 'OrdersDB',
+          },
+        },
+      ],
+      id: 'DataStoreFlow',
+      name: 'Data Store Flow',
+      summary: 'Flow that includes a data store',
+      version: '1.0.0',
+    },
+  },
+  {
+    id: 'Orders/DataProductFlow/index.mdx',
+    slug: 'orders/dataproductflow',
+    body: '',
+    collection: 'flows',
+    data: {
+      steps: [
+        {
+          id: 'orders-service',
+          title: 'Orders Service',
+          service: {
+            id: 'SubscriptionService',
+            version: 'latest',
+          },
+          next_step: {
+            id: 'order-analytics',
+            label: 'Publishes analytics-ready facts',
+          },
+        },
+        {
+          id: 'order-analytics',
+          title: 'Order Analytics',
+          dataProduct: {
+            id: 'OrderAnalytics',
+          },
+        },
+      ],
+      id: 'DataProductFlow',
+      name: 'Data Product Flow',
+      summary: 'Flow that includes a data product',
+      version: '1.0.0',
     },
   },
 ];
@@ -296,6 +406,66 @@ export const mockFlowByIds = [
       summary: 'Business flow for processing payments in an e-commerce platform',
       version: '1.0.0',
       type: 'node',
+    },
+  },
+  {
+    id: 'Orders/DataStoreFlow/index.mdx',
+    slug: 'orders/datastoreflow',
+    body: '',
+    collection: 'flows',
+    data: {
+      steps: [
+        {
+          id: 'orders-service',
+          title: 'Orders Service',
+          service: {
+            id: 'SubscriptionService',
+            version: 'latest',
+          },
+          next_step: 'orders-db',
+        },
+        {
+          id: 'orders-db',
+          title: 'Orders DB',
+          container: {
+            id: 'OrdersDB',
+          },
+        },
+      ],
+      id: 'DataStoreFlow',
+      name: 'Data Store Flow',
+      summary: 'Flow that includes a data store',
+      version: '1.0.0',
+    },
+  },
+  {
+    id: 'Orders/DataProductFlow/index.mdx',
+    slug: 'orders/dataproductflow',
+    body: '',
+    collection: 'flows',
+    data: {
+      steps: [
+        {
+          id: 'orders-service',
+          title: 'Orders Service',
+          service: {
+            id: 'SubscriptionService',
+            version: 'latest',
+          },
+          next_step: 'order-analytics',
+        },
+        {
+          id: 'order-analytics',
+          title: 'Order Analytics',
+          dataProduct: {
+            id: 'OrderAnalytics',
+          },
+        },
+      ],
+      id: 'DataProductFlow',
+      name: 'Data Product Flow',
+      summary: 'Flow that includes a data product',
+      version: '1.0.0',
     },
   },
   {

--- a/packages/core/eventcatalog/src/utils/__tests__/flows/node-graph.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/flows/node-graph.spec.ts
@@ -1,6 +1,6 @@
 import { getNodesAndEdges } from '../../node-graphs/flows-node-graph';
 import { expect, describe, it, vi, beforeEach } from 'vitest';
-import { mockEvents, mockFlow, mockFlowByIds, mockServices } from './mocks';
+import { mockContainers, mockDataProducts, mockEvents, mockFlow, mockFlowByIds, mockServices } from './mocks';
 import { getCollection } from 'astro:content';
 let expectedNodes: any;
 
@@ -17,6 +17,12 @@ vi.mock('astro:content', async (importOriginal) => {
       }
       if (key === 'services') {
         return Promise.resolve(mockServices);
+      }
+      if (key === 'containers') {
+        return Promise.resolve(mockContainers);
+      }
+      if (key === 'data-products') {
+        return Promise.resolve(mockDataProducts);
       }
       return Promise.resolve([]);
     },
@@ -151,6 +157,59 @@ describe('Flows NodeGraph', () => {
       );
     });
 
+    it('resolves container step nodes to the latest container version when no version is given', async () => {
+      const { nodes } = await getNodesAndEdges({ id: 'DataStoreFlow', version: '1.0.0' });
+
+      const containerNode = nodes.find((n: any) => n.id === 'step-orders-db');
+
+      expect(containerNode).toEqual(
+        expect.objectContaining({
+          type: 'data',
+          data: expect.objectContaining({
+            data: expect.objectContaining({
+              id: 'OrdersDB',
+              version: '1.0.0',
+              container_type: 'database',
+            }),
+            container: expect.objectContaining({
+              id: 'OrdersDB',
+              version: '1.0.0',
+            }),
+            contextMenu: expect.arrayContaining([
+              expect.objectContaining({
+                label: 'Read documentation',
+                href: expect.stringContaining('/docs/containers/OrdersDB/1.0.0'),
+              }),
+            ]),
+          }),
+        })
+      );
+    });
+
+    it('resolves data product step nodes to the latest data product version when no version is given', async () => {
+      const { nodes } = await getNodesAndEdges({ id: 'DataProductFlow', version: '1.0.0' });
+
+      const dataProductNode = nodes.find((n: any) => n.id === 'step-order-analytics');
+
+      expect(dataProductNode).toEqual(
+        expect.objectContaining({
+          type: 'data-products',
+          data: expect.objectContaining({
+            dataProduct: expect.objectContaining({
+              id: 'OrderAnalytics',
+              version: '1.0.0',
+            }),
+            contextMenu: expect.arrayContaining([
+              expect.objectContaining({
+                label: 'Read documentation',
+                href: expect.stringContaining('/docs/data-products/OrderAnalytics/1.0.0'),
+              }),
+            ]),
+          }),
+        })
+      );
+    });
+
     it('does not attach a contextMenu to plain step nodes (no resource)', async () => {
       const { nodes } = await getNodesAndEdges({ id: 'PaymentFlow', version: '1.0.0' });
 
@@ -196,6 +255,12 @@ describe('Flows NodeGraph', () => {
               }
               if (key === 'services') {
                 return Promise.resolve(mockServices);
+              }
+              if (key === 'containers') {
+                return Promise.resolve(mockContainers);
+              }
+              if (key === 'data-products') {
+                return Promise.resolve(mockDataProducts);
               }
               return Promise.resolve([]);
             },

--- a/packages/core/eventcatalog/src/utils/collections/flows.ts
+++ b/packages/core/eventcatalog/src/utils/collections/flows.ts
@@ -24,11 +24,13 @@ export const getFlows = async ({ getAllVersions = true }: Props = {}): Promise<F
   }
 
   // 1. Fetch collections in parallel
-  const [allFlows, allEvents, allCommands, allQueries] = await Promise.all([
+  const [allFlows, allEvents, allCommands, allQueries, allContainers, allDataProducts] = await Promise.all([
     getCollection('flows'),
     getCollection('events'),
     getCollection('commands'),
     getCollection('queries'),
+    getCollection('containers'),
+    getCollection('data-products'),
   ]);
 
   const allMessages = [...allEvents, ...allCommands, ...allQueries];
@@ -36,6 +38,8 @@ export const getFlows = async ({ getAllVersions = true }: Props = {}): Promise<F
   // 2. Build optimized maps
   const flowMap = createVersionedMap(allFlows);
   const messageMap = createVersionedMap(allMessages);
+  const containerMap = createVersionedMap(allContainers);
+  const dataProductMap = createVersionedMap(allDataProducts);
 
   // 3. Filter flows
   const targetFlows = allFlows.filter((flow) => {
@@ -54,6 +58,30 @@ export const getFlows = async ({ getAllVersions = true }: Props = {}): Promise<F
     const steps = flow.data.steps || [];
 
     const hydrateSteps = steps.map((step) => {
+      if (step.container) {
+        const pointer = step.container;
+        if (!pointer) return { ...step, type: 'node' };
+        const container = findInMap(containerMap, pointer.id, pointer.version);
+
+        return {
+          ...step,
+          type: 'container',
+          container: container ? [container] : [],
+        };
+      }
+
+      if (step.dataProduct) {
+        const pointer = step.dataProduct;
+        if (!pointer) return { ...step, type: 'node' };
+        const dataProduct = findInMap(dataProductMap, pointer.id, pointer.version);
+
+        return {
+          ...step,
+          type: 'data-products',
+          dataProduct: dataProduct ? [dataProduct] : [],
+        };
+      }
+
       if (!step.message) return { ...step, type: 'node' }; // Preserve existing step data for non-messages
 
       const message = findInMap(messageMap, step.message.id, step.message.version);

--- a/packages/core/eventcatalog/src/utils/node-graphs/flows-node-graph.ts
+++ b/packages/core/eventcatalog/src/utils/node-graphs/flows-node-graph.ts
@@ -26,6 +26,8 @@ interface Maps {
   messageMap: Map<string, any[]>;
   serviceMap: Map<string, any[]>;
   flowMap: Map<string, any[]>;
+  containerMap: Map<string, any[]>;
+  dataProductMap: Map<string, any[]>;
 }
 
 const getServiceNode = (step: any, serviceMap: Map<string, any[]>) => {
@@ -43,6 +45,26 @@ const getFlowNode = (step: any, flowMap: Map<string, any[]>) => {
     ...step,
     type: flow ? flow.collection : 'step',
     flow,
+  };
+};
+
+const getContainerNode = (step: any, containerMap: Map<string, any[]>) => {
+  const pointer = step.container;
+  const container = findInMap(containerMap, pointer.id, pointer.version);
+  return {
+    ...step,
+    type: container ? 'data' : 'step',
+    container,
+  };
+};
+
+const getDataProductNode = (step: any, dataProductMap: Map<string, any[]>) => {
+  const pointer = step.dataProduct;
+  const dataProduct = findInMap(dataProductMap, pointer.id, pointer.version);
+  return {
+    ...step,
+    type: dataProduct ? 'data-products' : 'step',
+    dataProduct,
   };
 };
 
@@ -97,6 +119,8 @@ const buildFlowGraphInternal = (
   const hydratedSteps = steps.map((step: any) => {
     if (step.service) return getServiceNode(step, maps.serviceMap);
     if (step.flow) return getFlowNode(step, maps.flowMap);
+    if (step.container) return getContainerNode(step, maps.containerMap);
+    if (step.dataProduct) return getDataProductNode(step, maps.dataProductMap);
     if (step.message) return getMessageNode(step, maps.messageMap);
     if (step.actor) return { ...step, type: 'actor', actor: step.actor };
     if (step.custom) return { ...step, type: 'custom', custom: step.custom };
@@ -159,6 +183,23 @@ const buildFlowGraphInternal = (
         version: step.message.data.version,
       });
     }
+    if (step.container?.data) {
+      node.data.data = { ...step.container.data };
+      node.data.container = { ...step.container, ...step.container.data };
+      node.data.contextMenu = buildContextMenuForResource({
+        collection: 'containers',
+        id: step.container.data.id,
+        version: step.container.data.version,
+      });
+    }
+    if (step.dataProduct?.data) {
+      node.data.dataProduct = { ...step.dataProduct, ...step.dataProduct.data };
+      node.data.contextMenu = buildContextMenuForResource({
+        collection: 'data-products',
+        id: step.dataProduct.data.id,
+        version: step.dataProduct.data.version,
+      });
+    }
     if (step.actor) {
       node.data.actor = { ...step.actor, ...step.actor.data };
       node.data = { ...node.data, ...step.actor };
@@ -214,12 +255,14 @@ const buildFlowGraphInternal = (
 export const getNodesAndEdges = async ({ id, defaultFlow, version, mode = 'simple', renderAllEdges = false }: Props) => {
   const graph = defaultFlow || createDagreGraph({ ranksep: 360, nodesep: 200 });
 
-  const [flows, events, commands, queries, services] = await Promise.all([
+  const [flows, events, commands, queries, services, containers, dataProducts] = await Promise.all([
     getCollection('flows'),
     getCollection('events'),
     getCollection('commands'),
     getCollection('queries'),
     getCollection('services'),
+    getCollection('containers'),
+    getCollection('data-products'),
   ]);
 
   const flow = flows.find((flow) => flow.data.id === id && flow.data.version === version);
@@ -236,6 +279,8 @@ export const getNodesAndEdges = async ({ id, defaultFlow, version, mode = 'simpl
     messageMap: createVersionedMap(messages),
     serviceMap: createVersionedMap(services),
     flowMap: createVersionedMap(flows),
+    containerMap: createVersionedMap(containers),
+    dataProductMap: createVersionedMap(dataProducts),
   };
 
   const subFlowCache = new Map<string, { nodes: any[]; edges: any[] }>();

--- a/packages/sdk/src/flow-builder.ts
+++ b/packages/sdk/src/flow-builder.ts
@@ -49,6 +49,28 @@ export type FlowServiceStepInput = FlowStepInput & {
 };
 
 /**
+ * Payload for a flow step that references a data store/container.
+ */
+export type FlowDataStoreStepInput = FlowStepInput & {
+  container?: {
+    id: string;
+    version?: string;
+  };
+  version?: string;
+};
+
+/**
+ * Payload for a flow step that references a data product.
+ */
+export type FlowDataProductStepInput = FlowStepInput & {
+  dataProduct?: {
+    id: string;
+    version?: string;
+  };
+  version?: string;
+};
+
+/**
  * Payload for a flow step that represents a user or actor.
  */
 export type FlowActorStepInput = FlowStepInput & {
@@ -112,6 +134,8 @@ const cloneStep = (step: FlowStep): FlowStep => ({
   ...(step.message ? { message: { ...step.message } } : {}),
   ...(step.service ? { service: { ...step.service } } : {}),
   ...(step.flow ? { flow: { ...step.flow } } : {}),
+  ...(step.container ? { container: { ...step.container } } : {}),
+  ...(step.dataProduct ? { dataProduct: { ...step.dataProduct } } : {}),
   ...(step.actor ? { actor: { ...step.actor } } : {}),
   ...(step.custom
     ? {
@@ -330,6 +354,96 @@ export class FlowBuilder<TMessageId extends string = string> {
         title: step.title || String(step.id),
         ...(step.summary ? { summary: step.summary } : {}),
         service: { ...service, ...(step.version && !service.version ? { version: step.version } : {}) },
+      },
+      step.nextSteps
+    );
+  }
+
+  /**
+   * Add a data store step.
+   *
+   * Data store steps reference container resources in EventCatalog. If a
+   * version is not provided, EventCatalog resolves the latest matching
+   * container version when rendering the flow.
+   *
+   * @param step - The data store step payload.
+   *
+   * @example
+   * ```ts
+   * FlowBuilder.create({
+   *   id: 'OrderFlow',
+   *   name: 'Order Flow',
+   *   version: '1.0.0',
+   *   markdown: '',
+   * })
+   *   .addDataStoreStep({
+   *     id: 'OrdersDB',
+   *     container: { id: 'OrdersDB', version: '1.0.0' },
+   *   });
+   * ```
+   */
+  addDataStoreStep(step: FlowDataStoreStepInput) {
+    const fallbackContainer = {
+      id: String(step.id),
+      ...(step.version ? { version: step.version } : {}),
+    };
+    const container = step.container ?? fallbackContainer;
+
+    return this.addStepWithNext(
+      {
+        id: step.id,
+        title: step.title || String(step.id),
+        ...(step.summary ? { summary: step.summary } : {}),
+        container: { ...container, ...(step.version && !container.version ? { version: step.version } : {}) },
+      },
+      step.nextSteps
+    );
+  }
+
+  /**
+   * Add a container step.
+   *
+   * Alias for `addDataStoreStep`.
+   */
+  addContainerStep(step: FlowDataStoreStepInput) {
+    return this.addDataStoreStep(step);
+  }
+
+  /**
+   * Add a data product step.
+   *
+   * If a version is not provided, EventCatalog resolves the latest matching
+   * data product version when rendering the flow.
+   *
+   * @param step - The data product step payload.
+   *
+   * @example
+   * ```ts
+   * FlowBuilder.create({
+   *   id: 'OrderFlow',
+   *   name: 'Order Flow',
+   *   version: '1.0.0',
+   *   markdown: '',
+   * })
+   *   .addDataProductStep({
+   *     id: 'OrderAnalytics',
+   *     dataProduct: { id: 'OrderAnalytics', version: '1.0.0' },
+   *   });
+   * ```
+   */
+  addDataProductStep(step: FlowDataProductStepInput) {
+    const fallbackDataProduct = {
+      id: String(step.id),
+      ...(step.version ? { version: step.version } : {}),
+    };
+    const dataProduct = step.dataProduct ?? fallbackDataProduct;
+
+    return this.addStepWithNext(
+      {
+        id: step.id,
+        title: step.title || String(step.id),
+        ...(step.summary ? { summary: step.summary } : {}),
+        dataProduct: { ...dataProduct, ...(step.version && !dataProduct.version ? { version: step.version } : {}) },
       },
       step.nextSteps
     );

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -126,6 +126,7 @@ import {
   writeVersionedFlow,
 } from './flows';
 export { FlowBuilder } from './flow-builder';
+export type * from './flow-builder';
 
 import {
   getDataStore,

--- a/packages/sdk/src/test/flows.test.ts
+++ b/packages/sdk/src/test/flows.test.ts
@@ -757,9 +757,19 @@ describe('FlowBuilder', () => {
         id: 'PaymentService',
         version: '0.0.2',
         nextSteps: [
-          { id: 'PaymentProcessed', label: 'Payment processed' },
+          { id: 'PaymentsDB', label: 'Store payment' },
           { id: 'Stripe', label: 'Authorize payment' },
         ],
+      })
+      .addDataStoreStep({
+        id: 'PaymentsDB',
+        version: '1.0.0',
+        nextSteps: [{ id: 'RevenueAnalytics', label: 'Update analytics' }],
+      })
+      .addDataProductStep({
+        id: 'RevenueAnalytics',
+        version: '1.0.0',
+        nextSteps: [{ id: 'PaymentProcessed', label: 'Payment processed' }],
       })
       .addMessageStep({
         id: 'PaymentProcessed',
@@ -810,9 +820,21 @@ describe('FlowBuilder', () => {
           title: 'PaymentService',
           service: { id: 'PaymentService', version: '0.0.2' },
           next_steps: [
-            { id: 'PaymentProcessed', label: 'Payment processed' },
+            { id: 'PaymentsDB', label: 'Store payment' },
             { id: 'Stripe', label: 'Authorize payment' },
           ],
+        },
+        {
+          id: 'PaymentsDB',
+          title: 'PaymentsDB',
+          container: { id: 'PaymentsDB', version: '1.0.0' },
+          next_step: { id: 'RevenueAnalytics', label: 'Update analytics' },
+        },
+        {
+          id: 'RevenueAnalytics',
+          title: 'RevenueAnalytics',
+          dataProduct: { id: 'RevenueAnalytics', version: '1.0.0' },
+          next_step: { id: 'PaymentProcessed', label: 'Payment processed' },
         },
         {
           id: 'PaymentProcessed',
@@ -936,7 +958,7 @@ describe('FlowBuilder', () => {
     ]);
   });
 
-  it('builds message, service, external system, flow, actor, and custom details from explicit payloads', () => {
+  it('builds message, service, data store, data product, external system, flow, actor, and custom details from explicit payloads', () => {
     const flow = FlowBuilder.create({
       id: 'OrderFlow',
       name: 'Order Flow',
@@ -952,6 +974,16 @@ describe('FlowBuilder', () => {
         id: 'OrderServiceStep',
         title: 'Order Service',
         service: { id: 'OrderService', version: '1.0.0' },
+      })
+      .addDataStoreStep({
+        id: 'OrdersDBStep',
+        title: 'Orders DB',
+        container: { id: 'OrdersDB', version: '1.0.0' },
+      })
+      .addDataProductStep({
+        id: 'OrderAnalyticsStep',
+        title: 'Order Analytics',
+        dataProduct: { id: 'OrderAnalytics', version: '1.0.0' },
       })
       .addExternalSystemStep({
         id: 'SAPStep',
@@ -987,6 +1019,16 @@ describe('FlowBuilder', () => {
         service: { id: 'OrderService', version: '1.0.0' },
       },
       {
+        id: 'OrdersDBStep',
+        title: 'Orders DB',
+        container: { id: 'OrdersDB', version: '1.0.0' },
+      },
+      {
+        id: 'OrderAnalyticsStep',
+        title: 'Order Analytics',
+        dataProduct: { id: 'OrderAnalytics', version: '1.0.0' },
+      },
+      {
         id: 'SAPStep',
         title: 'SAP',
         externalSystem: { name: 'SAP', summary: 'ERP', url: 'https://example.com/sap' },
@@ -1005,6 +1047,44 @@ describe('FlowBuilder', () => {
         id: 'CustomStep',
         title: 'Custom',
         custom: { title: 'Custom Node', type: 'manual' },
+      },
+    ]);
+  });
+
+  it('builds a data store step from the step id when no explicit data store payload is provided', () => {
+    const flow = FlowBuilder.create({
+      id: 'OrderFlow',
+      name: 'Order Flow',
+      version: '1.0.0',
+      markdown: '# Order Flow',
+    })
+      .addDataStoreStep({ id: 'OrdersDB' })
+      .build();
+
+    expect(flow.steps).toEqual([
+      {
+        id: 'OrdersDB',
+        title: 'OrdersDB',
+        container: { id: 'OrdersDB' },
+      },
+    ]);
+  });
+
+  it('builds a data product step from the step id when no explicit data product payload is provided', () => {
+    const flow = FlowBuilder.create({
+      id: 'OrderFlow',
+      name: 'Order Flow',
+      version: '1.0.0',
+      markdown: '# Order Flow',
+    })
+      .addDataProductStep({ id: 'OrderAnalytics' })
+      .build();
+
+    expect(flow.steps).toEqual([
+      {
+        id: 'OrderAnalytics',
+        title: 'OrderAnalytics',
+        dataProduct: { id: 'OrderAnalytics' },
       },
     ]);
   });

--- a/packages/sdk/src/types.d.ts
+++ b/packages/sdk/src/types.d.ts
@@ -190,6 +190,7 @@ export interface Service extends BaseSchema {
     repository?: DetailPanelProperty;
     owners?: DetailPanelProperty;
     changelog?: DetailPanelProperty;
+    flows?: DetailPanelProperty;
   };
 }
 
@@ -327,6 +328,7 @@ export interface DataProduct extends BaseSchema {
     repository?: DetailPanelProperty;
     owners?: DetailPanelProperty;
     changelog?: DetailPanelProperty;
+    flows?: DetailPanelProperty;
   };
 }
 
@@ -345,6 +347,8 @@ export interface FlowStep {
   message?: ResourcePointer;
   service?: ResourcePointer;
   flow?: ResourcePointer;
+  container?: ResourcePointer;
+  dataProduct?: ResourcePointer;
   actor?: {
     name: string;
     summary?: string;

--- a/packages/visualiser/src/types/index.ts
+++ b/packages/visualiser/src/types/index.ts
@@ -191,6 +191,7 @@ export type NodeType =
   | "externalSystem"
   | "external-system"
   | "data"
+  | "container"
   | "view"
   | "actor"
   | "data-product"


### PR DESCRIPTION
## What This PR Does

Adds first-class support for `container` (data store) and `dataProduct` step types inside EventCatalog flows. Flows can now reference data stores and data products directly as steps, alongside the existing message, service, sub-flow, actor, and custom step types. The SDK exposes new builders, the content schema accepts the new pointer types, and the flow node graph and sidebar render them appropriately.

## Changes Overview

### Key Changes

- **SDK (`@eventcatalog/sdk`)**:
  - New `addDataStoreStep`, `addContainerStep` (alias), and `addDataProductStep` methods on `FlowBuilder`.
  - New `FlowDataStoreStepInput` and `FlowDataProductStepInput` payload types.
  - `FlowStep` now accepts `container` and `dataProduct` resource pointers.
  - `Service` and `DataProduct` detail panels accept an optional `flows` property.
- **Core (`@eventcatalog/core`)**:
  - Flow content schema accepts `container` and `dataProduct` pointers and counts them in the single-type-per-step rule.
  - `getFlows` and `flows-node-graph` hydrate container and data product references, and the graph emits `data` / `data-products` nodes with appropriate context menus.
  - Sidebar builders include flows under containers and data products (via the new `detailsPanel.flows` option).
  - `data-products` collection gains a `detailsPanel` (incl. `flows`); containers gain `detailsPanel.flows`.
- **Visualiser (`@eventcatalog/visualiser`)**:
  - `NodeType` union extended with `"container"`.
- **Examples**:
  - New flow examples under Orders, Payment Refund, and Subscription Payment Failure exercising the new step types.

## How It Works

A flow step may now carry a `container` or `dataProduct` pointer (`{ id, version? }`) in the same way it already carries `message`, `service`, or `flow`. The content collection validator enforces that at most one of these resource types is set per step.

When flows are collected, `getFlows` looks up matching container and data product entries by `id` + `version` (resolving to the latest available version when no version is supplied) and attaches them to the step. The node-graph builder then produces a `data` node for containers and a `data-products` node for data products, wired into the same Dagre layout and context-menu pipeline as existing nodes.

The sidebar gains entries for flows under containers and data products via the new `detailsPanel.flows` option, mirroring the existing services flow listing.

The SDK builder methods accept the same `FlowStepInput` base (id, title, summary, nextSteps) plus an optional explicit `container` / `dataProduct` pointer, falling back to the step `id` when not provided.

## Breaking Changes

None. All new fields are optional; existing flows, services, data products, and containers continue to work unchanged.

## Additional Notes

- The default example catalog has been extended with several new flows that demonstrate the new step types — useful for visual verification.