### PR TITLE
refactor(core): restyle admonition and reuse for version callouts

### DIFF
--- a/.changeset/quiet-pandas-whisper.md
+++ b/.changeset/quiet-pandas-whisper.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Refresh Admonition component with refined styling and reuse it for the "new version found" callouts on doc pages.

--- a/packages/core/eventcatalog/src/components/MDX/Admonition.tsx
+++ b/packages/core/eventcatalog/src/components/MDX/Admonition.tsx
@@ -1,14 +1,10 @@
-import { InformationCircleIcon, ExclamationTriangleIcon } from '@heroicons/react/24/outline';
-
-type AdmonitionType = 'danger' | 'alert' | 'warning' | 'info' | 'note';
+type AdmonitionType = 'danger' | 'alert' | 'warning' | 'info' | 'note' | 'tip';
 
 interface AdmonitionConfig {
-  icon: typeof InformationCircleIcon;
+  iconPath: string;
   title: string;
   containerClasses: string;
-  iconClasses: string;
-  titleClasses: string;
-  contentClasses: string;
+  accentClasses: string;
 }
 
 const getConfigurationByType = (type: string): AdmonitionConfig => {
@@ -16,39 +12,38 @@ const getConfigurationByType = (type: string): AdmonitionConfig => {
     case 'danger':
     case 'alert':
       return {
-        icon: ExclamationTriangleIcon,
+        iconPath: 'M7.86 2h8.28L22 7.86v8.28L16.14 22H7.86L2 16.14V7.86L7.86 2z M12 8v4 M12 16h.01',
         title: type === 'danger' ? 'Danger' : 'Alert',
-        containerClasses: 'bg-red-50 dark:bg-red-950/50 border-red-500',
-        iconClasses: 'text-red-500 dark:text-red-400',
-        titleClasses: 'text-red-600 dark:text-red-300',
-        contentClasses: 'text-red-700 dark:text-red-200',
+        containerClasses: 'bg-red-50/60 dark:bg-red-950/30 border border-red-200/70 dark:border-red-900/60',
+        accentClasses: 'text-red-700 dark:text-red-300',
       };
     case 'warning':
       return {
-        icon: ExclamationTriangleIcon,
+        iconPath: 'M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0zM12 9v4 M12 17h.01',
         title: 'Warning',
-        containerClasses: 'bg-yellow-50 dark:bg-yellow-950/50 border-yellow-500',
-        iconClasses: 'text-yellow-500 dark:text-yellow-400',
-        titleClasses: 'text-yellow-600 dark:text-yellow-300',
-        contentClasses: 'text-yellow-700 dark:text-yellow-200',
+        containerClasses: 'bg-amber-50/60 dark:bg-amber-950/30 border border-amber-200/70 dark:border-amber-900/60',
+        accentClasses: 'text-amber-700 dark:text-amber-300',
       };
     case 'note':
       return {
-        icon: InformationCircleIcon,
+        iconPath: 'M12 20h9 M16.5 3.5a2.121 2.121 0 1 1 3 3L7 19l-4 1 1-4 12.5-12.5z',
         title: 'Note',
-        containerClasses: 'bg-blue-50 dark:bg-blue-950/50 border-blue-500',
-        iconClasses: 'text-blue-500 dark:text-blue-400',
-        titleClasses: 'text-blue-600 dark:text-blue-300',
-        contentClasses: 'text-blue-700 dark:text-blue-200',
+        containerClasses: 'bg-slate-50/70 dark:bg-slate-900/40 border border-slate-200/70 dark:border-slate-700/60',
+        accentClasses: 'text-slate-600 dark:text-slate-300',
+      };
+    case 'tip':
+      return {
+        iconPath: 'M9 18h6 M10 22h4 M12 2a7 7 0 0 0-4 12.74V17h8v-2.26A7 7 0 0 0 12 2z',
+        title: 'Tip',
+        containerClasses: 'bg-emerald-50/60 dark:bg-emerald-900/40 border border-emerald-200/70 dark:border-emerald-700/80',
+        accentClasses: 'text-emerald-700 dark:text-emerald-300',
       };
     default:
       return {
-        icon: InformationCircleIcon,
+        iconPath: 'M12 2a10 10 0 100 20 10 10 0 000-20zM12 8h.01M11 12h1v4h1',
         title: 'Info',
-        containerClasses: 'bg-indigo-50 dark:bg-indigo-950/50 border-indigo-500',
-        iconClasses: 'text-indigo-500 dark:text-indigo-400',
-        titleClasses: 'text-indigo-600 dark:text-indigo-300',
-        contentClasses: 'text-indigo-700 dark:text-indigo-200',
+        containerClasses: 'bg-blue-50/60 dark:bg-blue-950/30 border border-blue-200/70 dark:border-blue-900/60',
+        accentClasses: 'text-blue-700 dark:text-blue-300',
       };
   }
 };
