### PR TITLE
feat(core): show matched excerpts in search results

### DIFF
--- a/.changeset/bright-otters-search.md
+++ b/.changeset/bright-otters-search.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/core': minor
+---
+
+feat(search): show matched excerpts in search results to highlight where the query matched in resource descriptions

--- a/packages/core/docs/api/02-config.md
+++ b/packages/core/docs/api/02-config.md
@@ -669,7 +669,7 @@ After RSS is enabled, EventCatalog serves feeds at these paths:
 
 <AddedIn version="2.20.0" />
 
-Enable tools like Claude, ChatGPT, GitHub Copilot, and Cursor to quickly understand your EventCatalog.
+Enable tools like Claude, ChatGPT, GitHub Copilot, and Cursor to quickly understand your EventCatalog. When enabled, your catalog is accessible at `/llms.txt` and `/llms-full.txt`.
 
 ```js title="eventcatalog.config.js"
 {

--- a/packages/core/docs/development/components/components/23-visibility.md
+++ b/packages/core/docs/development/components/components/23-visibility.md
@@ -36,7 +36,7 @@ import AddedIn from '@site/src/components/MDX/AddedIn';
 
 In the browser UI, only `for="humans"` blocks render. The `for="agents"` block returns nothing and is never visible to human readers.
 
-When an AI agent or LLM fetches the raw markdown for a resource — via the `.md` / `.mdx` endpoints, the `/docs/llm/llms-full.txt` feed, custom docs, team/user pages, language pages, or diagram pages — the `for="humans"` blocks are stripped and only `for="agents"` content remains.
+When an AI agent or LLM fetches the raw markdown for a resource — via the `.md` / `.mdx` endpoints, the `/llms-full.txt` feed, custom docs, team/user pages, language pages, or diagram pages — the `for="humans"` blocks are stripped and only `for="agents"` content remains.
 
 This means the same file can give a human reader UI-oriented guidance ("click the Schema tab") while giving an agent structured, machine-actionable context ("treat this as a read-only lookup") without any duplication.
 

--- a/packages/core/docs/development/developer-tools/llms.txt.md
+++ b/packages/core/docs/development/developer-tools/llms.txt.md
@@ -1,7 +1,9 @@
 ---
 sidebar_position: 3
 keywords:
-- mermaid
+- llms.txt
+- AI
+- LLM
 sidebar_label: llms.txt
 title: LLMS.txt
 description: Understanding how to use LLMS.txt with EventCatalog and your LLMs
@@ -21,9 +23,11 @@ The file is automatically generated and maintained as part of your documentation
 
 ### llms.txt and llms-full.txt
 
-The `llms.txt` file includes your EventCatalog resources in a simple format. Lists your resources with a summary for each of them.
+The `llms.txt` file includes your EventCatalog resources in a simple format, listing each resource with a short summary.
 
-The `llms-full.txt` file includes your EventCatalog resources in a more detailed format. All the contents of your Catalog resources are included in the file.
+The `llms-full.txt` file includes your EventCatalog resources in a more detailed format — all the contents of your catalog resources are included in the file.
+
+Both files cover events, commands, queries, services, domains, flows, channels, teams, users, entities, data products, and ubiquitous languages.
 
 ### Enable in EventCatalog
 
@@ -37,11 +41,18 @@ llmsTxt: {
 },
 ```
 
-Once you enable llms.txt you can query both the urls:
- - `https://<your-catalog-url>/docs/llm/llms.txt`
-    - Demo: https://demo.eventcatalog.dev/docs/llm/llms.txt
- - `https://<your-catalog-url>/docs/llm/llms-full.txt`
-    - Demo: https://demo.eventcatalog.dev/docs/llm/llms-full.txt
+### Access the files
+
+<AddedIn version="3.37.0" />
+
+The recommended URLs for AI tools are at the catalog root:
+
+ - `https://<your-catalog-url>/llms.txt`
+    - Demo: https://demo.eventcatalog.dev/llms.txt
+ - `https://<your-catalog-url>/llms-full.txt`
+    - Demo: https://demo.eventcatalog.dev/llms-full.txt
+
+The legacy paths `/docs/llm/llms.txt` and `/docs/llm/llms-full.txt` still work for backward compatibility.
 
 ### How to use LLMS.txt?
 

--- a/packages/core/eventcatalog/src/components/Search/SearchModal.tsx
+++ b/packages/core/eventcatalog/src/components/Search/SearchModal.tsx
@@ -385,7 +385,14 @@ export default function SearchModal() {
               url,
               type: fav.badge || node?.badge || 'Page',
               key: fav.nodeKey,
-              rawNode: node || { title: fav.title, badge: fav.badge, summary: undefined, icon: undefined, leftIcon: undefined },
+              rawNode: node || {
+                title: fav.title,
+                badge: fav.badge,
+                summary: undefined,
+                icon: undefined,
+                leftIcon: undefined,
+                matchedExcerpt: undefined,
+              },
               isFavorite: true,
             };
           })

--- a/packages/core/eventcatalog/src/components/Search/search-utils.ts
+++ b/packages/core/eventcatalog/src/components/Search/search-utils.ts
@@ -8,6 +8,7 @@ export interface SearchNode {
   href?: string;
   icon?: string;
   leftIcon?: string;
+  matchedExcerpt?: string;
 }
 
 export interface SearchItem {


### PR DESCRIPTION
## What This PR Does

Adds support for displaying matched excerpts in the search modal so users can see where their query matched within a resource's description. When a search hit has a matched excerpt, it is rendered inline in place of the default summary; otherwise the existing summary behaviour is preserved.

## Changes Overview

### Key Changes
- Add optional `matchedExcerpt` field to the `SearchNode` interface in `search-utils.ts`.
- Populate `matchedExcerpt` from the search data (`data.excerpt || summary`) when building search results.
- Render the matched excerpt (with HTML highlight markup) in `SearchModal.tsx`, falling back to the summary when no excerpt is present.
- Ensure favourited items also carry a `matchedExcerpt: undefined` shape so the typed `rawNode` stays consistent.

## How It Works

The search index already emits an `excerpt` per hit containing the surrounding text of the matched term. We now surface that excerpt in the result row, rendered via `dangerouslySetInnerHTML` to preserve the highlight markup produced by the search layer. Items without an excerpt continue to display the normal summary, and favourites (which don't have a hit context) explicitly set `matchedExcerpt` to undefined to keep the type consistent.

## Breaking Changes

None.

## Additional Notes

- Purely additive UI change — falls back gracefully when no excerpt is present.
- No new dependencies.