### PR TITLE
feat(core): support security and allowedHosts in astro config

### DIFF
--- a/.changeset/sleepy-koalas-dream.md
+++ b/.changeset/sleepy-koalas-dream.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Support `security` and `server.allowedHosts` configuration options in `eventcatalog.config.js`, forwarding them to the underlying Astro config.

--- a/packages/core/eventcatalog/astro.config.mjs
+++ b/packages/core/eventcatalog/astro.config.mjs
@@ -40,7 +40,15 @@ const expressiveCodeConfig = {
 // https://astro.build/config
 export default defineConfig({
   base,
-  server: { port: config.port || 3000, host: host },
+  server: { 
+    port: config.port || 3000,
+    host: host,
+    // Add allowed hosts if its set
+    ...(config.server?.allowedHosts ? { allowedHosts: config.server?.allowedHosts } : {}),
+  },
+
+  // If security is set
+  ...(config.security ? { security: config.security } : {}),
 
   // In dev mode (EVENTCATALOG_DEV_MODE=true) we need 'server' output so that
   // routes which opt into SSR via `export const prerender = false` (e.g. the


### PR DESCRIPTION
## What This PR Does

Adds support for two new optional configuration options in `eventcatalog.config.js`: `security` (forwarded to Astro's [`security`](https://docs.astro.build/en/reference/configuration-reference/#security) config) and `server.allowedHosts` (forwarded to Astro's dev server config). This lets users opt out of Astro's default origin checking for SSR routes and whitelist additional hosts when running EventCatalog behind proxies or tunnels.

## Changes Overview

### Key Changes
- `packages/core/eventcatalog/astro.config.mjs` — spreads `config.security` into the Astro config when present and forwards `config.server.allowedHosts` into the dev server options
- `packages/core/docs/api/02-config.md` — documents the new `security` option, added in version `3.39.2`

## How It Works

The Astro config is composed from the user's `eventcatalog.config.js`. Both new options are wired in conditionally so existing catalogs that don't set them keep their current behavior:

- `server.allowedHosts` is spread into the existing `server` object only when defined.
- `security` is spread into the top-level Astro config only when defined, allowing users to set `{ checkOrigin: false }` for SSR deployments where the origin header does not match the request URL.

## Breaking Changes

None. Both options are optional and default to Astro's existing behavior.

## Additional Notes

- Patch release for `@eventcatalog/core`.
- Useful for users running EventCatalog in SSR mode behind reverse proxies, tunnels (e.g. ngrok), or container hostnames.