### PR TITLE
fix(core): allow hiding individual sidebar items

### DIFF
--- a/.changeset/quiet-otters-march.md
+++ b/.changeset/quiet-otters-march.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/core': patch
+---
+
+Support hiding individual sidebar items (Browse, Organization, Settings) via `sidebar` config in `eventcatalog.config.js`. Section headers and dividers now hide when all items in that section are hidden. Legacy group ids (`/docs`, `/discover`, `/directory`, `/settings`) still work as aliases.

--- a/packages/core/eventcatalog/src/layouts/VerticalSideBarLayout.astro
+++ b/packages/core/eventcatalog/src/layouts/VerticalSideBarLayout.astro
@@ -64,6 +64,7 @@ import { isCollectionVisibleInCatalog } from '@eventcatalog';
 import { buildUrl } from '@utils/url-builder';
 import { getQueries } from '@utils/collections/queries';
 import { hasLandingPageForDocs } from '@utils/pages';
+import { filterSidebarItems } from '@utils/sidebar-visibility';
 
 import { isEmbedEnabled, isCustomStylesEnabled, isEventCatalogScaleEnabled, isCustomDocsEnabled, isSSR } from '@utils/feature';
 
@@ -128,66 +129,66 @@ const getDefaultUrl = (route: string, defaultValue: string) => {
 
 const userSideBarConfiguration = config.sidebar || [];
 
-const navigationItems = [
-  {
-    id: '/',
-    label: 'Catalog',
-    icon: BookOpen,
-    href: buildUrl(config.landingPage || '/'),
-    current:
-      currentPath === '/' ||
-      (currentPath.includes('/docs') && !currentPath.includes('/docs/custom')) ||
-      currentPath.includes('/architecture/') ||
-      currentPath.includes('/visualiser') ||
-      (currentPath.includes('/schemas') &&
-        !currentPath.includes('/schemas/explorer') &&
-        !currentPath.includes('/schemas/fields')),
-  },
-  {
-    id: '/docs/custom',
-    label: 'Documentation',
-    icon: FileText,
-    href: getDefaultUrl('docs/custom', '/docs/custom'),
-    current: currentPath.includes('/docs/custom'),
-    isPremium: true,
-    visible: isCustomDocsEnabled() && customDocs.length > 0,
-  },
-  {
-    id: '/schemas/explorer',
-    label: 'Schemas',
-    icon: FileCode,
-    href: buildUrl('/schemas/explorer'),
-    current: currentPath.includes('/schemas/explorer') && !currentPath.includes('/schemas/fields'),
-  },
-  ...(isSSR()
-    ? [
-        {
-          id: '/schemas/fields',
-          label: 'Schema Insights',
-          icon: Waypoints,
-          href: buildUrl('/schemas/fields'),
-          current: currentPath.includes('/schemas/fields'),
-        },
-      ]
-    : []),
-].filter((item) => {
-  const userSideBarOption = userSideBarConfiguration.find((config: { id: string; visible: boolean }) => config.id === item.id);
-  const defaultVisible = item.visible ?? true;
-  return userSideBarOption ? userSideBarOption.visible : defaultVisible;
-});
+const navigationItems = filterSidebarItems(
+  [
+    {
+      id: '/',
+      label: 'Catalog',
+      icon: BookOpen,
+      href: buildUrl(config.landingPage || '/'),
+      current:
+        currentPath === '/' ||
+        (currentPath.includes('/docs') && !currentPath.includes('/docs/custom')) ||
+        currentPath.includes('/architecture/') ||
+        currentPath.includes('/visualiser') ||
+        (currentPath.includes('/schemas') &&
+          !currentPath.includes('/schemas/explorer') &&
+          !currentPath.includes('/schemas/fields')),
+    },
+    {
+      id: '/docs/custom',
+      aliases: ['/docs'],
+      label: 'Documentation',
+      icon: FileText,
+      href: getDefaultUrl('docs/custom', '/docs/custom'),
+      current: currentPath.includes('/docs/custom'),
+      isPremium: true,
+      visible: isCustomDocsEnabled() && customDocs.length > 0,
+    },
+    {
+      id: '/schemas/explorer',
+      label: 'Schemas',
+      icon: FileCode,
+      href: buildUrl('/schemas/explorer'),
+      current: currentPath.includes('/schemas/explorer') && !currentPath.includes('/schemas/fields'),
+    },
+    ...(isSSR()
+      ? [
+          {
+            id: '/schemas/fields',
+            label: 'Schema Insights',
+            icon: Waypoints,
+            href: buildUrl('/schemas/fields'),
+            current: currentPath.includes('/schemas/fields'),
+          },
+        ]
+      : []),
+  ],
+  userSideBarConfiguration
+);
 
-const studioNavigationItem = [
-  {
-    id: '/studio',
-    label: 'EventCatalog Studio',
-    icon: SquareDashedMousePointerIcon,
-    href: buildUrl('/studio'),
-    current: currentPath.includes('/studio'),
-  },
-].filter((item) => {
-  const userSideBarOption = userSideBarConfiguration.find((config: { id: string; visible: boolean }) => config.id === item.id);
-  return userSideBarOption ? userSideBarOption.visible : true;
-});
+const studioNavigationItem = filterSidebarItems(
+  [
+    {
+      id: '/studio',
+      label: 'EventCatalog Studio',
+      icon: SquareDashedMousePointerIcon,
+      href: buildUrl('/studio'),
+      current: currentPath.includes('/studio'),
+    },
+  ],
+  userSideBarConfiguration
+);
 
 const premiumFeatures: Array<{
   id: string;
@@ -198,86 +199,119 @@ const premiumFeatures: Array<{
   isPremium?: boolean;
 }> = [];
 
-const browseItems = [
-  {
-    label: 'Domains',
-    icon: RectangleGroupIcon,
-    href: buildUrl('/discover/domains'),
-    current: currentPath === buildUrl('/discover/domains'),
-  },
-  {
-    label: 'Services',
-    icon: ServerIcon,
-    href: buildUrl('/discover/services'),
-    current: currentPath === buildUrl('/discover/services'),
-  },
-  {
-    label: 'External Systems',
-    icon: GlobeAltIcon,
-    href: buildUrl('/discover/external-systems'),
-    current: currentPath === buildUrl('/discover/external-systems'),
-  },
-  {
-    label: 'Events',
-    icon: BoltIcon,
-    href: buildUrl('/discover/events'),
-    current: currentPath === buildUrl('/discover/events'),
-  },
-  {
-    label: 'Commands',
-    icon: ChatBubbleLeftIcon,
-    href: buildUrl('/discover/commands'),
-    current: currentPath === buildUrl('/discover/commands'),
-  },
-  {
-    label: 'Queries',
-    icon: MagnifyingGlassIcon,
-    href: buildUrl('/discover/queries'),
-    current: currentPath === buildUrl('/discover/queries'),
-  },
-  {
-    label: 'Flows',
-    icon: QueueListIcon,
-    href: buildUrl('/discover/flows'),
-    current: currentPath === buildUrl('/discover/flows'),
-  },
-  {
-    label: 'Data Stores',
-    icon: Database,
-    href: buildUrl('/discover/containers'),
-    current: currentPath === buildUrl('/discover/containers'),
-  },
-  {
-    label: 'Data Products',
-    icon: CubeIcon,
-    href: buildUrl('/discover/data-products'),
-    current: currentPath === buildUrl('/discover/data-products'),
-  },
-];
+const browseItems = filterSidebarItems(
+  [
+    {
+      id: '/discover/domains',
+      aliases: ['/discover'],
+      label: 'Domains',
+      icon: RectangleGroupIcon,
+      href: buildUrl('/discover/domains'),
+      current: currentPath === buildUrl('/discover/domains'),
+    },
+    {
+      id: '/discover/services',
+      aliases: ['/discover'],
+      label: 'Services',
+      icon: ServerIcon,
+      href: buildUrl('/discover/services'),
+      current: currentPath === buildUrl('/discover/services'),
+    },
+    {
+      id: '/discover/external-systems',
+      aliases: ['/discover'],
+      label: 'External Systems',
+      icon: GlobeAltIcon,
+      href: buildUrl('/discover/external-systems'),
+      current: currentPath === buildUrl('/discover/external-systems'),
+    },
+    {
+      id: '/discover/events',
+      aliases: ['/discover'],
+      label: 'Events',
+      icon: BoltIcon,
+      href: buildUrl('/discover/events'),
+      current: currentPath === buildUrl('/discover/events'),
+    },
+    {
+      id: '/discover/commands',
+      aliases: ['/discover'],
+      label: 'Commands',
+      icon: ChatBubbleLeftIcon,
+      href: buildUrl('/discover/commands'),
+      current: currentPath === buildUrl('/discover/commands'),
+    },
+    {
+      id: '/discover/queries',
+      aliases: ['/discover'],
+      label: 'Queries',
+      icon: MagnifyingGlassIcon,
+      href: buildUrl('/discover/queries'),
+      current: currentPath === buildUrl('/discover/queries'),
+    },
+    {
+      id: '/discover/flows',
+      aliases: ['/discover'],
+      label: 'Flows',
+      icon: QueueListIcon,
+      href: buildUrl('/discover/flows'),
+      current: currentPath === buildUrl('/discover/flows'),
+    },
+    {
+      id: '/discover/containers',
+      aliases: ['/discover'],
+      label: 'Data Stores',
+      icon: Database,
+      href: buildUrl('/discover/containers'),
+      current: currentPath === buildUrl('/discover/containers'),
+    },
+    {
+      id: '/discover/data-products',
+      aliases: ['/discover'],
+      label: 'Data Products',
+      icon: CubeIcon,
+      href: buildUrl('/discover/data-products'),
+      current: currentPath === buildUrl('/discover/data-products'),
+    },
+  ],
+  userSideBarConfiguration
+);
 
-const organizationItems = [
-  {
-    label: 'Teams',
-    icon: UsersRound,
-    href: buildUrl('/directory/teams'),
-    current: currentPath === buildUrl('/directory/teams'),
-  },
-  {
-    label: 'Users',
-    icon: UserRound,
-    href: buildUrl('/directory/users'),
-    current: currentPath === buildUrl('/directory/users'),
-  },
-];
+const organizationItems = filterSidebarItems(
+  [
+    {
+      id: '/directory/teams',
+      aliases: ['/directory'],
+      label: 'Teams',
+      icon: UsersRound,
+      href: buildUrl('/directory/teams'),
+      current: currentPath === buildUrl('/directory/teams'),
+    },
+    {
+      id: '/directory/users',
+      aliases: ['/directory'],
+      label: 'Users',
+      icon: UserRound,
+      href: buildUrl('/directory/users'),
+      current: currentPath === buildUrl('/directory/users'),
+    },
+  ],
+  userSideBarConfiguration
+);
 
-const settingsItems = [
-  {
-    label: 'Settings',
-    icon: Settings,
-    href: buildUrl('/settings/general'),
-    current: currentPath.startsWith(buildUrl('/settings')),
-  },
-];
+const settingsItems = filterSidebarItems(
+  [
+    {
+      id: '/settings/general',
+      aliases: ['/settings'],
+      label: 'Settings',
+      icon: Settings,
+      href: buildUrl('/settings/general'),
+      current: currentPath.startsWith(buildUrl('/settings')),
+    },
+  ],
+  userSideBarConfiguration
+);
 
 const currentNavigationItem = [...navigationItems, ...studioNavigationItem, ...premiumFeatures].find((item) => item.current);
 const { title, description, showNestedSideBar = true, showHeader = true } = Astro.props;
@@ -521,58 +555,64 @@ const canPageBeEmbedded = isEmbedEnabled();
               })
             }
 
