### PR TITLE
fix(core): improve Flow and NodeGraph MDX embed behaviour

### DIFF
--- a/.changeset/swift-otters-dance.md
+++ b/.changeset/swift-otters-dance.md
@@ -1,0 +1,6 @@
+---
+'@eventcatalog/core': patch
+'@eventcatalog/visualiser': patch
+---
+
+Improve `<Flow />` and `<NodeGraph />` MDX embeds: support boolean MDX props for `search`, `legend`, and `walkthrough`; avoid duplicate page node graph when a `<Flow />` or `<NodeGraph />` is already embedded; use unique portal IDs per flow embed; render a compact NodeGraph menu button when no title is provided.

--- a/packages/core/eventcatalog/src/components/MDX/Flow/Flow.astro
+++ b/packages/core/eventcatalog/src/components/MDX/Flow/Flow.astro
@@ -6,10 +6,15 @@ import AstroNodeGraph from '../NodeGraph/AstroNodeGraph';
 import { getVersionFromCollection } from '@utils/collections/versions';
 import { isVisualiserEnabled, isEventCatalogChatEnabled, isDevMode } from '@utils/feature';
 import { loadSavedLayout, applyLayoutToNodes, buildResourceKey } from '@utils/node-graphs/layout-persistence';
+import { randomUUID } from 'node:crypto';
+import { parseMdxBooleanProp } from '@utils/markdown';
 
 const isChatEnabled = isEventCatalogChatEnabled();
 
-const { id, version = 'latest', maxHeight, includeKey = true, mode = 'simple', walkthrough = true, search = true } = Astro.props;
+const { id, version = 'latest', maxHeight, mode = 'simple' } = Astro.props;
+const includeKey = parseMdxBooleanProp(Astro.props.legend ?? Astro.props.includeKey, true);
+const search = parseMdxBooleanProp(Astro.props.search, false);
+const walkthrough = parseMdxBooleanProp(Astro.props.walkthrough, false);
 
 // Find the flow for the given id and version
 const flows = await getFlows();