@@ -62,16 +57,31 @@ interface AdmonitionProps {
 
 export default function Admonition({ children, type = 'info', className = '', title }: AdmonitionProps) {
   const config = getConfigurationByType(type);
-  const Icon = config.icon;
 
   return (
-    <div className={`${config.containerClasses} border-l-4 p-4 my-4 ${className} rounded-md not-prose`}>
-      <div className="flex flex-col">
-        <div className="flex items-center justify-start">
-          <Icon className={`h-6 w-6 ${config.iconClasses} stroke-2`} aria-hidden="true" />
-          <h3 className={`ml-2 ${config.titleClasses} font-bold text-md`}>{title || config.title}</h3>
-        </div>
-        <div className={`mt-2 ${config.contentClasses} text-md`}>{children}</div>
+    <div
+      className={`ec-admonition ${config.containerClasses} rounded-md px-3 py-2.5 my-4 text-[0.85rem] leading-relaxed not-prose ${className}`}
+    >
+      <div className={`flex items-center gap-1.5 mb-1 ${config.accentClasses}`}>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.25"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="lucide shrink-0"
+          aria-hidden="true"
+        >
+          <path d={config.iconPath} />
+        </svg>
+        <span className="text-[0.7rem] font-semibold uppercase tracking-wider">{title || config.title}</span>
+      </div>
+      <div className="prose prose-sm dark:prose-invert w-full max-w-none! prose-p:my-0.5 prose-p:text-inherit prose-p:text-[0.85rem] prose-p:leading-relaxed prose-code:text-[0.8rem]">
+        {children}
       </div>
     </div>
   );

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/[docType]/[docId]/[docVersion]/index.astro
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/[docType]/[docId]/[docVersion]/index.astro
@@ -2,6 +2,7 @@
 import { render } from 'astro:content';
 
 import VerticalSideBarLayout from '@layouts/VerticalSideBarLayout.astro';
+import Admonition from '@components/MDX/Admonition';
 import components from '@components/MDX/components';
 import CopyAsMarkdown from '@components/CopyAsMarkdown';
 import { buildUrl } from '@utils/url-builder';
@@ -99,33 +100,14 @@ const pagefindAttributes =
         <div data-pagefind-ignore>
           {
             props.data.version !== props.data.latestVersion && (
-              <div class="rounded-md bg-[rgb(var(--ec-accent-subtle))] p-4 not-prose my-4">
-                <div class="flex">
-                  <div class="flex-shrink-0">
-                    <svg class="h-5 w-5 text-[rgb(var(--ec-accent))]" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                      <path
-                        fill-rule="evenodd"
-                        d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z"
-                        clip-rule="evenodd"
-                      />
-                    </svg>
-                  </div>
-                  <div class="ml-3">
-                    <h3 class="text-sm font-medium text-[rgb(var(--ec-accent-text))]">New version found</h3>
-                    <div class="mt-2 text-sm text-[rgb(var(--ec-accent-text))]">
-                      <p>
-                        You are looking at a previous version of the {singularResourceName} doc <strong>{title}</strong>.{' '}
-                        <a
-                          class="underline hover:text-primary block pt-2"
-                          href={buildUrl(`${docsBasePath}/${props.data.latestVersion}`)}
-                        >
-                          The latest version of this doc is <span>v{props.data.latestVersion}</span> &rarr;
-                        </a>
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              </div>
+              <Admonition type="warning" title="New version found">
+                <p>
+                  You are looking at a previous version of the {singularResourceName} doc <strong>{title}</strong>.{' '}
+                  <a class="underline block pt-2" href={buildUrl(`${docsBasePath}/${props.data.latestVersion}`)}>
+                    The latest version of this doc is <span>v{props.data.latestVersion}</span> &rarr;
+                  </a>
+                </p>
+              </Admonition>
             )
           }
         </div>

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/[docType]/[docId]/index.astro
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/[docType]/[docId]/index.astro
@@ -2,6 +2,7 @@
 import { render } from 'astro:content';
 
 import VerticalSideBarLayout from '@layouts/VerticalSideBarLayout.astro';
+import Admonition from '@components/MDX/Admonition';
 import components from '@components/MDX/components';
 import CopyAsMarkdown from '@components/CopyAsMarkdown';
 import { buildUrl } from '@utils/url-builder';
@@ -93,33 +94,14 @@ const pagefindAttributes =
         <div data-pagefind-ignore>
           {
             props.data.version !== props.data.latestVersion && (
-              <div class="rounded-md bg-[rgb(var(--ec-accent-subtle))] p-4 not-prose my-4">
-                <div class="flex">
-                  <div class="flex-shrink-0">
-                    <svg class="h-5 w-5 text-[rgb(var(--ec-accent))]" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                      <path
-                        fill-rule="evenodd"
-                        d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z"
-                        clip-rule="evenodd"
-                      />
-                    </svg>
-                  </div>
-                  <div class="ml-3">
-                    <h3 class="text-sm font-medium text-[rgb(var(--ec-accent-text))]">New version found</h3>
-                    <div class="mt-2 text-sm text-[rgb(var(--ec-accent-text))]">
-                      <p>
-                        You are looking at a previous version of the {singularResourceName} doc <strong>{title}</strong>.{' '}
-                        <a
-                          class="underline hover:text-primary block pt-2"
-                          href={buildUrl(`${docsBasePath}/${props.data.latestVersion}`)}
-                        >
-                          The latest version of this doc is <span>v{props.data.latestVersion}</span> &rarr;
-                        </a>
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              </div>
+              <Admonition type="warning" title="New version found">
+                <p>
+                  You are looking at a previous version of the {singularResourceName} doc <strong>{title}</strong>.{' '}
+                  <a class="underline block pt-2" href={buildUrl(`${docsBasePath}/${props.data.latestVersion}`)}>
+                    The latest version of this doc is <span>v{props.data.latestVersion}</span> &rarr;
+                  </a>
+                </p>
+              </Admonition>
             )
           }
         </div>

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/graphql/[filename].astro
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/graphql/[filename].astro
@@ -109,34 +109,18 @@ const pagefindAttributes =
         <div data-pagefind-ignore>
           {
             data.version !== data.latestVersion && (
-              <div class="rounded-md bg-[rgb(var(--ec-accent-subtle))] p-4 not-prose my-4">
-                <div class="flex">
-                  <div class="flex-shrink-0">
-                    <svg class="h-5 w-5 text-[rgb(var(--ec-accent))]" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                      <path
-                        fill-rule="evenodd"
-                        d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z"
-                        clip-rule="evenodd"
-                      />
-                    </svg>
-                  </div>
-                  <div class="ml-3">
-                    <h3 class="text-sm font-medium text-[rgb(var(--ec-accent-text))]">New version found</h3>
-                    <div class="mt-2 text-sm text-[rgb(var(--ec-accent-text))]">
-                      <p>
-                        You are looking at a previous version of the service <strong>{data.name}</strong>.{' '}
-                        <a
-                          class="underline hover:text-primary block pt-2"
-                          href={buildUrl(`/docs/${collection}/${data.id}/${data.latestVersion}/graphql/${filename}`)}
-                        >
-                          The latest version of this GraphQL schema is
-                          <span>v{data.latestVersion}</span> &rarr;
-                        </a>
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              </div>
+              <Admonition type="warning" title="New version found">
+                <p>
+                  You are looking at a previous version of the service <strong>{data.name}</strong>.{' '}
+                  <a
+                    class="underline block pt-2"
+                    href={buildUrl(`/docs/${collection}/${data.id}/${data.latestVersion}/graphql/${filename}`)}
+                  >
+                    The latest version of this GraphQL schema is
+                    <span>v{data.latestVersion}</span> &rarr;
+                  </a>
+                </p>
+              </Admonition>
             )
           }
         </div>

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/index.astro
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/index.astro
@@ -349,10 +349,7 @@ if (!hasCurrentFlowEmbed && !hasCurrentPageNodeGraph) {
                     )
                   }
                   <div class="flex items-center gap-2">
-                    <h2
-                      id="doc-page-header"
-                      class={`text-2xl md:text-4xl font-bold text-[rgb(var(--ec-page-text))] ${props.data.deprecated && hasDeprecated ? 'text-red-500' : ''}`}
-                    >
+                    <h2 id="doc-page-header" class="text-2xl md:text-4xl font-bold text-[rgb(var(--ec-page-text))]">
                       {props.data.name}
                       {props.data.latestVersion !== props.data.version && <span>(v{props.data.version})</span>}
                     </h2>
@@ -485,35 +482,19 @@ if (!hasCurrentFlowEmbed && !hasCurrentPageNodeGraph) {
         <div data-pagefind-ignore>
           {
             props.data.version !== props.data.latestVersion && (
-              <div class="rounded-md bg-[rgb(var(--ec-accent-subtle))] p-4 not-prose my-4">
-                <div class="flex">
-                  <div class="flex-shrink-0">
-                    <svg class="h-5 w-5 text-[rgb(var(--ec-accent))]" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                      <path
-                        fill-rule="evenodd"
-                        d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z"
-                        clip-rule="evenodd"
-                      />
-                    </svg>
-                  </div>
-                  <div class="ml-3">
-                    <h3 class="text-sm font-medium text-[rgb(var(--ec-accent-text))]">New version found</h3>
-                    <div class="mt-2 text-sm text-[rgb(var(--ec-accent-text))]">
-                      <p>
-                        You are looking at a previous version of the {props.collection.slice(0, props.collection.length - 1)}{' '}
-                        <strong>{props.data.name}</strong>.{' '}
-                        <a
-                          class="underline hover:text-primary block pt-2"
-                          href={buildUrl(`/docs/${props.collection}/${props.data.id}/${props.data.latestVersion}`)}
-                        >
-                          The latest version of this {props.collection.slice(0, props.collection.length - 1)} is
-                          <span>v{props.data.latestVersion}</span> &rarr;
-                        </a>
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              </div>
+              <Admonition type="warning" title="New version found">
+                <p>
+                  You are looking at a previous version of the {props.collection.slice(0, props.collection.length - 1)}{' '}
+                  <strong>{props.data.name}</strong>.{' '}
+                  <a
+                    class="underline block pt-2"
+                    href={buildUrl(`/docs/${props.collection}/${props.data.id}/${props.data.latestVersion}`)}
+                  >
+                    The latest version of this {props.collection.slice(0, props.collection.length - 1)} is
+                    <span>v{props.data.latestVersion}</span> &rarr;
+                  </a>
+                </p>
+              </Admonition>
             )
           }
         </div>


### PR DESCRIPTION
## What This PR Does

Refreshes the `Admonition` MDX component with a lighter, more compact look (inline SVG icons, smaller uppercase label, softer surface colors) and adds a new `tip` variant. The four doc page templates that previously hand-rolled a "New version found" callout now use the `Admonition` component directly, removing ~150 lines of duplicated markup.

## Changes Overview

### Key Changes
- Restyled `Admonition.tsx`: inline SVG icons (no `@heroicons` dependency for this component), tighter padding, uppercase label, softer borders/backgrounds, and a new `tip` type.
- Replaced the bespoke "New version found" callout block in:
  - `docs/[type]/[id]/[version]/index.astro`
  - `docs/[type]/[id]/[version]/[docType]/[docId]/index.astro`
  - `docs/[type]/[id]/[version]/[docType]/[docId]/[docVersion]/index.astro`
  - `docs/[type]/[id]/[version]/graphql/[filename].astro`
  with a single `<Admonition type="warning" title="New version found">`.
- Removed a stray `text-red-500` class on the doc page header that referenced an undefined `hasDeprecated` flag.

## How It Works

`Admonition` now ships its own inline SVG paths per type, keeping the component self-contained and easier to theme. Each variant exposes a `containerClasses` (surface + border) and `accentClasses` (icon + label color) pair, and the body wraps children in a small `prose` block so MDX-rendered content keeps consistent typography. The four doc templates import the component and pass the existing copy as children, so the user-facing message is unchanged — only the look and the implementation are.

## Breaking Changes

None. Public Admonition API (`type`, `title`, `className`, `children`) is unchanged; the visual treatment is updated.

## Additional Notes

- New `tip` admonition type is available for use in MDX docs going forward.
- Heroicons import was removed from `Admonition.tsx`; other usages of `@heroicons/react` elsewhere in the app are untouched.