-            <hr class="rail-divider my-3 border-t border-[rgb(var(--ec-sidebar-border)/0.7)]" />
-
-            <div
-              class="rail-section-label px-3 pb-1 text-[0.65rem] font-semibold tracking-[0.18em] uppercase text-[rgb(var(--ec-sidebar-text)/0.5)]"
-            >
-              Browse
-            </div>
-
             {
-              browseItems.map((item) => (
-                <a
-                  href={item.href}
-                  data-role="secondary-nav-item"
-                  aria-label={item.label}
-                  class={`nav-secondary-item flex items-center gap-3 px-3 py-2.5 rounded-xl border text-[13px] font-medium transition-all duration-150 ${
-                    item.current
-                      ? 'border-[rgb(var(--ec-accent)/0.2)] bg-[rgb(var(--ec-page-bg)/0.88)] text-[rgb(var(--ec-accent))] shadow-sm'
-                      : 'border-transparent text-[rgb(var(--ec-sidebar-text))] hover:border-[rgb(var(--ec-sidebar-border)/0.65)] hover:bg-[rgb(var(--ec-page-bg)/0.78)] hover:text-[rgb(var(--ec-page-text))]'
-                  }`}
-                  title={item.label}
-                >
-                  <item.icon className="h-3.5 w-3.5 flex-shrink-0" aria-hidden="true" />
-                  <span class="nav-item-label">{item.label}</span>
-                </a>
-              ))
+              browseItems.length > 0 && (
+                <Fragment>
+                  <hr class="rail-divider my-3 border-t border-[rgb(var(--ec-sidebar-border)/0.7)]" />
+
+                  <div class="rail-section-label px-3 pb-1 text-[0.65rem] font-semibold tracking-[0.18em] uppercase text-[rgb(var(--ec-sidebar-text)/0.5)]">
+                    Browse
+                  </div>
+
+                  {browseItems.map((item) => (
+                    <a
+                      id={item.id}
+                      href={item.href}
+                      data-role="secondary-nav-item"
+                      aria-label={item.label}
+                      class={`nav-secondary-item flex items-center gap-3 px-3 py-2.5 rounded-xl border text-[13px] font-medium transition-all duration-150 ${
+                        item.current
+                          ? 'border-[rgb(var(--ec-accent)/0.2)] bg-[rgb(var(--ec-page-bg)/0.88)] text-[rgb(var(--ec-accent))] shadow-sm'
+                          : 'border-transparent text-[rgb(var(--ec-sidebar-text))] hover:border-[rgb(var(--ec-sidebar-border)/0.65)] hover:bg-[rgb(var(--ec-page-bg)/0.78)] hover:text-[rgb(var(--ec-page-text))]'
+                      }`}
+                      title={item.label}
+                    >
+                      <item.icon className="h-3.5 w-3.5 flex-shrink-0" aria-hidden="true" />
+                      <span class="nav-item-label">{item.label}</span>
+                    </a>
+                  ))}
+                </Fragment>
+              )
             }
 
