### PR TITLE
feat(core): unify resource reference colors and fix custom docs theming

### DIFF
--- a/.changeset/calm-pandas-document.md
+++ b/.changeset/calm-pandas-document.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Apply theme variables to custom documentation pages so they respect light/dark mode, and hide the custom docs sidebar nav item when no custom docs are configured.

--- a/.changeset/swift-otters-glide.md
+++ b/.changeset/swift-otters-glide.md
@@ -1,0 +1,6 @@
+---
+"@eventcatalog/core": minor
+"@eventcatalog/visualiser": minor
+---
+
+Unify resource reference colors across tables, MDX components, and the sidebar via a shared collection-colors utility. Add data-product support to ResourceRef with rich tooltip styling, custom icon support, and updated visualiser data node palette.

--- a/packages/core/docs/development/bring-your-own-documentation/custom-pages/03-components.md
+++ b/packages/core/docs/development/bring-your-own-documentation/custom-pages/03-components.md
@@ -36,6 +36,10 @@ This is my custom documentation page, here is a NodeGraph:
 Rest of my markdown content...
 ```
 
+:::note Required props
+In custom documentation pages, `id`, `version`, and `type` are all required. A `<NodeGraph />` missing any of these props is silently ignored.
+:::
+
 #### NodeGraph props
 
 | Prop | Type | Required | Description |
@@ -43,4 +47,7 @@ Rest of my markdown content...
 | `id` | string | Yes | The id of the resource (domain, service, or message) |
 | `version` | string | Yes | The version of the resource |
 | `type` | string | Yes | The type of the resource (domain, service, command, event, query) |
+| `search` | boolean | No | Show or hide the search bar. Accepts `true`/`false` or `"true"`/`"false"`. Defaults to `true`. |
+| `legend` | boolean | No | Show or hide the legend. Accepts `true`/`false` or `"true"`/`"false"`. Defaults to `true`. |
+| `mode` | string | No | `"simple"` or `"full"`. Defaults to `"simple"`. |
 

--- a/packages/core/docs/development/components/components/08-flow.md
+++ b/packages/core/docs/development/components/components/08-flow.md
@@ -14,20 +14,29 @@ Embed flows into your pages.
 **Example**
 
 ```jsx /domains/MyDomain/index.mdx
