### PR TITLE
feat(core): serve llms.txt from catalog root and include data products

### DIFF
--- a/.changeset/swift-tigers-llms-root.md
+++ b/.changeset/swift-tigers-llms-root.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/core': minor
+---
+
+Serve `llms.txt` and `llms-full.txt` from the catalog root and include data products and ubiquitous languages in the generated output. AI tools can now read the catalog at `/llms.txt` instead of `/docs/llm/llms.txt`, and the docs `.md`/`.mdx` endpoints now resolve data products as well.

--- a/packages/core/eventcatalog/src/__tests__/middleware-auth.spec.ts
+++ b/packages/core/eventcatalog/src/__tests__/middleware-auth.spec.ts
@@ -128,11 +128,18 @@ describe('middleware-auth', () => {
   });
 
   describe('getPublicRoutes', () => {
+    it('includes root llms.txt routes when llms text access is enabled', () => {
+      expect(getPublicRoutes(true)).toContain('/llms.txt');
+      expect(getPublicRoutes(true)).toContain('/llms-full.txt');
+    });
+
     it('includes schemas.txt when llms text access is enabled', () => {
       expect(getPublicRoutes(true)).toContain('/docs/llm/schemas.txt');
     });
 
     it('does not expose llms routes when llms text access is disabled', () => {
+      expect(getPublicRoutes(false)).not.toContain('/llms.txt');
+      expect(getPublicRoutes(false)).not.toContain('/llms-full.txt');
       expect(getPublicRoutes(false)).not.toContain('/docs/llm/schemas.txt');
       expect(getPublicRoutes(false)).not.toContain('/docs/llm/llms.txt');
       expect(getPublicRoutes(false)).not.toContain('/docs/llm/llms-full.txt');

--- a/packages/core/eventcatalog/src/components/Settings/LlmAccessSettingsForm.tsx
+++ b/packages/core/eventcatalog/src/components/Settings/LlmAccessSettingsForm.tsx
@@ -83,7 +83,7 @@ export const LlmAccessSettingsForm = ({
 
       <Row
         title="llms.txt"
-        description="Generate llms.txt files so tools like Claude, ChatGPT, and Cursor can read your catalog at /docs/llm/llms.txt."
+        description="Generate llms.txt files so tools like Claude, ChatGPT, and Cursor can read your catalog at /llms.txt."
         canEdit={canEdit}
         dirty={dirty}
         saving={saving}
@@ -93,9 +93,7 @@ export const LlmAccessSettingsForm = ({
           icon={<Bot className="h-4 w-4" aria-hidden />}
           label={llmsTxtEnabled ? 'Enabled' : 'Disabled'}
           hint={
-            llmsTxtEnabled
-              ? 'AI tools can read your catalog at /docs/llm/llms.txt.'
-              : 'AI tools will not be able to read your catalog.'
+            llmsTxtEnabled ? 'AI tools can read your catalog at /llms.txt.' : 'AI tools will not be able to read your catalog.'
           }
           checked={llmsTxtEnabled}
           disabled={!canEdit}

--- a/packages/core/eventcatalog/src/enterprise/auth/middleware/middleware-auth.ts
+++ b/packages/core/eventcatalog/src/enterprise/auth/middleware/middleware-auth.ts
@@ -87,7 +87,14 @@ export function getPublicRoutes(isLLMSTextEnabled: boolean) {
     return publicRoutes;
   }
 
-  return [...publicRoutes, '/docs/llm/llms.txt', '/docs/llm/llms-full.txt', '/docs/llm/schemas.txt'];
+  return [
+    ...publicRoutes,
+    '/llms.txt',
+    '/llms-full.txt',
+    '/docs/llm/llms.txt',
+    '/docs/llm/llms-full.txt',
+    '/docs/llm/schemas.txt',
+  ];
 }
 
 export const authMiddleware: MiddlewareHandler = async (context, next) => {

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version].md.ts
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version].md.ts
@@ -14,6 +14,7 @@ const events = await getCollection('events');
 const commands = await getCollection('commands');
 const queries = await getCollection('queries');
 const services = await getCollection('services');
+const dataProducts = await getCollection('data-products');
 const domains = await getCollection('domains');
 const flows = await getCollection('flows');
 const channels = await getCollection('channels');
@@ -25,6 +26,7 @@ const collections = {
   commands,
   queries,
   services,
+  'data-products': dataProducts,
   domains,
   flows,
   channels,

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version].mdx.ts
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version].mdx.ts
@@ -12,6 +12,7 @@ const events = await getCollection('events');
 const commands = await getCollection('commands');
 const queries = await getCollection('queries');
 const services = await getCollection('services');
+const dataProducts = await getCollection('data-products');
 const domains = await getCollection('domains');
 const flows = await getCollection('flows');
 const channels = await getCollection('channels');
@@ -25,6 +26,7 @@ const collections = {
   commands,
   queries,
   services,
+  'data-products': dataProducts,
   domains,
   flows,
   channels,

--- a/packages/core/eventcatalog/src/pages/docs/llm/llms-full.txt.ts
+++ b/packages/core/eventcatalog/src/pages/docs/llm/llms-full.txt.ts
@@ -9,6 +9,7 @@ type AllowedCollections =
   | 'commands'
   | 'queries'
   | 'services'
+  | 'data-products'
   | 'domains'
   | 'teams'
   | 'users'
@@ -17,12 +18,14 @@ type AllowedCollections =
   | 'entities'
   | 'flows'
   | 'containers'
+  | 'ubiquitousLanguages'
   | 'resourceDocs';
 
 const events = await getCollection('events');
 const commands = await getCollection('commands');
 const queries = await getCollection('queries');
 const services = await getCollection('services');
+const dataProducts = await getCollection('data-products');
 const domains = await getCollection('domains');
 const teams = await getCollection('teams');
 const users = await getCollection('users');
@@ -30,6 +33,7 @@ const entities = await getCollection('entities');
 const channels = await getCollection('channels');
 const flows = await getCollection('flows');
 const containers = await getCollection('containers');
+const ubiquitousLanguages = await getCollection('ubiquitousLanguages');
 const customDocs = await getCollection('customPages');
 const resourceDocs = isResourceDocsEnabled() ? await getCollection('resourceDocs') : [];
 
@@ -43,6 +47,7 @@ export const GET: APIRoute = async ({ params, request }) => {
     ...commands,
     ...queries,
     ...services,
+    ...dataProducts,
     ...domains,
     ...teams,
     ...users,
@@ -50,6 +55,7 @@ export const GET: APIRoute = async ({ params, request }) => {
     ...channels,
     ...containers,
     ...flows,
+    ...ubiquitousLanguages,
   ];
 
   if (isCustomDocsEnabled()) {

--- a/packages/core/eventcatalog/src/pages/docs/llm/llms.txt.ts
+++ b/packages/core/eventcatalog/src/pages/docs/llm/llms.txt.ts
@@ -11,6 +11,7 @@ const commands = await getCollection('commands');
 const queries = await getCollection('queries');
 
 const services = await getCollection('services');
+const dataProducts = await getCollection('data-products');
 const domains = await getCollection('domains');
 
 const teams = await getCollection('teams');
@@ -141,6 +142,8 @@ export const GET: APIRoute = async ({ params, request }) => {
     queries.map((item) => formatVersionedItem(item, 'queries')).join(''),
     '\n## Services',
     services.map((item) => formatVersionedItem(item, 'services')).join(''),
+    '\n## Data Products',
+    dataProducts.map((item) => formatVersionedItem(item, 'data-products')).join('\n'),
     '\n## Domains',
     domains.map((item) => formatVersionedItem(item, 'domains')).join(''),
     '\n## Flows',

--- a/packages/core/eventcatalog/src/pages/llms-full.txt.ts
+++ b/packages/core/eventcatalog/src/pages/llms-full.txt.ts
@@ -1,0 +1,1 @@
+export { GET } from './docs/llm/llms-full.txt.ts';

--- a/packages/core/eventcatalog/src/pages/llms.txt.ts
+++ b/packages/core/eventcatalog/src/pages/llms.txt.ts
@@ -1,0 +1,1 @@
+export { GET } from './docs/llm/llms.txt.ts';

--- a/packages/core/eventcatalog/src/pages/settings/llm-access.astro
+++ b/packages/core/eventcatalog/src/pages/settings/llm-access.astro
@@ -15,8 +15,8 @@ const initial = {
 const hasScalePlan = isEventCatalogScaleEnabled();
 
 const apiBase = buildUrl('/api/settings');
-const llmsTxtUrl = buildUrl('/docs/llm/llms.txt');
-const llmsFullTxtUrl = buildUrl('/docs/llm/llms-full.txt');
+const llmsTxtUrl = buildUrl('/llms.txt');
+const llmsFullTxtUrl = buildUrl('/llms-full.txt');
 const schemasTxtUrl = buildUrl('/docs/llm/schemas.txt');
 ---
 


### PR DESCRIPTION
## What This PR Does

Adds root-level `/llms.txt` and `/llms-full.txt` routes so AI tools like Claude, ChatGPT, and Cursor can read the catalog at the conventional location instead of the nested `/docs/llm/...` paths. Also expands the LLM text output and the docs `.md`/`.mdx` endpoints to include data products and ubiquitous languages alongside existing resource types.

## Changes Overview

### Key Changes
- New routes: `packages/core/eventcatalog/src/pages/llms.txt.ts` and `llms-full.txt.ts` re-export the existing handlers from `/docs/llm/`.
- Auth middleware: `getPublicRoutes` now exposes `/llms.txt` and `/llms-full.txt` when LLM text access is enabled.
- LLM outputs: `docs/llm/llms.txt.ts` and `docs/llm/llms-full.txt.ts` now include `data-products` and `ubiquitousLanguages`.
- Docs endpoints: `docs/[type]/[id]/[version].md.ts` and `.mdx.ts` resolve the `data-products` collection.
- Settings UI: `LlmAccessSettingsForm` and `settings/llm-access.astro` reference the new `/llms.txt` URL.
- Tests: `middleware-auth.spec.ts` asserts the new root routes are gated correctly.

## How It Works

The root routes are thin re-exports of the existing `GET` handlers under `/docs/llm/`, so behaviour stays identical — only the path changes. The auth middleware adds both the new and existing paths to the public allowlist when `isLLMSTextEnabled` is true, keeping backward compatibility with the previous URLs. The LLM text generators now pull from the `data-products` and `ubiquitousLanguages` collections so AI consumers see the full catalog surface, and the per-resource `.md`/`.mdx` endpoints accept `data-products` as a valid type for direct lookups.

## Breaking Changes

None. The original `/docs/llm/llms.txt` and `/docs/llm/llms-full.txt` paths continue to work; the root paths are additive.

## Additional Notes

The settings UI now advertises the shorter `/llms.txt` URL as the primary location. Worth confirming any external documentation that references the old path is updated in a follow-up.