-            <hr class="rail-divider my-3 border-t border-[rgb(var(--ec-sidebar-border)/0.7)]" />
-
-            <div
-              class="rail-section-label px-3 pb-1 text-[0.65rem] font-semibold tracking-[0.18em] uppercase text-[rgb(var(--ec-sidebar-text)/0.5)]"
-            >
-              Organization
-            </div>
-
             {
-              organizationItems.map((item) => (
-                <a
-                  href={item.href}
-                  data-role="secondary-nav-item"
-                  aria-label={item.label}
-                  class={`nav-secondary-item flex items-center gap-3 px-3 py-2.5 rounded-xl border text-[13px] font-medium transition-all duration-150 ${
-                    item.current
-                      ? 'border-[rgb(var(--ec-accent)/0.2)] bg-[rgb(var(--ec-page-bg)/0.88)] text-[rgb(var(--ec-accent))] shadow-sm'
-                      : 'border-transparent text-[rgb(var(--ec-sidebar-text))] hover:border-[rgb(var(--ec-sidebar-border)/0.65)] hover:bg-[rgb(var(--ec-page-bg)/0.78)] hover:text-[rgb(var(--ec-page-text))]'
-                  }`}
-                  title={item.label}
-                >
-                  <item.icon className="h-3.5 w-3.5 flex-shrink-0" aria-hidden="true" />
-                  <span class="nav-item-label">{item.label}</span>
-                </a>
-              ))
+              organizationItems.length > 0 && (
+                <Fragment>
+                  <hr class="rail-divider my-3 border-t border-[rgb(var(--ec-sidebar-border)/0.7)]" />
+
+                  <div class="rail-section-label px-3 pb-1 text-[0.65rem] font-semibold tracking-[0.18em] uppercase text-[rgb(var(--ec-sidebar-text)/0.5)]">
+                    Organization
+                  </div>
+
+                  {organizationItems.map((item) => (
+                    <a
+                      id={item.id}
+                      href={item.href}
+                      data-role="secondary-nav-item"
+                      aria-label={item.label}
+                      class={`nav-secondary-item flex items-center gap-3 px-3 py-2.5 rounded-xl border text-[13px] font-medium transition-all duration-150 ${
+                        item.current
+                          ? 'border-[rgb(var(--ec-accent)/0.2)] bg-[rgb(var(--ec-page-bg)/0.88)] text-[rgb(var(--ec-accent))] shadow-sm'
+                          : 'border-transparent text-[rgb(var(--ec-sidebar-text))] hover:border-[rgb(var(--ec-sidebar-border)/0.65)] hover:bg-[rgb(var(--ec-page-bg)/0.78)] hover:text-[rgb(var(--ec-page-text))]'
+                      }`}
+                      title={item.label}
+                    >
+                      <item.icon className="h-3.5 w-3.5 flex-shrink-0" aria-hidden="true" />
+                      <span class="nav-item-label">{item.label}</span>
+                    </a>
+                  ))}
+                </Fragment>
+              )
             }
 
             {premiumFeatures.length > 0 && <hr class="rail-divider my-2 border-t border-[rgb(var(--ec-sidebar-border)/0.7)]" />}