-<Flow id="CancelSubscription" version="latest" includeKey={false} />
+<Flow id="CancelSubscription" version="latest" legend={false} />
 ```
 
 ### Output
 ![Example output](./img/flows.png)
 
 ### Props
+
+<AddedIn version="3.36.3" />
+
 | Name                    | Type      | Default           | Description                                                       |
 | ----------------------- | --------- | ----------------- | ----------------------------------------------------------------- |
 | `id` (required)                 | `string`  | (empty)           | Flow id to render in your page                               |
-| `version` (optional)             | `string`  | "latest"           | Version of the flow to render. Supports exact version and semver versions (e.g 1.0.x, ^1.3.5, latest)|
-| `includeKey` (optional)             | `boolean`  | true           | Renders the diagram key on the UI |
-| `search` (optional)             | `boolean`  | true           | Show or hide the search bar in the flow _(Added in v2.50.3)_ |
-| `mode` (optional)             | `string` ("simple" or "full")  | "simple"           | `simple` will render the flow in a simplfied view not rendering descriptions. Full will render the flow in a full view, rendering descriptions and other information _(Added in v2.50.3)_|
+| `version` (optional)             | `string`  | `"latest"`           | Version of the flow to render. Supports exact version and semver versions (e.g 1.0.x, ^1.3.5, latest)|
+| `legend` (optional)             | `boolean`  | `true`           | Show or hide the diagram key. Accepts `true`/`false` or `"true"`/`"false"`. `includeKey` is still accepted as an alias. |
+| `search` (optional)             | `boolean`  | `false`           | Show or hide the search bar in the flow. Accepts `true`/`false` or `"true"`/`"false"`. |
+| `walkthrough` (optional)             | `boolean`  | `false`           | Show or hide the step walkthrough controls. Accepts `true`/`false` or `"true"`/`"false"`. |
+| `mode` (optional)             | `string` ("simple" or "full")  | `"simple"`           | `simple` renders the flow in a simplified view without descriptions. `full` renders descriptions and other information.|
+
+:::tip Multiple embeds per page
+You can embed multiple `<Flow />` components on the same page and each one renders independently.
+:::
+
 
 ## Interactive controls
 

--- a/packages/core/docs/development/components/components/12-nodegraph.md
+++ b/packages/core/docs/development/components/components/12-nodegraph.md
@@ -25,12 +25,15 @@ The `<NodeGraph/>` component is supported in domains, services, and all messages
 ![Example output](./img/nodegraph.png)
 
 #### Props
+
+<AddedIn version="3.36.3" />
+
 | Name                    | Type      | Default           | Description                                                       |
 | ----------------------- | --------- | ----------------- | ----------------------------------------------------------------- |
-| `maxHeight` (optional)             | `string`  | 30           | Max height to set the nodegraph in your document|
-| `search` (optional)             | `boolean`  | true           | Show or hide the search bar in the nodegraph _(Added in v2.50.3)_ |
-| `legend` (optional)             | `boolean`  | true           | Show or hide the legend in the nodegraph _(Added in v2.50.3)_ |
-| `mode` (optional)             | `string` ("simple" or "full")  | "simple"           | `simple` will render the nodegraph in a simplfied view not rendering descriptions. Full will render the nodegraph in a full view, rendering descriptions and other information _(Added in v2.50.3)_|
+| `maxHeight` (optional)             | `string`  | `30`           | Max height to set the nodegraph in your document|
+| `search` (optional)             | `boolean`  | `true`           | Show or hide the search bar. Accepts `true`/`false` or `"true"`/`"false"`. |
+| `legend` (optional)             | `boolean`  | `true`           | Show or hide the legend. Accepts `true`/`false` or `"true"`/`"false"`. |
+| `mode` (optional)             | `string` ("simple" or "full")  | `"simple"`           | `simple` renders a simplified view without descriptions. `full` renders descriptions and other information.|
 
 
 ## Interactive controls

--- a/packages/core/eventcatalog/src/components/FieldsExplorer/FieldsTable.tsx
+++ b/packages/core/eventcatalog/src/components/FieldsExplorer/FieldsTable.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { SearchX, Copy, Check, AlertTriangle } from 'lucide-react';
 import { BoltIcon, ChatBubbleLeftIcon, MagnifyingGlassIcon } from '@heroicons/react/24/solid';
 import { buildUrl } from '@utils/url-builder';
+import { getCollectionTextColorClass } from '@utils/collection-colors';
 
 export interface FieldResult {
   path: string;
@@ -28,13 +29,6 @@ export interface FieldsTableProps {
   isScaleEnabled?: boolean;
 }
 
-const colorClasses: Record<string, string> = {
-  orange: 'text-orange-500',
-  blue: 'text-blue-500',
-  green: 'text-green-500',
-  gray: 'text-gray-500',
-};
-
 const getColorAndIconForMessageType = (type: string) => {
   switch (type) {
     case 'event':
@@ -58,7 +52,7 @@ function MessageBadge({ id, name, version, type }: { id: string; name?: string; 
       onClick={(e) => e.stopPropagation()}
       className="group/msg inline-flex items-center gap-1.5 text-[0.8rem] text-[rgb(var(--ec-page-text-muted))] hover:text-[rgb(var(--ec-accent))] transition-colors"
     >
-      <Icon className={`h-3.5 w-3.5 ${colorClasses[color] || 'text-gray-500'} flex-shrink-0`} />
+      <Icon className={`h-3.5 w-3.5 ${getCollectionTextColorClass(color)} flex-shrink-0`} />
       <span className="truncate max-w-[160px] text-[rgb(var(--ec-page-text-muted))] group-hover/msg:text-[rgb(var(--ec-accent))]">
         {name || id}
       </span>

--- a/packages/core/eventcatalog/src/components/MDX/MessageTable/MessageTable.client.tsx
+++ b/packages/core/eventcatalog/src/components/MDX/MessageTable/MessageTable.client.tsx
@@ -1,4 +1,5 @@
 import { getColorAndIconForCollection } from '@utils/collections/icons';
+import { getCollectionTextColorClass } from '@utils/collection-colors';
 import { buildUrl } from '@utils/url-builder';
 import { useState, useMemo, useCallback, memo } from 'react';
 
@@ -37,7 +38,7 @@ const MessageRow = memo(
         <td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-[rgb(var(--ec-page-text))] sm:pl-6 relative">
           <a href={url} className="absolute inset-0 z-10" aria-label={`View details for ${message.name}`} />
           <div className="flex items-center gap-2 relative">
-            <Icon className={`h-5 w-5 text-${color}-500`} />
+            <Icon className={`h-5 w-5 ${getCollectionTextColorClass(color)}`} />
             <span className="group-hover:text-blue-600 break-all">{message.name}</span>
           </div>
         </td>

--- a/packages/core/eventcatalog/src/components/MDX/ResourceGroupTable/ResourceGroupTable.client.tsx
+++ b/packages/core/eventcatalog/src/components/MDX/ResourceGroupTable/ResourceGroupTable.client.tsx
@@ -1,4 +1,5 @@
 import { getColorAndIconForCollection } from '@utils/collections/icons';
+import { getCollectionTextColorClass } from '@utils/collection-colors';
 import { buildUrl } from '@utils/url-builder';
 import { useState, useMemo, useCallback, memo } from 'react';
 
@@ -41,7 +42,7 @@ const ResourceRow = memo(
         <td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-[rgb(var(--ec-page-text))] sm:pl-6 relative">
           <a href={url} className="absolute inset-0 z-10" aria-label={`View details for ${resource.name}`} />
           <div className="flex items-center gap-2 relative">
-            <Icon className={`h-5 w-5 text-${color}-500`} />
+            <Icon className={`h-5 w-5 ${getCollectionTextColorClass(color)}`} />
             <span className="group-hover:text-[rgb(var(--ec-accent))] break-all">{resource.name}</span>
           </div>
         </td>

--- a/packages/core/eventcatalog/src/components/MDX/ResourceLink/ResourceLink.astro
+++ b/packages/core/eventcatalog/src/components/MDX/ResourceLink/ResourceLink.astro
@@ -2,9 +2,11 @@
 import { buildUrl } from '@utils/url-builder';
 import { getItemsFromCollectionByIdAndSemverOrLatest, resourceToCollectionMap } from '@utils/collections/util';
 import { getCollection } from 'astro:content';
+import { getResourceReferenceStyle } from '@utils/resource-reference-colors';
 
 const { id, version, type } = Astro.props;
 const collection = resourceToCollectionMap[type as keyof typeof resourceToCollectionMap];
+const resourceReferenceStyle = getResourceReferenceStyle(type);
 
 let slotHTML = await Astro.slots.render('default');
 let href = '#';
@@ -43,7 +45,11 @@ try {
 
 {
   !linkHasError && (
-    <a href={href} class="text-[rgb(var(--ec-accent))] hover:text-[rgb(var(--ec-accent-hover))]">
+    <a
+      href={href}
+      class="rounded px-1 -mx-1 text-[var(--ec-resource-ref-color)] hover:bg-[var(--ec-resource-ref-bg)] transition-colors"
+      style={resourceReferenceStyle}
+    >
       {slotHTML}
     </a>
   )

--- a/packages/core/eventcatalog/src/components/MDX/ResourceRef/ResourceRef.astro
+++ b/packages/core/eventcatalog/src/components/MDX/ResourceRef/ResourceRef.astro
@@ -14,6 +14,8 @@ import {
 } from '@utils/collections/util';
 import { getCollection } from 'astro:content';
 import { getServiceSpecifications, getSpecUrl, getSpecLabel } from '@components/Grids/specification-utils';
+import { getResourceReferenceStyle } from '@utils/resource-reference-colors';
+import { isIconPath, resolveIconUrl } from '@utils/icon';
 
 interface Props {
   type:
@@ -29,7 +31,8 @@ interface Props {
     | 'container'
     | 'user'
     | 'team'
-    | 'doc';
+    | 'doc'
+    | 'data-product';
   version?: string;
 }
 
@@ -56,22 +59,21 @@ const normalizedResourceId = normalizeCustomDocPath(resourceId).toLowerCase();
 // Map type to collection name
 const collection = resourceToCollectionMap[type as keyof typeof resourceToCollectionMap];
 
-// Type-specific styling using CSS variables from theme.css
-// Maps to --ec-badge-{type}-text variables for consistency
-const typeStyles: Record<string, { borderColor: string; label: string }> = {
-  entity: { borderColor: 'var(--ec-badge-query-text)', label: 'Entity' }, // purple
-  service: { borderColor: 'var(--ec-badge-service-text)', label: 'Service' }, // pink
-  event: { borderColor: 'var(--ec-badge-event-text)', label: 'Event' }, // amber/orange
-  command: { borderColor: 'var(--ec-badge-command-text)', label: 'Command' }, // pink
-  query: { borderColor: 'var(--ec-badge-query-text)', label: 'Query' }, // purple
-  domain: { borderColor: 'var(--ec-badge-domain-text)', label: 'Domain' }, // yellow
-  flow: { borderColor: 'var(--ec-badge-design-text)', label: 'Flow' }, // teal
-  channel: { borderColor: 'var(--ec-badge-channel-text)', label: 'Channel' }, // indigo
-  diagram: { borderColor: 'var(--ec-badge-default-text)', label: 'Diagram' }, // gray
-  container: { borderColor: 'var(--ec-badge-default-text)', label: 'Container' }, // gray
-  user: { borderColor: 'var(--ec-badge-default-text)', label: 'User' }, // gray
-  team: { borderColor: 'var(--ec-badge-default-text)', label: 'Team' }, // gray
-  doc: { borderColor: 'var(--ec-badge-default-text)', label: 'Doc' }, // gray
+const typeLabels: Record<string, string> = {
+  entity: 'Entity',
+  service: 'Service',
+  event: 'Event',
+  command: 'Command',
+  query: 'Query',
+  domain: 'Domain',
+  flow: 'Flow',
+  channel: 'Channel',
+  diagram: 'Diagram',
+  container: 'Container',
+  user: 'User',
+  team: 'Team',
+  doc: 'Custom Doc',
+  'data-product': 'Data Product',
 };
 
 // SVG icons for each type (from heroicons outline)
@@ -97,11 +99,14 @@ const typeIcons: Record<string, string> = {
     '<path stroke-linecap="round" stroke-linejoin="round" d="M20.25 6.375c0 2.278-3.694 4.125-8.25 4.125S3.75 8.653 3.75 6.375m16.5 0c0-2.278-3.694-4.125-8.25-4.125S3.75 4.097 3.75 6.375m16.5 0v11.25c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125V6.375m16.5 0v3.75m-16.5-3.75v3.75m16.5 0v3.75C20.25 16.153 16.556 18 12 18s-8.25-1.847-8.25-4.125v-3.75m16.5 0c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125" />', // Database
   user: '<path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z" />', // User
   team: '<path stroke-linecap="round" stroke-linejoin="round" d="M18 18.72a9.094 9.094 0 003.741-.479 3 3 0 00-4.682-2.72m.94 3.198l.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0112 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 016 18.719m12 0a5.971 5.971 0 00-.941-3.197m0 0A5.995 5.995 0 0012 12.75a5.995 5.995 0 00-5.058 2.772m0 0a3 3 0 00-4.681 2.72 8.986 8.986 0 003.74.477m.94-3.197a5.971 5.971 0 00-.94 3.197M15 6.75a3 3 0 11-6 0 3 3 0 016 0zm6 3a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0zm-13.5 0a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0z" />', // UserGroup
-  doc: '<path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-8.25a2.25 2.25 0 00-2.25-2.25h-10.5A2.25 2.25 0 004.5 6v12a2.25 2.25 0 002.25 2.25h5.25M16.5 18.75h6m-3-3v6" />', // Document with plus
+  doc: '<path stroke-linecap="round" stroke-linejoin="round" d="M14 2v4a2 2 0 002 2h4" /><path stroke-linecap="round" stroke-linejoin="round" d="M15 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V7z" /><path stroke-linecap="round" stroke-linejoin="round" d="M10 9H8" /><path stroke-linecap="round" stroke-linejoin="round" d="M16 13H8" /><path stroke-linecap="round" stroke-linejoin="round" d="M16 17H8" />', // FileText
+  'data-product':
+    '<path stroke-linecap="round" stroke-linejoin="round" d="M21 7.5l-9-5.25L3 7.5m18 0l-9 5.25M21 7.5v9l-9 5.25M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9" />', // Cube
 };
 
-const style = typeStyles[type] || typeStyles.entity;
+const label = typeLabels[type] || typeLabels.entity;
 const iconPath = typeIcons[type] || typeIcons.entity;
+const resourceReferenceStyle = getResourceReferenceStyle(type);
 
 let resource: any = null;
 let href = '#';
@@ -172,6 +177,7 @@ const hasVisualizer = ['domain', 'service', 'event', 'query', 'command', 'contai
 // Check deprecation status
 const deprecation = resource ? getDeprecatedDetails(resource) : null;
 const isDeprecated = deprecation?.isMarkedAsDeprecated || false;
+const resourceIconUrl = isIconPath(resource?.data?.styles?.icon) ? resolveIconUrl(resource.data.styles.icon) : null;
 
 // Get owners (first 2)
 const owners = resource?.data?.owners?.slice(0, 2) || [];
@@ -234,7 +240,7 @@ const hasSpecifications = specifications.length > 0;
 const tooltipId = `ref-tooltip-${Math.random().toString(36).slice(2, 9)}`;
 ---
 
-<span class="resource-ref-wrapper inline">
+<span class="resource-ref-wrapper inline relative">
   {
     hasError ? (
       <span
@@ -249,14 +255,13 @@ const tooltipId = `ref-tooltip-${Math.random().toString(36).slice(2, 9)}`;
           href={href}
           class:list={[
             'resource-ref-trigger inline-flex items-center gap-1 px-1 -mx-1 rounded font-medium underline decoration-dotted decoration-2 underline-offset-[3px] transition-colors',
-            isDeprecated
-              ? 'text-amber-700 dark:text-amber-400 decoration-amber-500/60'
-              : 'text-[rgb(var(--ec-accent-text))] decoration-[rgb(var(--ec-primary))] hover:bg-[rgb(var(--ec-accent-subtle))]',
+            'text-[var(--ec-resource-ref-color)] decoration-[var(--ec-resource-ref-color)] hover:bg-[var(--ec-resource-ref-bg)]',
           ]}
+          style={resourceReferenceStyle}
           data-tooltip-id={tooltipId}
         >
           <svg
-            class="w-3.5 h-3.5 flex-shrink-0 text-[rgb(var(--ec-primary))]"
+            class="w-3.5 h-3.5 flex-shrink-0 text-[var(--ec-resource-ref-color)]"
             fill="none"
             viewBox="0 0 24 24"
             stroke="currentColor"
@@ -271,7 +276,7 @@ const tooltipId = `ref-tooltip-${Math.random().toString(36).slice(2, 9)}`;
         <span
           id={tooltipId}
           class="resource-ref-tooltip fixed w-80 bg-[rgb(var(--ec-card-bg))] border border-[rgb(var(--ec-page-border))] border-l-[3px] rounded-r-lg rounded-l-none shadow-lg shadow-black/8 z-[9999] text-left overflow-hidden opacity-0 pointer-events-none transition-all duration-150 scale-95 origin-top-left"
-          style={`border-left-color: rgb(${style.borderColor});`}
+          style={`${resourceReferenceStyle}; border-left-color: var(--ec-resource-ref-color);`}
         >
           {/* Deprecation banner */}
           {isDeprecated && (
@@ -289,29 +294,41 @@ const tooltipId = `ref-tooltip-${Math.random().toString(36).slice(2, 9)}`;
 
           <span class="block p-3">
             {/* Header: Name with icon top-right */}
-            <span class="flex justify-between items-start mb-2">
-              <span class="flex flex-col">
-                <span class="flex items-baseline gap-2">
-                  <span class="font-semibold text-[rgb(var(--ec-page-text))] text-[0.95rem] leading-tight">
-                    {resource?.data?.name || resourceId}
-                  </span>
-                  <span class="text-[0.65rem] text-[rgb(var(--ec-page-text-muted))] uppercase tracking-wide">{style.label}</span>
+            <span class="grid grid-cols-[minmax(0,1fr)_1.25rem] items-start gap-3 border-b border-[rgb(var(--ec-page-border))] pb-2 mb-3">
+              <span class="flex min-w-0 flex-col">
+                <span class="font-semibold text-[rgb(var(--ec-page-text))] text-[0.95rem] leading-tight">
+                  {resource?.data?.name || resourceId}
                 </span>
-                {isVersionedResource && (
-                  <span class="text-[0.7rem] font-mono text-[rgb(var(--ec-page-text-muted))] mt-0.5">
-                    v{resource?.data?.version}
-                  </span>
+                <span class="mt-0.5 flex items-center gap-1.5 text-[0.7rem] text-[rgb(var(--ec-page-text-muted))] uppercase tracking-wide">
+                  <span class="text-[0.65rem] text-[rgb(var(--ec-page-text-muted))] uppercase tracking-wide">{label}</span>
+                  {isVersionedResource && (
+                    <>
+                      <span aria-hidden="true">•</span>
+                      <span class="font-mono normal-case">v{resource?.data?.version}</span>
+                    </>
+                  )}
+                </span>
+              </span>
+              <span class="flex h-[24px] w-[24px] items-start justify-end mr-4">
+                {resourceIconUrl ? (
+                  <img
+                    src={resourceIconUrl}
+                    alt=""
+                    class="not-prose m-0 block  h-[24px] w-[24px] object-contain"
+                    loading="lazy"
+                  />
+                ) : (
+                  <svg
+                    class="h-5 w-5"
+                    style="color: var(--ec-resource-ref-color);"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    stroke-width="1.5"
+                    set:html={iconPath}
+                  />
                 )}
               </span>
-              <svg
-                class="w-5 h-5 flex-shrink-0"
-                style={`color: rgb(${style.borderColor});`}
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                stroke-width="1.5"
-                set:html={iconPath}
-              />
             </span>
 
             {/* Summary */}
@@ -413,7 +430,7 @@ const tooltipId = `ref-tooltip-${Math.random().toString(36).slice(2, 9)}`;
             ) : null}
 
             {/* Actions */}
-            <span class="flex items-center justify-between pt-2 border-t border-[rgb(var(--ec-page-border))] text-[0.7rem]">
+            <span class="flex items-center justify-between pt-1 text-[0.7rem]">
               <span class="flex items-center gap-3">
                 {type === 'flow' && (
                   <a
@@ -450,7 +467,11 @@ const tooltipId = `ref-tooltip-${Math.random().toString(36).slice(2, 9)}`;
                   </a>
                 )}
               </span>
-              <a href={href} class="text-[rgb(var(--ec-accent))] hover:underline font-medium">
+              <a
+                href={href}
+                class="text-[var(--ec-resource-ref-color)] hover:underline font-medium"
+                style="color: var(--ec-resource-ref-color);"
+              >
                 {type === 'diagram' ? 'View diagram' : type === 'doc' ? 'View doc' : 'View docs'}
               </a>
             </span>

--- a/packages/core/eventcatalog/src/components/SideNav/NestedSideBar/utils.ts
+++ b/packages/core/eventcatalog/src/components/SideNav/NestedSideBar/utils.ts
@@ -14,6 +14,7 @@ export const getBadgeClasses = (badge: string): string => {
     message: 'bg-[rgb(var(--ec-badge-message-bg))] text-[rgb(var(--ec-badge-message-text))]',
     design: 'bg-[rgb(var(--ec-badge-design-bg))] text-[rgb(var(--ec-badge-design-text))]',
     channel: 'bg-[rgb(var(--ec-badge-channel-bg))] text-[rgb(var(--ec-badge-channel-text))]',
+    container: 'bg-[rgb(var(--ec-badge-container-bg))] text-[rgb(var(--ec-badge-container-text))]',
     'data product': 'bg-[rgb(var(--ec-badge-data-product-bg))] text-[rgb(var(--ec-badge-data-product-text))]',
   };
   return badgeColors[badge.toLowerCase()] || 'bg-[rgb(var(--ec-badge-default-bg))] text-[rgb(var(--ec-badge-default-text))]';

--- a/packages/core/eventcatalog/src/components/Tables/Discover/columns.tsx
+++ b/packages/core/eventcatalog/src/components/Tables/Discover/columns.tsx
@@ -4,25 +4,12 @@ import { DocumentTextIcon, MapIcon } from '@heroicons/react/24/solid';
 import { ArrowDownIcon, ArrowUpIcon, EllipsisVerticalIcon, StarIcon } from '@heroicons/react/24/outline';
 import { buildUrl } from '@utils/url-builder';
 import { getColorAndIconForCollection } from '@utils/collections/icons';
+import { getCollectionTextColorClass } from '@utils/collection-colors';
 import { isIconPath, resolveIconUrl } from '@utils/icon';
 import { useStore } from '@nanostores/react';
 import { favoritesStore, toggleFavorite, type FavoriteItem } from '../../../stores/favorites-store';
 import type { DiscoverTableData, CollectionType } from './DiscoverTable';
 import type { TableConfiguration } from '@types';
-
-// Color mapping to ensure Tailwind classes are included in the build
-const colorClasses: Record<string, string> = {
-  orange: 'text-orange-500',
-  blue: 'text-blue-500',
-  green: 'text-green-500',
-  pink: 'text-pink-500',
-  yellow: 'text-yellow-500',
-  teal: 'text-teal-500',
-  purple: 'text-purple-500',
-  red: 'text-red-500',
-  gray: 'text-gray-500',
-  cyan: 'text-cyan-500',
-};
 
 const columnHelper = createColumnHelper<DiscoverTableData>();
 
@@ -80,7 +67,7 @@ const ResourceNameCell = ({ item }: { item: DiscoverTableData }) => {
       {resourceIconUrl ? (
         <img src={resourceIconUrl} alt="" className="h-5 w-5 flex-shrink-0 rounded-sm object-contain" />
       ) : (
-        <Icon className={`h-4 w-4 flex-shrink-0 ${colorClasses[color] || 'text-[rgb(var(--ec-icon-color))]'}`} />
+        <Icon className={`h-4 w-4 flex-shrink-0 ${getCollectionTextColorClass(color, 'text-[rgb(var(--ec-icon-color))]')}`} />
       )}
       <span className="text-sm font-semibold text-[rgb(var(--ec-page-text))] group-hover:text-[rgb(var(--ec-accent))]">
         {item.data.name}
@@ -248,7 +235,7 @@ const CollectionListCell = ({
           href={buildUrl(`/docs/${item.collection}/${item.data.id}/${item.data.version}`)}
           className="group inline-flex items-center gap-1.5 text-[0.8rem] text-[rgb(var(--ec-icon-color))] hover:text-[rgb(var(--ec-accent))] transition-colors"
         >
-          <item.Icon className={`h-3.5 w-3.5 ${colorClasses[item.color] || 'text-gray-500'} flex-shrink-0`} />
+          <item.Icon className={`h-3.5 w-3.5 ${getCollectionTextColorClass(item.color)} flex-shrink-0`} />
           <span className="truncate max-w-[120px]" title={item.data.name}>
             {item.data.name}
           </span>

--- a/packages/core/eventcatalog/src/components/Tables/columns/ContainersTableColumns.tsx
+++ b/packages/core/eventcatalog/src/components/Tables/columns/ContainersTableColumns.tsx
@@ -21,8 +21,8 @@ export const columns = (tableConfiguration: TableConfiguration) => [
           href={buildUrl(`/docs/${containerRaw.collection}/${containerRaw.data.id}/${containerRaw.data.version}`)}
           className="group inline-flex items-center"
         >
-          <span className="inline-flex items-center rounded-md border border-[rgb(var(--ec-page-border))] bg-[rgb(var(--ec-card-bg,var(--ec-page-bg)))] hover:border-blue-400 dark:hover:border-blue-500 hover:bg-blue-50 dark:hover:bg-blue-500/10 transition-colors">
-            <span className="flex items-center justify-center w-6 h-6 bg-blue-500 rounded-l-md">
+          <span className="inline-flex items-center rounded-md border border-[rgb(var(--ec-page-border))] bg-[rgb(var(--ec-card-bg,var(--ec-page-bg)))] hover:border-indigo-400 dark:hover:border-indigo-500 hover:bg-indigo-50 dark:hover:bg-indigo-500/10 transition-colors">
+            <span className="flex items-center justify-center w-6 h-6 bg-indigo-500 rounded-l-md">
               <DatabaseIcon className="h-3 w-3 text-white" />
             </span>
             <span className="px-2 py-1 text-xs text-[rgb(var(--ec-page-text))] group-hover:text-[rgb(var(--ec-page-text))]">

--- a/packages/core/eventcatalog/src/components/Tables/columns/ServiceTableColumns.tsx
+++ b/packages/core/eventcatalog/src/components/Tables/columns/ServiceTableColumns.tsx
@@ -5,6 +5,7 @@ import { useMemo, useState } from 'react';
 import { filterByName, filterCollectionByName } from '../filters/custom-filters';
 import { buildUrl } from '@utils/url-builder';
 import { getColorAndIconForCollection } from '@utils/collections/icons';
+import { getCollectionTextColorClass } from '@utils/collection-colors';
 import { createBadgesColumn } from './SharedColumns';
 import FavoriteButton from '@components/FavoriteButton';
 import type { TData } from '../Table';
@@ -95,7 +96,7 @@ export const columns = (tableConfiguration: TableConfiguration) => [
               href={buildUrl(`/docs/${consumer.collection}/${consumer.data.id}/${consumer.data.version}`)}
               className="group inline-flex items-center gap-1.5 text-xs hover:text-[rgb(var(--ec-accent))] transition-colors"
             >
-              <consumer.Icon className={`h-3.5 w-3.5 text-${consumer.color}-500 flex-shrink-0`} />
+              <consumer.Icon className={`h-3.5 w-3.5 ${getCollectionTextColorClass(consumer.color)} flex-shrink-0`} />
               <span className="truncate max-w-[120px]" title={consumer.data.name}>
                 {consumer.data.name}
               </span>
@@ -154,7 +155,7 @@ export const columns = (tableConfiguration: TableConfiguration) => [
               href={buildUrl(`/docs/${sender.collection}/${sender.data.id}/${sender.data.version}`)}
               className="group inline-flex items-center gap-1.5 text-xs hover:text-[rgb(var(--ec-accent))] transition-colors"
             >
-              <sender.Icon className={`h-3.5 w-3.5 text-${sender.color}-500 flex-shrink-0`} />
+              <sender.Icon className={`h-3.5 w-3.5 ${getCollectionTextColorClass(sender.color)} flex-shrink-0`} />
               <span className="truncate max-w-[120px]" title={sender.data.name}>
                 {sender.data.name}
               </span>

--- a/packages/core/eventcatalog/src/components/Tables/columns/TeamsTableColumns.tsx
+++ b/packages/core/eventcatalog/src/components/Tables/columns/TeamsTableColumns.tsx
@@ -6,20 +6,8 @@ import type { TData } from '../Table';
 import type { CollectionUserTypes } from '@types';
 import type { TableConfiguration } from '@types';
 import { getColorAndIconForCollection } from '@utils/collections/icons';
+import { getCollectionTextColorClass } from '@utils/collection-colors';
 const columnHelper = createColumnHelper<TData<CollectionUserTypes>>();
-
-const colorClasses: Record<string, string> = {
-  orange: 'text-orange-500',
-  blue: 'text-blue-500',
-  green: 'text-green-500',
-  pink: 'text-pink-500',
-  yellow: 'text-yellow-500',
-  teal: 'text-teal-500',
-  purple: 'text-purple-500',
-  red: 'text-red-500',
-  gray: 'text-gray-500',
-  cyan: 'text-cyan-500',
-};
 
 const CollectionListCell = ({
   items,
@@ -49,7 +37,9 @@ const CollectionListCell = ({
             href={href}
             className="group inline-flex items-center gap-1.5 text-[0.8rem] text-[rgb(var(--ec-icon-color))] transition-colors hover:text-[rgb(var(--ec-accent))]"
           >
-            <Icon className={`h-3.5 w-3.5 flex-shrink-0 ${colorClasses[color] || 'text-[rgb(var(--ec-icon-color))]'}`} />
+            <Icon
+              className={`h-3.5 w-3.5 flex-shrink-0 ${getCollectionTextColorClass(color, 'text-[rgb(var(--ec-icon-color))]')}`}
+            />
             <span className="max-w-[140px] truncate" title={item.data.name}>
               {item.data.name}
             </span>

--- a/packages/core/eventcatalog/src/components/Tables/columns/UserTableColumns.tsx
+++ b/packages/core/eventcatalog/src/components/Tables/columns/UserTableColumns.tsx
@@ -6,20 +6,8 @@ import type { TData } from '../Table';
 import type { CollectionUserTypes } from '@types';
 import type { TableConfiguration } from '@types';
 import { getColorAndIconForCollection } from '@utils/collections/icons';
+import { getCollectionTextColorClass } from '@utils/collection-colors';
 const columnHelper = createColumnHelper<TData<CollectionUserTypes>>();
-
-const colorClasses: Record<string, string> = {
-  orange: 'text-orange-500',
-  blue: 'text-blue-500',
-  green: 'text-green-500',
-  pink: 'text-pink-500',
-  yellow: 'text-yellow-500',
-  teal: 'text-teal-500',
-  purple: 'text-purple-500',
-  red: 'text-red-500',
-  gray: 'text-gray-500',
-  cyan: 'text-cyan-500',
-};
 
 const CollectionListCell = ({
   items,
@@ -52,7 +40,9 @@ const CollectionListCell = ({
             href={href}
             className="group inline-flex items-center gap-1.5 text-[0.8rem] text-[rgb(var(--ec-icon-color))] transition-colors hover:text-[rgb(var(--ec-accent))]"
           >
-            <Icon className={`h-3.5 w-3.5 flex-shrink-0 ${colorClasses[color] || 'text-[rgb(var(--ec-icon-color))]'}`} />
+            <Icon
+              className={`h-3.5 w-3.5 flex-shrink-0 ${getCollectionTextColorClass(color, 'text-[rgb(var(--ec-icon-color))]')}`}
+            />
             <span className="max-w-[140px] truncate" title={item.data.name}>
               {item.data.name}
             </span>

--- a/packages/core/eventcatalog/src/enterprise/custom-documentation/pages/docs/custom/index.astro
+++ b/packages/core/eventcatalog/src/enterprise/custom-documentation/pages/docs/custom/index.astro
@@ -182,7 +182,7 @@ const editUrl =
                     class="group flex flex-col border border-[rgb(var(--ec-page-border))] rounded-lg p-4 hover:border-[rgb(var(--ec-content-text-muted))] hover:bg-[rgb(var(--ec-content-hover))] transition-colors w-full sm:w-1/2"
                   >
                     <span class="text-sm text-[rgb(var(--ec-page-text-muted))] mb-1">Previous</span>
-                    <span class="font-medium text-[rgb(var(--ec-page-text))] group-hover:text-primary-600 transition-colors">
+                    <span class="font-medium text-[rgb(var(--ec-page-text))] group-hover:text-[rgb(var(--ec-accent))] transition-colors">
                       {prev.label}
                     </span>
                   </a>
@@ -198,7 +198,7 @@ const editUrl =
                     class="group flex flex-col items-end text-right border border-[rgb(var(--ec-page-border))] rounded-lg p-4 hover:border-[rgb(var(--ec-content-text-muted))] hover:bg-[rgb(var(--ec-content-hover))] transition-colors w-full sm:w-1/2"
                   >
                     <span class="text-sm text-[rgb(var(--ec-page-text-muted))] mb-1">Next</span>
-                    <span class="font-medium text-[rgb(var(--ec-page-text))] group-hover:text-primary-600 transition-colors">
+                    <span class="font-medium text-[rgb(var(--ec-page-text))] group-hover:text-[rgb(var(--ec-accent))] transition-colors">
                       {next.label}
                     </span>
                   </a>

--- a/packages/core/eventcatalog/src/enterprise/custom-documentation/pages/docs/custom/root-index.astro
+++ b/packages/core/eventcatalog/src/enterprise/custom-documentation/pages/docs/custom/root-index.astro
@@ -99,28 +99,28 @@ if (!isCustomDocsEnabled()) {
 ---
 
 <VerticalSideBarLayout title="Custom Documentation" showNestedSideBar={false}>
-  <body class="min-h-screen font-inter">
+  <body class="min-h-screen font-inter bg-[rgb(var(--ec-page-bg))] text-[rgb(var(--ec-page-text))]">
     <main class="container px-8 lg:px-8 mx-auto py-8 max-w-[80em]">
       <div class="mb-12">
         <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-6">
           <div>
             <div class="flex flex-wrap items-center gap-3 mb-3">
-              <h1 class="text-4xl font-semibold text-gray-900 font-inter">Custom Documentation</h1>
+              <h1 class="text-4xl font-semibold text-[rgb(var(--ec-page-text))] font-inter">Custom Documentation</h1>
               <div
                 class="inline-flex items-center px-3 py-1.5 rounded-full text-xs font-medium bg-[rgb(var(--ec-accent-subtle))] text-[rgb(var(--ec-accent-text))] border border-[rgb(var(--ec-accent)/0.3)] shadow-xs"
               >
                 Pro feature
               </div>
             </div>
-            <p class="text-base mb-0 text-gray-600 max-w-3xl">
+            <p class="text-base mb-0 text-[rgb(var(--ec-page-text-muted))] max-w-3xl">
               Add custom documentation to EventCatalog to create a unified source of truth for your team. Document your
               architecture decisions, patterns, and guidelines.
             </p>
           </div>
           <div class="flex space-x-4 shrink-0">
             <a
-              href="https://www.eventcatalog.dev/docs/custom-documentation"
-              class="inline-flex items-center justify-center px-5 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50"
+              href="https://www.eventcatalog.dev/docs/development/bring-your-own-documentation/custom-pages/introduction"
+              class="inline-flex items-center justify-center px-5 py-2 border border-[rgb(var(--ec-page-border))] text-sm font-medium rounded-md text-[rgb(var(--ec-page-text))] bg-[rgb(var(--ec-card-bg))] hover:bg-[rgb(var(--ec-content-hover))] transition-colors"
             >
               Read documentation &rarr;
             </a>
@@ -128,7 +128,7 @@ if (!isCustomDocsEnabled()) {
               !isCustomDocsEnabled() && (
                 <a
                   href="https://www.eventcatalog.dev/pro/trial"
-                  class="inline-flex items-center justify-center px-5 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-gradient-to-r from-[rgb(var(--ec-accent-gradient-from))] to-[rgb(var(--ec-accent-gradient-to))] hover:opacity-90 shadow-xs"
+                  class="inline-flex items-center justify-center px-5 py-2 border border-transparent text-sm font-medium rounded-md text-[rgb(var(--ec-button-text))] bg-gradient-to-r from-[rgb(var(--ec-accent-gradient-from))] to-[rgb(var(--ec-accent-gradient-to))] hover:opacity-90 shadow-xs"
                 >
                   Start 14-day trial
                 </a>
@@ -138,58 +138,62 @@ if (!isCustomDocsEnabled()) {
         </div>
       </div>
 
-      <h2 class="text-2xl font-semibold mb-2 text-gray-900">Setup Guide</h2>
-      <p class="text-gray-600 mb-8 max-w-3xl">
+      <h2 class="text-2xl font-semibold mb-2 text-[rgb(var(--ec-page-text))]">Setup Guide</h2>
+      <p class="text-[rgb(var(--ec-page-text-muted))] mb-8 max-w-3xl">
         Custom documentation let's you bring any documentation into EventCatalog. This is useful for documenting your architecture
         decisions, patterns, and guidelines. Follow these steps to get started:
       </p>
 
       <div class="space-y-10 mb-12">
-        <div class="bg-white p-6 rounded-lg shadow-xs border border-gray-200">
+        <div class="bg-[rgb(var(--ec-card-bg))] p-6 rounded-lg shadow-xs border border-[rgb(var(--ec-page-border))]">
           <div class="flex items-start gap-4">
             <div
-              class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-blue-100 text-blue-600 text-lg font-medium shrink-0 mt-1"
+              class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-[rgb(var(--ec-accent-subtle))] text-[rgb(var(--ec-accent))] text-lg font-medium shrink-0 mt-1"
             >
               1
             </div>
             <div class="w-full">
-              <h3 class="text-xl font-semibold text-gray-900 mb-3">Create the content structure</h3>
-              <p class="text-gray-600 mb-4">Create a folder structure in your directory to organize your documentation.</p>
+              <h3 class="text-xl font-semibold text-[rgb(var(--ec-page-text))] mb-3">Create the content structure</h3>
+              <p class="text-[rgb(var(--ec-page-text-muted))] mb-4">
+                Create a folder structure in your directory to organize your documentation.
+              </p>
               <Code code={folderStructureExample} lang="bash" frame="terminal" />
             </div>
           </div>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow-xs border border-gray-200">
+        <div class="bg-[rgb(var(--ec-card-bg))] p-6 rounded-lg shadow-xs border border-[rgb(var(--ec-page-border))]">
           <div class="flex items-start gap-4">
             <div
-              class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-blue-100 text-blue-600 text-lg font-medium shrink-0 mt-1"
+              class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-[rgb(var(--ec-accent-subtle))] text-[rgb(var(--ec-accent))] text-lg font-medium shrink-0 mt-1"
             >
               2
             </div>
             <div class="w-full">
-              <h3 class="text-xl font-semibold text-gray-900 mb-3">Add MDX files</h3>
-              <p class="text-gray-600 mb-4">Create MDX files with frontmatter and markdown content.</p>
+              <h3 class="text-xl font-semibold text-[rgb(var(--ec-page-text))] mb-3">Add MDX files</h3>
+              <p class="text-[rgb(var(--ec-page-text-muted))] mb-4">Create MDX files with frontmatter and markdown content.</p>
               <Code code={mdxFileExample} lang="mdx" frame="terminal" />
             </div>
           </div>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow-xs border border-gray-200">
+        <div class="bg-[rgb(var(--ec-card-bg))] p-6 rounded-lg shadow-xs border border-[rgb(var(--ec-page-border))]">
           <div class="flex items-start gap-4">
             <div
-              class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-blue-100 text-blue-600 text-lg font-medium shrink-0 mt-1"
+              class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-[rgb(var(--ec-accent-subtle))] text-[rgb(var(--ec-accent))] text-lg font-medium shrink-0 mt-1"
             >
               3
             </div>
             <div class="w-full">
-              <h3 class="text-xl font-semibold text-gray-900 mb-3">Update your eventcatalog.config.js file</h3>
-              <p class="text-gray-600 mb-4">
+              <h3 class="text-xl font-semibold text-[rgb(var(--ec-page-text))] mb-3">Update your eventcatalog.config.js file</h3>
+              <p class="text-[rgb(var(--ec-page-text-muted))] mb-4">
                 Add the customDocs configuration to your eventcatalog.config.js file to define your sidebar structure.
               </p>
               <Code code={configExample} lang="js" frame="terminal" />
-              <p class="text-gray-600 mt-4">This configuration defines the sidebar structure for your custom documentation:</p>
-              <ul class="list-disc list-inside text-gray-600 mt-2 ml-2 space-y-1">
+              <p class="text-[rgb(var(--ec-page-text-muted))] mt-4">
+                This configuration defines the sidebar structure for your custom documentation:
+              </p>
+              <ul class="list-disc list-inside text-[rgb(var(--ec-page-text-muted))] mt-2 ml-2 space-y-1">
                 <li>
                   <strong>label</strong>: The display name for each sidebar section
                 </li>
@@ -210,25 +214,25 @@ if (!isCustomDocsEnabled()) {
           </div>
         </div>
 
-        <div class="bg-white p-6 rounded-lg shadow-xs border border-gray-200">
+        <div class="bg-[rgb(var(--ec-card-bg))] p-6 rounded-lg shadow-xs border border-[rgb(var(--ec-page-border))]">
           <div class="flex items-start gap-4">
             <div
-              class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-blue-100 text-blue-600 text-lg font-medium shrink-0 mt-1"
+              class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-[rgb(var(--ec-accent-subtle))] text-[rgb(var(--ec-accent))] text-lg font-medium shrink-0 mt-1"
             >
               4
             </div>
             <div class="w-full">
-              <h3 class="text-xl font-semibold text-gray-900 mb-3">Restart EventCatalog</h3>
-              <p class="text-gray-600 mb-4">
+              <h3 class="text-xl font-semibold text-[rgb(var(--ec-page-text))] mb-3">Restart EventCatalog</h3>
+              <p class="text-[rgb(var(--ec-page-text-muted))] mb-4">
                 After configuring your documentation, restart EventCatalog to see your custom documentation.
               </p>
               <div class="mb-4">
                 <Code code="npm run dev" lang="bash" frame="terminal" />
               </div>
-              <p class="text-gray-600 mb-4">
+              <p class="text-[rgb(var(--ec-page-text-muted))] mb-4">
                 Once restarted, you'll see your custom documentation displayed with the sidebar structure you defined:
               </p>
-              <div class="border border-gray-200 rounded-lg overflow-hidden">
+              <div class="border border-[rgb(var(--ec-page-border))] rounded-lg overflow-hidden">
                 <img src="/images/custom-docs-placeholder.png" alt="Example of custom documentation interface" class="w-full" />
               </div>
             </div>

--- a/packages/core/eventcatalog/src/layouts/VerticalSideBarLayout.astro
+++ b/packages/core/eventcatalog/src/layouts/VerticalSideBarLayout.astro
@@ -150,7 +150,7 @@ const navigationItems = [
     href: getDefaultUrl('docs/custom', '/docs/custom'),
     current: currentPath.includes('/docs/custom'),
     isPremium: true,
-    visible: isCustomDocsEnabled(),
+    visible: isCustomDocsEnabled() && customDocs.length > 0,
   },
   {
     id: '/schemas/explorer',

--- a/packages/core/eventcatalog/src/styles/tailwind.css
+++ b/packages/core/eventcatalog/src/styles/tailwind.css
@@ -1,4 +1,4 @@
-@import "tailwindcss";
+@import 'tailwindcss';
 
 @plugin "@tailwindcss/typography";
 
@@ -24,23 +24,41 @@
   --animate-contentShow: contentShow 200ms ease-out;
 
   @keyframes progress-bar {
-    0% { transform: translateX(-100%); }
-    100% { transform: translateX(100%); }
+    0% {
+      transform: translateX(-100%);
+    }
+    100% {
+      transform: translateX(100%);
+    }
   }
 
   @keyframes progress-bar-reverse {
-    0% { transform: translateX(100%); }
-    100% { transform: translateX(-100%); }
+    0% {
+      transform: translateX(100%);
+    }
+    100% {
+      transform: translateX(-100%);
+    }
   }
 
   @keyframes overlayShow {
-    from { opacity: 0; }
-    to { opacity: 1; }
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
   }
 
   @keyframes contentShow {
-    from { opacity: 0; transform: scale(0.96); }
-    to { opacity: 1; transform: scale(1); }
+    from {
+      opacity: 0;
+      transform: scale(0.96);
+    }
+    to {
+      opacity: 1;
+      transform: scale(1);
+    }
   }
 }
 
@@ -49,20 +67,20 @@
  * at runtime (e.g. `bg-${color}-50`). Tailwind v4 can't detect these from source
  * scanning, so we explicitly declare them here.
  *
- * Colors used: orange, blue, green, emerald, amber, violet, pink, purple, gray, yellow, teal
+ * Colors used: orange, blue, green, emerald, amber, violet, pink, purple, gray, yellow, teal, cyan, indigo
  * Used in: SchemaListItem, Grids/components, SchemaExplorer, MessageGrid
  */
-@source inline("bg-{orange,blue,green,emerald,amber,violet,pink,purple,gray}-{50,100}");
-@source inline("bg-{orange,blue,green,emerald,amber,violet,pink,purple,gray}-500/{10,20}");
-@source inline("text-{orange,blue,green,emerald,amber,violet,pink,purple,gray}-{400,500,600,700}");
-@source inline("border-l-{orange,blue,green,emerald,amber,violet,pink,purple,gray}-500");
+@source inline("bg-{orange,blue,green,emerald,amber,violet,pink,purple,gray,yellow,teal,cyan,indigo}-{50,100}");
+@source inline("bg-{orange,blue,green,emerald,amber,violet,pink,purple,gray,yellow,teal,cyan,indigo}-500/{10,20}");
+@source inline("text-{orange,blue,green,emerald,amber,violet,pink,purple,gray,yellow,teal,cyan,indigo}-{400,500,600,700}");
+@source inline("border-l-{orange,blue,green,emerald,amber,violet,pink,purple,gray,yellow,teal,cyan,indigo}-500");
 @source inline("ring-2");
-@source inline("ring-{orange,blue,green,emerald,amber,violet,pink,purple,gray}-500");
+@source inline("ring-{orange,blue,green,emerald,amber,violet,pink,purple,gray,yellow,teal,cyan,indigo}-500");
 
 /* Border color variants for MessageGrid cards */
-@source inline("border-{orange,blue,green,emerald,amber,violet,pink,purple,gray}-{200,300}");
-@source inline("{dark:,}border-{orange,blue,green,emerald,amber,violet,pink,purple,gray}-500/{30,50}");
-@source inline("{hover:,dark:hover:,}border-{orange,blue,green,emerald,amber,violet,pink,purple,gray,yellow,teal}-{300,400,500,500/50}");
+@source inline("border-{orange,blue,green,emerald,amber,violet,pink,purple,gray,yellow,teal,cyan,indigo}-{200,300}");
+@source inline("{dark:,}border-{orange,blue,green,emerald,amber,violet,pink,purple,gray,yellow,teal,cyan,indigo}-500/{30,50}");
+@source inline("{hover:,dark:hover:,}border-{orange,blue,green,emerald,amber,violet,pink,purple,gray,yellow,teal,cyan,indigo}-{300,400,500,500/50}");
 
 /* Explicit safelist classes used in various components */
 @source inline("bg-{blue,orange}-600");
@@ -72,13 +90,13 @@
 @source inline("text-[5px] text-[9px] min-h-[100px]");
 
 /* Gradient classes for dynamic colors */
-@source inline("from-{orange,blue,green,emerald,amber,violet,pink,purple,gray}-{100,200,300,400,500,600,700}");
-@source inline("to-{orange,blue,green,emerald,amber,violet,pink,purple,gray}-{100,200,300,400,500,600,700}");
+@source inline("from-{orange,blue,green,emerald,amber,violet,pink,purple,gray,yellow,teal,cyan,indigo}-{100,200,300,400,500,600,700}");
+@source inline("to-{orange,blue,green,emerald,amber,violet,pink,purple,gray,yellow,teal,cyan,indigo}-{100,200,300,400,500,600,700}");
 
 /* Dark variant safelist for dynamic colors */
-@source inline("{dark:,}bg-{orange,blue,green,emerald,amber,violet,pink,purple,gray}-{100,200,400,500}");
-@source inline("{dark:,}bg-{orange,blue,green,emerald,amber,violet,pink,purple,gray}-500/{20,30}");
-@source inline("{dark:,}text-{orange,blue,green,emerald,amber,violet,pink,purple,gray}-{100,300,400,500,800}");
-@source inline("{dark:,group-hover:,}text-{orange,blue,green,emerald,amber,violet,pink,purple,gray}-{100,300,400,500,600,800}");
-@source inline("{dark:,}ring-{orange,blue,green,emerald,amber,violet,pink,purple,gray}-500/30");
-@source inline("{group-hover:,dark:group-hover:,}text-{orange,blue,green,emerald,amber,violet,pink,purple,gray}-{400,600}");
+@source inline("{dark:,}bg-{orange,blue,green,emerald,amber,violet,pink,purple,gray,yellow,teal,cyan,indigo}-{100,200,400,500}");
+@source inline("{dark:,}bg-{orange,blue,green,emerald,amber,violet,pink,purple,gray,yellow,teal,cyan,indigo}-500/{20,30}");
+@source inline("{dark:,}text-{orange,blue,green,emerald,amber,violet,pink,purple,gray,yellow,teal,cyan,indigo}-{100,300,400,500,800}");
+@source inline("{dark:,group-hover:,}text-{orange,blue,green,emerald,amber,violet,pink,purple,gray,yellow,teal,cyan,indigo}-{100,300,400,500,600,800}");
+@source inline("{dark:,}ring-{orange,blue,green,emerald,amber,violet,pink,purple,gray,yellow,teal,cyan,indigo}-500/30");
+@source inline("{group-hover:,dark:group-hover:,}text-{orange,blue,green,emerald,amber,violet,pink,purple,gray,yellow,teal,cyan,indigo}-{400,600}");

--- a/packages/core/eventcatalog/src/styles/theme.css
+++ b/packages/core/eventcatalog/src/styles/theme.css
@@ -108,6 +108,8 @@
   --ec-badge-design-text: 15 118 110; /* teal-700 */
   --ec-badge-channel-bg: 224 231 255; /* indigo-100 */
   --ec-badge-channel-text: 67 56 202; /* indigo-700 */
+  --ec-badge-container-bg: 224 231 255; /* indigo-100 */
+  --ec-badge-container-text: 67 56 202; /* indigo-700 */
   --ec-badge-data-product-bg: 219 234 254; /* blue-100 */
   --ec-badge-data-product-text: 30 64 175; /* blue-800 */
   --ec-badge-default-bg: 243 244 246; /* gray-100 */
@@ -214,6 +216,8 @@
   --ec-badge-design-text: 94 234 212; /* teal-300 */
   --ec-badge-channel-bg: 49 46 129 / 0.3; /* indigo-900/30 */
   --ec-badge-channel-text: 165 180 252; /* indigo-300 */
+  --ec-badge-container-bg: 49 46 129 / 0.3; /* indigo-900/30 */
+  --ec-badge-container-text: 165 180 252; /* indigo-300 */
   --ec-badge-data-product-bg: 30 64 175 / 0.3; /* blue-800/30 */
   --ec-badge-data-product-text: 147 197 253; /* blue-300 */
   --ec-badge-default-bg: 63 63 70 / 0.3; /* zinc-700/30 */

--- a/packages/core/eventcatalog/src/styles/themes/forest.css
+++ b/packages/core/eventcatalog/src/styles/themes/forest.css
@@ -101,6 +101,8 @@
   --ec-badge-design-text: 22 101 52; /* green-800 */
   --ec-badge-channel-bg: 224 231 255; /* indigo-100 */
   --ec-badge-channel-text: 67 56 202; /* indigo-700 */
+  --ec-badge-container-bg: 224 231 255; /* indigo-100 */
+  --ec-badge-container-text: 67 56 202; /* indigo-700 */
   --ec-badge-data-product-bg: 219 234 254; /* blue-100 */
   --ec-badge-data-product-text: 30 64 175; /* blue-800 */
   --ec-badge-default-bg: 240 253 244; /* green-50 */
@@ -198,6 +200,8 @@
   --ec-badge-design-text: 134 239 172; /* green-300 */
   --ec-badge-channel-bg: 49 46 129 / 0.3; /* indigo-900/30 */
   --ec-badge-channel-text: 165 180 252; /* indigo-300 */
+  --ec-badge-container-bg: 49 46 129 / 0.3; /* indigo-900/30 */
+  --ec-badge-container-text: 165 180 252; /* indigo-300 */
   --ec-badge-data-product-bg: 30 64 175 / 0.3; /* blue-800/30 */
   --ec-badge-data-product-text: 147 197 253; /* blue-300 */
   --ec-badge-default-bg: 55 65 81 / 0.3; /* gray-700/30 */

--- a/packages/core/eventcatalog/src/styles/themes/ocean.css
+++ b/packages/core/eventcatalog/src/styles/themes/ocean.css
@@ -101,6 +101,8 @@
   --ec-badge-design-text: 15 118 110; /* teal-700 */
   --ec-badge-channel-bg: 224 231 255; /* indigo-100 */
   --ec-badge-channel-text: 67 56 202; /* indigo-700 */
+  --ec-badge-container-bg: 224 231 255; /* indigo-100 */
+  --ec-badge-container-text: 67 56 202; /* indigo-700 */
   --ec-badge-data-product-bg: 219 234 254; /* blue-100 */
   --ec-badge-data-product-text: 30 64 175; /* blue-800 */
   --ec-badge-default-bg: 240 253 250; /* teal-50 */
@@ -203,6 +205,8 @@
   --ec-badge-design-text: 94 234 212; /* teal-300 */
   --ec-badge-channel-bg: 49 46 129 / 0.3; /* indigo-900/30 */
   --ec-badge-channel-text: 165 180 252; /* indigo-300 */
+  --ec-badge-container-bg: 49 46 129 / 0.3; /* indigo-900/30 */
+  --ec-badge-container-text: 165 180 252; /* indigo-300 */
   --ec-badge-data-product-bg: 30 64 175 / 0.3; /* blue-800/30 */
   --ec-badge-data-product-text: 147 197 253; /* blue-300 */
   --ec-badge-default-bg: 51 65 85 / 0.3; /* slate-700/30 */

--- a/packages/core/eventcatalog/src/styles/themes/sapphire.css
+++ b/packages/core/eventcatalog/src/styles/themes/sapphire.css
@@ -101,6 +101,8 @@
   --ec-badge-design-text: 37 99 235; /* blue-600 */
   --ec-badge-channel-bg: 224 231 255; /* indigo-100 */
   --ec-badge-channel-text: 67 56 202; /* indigo-700 */
+  --ec-badge-container-bg: 224 231 255; /* indigo-100 */
+  --ec-badge-container-text: 67 56 202; /* indigo-700 */
   --ec-badge-data-product-bg: 219 234 254; /* blue-100 */
   --ec-badge-data-product-text: 30 64 175; /* blue-800 */
   --ec-badge-default-bg: 239 246 255; /* blue-50 */
@@ -198,6 +200,8 @@
   --ec-badge-design-text: 147 197 253; /* blue-300 */
   --ec-badge-channel-bg: 49 46 129 / 0.3; /* indigo-900/30 */
   --ec-badge-channel-text: 165 180 252; /* indigo-300 */
+  --ec-badge-container-bg: 49 46 129 / 0.3; /* indigo-900/30 */
+  --ec-badge-container-text: 165 180 252; /* indigo-300 */
   --ec-badge-data-product-bg: 30 64 175 / 0.3; /* blue-800/30 */
   --ec-badge-data-product-text: 147 197 253; /* blue-300 */
   --ec-badge-default-bg: 51 65 85 / 0.3; /* slate-700/30 */

--- a/packages/core/eventcatalog/src/styles/themes/sunset.css
+++ b/packages/core/eventcatalog/src/styles/themes/sunset.css
@@ -101,6 +101,8 @@
   --ec-badge-design-text: 234 88 12; /* orange-600 */
   --ec-badge-channel-bg: 224 231 255; /* indigo-100 */
   --ec-badge-channel-text: 67 56 202; /* indigo-700 */
+  --ec-badge-container-bg: 224 231 255; /* indigo-100 */
+  --ec-badge-container-text: 67 56 202; /* indigo-700 */
   --ec-badge-data-product-bg: 219 234 254; /* blue-100 */
   --ec-badge-data-product-text: 30 64 175; /* blue-800 */
   --ec-badge-default-bg: 255 247 237; /* orange-50 */
@@ -198,6 +200,8 @@
   --ec-badge-design-text: 253 186 116; /* orange-300 */
   --ec-badge-channel-bg: 49 46 129 / 0.3; /* indigo-900/30 */
   --ec-badge-channel-text: 165 180 252; /* indigo-300 */
+  --ec-badge-container-bg: 49 46 129 / 0.3; /* indigo-900/30 */
+  --ec-badge-container-text: 165 180 252; /* indigo-300 */
   --ec-badge-data-product-bg: 30 64 175 / 0.3; /* blue-800/30 */
   --ec-badge-data-product-text: 147 197 253; /* blue-300 */
   --ec-badge-default-bg: 64 64 64 / 0.3; /* neutral-700/30 */

--- a/packages/core/eventcatalog/src/utils/__tests__/resource-reference-colors.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/resource-reference-colors.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { getCollectionTextColorClass } from '@utils/collection-colors';
+import { getResourceReferenceColorName, getResourceReferenceStyle } from '@utils/resource-reference-colors';
+
+describe('resource-reference-colors', () => {
+  it('maps resource types to the same colors used in the explore tables', () => {
+    expect(getResourceReferenceColorName('service')).toBe('pink');
+    expect(getResourceReferenceColorName('event')).toBe('orange');
+    expect(getResourceReferenceColorName('command')).toBe('blue');
+    expect(getResourceReferenceColorName('query')).toBe('green');
+    expect(getResourceReferenceColorName('domain')).toBe('yellow');
+    expect(getResourceReferenceColorName('flow')).toBe('teal');
+    expect(getResourceReferenceColorName('channel')).toBe('purple');
+    expect(getResourceReferenceColorName('entity')).toBe('purple');
+    expect(getResourceReferenceColorName('container')).toBe('indigo');
+    expect(getResourceReferenceColorName('team')).toBe('gray');
+    expect(getResourceReferenceColorName('user')).toBe('gray');
+    expect(getResourceReferenceColorName('data-product')).toBe('cyan');
+  });
+
+  it('falls back to gray for unknown resource types', () => {
+    expect(getResourceReferenceColorName('unknown')).toBe('gray');
+  });
+
+  it('returns CSS variables using the Tailwind 500 shade', () => {
+    expect(getResourceReferenceStyle('service')).toBe(
+      '--ec-resource-ref-bg: rgb(236 72 153 / 0.12); --ec-resource-ref-color: rgb(236 72 153); color: var(--ec-resource-ref-color); text-decoration-color: var(--ec-resource-ref-color)'
+    );
+  });
+
+  it('uses the active theme accent color for custom documentation references', () => {
+    expect(getResourceReferenceStyle('doc')).toBe(
+      '--ec-resource-ref-bg: rgb(var(--ec-accent) / 0.12); --ec-resource-ref-color: rgb(var(--ec-accent)); color: var(--ec-resource-ref-color); text-decoration-color: var(--ec-resource-ref-color)'
+    );
+  });
+
+  it('returns static Tailwind text classes for collection colors', () => {
+    expect(getCollectionTextColorClass('indigo')).toBe('text-indigo-500');
+    expect(getCollectionTextColorClass('unknown', 'text-[rgb(var(--ec-icon-color))]')).toBe('text-[rgb(var(--ec-icon-color))]');
+  });
+});

--- a/packages/core/eventcatalog/src/utils/collection-colors.ts
+++ b/packages/core/eventcatalog/src/utils/collection-colors.ts
@@ -1,0 +1,76 @@
+export type CollectionColor =
+  | 'orange'
+  | 'blue'
+  | 'green'
+  | 'pink'
+  | 'yellow'
+  | 'teal'
+  | 'purple'
+  | 'red'
+  | 'gray'
+  | 'cyan'
+  | 'indigo';
+
+export const getColorForCollection = (collection: string): CollectionColor => {
+  switch (collection) {
+    case 'events':
+      return 'orange';
+    case 'commands':
+      return 'blue';
+    case 'queries':
+      return 'green';
+    case 'flows':
+      return 'teal';
+    case 'teams':
+      return 'gray';
+    case 'users':
+      return 'gray';
+    case 'channels':
+      return 'purple';
+    case 'ubiquitousLanguages':
+      return 'green';
+    case 'entities':
+      return 'purple';
+    case 'domains':
+      return 'yellow';
+    case 'services':
+      return 'pink';
+    case 'data-products':
+      return 'cyan';
+    case 'containers':
+      return 'indigo';
+    default:
+      return 'gray';
+  }
+};
+
+export const tailwind500RgbByColor: Record<CollectionColor, string> = {
+  orange: '249 115 22',
+  blue: '59 130 246',
+  green: '34 197 94',
+  pink: '236 72 153',
+  yellow: '234 179 8',
+  teal: '20 184 166',
+  purple: '168 85 247',
+  red: '239 68 68',
+  gray: '107 114 128',
+  cyan: '6 182 212',
+  indigo: '99 102 241',
+};
+
+export const collectionTextColorClassByColor: Record<CollectionColor, string> = {
+  orange: 'text-orange-500',
+  blue: 'text-blue-500',
+  green: 'text-green-500',
+  pink: 'text-pink-500',
+  yellow: 'text-yellow-500',
+  teal: 'text-teal-500',
+  purple: 'text-purple-500',
+  red: 'text-red-500',
+  gray: 'text-gray-500',
+  cyan: 'text-cyan-500',
+  indigo: 'text-indigo-500',
+};
+
+export const getCollectionTextColorClass = (color: string, fallback = 'text-gray-500'): string =>
+  collectionTextColorClassByColor[color as CollectionColor] || fallback;

--- a/packages/core/eventcatalog/src/utils/collections/icons.ts
+++ b/packages/core/eventcatalog/src/utils/collections/icons.ts
@@ -13,6 +13,7 @@ import {
   CubeIcon,
 } from '@heroicons/react/24/outline';
 import { BookText, Box, DatabaseIcon } from 'lucide-react';
+import { getColorForCollection } from '@utils/collection-colors';
 
 export const getIconForCollection = (collection: string) => {
   switch (collection) {
@@ -53,33 +54,5 @@ export const getIconForCollection = (collection: string) => {
 
 export const getColorAndIconForCollection = (collection: string) => {
   const icon = getIconForCollection(collection);
-
-  switch (collection) {
-    case 'events':
-      return { color: 'orange', Icon: icon };
-    case 'commands':
-      return { color: 'blue', Icon: icon };
-    case 'queries':
-      return { color: 'green', Icon: icon };
-    case 'flows':
-      return { color: 'teal', Icon: icon };
-    case 'teams':
-      return { color: 'red', Icon: icon };
-    case 'users':
-      return { color: 'gray', Icon: icon };
-    case 'channels':
-      return { color: 'purple', Icon: icon };
-    case 'ubiquitousLanguages':
-      return { color: 'green', Icon: icon };
-    case 'entities':
-      return { color: 'purple', Icon: icon };
-    case 'domains':
-      return { color: 'yellow', Icon: icon };
-    case 'services':
-      return { color: 'pink', Icon: icon };
-    case 'data-products':
-      return { color: 'cyan', Icon: icon };
-    default:
-      return { color: 'gray', Icon: icon };
-  }
+  return { color: getColorForCollection(collection), Icon: icon };
 };

--- a/packages/core/eventcatalog/src/utils/resource-reference-colors.ts
+++ b/packages/core/eventcatalog/src/utils/resource-reference-colors.ts
@@ -1,0 +1,49 @@
+import { getColorForCollection, tailwind500RgbByColor, type CollectionColor } from './collection-colors';
+import { resourceToCollectionMap } from './collections/util';
+
+export type ResourceReferenceType =
+  | 'entity'
+  | 'service'
+  | 'event'
+  | 'command'
+  | 'query'
+  | 'domain'
+  | 'flow'
+  | 'channel'
+  | 'diagram'
+  | 'container'
+  | 'user'
+  | 'team'
+  | 'doc'
+  | 'data-product';
+
+const resourceTypeToCollection = {
+  ...resourceToCollectionMap,
+  doc: 'customPages',
+} as Record<ResourceReferenceType, string>;
+
+export const getResourceReferenceColorName = (type: string): CollectionColor => {
+  const collection = resourceTypeToCollection[type as ResourceReferenceType] || '';
+  return getColorForCollection(collection);
+};
+
+export const getResourceReferenceStyle = (type: string): string => {
+  if (type === 'doc') {
+    return [
+      '--ec-resource-ref-bg: rgb(var(--ec-accent) / 0.12)',
+      '--ec-resource-ref-color: rgb(var(--ec-accent))',
+      'color: var(--ec-resource-ref-color)',
+      'text-decoration-color: var(--ec-resource-ref-color)',
+    ].join('; ');
+  }
+
+  const color = getResourceReferenceColorName(type);
+  const rgb = tailwind500RgbByColor[color];
+
+  return [
+    `--ec-resource-ref-bg: rgb(${rgb} / 0.12)`,
+    `--ec-resource-ref-color: rgb(${rgb})`,
+    'color: var(--ec-resource-ref-color)',
+    'text-decoration-color: var(--ec-resource-ref-color)',
+  ].join('; ');
+};

--- a/packages/visualiser/src/nodes/data/DataNode.tsx
+++ b/packages/visualiser/src/nodes/data/DataNode.tsx
@@ -27,7 +27,7 @@ function GlowHandle({ side }: { side: "left" | "right" }) {
         width: 12,
         height: 12,
         borderRadius: "50%",
-        background: "linear-gradient(135deg, #3b82f6, #2563eb)",
+        background: "linear-gradient(135deg, #6366f1, #4f46e5)",
         border: "2px solid rgb(var(--ec-page-bg))",
         zIndex: 20,
         animation: "ec-data-handle-pulse 2s ease-in-out infinite",
@@ -87,7 +87,7 @@ function PostItData(props: DataNode) {
     <div
       className={classNames(
         "relative min-w-44 max-w-56 min-h-[120px]",
-        props?.selected ? "ring-2 ring-blue-400/60 ring-offset-1" : "",
+        props?.selected ? "ring-2 ring-indigo-400/60 ring-offset-1" : "",
       )}
     >
       <Handle
@@ -108,14 +108,14 @@ function PostItData(props: DataNode) {
         className="absolute inset-0"
         style={{
           background:
-            "linear-gradient(135deg, #bfdbfe 0%, #93c5fd 40%, #3b82f6 100%)",
+            "linear-gradient(135deg, #c7d2fe 0%, #a5b4fc 40%, #6366f1 100%)",
           boxShadow:
             "1px 1px 3px rgba(0,0,0,0.15), 3px 4px 8px rgba(0,0,0,0.08)",
           transform: "rotate(-1deg)",
           border: deprecated
             ? "2px dashed rgba(239, 68, 68, 0.5)"
             : draft
-              ? "2px dashed rgba(59, 130, 246, 0.5)"
+              ? "2px dashed rgba(99, 102, 241, 0.5)"
               : "none",
         }}
       >
@@ -130,7 +130,7 @@ function PostItData(props: DataNode) {
             height: 0,
             borderStyle: "solid",
             borderWidth: "18px 0 0 18px",
-            borderColor: "#2563eb transparent transparent transparent",
+            borderColor: "#4f46e5 transparent transparent transparent",
             opacity: 0.3,
           }}
         />
@@ -141,8 +141,11 @@ function PostItData(props: DataNode) {
         {/* Type label row */}
         <div className="flex items-center justify-between mb-2">
           <div className="flex items-center gap-1">
-            <Database className="w-3 h-3 text-blue-900/50" strokeWidth={2.5} />
-            <span className="text-[8px] font-bold text-blue-900/50 uppercase tracking-widest">
+            <Database
+              className="w-3 h-3 text-indigo-950/50"
+              strokeWidth={2.5}
+            />
+            <span className="text-[8px] font-bold text-indigo-950/50 uppercase tracking-widest">
               Data
             </span>
           </div>
@@ -174,7 +177,9 @@ function PostItData(props: DataNode) {
           <div
             className={classNames(
               "text-[13px] font-bold leading-snug min-w-0 truncate",
-              deprecated ? "text-blue-950/40 line-through" : "text-blue-950",
+              deprecated
+                ? "text-indigo-950/40 line-through"
+                : "text-indigo-950",
             )}
           >
             {name}
@@ -183,7 +188,7 @@ function PostItData(props: DataNode) {
 
         {/* Version */}
         {version && (
-          <div className="text-[9px] text-blue-900/40 font-semibold mt-0.5">
+          <div className="text-[9px] text-indigo-950/40 font-semibold mt-0.5">
             v{version}
           </div>
         )}
@@ -191,7 +196,7 @@ function PostItData(props: DataNode) {
         {/* Summary */}
         {mode === "full" && summary && (
           <div
-            className="mt-2 pt-1.5 border-t border-blue-900/10 text-[9px] text-blue-950/60 leading-relaxed overflow-hidden"
+            className="mt-2 pt-1.5 border-t border-indigo-950/10 text-[9px] text-indigo-950/60 leading-relaxed overflow-hidden"
             style={LINE_CLAMP_STYLE}
             title={summary}
           >
@@ -233,20 +238,20 @@ function DefaultData(props: DataNode) {
     <div
       className={classNames(
         "relative min-w-48 max-w-60 rounded-xl border-2 overflow-visible",
-        props?.selected ? "ring-2 ring-blue-400/60 ring-offset-2" : "",
+        props?.selected ? "ring-2 ring-indigo-400/60 ring-offset-2" : "",
         deprecated
           ? "border-dashed border-red-500"
           : draft
-            ? `border-dashed ${isDark ? "border-blue-400" : "border-blue-400/60"}`
-            : "border-blue-500",
+            ? `border-dashed ${isDark ? "border-indigo-400" : "border-indigo-400/60"}`
+            : "border-indigo-500",
       )}
       style={{
         background: deprecated
           ? `repeating-linear-gradient(135deg, transparent, transparent 6px, ${deprecatedStripe} 6px, ${deprecatedStripe} 7px), var(--ec-data-node-bg, rgb(var(--ec-card-bg)))`
           : draft
-            ? `repeating-linear-gradient(135deg, transparent, transparent 4px, ${isDark ? "rgba(59,130,246,0.25)" : "rgba(59,130,246,0.15)"} 4px, ${isDark ? "rgba(59,130,246,0.25)" : "rgba(59,130,246,0.15)"} 4.5px), repeating-linear-gradient(45deg, transparent, transparent 4px, ${isDark ? "rgba(59,130,246,0.25)" : "rgba(59,130,246,0.15)"} 4px, ${isDark ? "rgba(59,130,246,0.25)" : "rgba(59,130,246,0.15)"} 4.5px), var(--ec-data-node-bg, rgb(var(--ec-card-bg)))`
+            ? `repeating-linear-gradient(135deg, transparent, transparent 4px, ${isDark ? "rgba(99,102,241,0.25)" : "rgba(99,102,241,0.15)"} 4px, ${isDark ? "rgba(99,102,241,0.25)" : "rgba(99,102,241,0.15)"} 4.5px), repeating-linear-gradient(45deg, transparent, transparent 4px, ${isDark ? "rgba(99,102,241,0.25)" : "rgba(99,102,241,0.15)"} 4px, ${isDark ? "rgba(99,102,241,0.25)" : "rgba(99,102,241,0.15)"} 4.5px), var(--ec-data-node-bg, rgb(var(--ec-card-bg)))`
             : "var(--ec-data-node-bg, rgb(var(--ec-card-bg)))",
-        boxShadow: "0 2px 12px rgba(59, 130, 246, 0.15)",
+        boxShadow: "0 2px 12px rgba(99, 102, 241, 0.15)",
       }}
     >
       <Handle
@@ -270,7 +275,7 @@ function DefaultData(props: DataNode) {
         <span
           className={classNames(
             "inline-flex items-center gap-1 text-[7px] font-bold uppercase tracking-widest text-white px-1.5 py-0.5 rounded shadow-sm",
-            deprecated ? "bg-red-500" : "bg-blue-500",
+            deprecated ? "bg-red-500" : "bg-indigo-500",
           )}
         >
           <Database className="w-2.5 h-2.5" strokeWidth={2.5} />
@@ -280,7 +285,7 @@ function DefaultData(props: DataNode) {
       </div>
       {typeLabel && (
         <span
-          className="z-10 text-[7px] font-semibold text-[rgb(var(--ec-page-text))] bg-[rgb(var(--ec-card-bg))] border border-blue-500 rounded-full px-1.5 py-0.5 uppercase tracking-wide"
+          className="z-10 text-[7px] font-semibold text-[rgb(var(--ec-page-text))] bg-[rgb(var(--ec-card-bg))] border border-indigo-500 rounded-full px-1.5 py-0.5 uppercase tracking-wide"
           style={{ position: "absolute", top: -8, right: 10 }}
         >
           {typeLabel}
@@ -327,9 +332,9 @@ function DefaultData(props: DataNode) {
         {/* Owners */}
         <OwnerIndicator
           owners={ownersNormalized}
-          accentColor="bg-blue-400"
-          borderColor="rgba(59,130,246,0.08)"
-          iconClass="text-blue-300"
+          accentColor="bg-indigo-400"
+          borderColor="rgba(99,102,241,0.08)"
+          iconClass="text-indigo-300"
         />
       </div>
     </div>

--- a/packages/visualiser/src/nodes/data/config.ts
+++ b/packages/visualiser/src/nodes/data/config.ts
@@ -6,7 +6,7 @@ import { SERVICE, CHANNEL, ACTOR } from "../node-types";
 export default {
   type: "data",
   icon: Database,
-  color: "blue",
+  color: "indigo",
   targetCanConnectTo: [...SERVICE, ...CHANNEL, "external-system", ...ACTOR],
   sourceCanConnectTo: [...SERVICE, ...CHANNEL, "external-system", ...ACTOR],
   validateConnection: (connection: Connection) => {


### PR DESCRIPTION
## What This PR Does

Two related improvements bundled together. First, custom documentation pages now respect EventCatalog theme variables (light/dark mode + custom themes) and the custom docs sidebar item is hidden when no custom docs are configured. Second, a shared collection-colors utility now drives resource reference colors consistently across MDX components, table columns, the sidebar, and the visualiser — and `ResourceRef` gains data-product support with a richer tooltip layout that surfaces custom icons.

## Changes Overview

### Custom docs theming and nav visibility
- Replace hardcoded colors in `root-index.astro` with theme CSS variables (`--ec-page-bg`, `--ec-page-text`, `--ec-card-bg`, `--ec-page-border`, `--ec-accent-subtle`, `--ec-accent`, `--ec-content-hover`, `--ec-button-text`).
- Use `[rgb(var(--ec-accent))]` in the `index.astro` prev/next pager so hover follows the active theme.
- Hide the "Custom Documentation" sidebar nav item when `customDocs.length === 0`.

### Unified resource reference colors
- New `utils/collection-colors.ts` centralises the color tokens used per collection type (event, command, query, service, domain, flow, channel, entity, data-product, doc, etc.).
- New `utils/resource-reference-colors.ts` exposes `getResourceReferenceStyle()` returning the CSS custom properties consumed by `ResourceRef`/`ResourceLink`.
- `theme.css` and each theme file (`forest`, `ocean`, `sapphire`, `sunset`) declare the matching variables; `tailwind.css` aligns the badge palette.
- Table column components (`ContainersTableColumns`, `ServiceTableColumns`, `TeamsTableColumns`, `UserTableColumns`, `Discover/columns`), `FieldsTable`, `MessageTable`, `ResourceGroupTable`, `SideNav/NestedSideBar/utils`, and `collections/icons` now consume the same source of truth.

### ResourceRef enhancements
- Adds `data-product` as a supported resource type with a Cube icon.
- Replaces the inline `typeStyles` map with the shared style helper.
- Tooltip header switches to a grid layout with the type label, version pill, and the resource's custom icon (falls back to the type icon when none is set).
- Slimmer footer (no extra border) and aligned spacing.

### Visualiser data node refresh
- `DataNode` and its config switch from a blue palette (`#3b82f6`/`blue-900`) to an indigo palette (`#6366f1`/`indigo-950`) so it matches the new data-product reference color.

## How It Works

Resource colors now flow from a single map in `collection-colors.ts`. The `resource-reference-colors` helper returns inline CSS variables (`--ec-resource-ref-color`, `--ec-resource-ref-bg`) that `ResourceRef`/`ResourceLink` apply via `style=`; downstream tables and the sidebar import the same tokens. Theme files declare the underlying RGB values per theme so light/dark/custom themes stay consistent. The tooltip reads `resource.data.styles.icon` and uses `isIconPath`/`resolveIconUrl` to render a custom icon when present.

A new spec (`resource-reference-colors.spec.ts`) covers the helper, ensuring every supported type returns a valid style object.

## Breaking Changes

None — additive changes only. Previous resource type colors are preserved, and the new `data-product` type only adds support.

## Additional Notes

- Built on top of the previous custom-docs theming commit on this branch; the PR contains both commits.
- The visualiser palette change is intentional — data products now visually match their reference color in MDX/tables.
- New utilities in `utils/collection-colors.ts` and `utils/resource-reference-colors.ts` are the canonical place to extend resource colors going forward.