@@ -28,6 +33,7 @@ const { nodes, edges } = await getNodesAndEdges({
 const resourceKey = buildResourceKey('flows', id, flow.data.version);
 const savedLayout = await loadSavedLayout(resourceKey);
 const nodesWithLayout = applyLayoutToNodes(nodes, savedLayout);
+const portalId = `${id}-${flow.data.version}-flow-${randomUUID()}-portal`;
 ---
 
 {
@@ -45,7 +51,7 @@ const nodesWithLayout = applyLayoutToNodes(nodes, savedLayout);
 
 <div
   class="h-[30em] my-6 mb-12 w-full relative border border-[rgb(var(--ec-page-border))] rounded-md"
-  id={`${id}-portal`}
+  id={portalId}
   style={{
     maxHeight: maxHeight ? `${maxHeight}em` : `30em`,
   }}
@@ -57,12 +63,10 @@ const nodesWithLayout = applyLayoutToNodes(nodes, savedLayout);
     id={id}
     nodes={nodesWithLayout}
     edges={edges}
-    hrefLabel={'View in visualizer'}
-    href={isVisualiserEnabled() ? `/visualiser/flows/${id}/${version}` : undefined}
-    linkTo={'visualiser'}
+    mode={mode}
     includeKey={includeKey}
-    footerLabel=`Flow diagram - ${flow.data.name} - v(${flow.data.version})`
     client:only="react"
+    portalId={portalId}
     showFlowWalkthrough={walkthrough}
     showSearch={search}
     isChatEnabled={isChatEnabled}

--- a/packages/core/eventcatalog/src/enterprise/custom-documentation/pages/docs/custom/index.astro
+++ b/packages/core/eventcatalog/src/enterprise/custom-documentation/pages/docs/custom/index.astro
@@ -9,7 +9,7 @@ import mdxComponents from '@components/MDX/components';
 import { getOwner } from '@utils/collections/owners';
 import { buildUrl, buildEditUrlForResource } from '@utils/url-builder';
 import { resourceToCollectionMap } from '@utils/collections/util';
-import { getMDXComponentsByName } from '@utils/markdown';
+import { getMDXComponentsByName, parseMdxBooleanProp } from '@utils/markdown';
 import { getAdjacentPages, getNavigationItems } from '@enterprise/custom-documentation/utils/custom-docs';
 import CustomDocsNav from '@enterprise/custom-documentation/components/CustomDocsNav/CustomDocsNav.astro';
 import NodeGraph from '@components/MDX/NodeGraph/NodeGraph.astro';
@@ -22,7 +22,10 @@ const doc = props.data;
 const { Content, headings } = await render(props as any);
 const currentSlug = props.id;
 
-const nodeGraphs = getMDXComponentsByName(props.body, 'NodeGraph') || [];
+const nodeGraphs =
+  getMDXComponentsByName(props.body, 'NodeGraph')?.filter((nodeGraph: any) => {
+    return nodeGraph.id && nodeGraph.version && nodeGraph.type;
+  }) || [];
 
 const { prev, next } = await getAdjacentPages(currentSlug);
 
@@ -152,8 +155,10 @@ const editUrl =
                     version={nodeGraph.version}
                     collection={collection}
                     title={nodeGraph.title}
-                    mode="simple"
+                    mode={nodeGraph.mode || 'simple'}
                     linksToVisualiser={true}
+                    showSearch={parseMdxBooleanProp(nodeGraph.search, true)}
+                    showLegend={parseMdxBooleanProp(nodeGraph.legend, true)}
                     href={
                       isVisualiserEnabled()
                         ? {

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/index.astro
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/index.astro
@@ -43,7 +43,7 @@ import {
   isRSSEnabled,
   isExportPDFEnabled,
 } from '@utils/feature';
-import { getMDXComponentsByName } from '@utils/markdown';
+import { getMDXComponentsByName, parseMdxBooleanProp } from '@utils/markdown';
 
 import type { CollectionTypes } from '@types';
 
@@ -265,10 +265,40 @@ const generatePromptForResource = (props: any) => {
 };
 
 // Handle node graphs in the markdown
-let nodeGraphs = getMDXComponentsByName(props.body || '', 'NodeGraph') || [];
+const currentPageNodeGraph = {
+  id: props.data.id,
+  version: props.data.version,
+  type: collectionToResourceMap[props.collection as keyof typeof collectionToResourceMap],
+};
+
+let nodeGraphs =
+  getMDXComponentsByName(props.body || '', 'NodeGraph')?.map((nodeGraph: any) => {
+    const graph = nodeGraph.id === undefined ? { ...currentPageNodeGraph, ...nodeGraph } : nodeGraph;
+
+    return {
+      ...graph,
+      search: parseMdxBooleanProp(nodeGraph.search, true),
+      legend: parseMdxBooleanProp(nodeGraph.legend, true),
+    };
+  }) || [];
+const flowEmbeds = getMDXComponentsByName(props.body || '', 'Flow') || [];
 
 // Get props for the node graph (when no id is passed, we assume its the current page)
-const nodeGraphPropsForPage = nodeGraphs.find((nodeGraph: any) => nodeGraph.id === undefined) || ({} as any);
+const hasCurrentFlowEmbed =
+  props.collection === 'flows' &&
+  flowEmbeds.some((flowEmbed: any) => {
+    const flowId = flowEmbed.id;
+    const flowVersion = flowEmbed.version || 'latest';
+
+    return flowId === props.data.id && (flowVersion === 'latest' || flowVersion === props.data.version);
+  });
+const hasCurrentPageNodeGraph = nodeGraphs.some((nodeGraph: any) => {
+  return (
+    nodeGraph.id === currentPageNodeGraph.id &&
+    nodeGraph.version === currentPageNodeGraph.version &&
+    nodeGraph.type === currentPageNodeGraph.type
+  );
+});
 
 const shouldRenderVersionList =
   shouldRenderSideBarSection(props, 'versions') && props.data.versions && props.data.versions.length > 1;
@@ -287,15 +317,14 @@ const httpMethodStyle = httpOperation?.method
   ? httpMethodColors[httpOperation.method.toUpperCase()] || { background: '#6b7280', color: '#ffffff' }
   : undefined;
 
-// This will render the graph for this page
-nodeGraphs.push({
-  id: props.data.id,
-  version: props.data.version,
-  type: collectionToResourceMap[props.collection as keyof typeof collectionToResourceMap],
-  ...nodeGraphPropsForPage,
-  search: nodeGraphPropsForPage?.search ? nodeGraphPropsForPage.search === 'true' : true,
-  legend: nodeGraphPropsForPage?.legend ? nodeGraphPropsForPage.legend === 'true' : true,
-});
+// This will render the graph for this page. Flow pages can already render their graph explicitly via <Flow />.
+if (!hasCurrentFlowEmbed && !hasCurrentPageNodeGraph) {
+  nodeGraphs.push({
+    ...currentPageNodeGraph,
+    search: true,
+    legend: true,
+  });
+}
 ---
 
 <VerticalSideBarLayout title={pageTitle} description={props.data.summary}>

--- a/packages/core/eventcatalog/src/utils/__tests__/markdown.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/markdown.spec.ts
@@ -1,4 +1,4 @@
-import { getMDXComponentsByName } from '@utils/markdown';
+import { getMDXComponentsByName, parseMdxBooleanProp } from '@utils/markdown';
 
 describe('markdown', () => {
   describe('getMDXComponentsByName', () => {
@@ -6,9 +6,21 @@ describe('markdown', () => {
       const markdown = `
         <SchemaViewer id="test" />
         <SchemaViewer id="test2" />
+        <SchemaViewer/>
         `;
       const components = getMDXComponentsByName(markdown, 'SchemaViewer');
-      expect(components).toEqual([{ id: 'test' }, { id: 'test2' }]);
+      expect(components).toEqual([{ id: 'test' }, { id: 'test2' }, {}]);
+    });
+  });
+
+  describe('parseMdxBooleanProp', () => {
+    it('parses boolean and string boolean MDX props with defaults', () => {
+      expect(parseMdxBooleanProp(undefined, true)).toBe(true);
+      expect(parseMdxBooleanProp(undefined, false)).toBe(false);
+      expect(parseMdxBooleanProp(true, false)).toBe(true);
+      expect(parseMdxBooleanProp(false, true)).toBe(false);
+      expect(parseMdxBooleanProp('true', false)).toBe(true);
+      expect(parseMdxBooleanProp('false', true)).toBe(false);
     });
   });
 });

--- a/packages/core/eventcatalog/src/utils/markdown.ts
+++ b/packages/core/eventcatalog/src/utils/markdown.ts
@@ -2,15 +2,15 @@
 // rarely used, but useful for components that need to know how many times
 // the user wants to render a component in a markdown file
 export const getMDXComponentsByName = (document: string, componentName: string) => {
-  // Define regex pattern to match <SchemaViewer ... />
-  const pattern = new RegExp(`<${componentName}\\s+([^>]*)\\/>`, 'g');
+  // Define regex pattern to match self-closing MDX components with or without props.
+  const pattern = new RegExp(`<${componentName}(\\s+[^>]*)?\\s*\\/>`, 'g');
 
   // Find all matches of the pattern
   const matches = [...document.matchAll(pattern)];
 
   // Extract the properties of each SchemaViewer
   const components = matches.map((match) => {
-    const propsString = match[1];
+    const propsString = match[1] || '';
     const props = {};
 
     // Use regex to extract key-value pairs from propsString
@@ -27,4 +27,9 @@ export const getMDXComponentsByName = (document: string, componentName: string) 
   });
 
   return components;
+};
+
+export const parseMdxBooleanProp = (value: unknown, defaultValue: boolean) => {
+  if (value === undefined) return defaultValue;
+  return value === true || value === 'true';
 };

--- a/packages/visualiser/src/components/NodeGraph.tsx
+++ b/packages/visualiser/src/components/NodeGraph.tsx
@@ -2137,6 +2137,13 @@ const NodeGraphBuilder = ({
     () => edges.some((edge: Edge) => edge.type === "flow-edge"),
     [edges],
   );
+  const isCompactMenuButton = !title;
+  const menuButtonClassName = isCompactMenuButton
+    ? "h-9 w-9 p-0 bg-[rgb(var(--ec-card-bg))] hover:bg-[rgb(var(--ec-accent-subtle))] border border-[rgb(var(--ec-page-border))] rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[rgb(var(--ec-accent))] flex items-center justify-center transition-colors duration-150 hover:border-[rgb(var(--ec-accent)/0.3)] group"
+    : "py-2.5 px-4 bg-[rgb(var(--ec-card-bg))] hover:bg-[rgb(var(--ec-accent-subtle))] border border-[rgb(var(--ec-page-border))] rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[rgb(var(--ec-accent))] flex items-center gap-3 transition-colors duration-150 hover:border-[rgb(var(--ec-accent)/0.3)] group whitespace-nowrap";
+  const menuIconClassName = isCompactMenuButton
+    ? "h-4 w-4 text-[rgb(var(--ec-page-text-muted))] flex-shrink-0 group-hover:text-[rgb(var(--ec-accent))] transition-colors duration-150"
+    : "h-5 w-5 text-[rgb(var(--ec-page-text-muted))] flex-shrink-0 group-hover:text-[rgb(var(--ec-accent))] transition-colors duration-150";
 
   return (
     <div
@@ -2160,7 +2167,7 @@ const NodeGraphBuilder = ({
                 <DropdownMenu.Root>
                   <DropdownMenu.Trigger asChild>
                     <button
-                      className="py-2.5 px-4 bg-[rgb(var(--ec-page-bg))] hover:bg-[rgb(var(--ec-accent-subtle)/0.4)] border border-[rgb(var(--ec-page-border))] rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[rgb(var(--ec-accent))] flex items-center gap-3 transition-all duration-200 hover:border-[rgb(var(--ec-accent)/0.3)] group whitespace-nowrap"
+                      className={menuButtonClassName}
                       aria-label="Open menu"
                     >
                       {title && (
@@ -2168,7 +2175,7 @@ const NodeGraphBuilder = ({
                           {title}
                         </span>
                       )}
-                      <MoreVertical className="h-5 w-5 text-[rgb(var(--ec-page-text-muted))] flex-shrink-0 group-hover:text-[rgb(var(--ec-accent))] transition-colors duration-150" />
+                      <MoreVertical className={menuIconClassName} />
                     </button>
                   </DropdownMenu.Trigger>
                   <DropdownMenu.Portal container={reactFlowWrapperRef.current}>
@@ -2265,7 +2272,7 @@ const NodeGraphBuilder = ({
                   <DropdownMenu.Root>
                     <DropdownMenu.Trigger asChild>
                       <button
-                        className="py-2.5 px-4 bg-[rgb(var(--ec-page-bg))] hover:bg-[rgb(var(--ec-accent-subtle)/0.4)] border border-[rgb(var(--ec-page-border))] rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[rgb(var(--ec-accent))] flex items-center gap-3 transition-all duration-200 hover:border-[rgb(var(--ec-accent)/0.3)] group whitespace-nowrap"
+                        className={menuButtonClassName}
                         aria-label="Open menu"
                       >
                         {title && (
@@ -2273,7 +2280,7 @@ const NodeGraphBuilder = ({
                             {title}
                           </span>
                         )}
-                        <MoreVertical className="h-5 w-5 text-[rgb(var(--ec-page-text-muted))] flex-shrink-0 group-hover:text-[rgb(var(--ec-accent))] transition-colors duration-150" />
+                        <MoreVertical className={menuIconClassName} />
                       </button>
                     </DropdownMenu.Trigger>
                     <DropdownMenu.Portal

--- a/packages/visualiser/src/components/StepWalkthrough.tsx
+++ b/packages/visualiser/src/components/StepWalkthrough.tsx
@@ -78,7 +78,6 @@ export default memo(function StepWalkthrough({
   edges,
   isFlowVisualization,
   onStepChange,
-  mode = "full",
 }: StepWalkthroughProps) {
   const [currentNodeId, setCurrentNodeId] = useState<string | null>(null);
   const [pathHistory, setPathHistory] = useState<string[]>([]);
@@ -229,7 +228,7 @@ export default memo(function StepWalkthrough({
     onStepChange(null, [], true); // Pass true to indicate full reset with zoom out
   }, [onStepChange]);
 
-  if (!isFlowVisualization || nodes.length === 0 || mode !== "full") {
+  if (!isFlowVisualization || nodes.length === 0) {
     return null;
   }
 


### PR DESCRIPTION
## What This PR Does

Cleans up how the `<Flow />` and `<NodeGraph />` MDX components behave when embedded into resource pages and custom docs. Boolean MDX props now parse correctly (true/false or "true"/"false"), the page-level node graph is suppressed when the page already renders one explicitly via `<Flow />` or `<NodeGraph />`, and each Flow embed gets a unique portal id so multiple flows on the same page no longer collide. Also adds a compact button style for the NodeGraph menu when no title is provided.

## Changes Overview

### Key Changes

- Add `parseMdxBooleanProp` helper in `@utils/markdown` and use it across `Flow.astro`, custom docs, and the resource doc page to handle `search`, `legend`, and `walkthrough` props.
- Update `getMDXComponentsByName` regex to also match self-closing components with no props (e.g. `<SchemaViewer/>`).
- In `pages/docs/[type]/[id]/[version]/index.astro`, skip pushing the auto page node graph when the page body already contains a `<Flow />` for the current flow or a `<NodeGraph />` referencing the current resource.
- Filter out incomplete `<NodeGraph />` embeds in custom docs (require `id`, `version`, `type`) and forward `mode`, `showSearch`, and `showLegend`.
- Generate a unique portal id per `<Flow />` embed (`${id}-${version}-flow-${uuid}-portal`) so multiple embeds on the same page render correctly.
- NodeGraph: render a compact icon-only menu button when no `title` is provided; extract shared className constants.
- StepWalkthrough: remove unused `mode` prop and its early-return branch.
- Add a test for `parseMdxBooleanProp` and extend the `getMDXComponentsByName` test to cover prop-less self-closing tags.

## How It Works

The MDX prop boolean parsing is centralised in `parseMdxBooleanProp(value, defaultValue)`, which accepts `true`, `false`, `"true"`, `"false"`, or `undefined`. Astro pages call this for every boolean prop coming out of MDX so authors can write either `search={true}` or `search="true"` consistently.

For the duplicate node graph issue, the resource page scans the MDX body for `<Flow />` and `<NodeGraph />` components. If an embed already covers the current resource, the implicit page-level node graph is skipped — otherwise it's appended as before. Flow embeds now also get a UUID-suffixed portal id so React Flow portals don't collide when more than one flow renders on the same page.

## Breaking Changes

None.

## Additional Notes

- The `mode` prop on `StepWalkthrough` is removed; it was unused after the recent walkthrough refactor.
- The `legend` prop on `<Flow />` is now preferred over `includeKey`, but `includeKey` is still accepted for backwards compatibility.