@@ -598,24 +638,29 @@ const canPageBeEmbedded = isEmbedEnabled();
             }
 
             <div class="mt-auto pt-3">
-              <hr class="rail-divider mb-3 border-t border-[rgb(var(--ec-sidebar-border)/0.7)]" />
               {
-                settingsItems.map((item) => (
-                  <a
-                    href={item.href}
-                    data-role="secondary-nav-item"
-                    aria-label={item.label}
-                    class={`nav-secondary-item flex items-center gap-3 px-3 py-2.5 rounded-xl border text-[13px] font-medium transition-all duration-150 ${
-                      item.current
-                        ? 'border-[rgb(var(--ec-accent)/0.2)] bg-[rgb(var(--ec-page-bg)/0.88)] text-[rgb(var(--ec-accent))] shadow-sm'
-                        : 'border-transparent text-[rgb(var(--ec-sidebar-text))] hover:border-[rgb(var(--ec-sidebar-border)/0.65)] hover:bg-[rgb(var(--ec-page-bg)/0.78)] hover:text-[rgb(var(--ec-page-text))]'
-                    }`}
-                    title={item.label}
-                  >
-                    <item.icon className="h-4 w-4 flex-shrink-0" aria-hidden="true" />
-                    <span class="nav-item-label">{item.label}</span>
-                  </a>
-                ))
+                settingsItems.length > 0 && (
+                  <Fragment>
+                    <hr class="rail-divider mb-3 border-t border-[rgb(var(--ec-sidebar-border)/0.7)]" />
+                    {settingsItems.map((item) => (
+                      <a
+                        id={item.id}
+                        href={item.href}
+                        data-role="secondary-nav-item"
+                        aria-label={item.label}
+                        class={`nav-secondary-item flex items-center gap-3 px-3 py-2.5 rounded-xl border text-[13px] font-medium transition-all duration-150 ${
+                          item.current
+                            ? 'border-[rgb(var(--ec-accent)/0.2)] bg-[rgb(var(--ec-page-bg)/0.88)] text-[rgb(var(--ec-accent))] shadow-sm'
+                            : 'border-transparent text-[rgb(var(--ec-sidebar-text))] hover:border-[rgb(var(--ec-sidebar-border)/0.65)] hover:bg-[rgb(var(--ec-page-bg)/0.78)] hover:text-[rgb(var(--ec-page-text))]'
+                        }`}
+                        title={item.label}
+                      >
+                        <item.icon className="h-4 w-4 flex-shrink-0" aria-hidden="true" />
+                        <span class="nav-item-label">{item.label}</span>
+                      </a>
+                    ))}
+                  </Fragment>
+                )
               }
             </div>
           </nav>

