### PR TITLE
fix(core): apply theme variables to custom docs pages and hide nav when empty

### DIFF
--- a/.changeset/calm-pandas-document.md
+++ b/.changeset/calm-pandas-document.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Apply theme variables to custom documentation pages so they respect light/dark mode, and hide the custom docs sidebar nav item when no custom docs are configured.

--- a/packages/core/docs/development/bring-your-own-documentation/custom-pages/03-components.md
+++ b/packages/core/docs/development/bring-your-own-documentation/custom-pages/03-components.md
@@ -36,6 +36,10 @@ This is my custom documentation page, here is a NodeGraph:
 Rest of my markdown content...
 ```
 
+:::note Required props
+In custom documentation pages, `id`, `version`, and `type` are all required. A `<NodeGraph />` missing any of these props is silently ignored.
+:::
+
 #### NodeGraph props
 
 | Prop | Type | Required | Description |
@@ -43,4 +47,7 @@ Rest of my markdown content...
 | `id` | string | Yes | The id of the resource (domain, service, or message) |
 | `version` | string | Yes | The version of the resource |
 | `type` | string | Yes | The type of the resource (domain, service, command, event, query) |
+| `search` | boolean | No | Show or hide the search bar. Accepts `true`/`false` or `"true"`/`"false"`. Defaults to `true`. |
+| `legend` | boolean | No | Show or hide the legend. Accepts `true`/`false` or `"true"`/`"false"`. Defaults to `true`. |
+| `mode` | string | No | `"simple"` or `"full"`. Defaults to `"simple"`. |
 

--- a/packages/core/docs/development/components/components/08-flow.md
+++ b/packages/core/docs/development/components/components/08-flow.md
@@ -14,20 +14,29 @@ Embed flows into your pages.
 **Example**
 
 ```jsx /domains/MyDomain/index.mdx