--- a/packages/core/eventcatalog/src/utils/__tests__/sidebar-visibility.test.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/sidebar-visibility.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { filterSidebarItems, isSidebarItemVisible } from '@utils/sidebar-visibility';
+
+describe('sidebar visibility', () => {
+  it('shows items by default', () => {
+    expect(isSidebarItemVisible({ id: '/directory/users' })).toBe(true);
+  });
+
+  it('uses the item default when no user configuration matches', () => {
+    expect(isSidebarItemVisible({ id: '/docs/custom', visible: false })).toBe(false);
+  });
+
+  it('hides items by exact id', () => {
+    expect(isSidebarItemVisible({ id: '/directory/users' }, [{ id: '/directory/users', visible: false }])).toBe(false);
+  });
+
+  it('uses aliases so legacy group ids can hide refactored sidebar items', () => {
+    const items = [
+      { id: '/directory/teams', aliases: ['/directory'] },
+      { id: '/directory/users', aliases: ['/directory'] },
+      { id: '/discover/events', aliases: ['/discover'] },
+    ];
+
+    expect(filterSidebarItems(items, [{ id: '/directory', visible: false }])).toEqual([
+      { id: '/discover/events', aliases: ['/discover'] },
+    ]);
+  });
+
+  it('lets exact item configuration override a matching alias', () => {
+    expect(
+      isSidebarItemVisible({ id: '/directory/users', aliases: ['/directory'] }, [
+        { id: '/directory', visible: false },
+        { id: '/directory/users', visible: true },
+      ])
+    ).toBe(true);
+  });
+});