-<Flow id="CancelSubscription" version="latest" includeKey={false} />
+<Flow id="CancelSubscription" version="latest" legend={false} />
 ```
 
 ### Output
 ![Example output](./img/flows.png)
 
 ### Props
+
+<AddedIn version="3.36.3" />
+
 | Name                    | Type      | Default           | Description                                                       |
 | ----------------------- | --------- | ----------------- | ----------------------------------------------------------------- |
 | `id` (required)                 | `string`  | (empty)           | Flow id to render in your page                               |
-| `version` (optional)             | `string`  | "latest"           | Version of the flow to render. Supports exact version and semver versions (e.g 1.0.x, ^1.3.5, latest)|
-| `includeKey` (optional)             | `boolean`  | true           | Renders the diagram key on the UI |
-| `search` (optional)             | `boolean`  | true           | Show or hide the search bar in the flow _(Added in v2.50.3)_ |
-| `mode` (optional)             | `string` ("simple" or "full")  | "simple"           | `simple` will render the flow in a simplfied view not rendering descriptions. Full will render the flow in a full view, rendering descriptions and other information _(Added in v2.50.3)_|
+| `version` (optional)             | `string`  | `"latest"`           | Version of the flow to render. Supports exact version and semver versions (e.g 1.0.x, ^1.3.5, latest)|
+| `legend` (optional)             | `boolean`  | `true`           | Show or hide the diagram key. Accepts `true`/`false` or `"true"`/`"false"`. `includeKey` is still accepted as an alias. |
+| `search` (optional)             | `boolean`  | `false`           | Show or hide the search bar in the flow. Accepts `true`/`false` or `"true"`/`"false"`. |
+| `walkthrough` (optional)             | `boolean`  | `false`           | Show or hide the step walkthrough controls. Accepts `true`/`false` or `"true"`/`"false"`. |
+| `mode` (optional)             | `string` ("simple" or "full")  | `"simple"`           | `simple` renders the flow in a simplified view without descriptions. `full` renders descriptions and other information.|
+
+:::tip Multiple embeds per page
+You can embed multiple `<Flow />` components on the same page and each one renders independently.
+:::
+
 
 ## Interactive controls
 

--- a/packages/core/docs/development/components/components/12-nodegraph.md
+++ b/packages/core/docs/development/components/components/12-nodegraph.md
@@ -25,12 +25,15 @@ The `<NodeGraph/>` component is supported in domains, services, and all messages
 ![Example output](./img/nodegraph.png)
 
 #### Props
+
+<AddedIn version="3.36.3" />
+
 | Name                    | Type      | Default           | Description                                                       |
 | ----------------------- | --------- | ----------------- | ----------------------------------------------------------------- |
-| `maxHeight` (optional)             | `string`  | 30           | Max height to set the nodegraph in your document|
-| `search` (optional)             | `boolean`  | true           | Show or hide the search bar in the nodegraph _(Added in v2.50.3)_ |
-| `legend` (optional)             | `boolean`  | true           | Show or hide the legend in the nodegraph _(Added in v2.50.3)_ |
-| `mode` (optional)             | `string` ("simple" or "full")  | "simple"           | `simple` will render the nodegraph in a simplfied view not rendering descriptions. Full will render the nodegraph in a full view, rendering descriptions and other information _(Added in v2.50.3)_|
+| `maxHeight` (optional)             | `string`  | `30`           | Max height to set the nodegraph in your document|
+| `search` (optional)             | `boolean`  | `true`           | Show or hide the search bar. Accepts `true`/`false` or `"true"`/`"false"`. |
+| `legend` (optional)             | `boolean`  | `true`           | Show or hide the legend. Accepts `true`/`false` or `"true"`/`"false"`. |
+| `mode` (optional)             | `string` ("simple" or "full")  | `"simple"`           | `simple` renders a simplified view without descriptions. `full` renders descriptions and other information.|
 
 
 ## Interactive controls

--- a/packages/core/eventcatalog/src/enterprise/custom-documentation/pages/docs/custom/index.astro
+++ b/packages/core/eventcatalog/src/enterprise/custom-documentation/pages/docs/custom/index.astro
@@ -182,7 +182,7 @@ const editUrl =
                     class="group flex flex-col border border-[rgb(var(--ec-page-border))] rounded-lg p-4 hover:border-[rgb(var(--ec-content-text-muted))] hover:bg-[rgb(var(--ec-content-hover))] transition-colors w-full sm:w-1/2"
                   >
                     <span class="text-sm text-[rgb(var(--ec-page-text-muted))] mb-1">Previous</span>
-                    <span class="font-medium text-[rgb(var(--ec-page-text))] group-hover:text-primary-600 transition-colors">
+                    <span class="font-medium text-[rgb(var(--ec-page-text))] group-hover:text-[rgb(var(--ec-accent))] transition-colors">
                       {prev.label}
                     </span>
                   </a>
@@ -198,7 +198,7 @@ const editUrl =
                     class="group flex flex-col items-end text-right border border-[rgb(var(--ec-page-border))] rounded-lg p-4 hover:border-[rgb(var(--ec-content-text-muted))] hover:bg-[rgb(var(--ec-content-hover))] transition-colors w-full sm:w-1/2"
                   >
                     <span class="text-sm text-[rgb(var(--ec-page-text-muted))] mb-1">Next</span>
-                    <span class="font-medium text-[rgb(var(--ec-page-text))] group-hover:text-primary-600 transition-colors">
+                    <span class="font-medium text-[rgb(var(--ec-page-text))] group-hover:text-[rgb(var(--ec-accent))] transition-colors">
                       {next.label}
                     </span>
                   </a>

--- a/packages/core/eventcatalog/src/enterprise/custom-documentation/pages/docs/custom/root-index.astro
+++ b/packages/core/eventcatalog/src/enterprise/custom-documentation/pages/docs/custom/root-index.astro
@@ -99,28 +99,28 @@ if (!isCustomDocsEnabled()) {
 ---
 
 <VerticalSideBarLayout title="Custom Documentation" showNestedSideBar={false}>
-  <body class="min-h-screen font-inter">
+  <body class="min-h-screen font-inter bg-[rgb(var(--ec-page-bg))] text-[rgb(var(--ec-page-text))]">
     <main class="container px-8 lg:px-8 mx-auto py-8 max-w-[80em]">
       <div class="mb-12">
         <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-6">
           <div>
             <div class="flex flex-wrap items-center gap-3 mb-3">
-              <h1 class="text-4xl font-semibold text-gray-900 font-inter">Custom Documentation</h1>
+              <h1 class="text-4xl font-semibold text-[rgb(var(--ec-page-text))] font-inter">Custom Documentation</h1>
               <div
                 class="inline-flex items-center px-3 py-1.5 rounded-full text-xs font-medium bg-[rgb(var(--ec-accent-subtle))] text-[rgb(var(--ec-accent-text))] border border-[rgb(var(--ec-accent)/0.3)] shadow-xs"
               >
                 Pro feature
               </div>
             </div>
-            <p class="text-base mb-0 text-gray-600 max-w-3xl">
+            <p class="text-base mb-0 text-[rgb(var(--ec-page-text-muted))] max-w-3xl">
               Add custom documentation to EventCatalog to create a unified source of truth for your team. Document your
               architecture decisions, patterns, and guidelines.
             </p>
           </div>
           <div class="flex space-x-4 shrink-0">
             <a
-              href="https://www.eventcatalog.dev/docs/custom-documentation"
-              class="inline-flex items-center justify-center px-5 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50"
+              href="https://www.eventcatalog.dev/docs/development/bring-your-own-documentation/custom-pages/introduction"
+              class="inline-flex items-center justify-center px-5 py-2 border border-[rgb(var(--ec-page-border))] text-sm font-medium rounded-md text-[rgb(var(--ec-page-text))] bg-[rgb(var(--ec-card-bg))] hover:bg-[rgb(var(--ec-content-hover))] transition-colors"
             >
               Read documentation &rarr;
             </a>
@@ -128,7 +128,7 @@ if (!isCustomDocsEnabled()) {
               !isCustomDocsEnabled() && (
                 <a
                   href="https://www.eventcatalog.dev/pro/trial"
-                  class="inline-flex items-center justify-center px-5 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-gradient-to-r from-[rgb(var(--ec-accent-gradient-from))] to-[rgb(var(--ec-accent-gradient-to))] hover:opacity-90 shadow-xs"
+                  class="inline-flex items-center justify-center px-5 py-2 border border-transparent text-sm font-medium rounded-md text-[rgb(var(--ec-button-text))] bg-gradient-to-r from-[rgb(var(--ec-accent-gradient-from))] to-[rgb(var(--ec-accent-gradient-to))] hover:opacity-90 shadow-xs"
                 >
                   Start 14-day trial
                 </a>
@@ -138,58 +138,62 @@ if (!isCustomDocsEnabled()) {
         </div>
       </div>
 
-      <h2 class="text-2xl font-semibold mb-2 text-gray-900">Setup Guide</h2>
-      <p class="text-gray-600 mb-8 max-w-3xl">
+      <h2 class="text-2xl font-semibold mb-2 text-[rgb(var(--ec-page-text))]">Setup Guide</h2>
+      <p class="text-[rgb(var(--ec-page-text-muted))] mb-8 max-w-3xl">
         Custom documentation let's you bring any documentation into EventCatalog. This is useful for documenting your architecture
         decisions, patterns, and guidelines. Follow these steps to get started:
       </p>
 
       <div class="space-y-10 mb-12">
-        <div class="bg-white p-6 rounded-lg shadow-xs border border-gray-200">
+        <div class="bg-[rgb(var(--ec-card-bg))] p-6 rounded-lg shadow-xs border border-[rgb(var(--ec-page-border))]">
           <div class="flex items-start gap-4">
             <div
-              class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-blue-100 text-blue-600 text-lg font-medium shrink-0 mt-1"
+              class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-[rgb(var(--ec-accent-subtle))] text-[rgb(var(--ec-accent))] text-lg font-medium shrink-0 mt-1"
             >
               1
             </div>
             <div class="w-full">
-              <h3 class="text-xl font-semibold text-gray-900 mb-3">Create the content structure</h3>
-              <p class="text-gray-600 mb-4">Create a folder structure in your directory to organize your documentation.</p>
+              <h3 class="text-xl font-semibold text-[rgb(var(--ec-page-text))] mb-3">Create the content structure</h3>
+              <p class="text-[rgb(var(--ec-page-text-muted))] mb-4">
+                Create a folder structure in your directory to organize your documentation.
+              </p>
               <Code code={folderStructureExample} lang="bash" frame="terminal" />
             </div>
           </div>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow-xs border border-gray-200">
+        <div class="bg-[rgb(var(--ec-card-bg))] p-6 rounded-lg shadow-xs border border-[rgb(var(--ec-page-border))]">
           <div class="flex items-start gap-4">
             <div
-              class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-blue-100 text-blue-600 text-lg font-medium shrink-0 mt-1"
+              class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-[rgb(var(--ec-accent-subtle))] text-[rgb(var(--ec-accent))] text-lg font-medium shrink-0 mt-1"
             >
               2
             </div>
             <div class="w-full">
-              <h3 class="text-xl font-semibold text-gray-900 mb-3">Add MDX files</h3>
-              <p class="text-gray-600 mb-4">Create MDX files with frontmatter and markdown content.</p>
+              <h3 class="text-xl font-semibold text-[rgb(var(--ec-page-text))] mb-3">Add MDX files</h3>
+              <p class="text-[rgb(var(--ec-page-text-muted))] mb-4">Create MDX files with frontmatter and markdown content.</p>
               <Code code={mdxFileExample} lang="mdx" frame="terminal" />
             </div>
           </div>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow-xs border border-gray-200">
+        <div class="bg-[rgb(var(--ec-card-bg))] p-6 rounded-lg shadow-xs border border-[rgb(var(--ec-page-border))]">
           <div class="flex items-start gap-4">
             <div
-              class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-blue-100 text-blue-600 text-lg font-medium shrink-0 mt-1"
+              class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-[rgb(var(--ec-accent-subtle))] text-[rgb(var(--ec-accent))] text-lg font-medium shrink-0 mt-1"
             >
               3
             </div>
             <div class="w-full">
-              <h3 class="text-xl font-semibold text-gray-900 mb-3">Update your eventcatalog.config.js file</h3>
-              <p class="text-gray-600 mb-4">
+              <h3 class="text-xl font-semibold text-[rgb(var(--ec-page-text))] mb-3">Update your eventcatalog.config.js file</h3>
+              <p class="text-[rgb(var(--ec-page-text-muted))] mb-4">
                 Add the customDocs configuration to your eventcatalog.config.js file to define your sidebar structure.
               </p>
               <Code code={configExample} lang="js" frame="terminal" />
-              <p class="text-gray-600 mt-4">This configuration defines the sidebar structure for your custom documentation:</p>
-              <ul class="list-disc list-inside text-gray-600 mt-2 ml-2 space-y-1">
+              <p class="text-[rgb(var(--ec-page-text-muted))] mt-4">
+                This configuration defines the sidebar structure for your custom documentation:
+              </p>
+              <ul class="list-disc list-inside text-[rgb(var(--ec-page-text-muted))] mt-2 ml-2 space-y-1">
                 <li>
                   <strong>label</strong>: The display name for each sidebar section
                 </li>
@@ -210,25 +214,25 @@ if (!isCustomDocsEnabled()) {
           </div>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow-xs border border-gray-200">
+        <div class="bg-[rgb(var(--ec-card-bg))] p-6 rounded-lg shadow-xs border border-[rgb(var(--ec-page-border))]">
           <div class="flex items-start gap-4">
             <div
-              class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-blue-100 text-blue-600 text-lg font-medium shrink-0 mt-1"
+              class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-[rgb(var(--ec-accent-subtle))] text-[rgb(var(--ec-accent))] text-lg font-medium shrink-0 mt-1"
             >
               4
             </div>
             <div class="w-full">
-              <h3 class="text-xl font-semibold text-gray-900 mb-3">Restart EventCatalog</h3>
-              <p class="text-gray-600 mb-4">
+              <h3 class="text-xl font-semibold text-[rgb(var(--ec-page-text))] mb-3">Restart EventCatalog</h3>
+              <p class="text-[rgb(var(--ec-page-text-muted))] mb-4">
                 After configuring your documentation, restart EventCatalog to see your custom documentation.
               </p>
               <div class="mb-4">
                 <Code code="npm run dev" lang="bash" frame="terminal" />
               </div>
-              <p class="text-gray-600 mb-4">
+              <p class="text-[rgb(var(--ec-page-text-muted))] mb-4">
                 Once restarted, you'll see your custom documentation displayed with the sidebar structure you defined:
               </p>
-              <div class="border border-gray-200 rounded-lg overflow-hidden">
+              <div class="border border-[rgb(var(--ec-page-border))] rounded-lg overflow-hidden">
                 <img src="/images/custom-docs-placeholder.png" alt="Example of custom documentation interface" class="w-full" />
               </div>
             </div>

--- a/packages/core/eventcatalog/src/layouts/VerticalSideBarLayout.astro
+++ b/packages/core/eventcatalog/src/layouts/VerticalSideBarLayout.astro
@@ -150,7 +150,7 @@ const navigationItems = [
     href: getDefaultUrl('docs/custom', '/docs/custom'),
     current: currentPath.includes('/docs/custom'),
     isPremium: true,
-    visible: isCustomDocsEnabled(),
+    visible: isCustomDocsEnabled() && customDocs.length > 0,
   },
   {
     id: '/schemas/explorer',


### PR DESCRIPTION
## What This PR Does

Fixes two issues with the Custom Documentation enterprise feature. First, the custom documentation pages (`/docs/custom` and its child pages) used hardcoded Tailwind colors (`bg-white`, `text-gray-900`, `bg-blue-100`, etc.) which broke under dark mode and custom themes. Second, the "Custom Documentation" entry was always shown in the vertical sidebar nav when the feature flag was enabled, even when no custom docs had been configured.

## Changes Overview

### Key Changes
- Replace hardcoded colors in `root-index.astro` with theme CSS variables (`--ec-page-bg`, `--ec-page-text`, `--ec-page-text-muted`, `--ec-card-bg`, `--ec-page-border`, `--ec-accent-subtle`, `--ec-accent`, `--ec-content-hover`, `--ec-button-text`).
- Replace hardcoded `text-primary-600` hover color in the prev/next pager (`index.astro`) with `[rgb(var(--ec-accent))]` so the accent follows the active theme.
- Hide the "Custom Documentation" sidebar nav item when `customDocs.length === 0`, even if the feature is enabled — avoids a dead nav entry.
- Update the "Read documentation" link to point at the current docs URL: `/docs/development/bring-your-own-documentation/custom-pages/introduction`.

## How It Works

EventCatalog uses CSS variables for theming (see `CLAUDE.md` theming guidelines). Pages should use `[rgb(var(--ec-*))]` Tailwind syntax instead of named colors so that the same component renders correctly under light, dark, and custom themes. This PR aligns the custom docs pages with that convention.

For the sidebar visibility, `VerticalSideBarLayout.astro` already had a `visible` flag for the nav item; we now AND it with `customDocs.length > 0` so the entry only renders when there is something to navigate to.

## Breaking Changes

None — purely visual and visibility fixes.

## Additional Notes

- Pre-existing repo-level `pnpm run format` and `pnpm run check` failures exist on `main` (pagefind generated files for prettier, unrelated Search type errors for astro check). The three files modified here pass `prettier --check` cleanly.
- No new tests — changes are CSS class swaps and a single boolean expression tweak.