--- a/packages/core/eventcatalog/src/utils/sidebar-visibility.ts
+++ b/packages/core/eventcatalog/src/utils/sidebar-visibility.ts
@@ -1,0 +1,41 @@
+export type SidebarVisibilityConfig = {
+  id: string;
+  visible: boolean;
+};
+
+export type SidebarConfigurableItem = {
+  id: string;
+  aliases?: string[];
+  visible?: boolean;
+};
+
+const getVisibilityOption = <T extends SidebarConfigurableItem>(
+  item: T,
+  configuration: SidebarVisibilityConfig[]
+): SidebarVisibilityConfig | undefined => {
+  const exactMatch = configuration.find((option) => option.id === item.id);
+
+  if (exactMatch) {
+    return exactMatch;
+  }
+
+  return configuration.find((option) => item.aliases?.includes(option.id));
+};
+
+export const isSidebarItemVisible = <T extends SidebarConfigurableItem>(
+  item: T,
+  configuration: SidebarVisibilityConfig[] = []
+): boolean => {
+  const visibilityOption = getVisibilityOption(item, configuration);
+
+  if (visibilityOption) {
+    return visibilityOption.visible;
+  }
+
+  return item.visible ?? true;
+};
+
+export const filterSidebarItems = <T extends SidebarConfigurableItem>(
+  items: T[],
+  configuration: SidebarVisibilityConfig[] = []
+): T[] => items.filter((item) => isSidebarItemVisible(item, configuration));


### PR DESCRIPTION
Closes #2533

## What This PR Does

Users can now hide individual items in the application sidebar (e.g. `/discover/events`, `/directory/teams`, `/settings/general`) via the `sidebar` config option in `eventcatalog.config.js`. Previously, only top-level navigation items were hideable while Browse, Organization, and Settings sections were always visible. Section headers and dividers are now also hidden when all items in that section are hidden, avoiding orphaned UI fragments. The legacy group ids (`/docs`, `/discover`, `/directory`, `/settings`) continue to work as aliases so existing configurations keep working.

## Changes Overview

### Key Changes

- New `sidebar-visibility.ts` utility with `filterSidebarItems` and `isSidebarItemVisible` helpers that match items by `id` and fall back to aliases (e.g. `/discover` matches `/discover/events`).
- `VerticalSideBarLayout.astro` now assigns ids to all Browse, Organization, and Settings items and passes them through `filterSidebarItems`.
- Section headers and dividers (Browse, Organization, Settings) only render when their section has at least one visible item.
- Unit tests covering exact id match, alias fallback, missing config, and `visible: false` defaults.
- Documentation updated with the full list of supported ids and a note about legacy group aliases.

## How It Works

Each sidebar item now declares an `id` and optionally `aliases`. The `filterSidebarItems` helper walks the user's `sidebar` config and looks for an exact id match first, then falls back to any alias. If neither matches, the item's own `visible` default applies (defaults to `true`). This keeps existing configs (`{ id: '/discover', visible: false }`) working while enabling fine-grained targeting like `{ id: '/discover/events', visible: false }`.

The Astro layout wraps each section's rendering in a `{section.length > 0 && ...}` guard so the section header and divider disappear together with the items.

## Breaking Changes

None. Legacy group ids continue to work as aliases.

## Additional Notes

- Docs page `00-application-sidebar.md` updated with the full id list and the alias note.
- Follow-up: docs in `website-2` will be updated via the docs-updater agent.