### PR TITLE
chore(create-eventcatalog): refresh templates and add editor script

### DIFF
--- a/.changeset/refresh-create-app-templates.md
+++ b/.changeset/refresh-create-app-templates.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/create-eventcatalog': patch
+---
+
+Refresh README templates and CLI completion output, and add `editor` npm script that runs `@eventcatalog/editor`.

--- a/packages/core/docs/development/01-fundamentals.md
+++ b/packages/core/docs/development/01-fundamentals.md
@@ -29,6 +29,13 @@ EventCatalog is a [docs-as-code](https://www.writethedocs.org/guide/docs-as-code
 
 EventCatalog does not force you to use a specific broker, schema format, or stack. You can use it with any broker, schema format, or stack and can fit into any workflow you have. EventCatalog fits your workflow, not the other way around.
 
+### Visual editing
+
+You can also use [EventCatalog Editor](/docs/editor/overview) to maintain your catalog through a local visual workflow.
+
+The editor runs on top of your EventCatalog project, writes changes back to the same local files, and gives you a Git-backed way to review and publish changes. This helps developers, architects, analysts, and product owners contribute to the catalog without needing to work directly in Markdown files.
+
+
 ## Ready to build?
 
 Now that you understand the fundamentals, [get started with EventCatalog](/docs/development/getting-started/installation).

--- a/packages/core/docs/development/01-getting-started/installation.md
+++ b/packages/core/docs/development/01-getting-started/installation.md
@@ -94,6 +94,14 @@ Look at my directory and generate EventCatalog documentation from information yo
 
 The generated files can be edited like any other EventCatalog documentation. Learn more about [EventCatalog skills](/docs/development/ask-your-architecture/skills/introduction).
 
+## Optional: Use EventCatalog Editor
+
+You can edit your catalog files directly in Markdown, or use [EventCatalog Editor](/docs/editor/overview) for a local visual editing workflow.
+
+The editor runs on top of your EventCatalog project, writes changes back to your local files, and gives you a Git-backed way to review and publish changes. This is useful when architects, developers, analysts, or product owners need to help maintain the catalog without working directly in Markdown.
+
+To use the editor, you need Git installed and editor access through [EventCatalog Cloud](https://eventcatalog.cloud). Learn how to [run EventCatalog Editor locally](/docs/editor/how-to/run-locally).
+
 ## Next steps
 
 - [Understand the project structure](/docs/development/getting-started/project-structure)

--- a/packages/core/docs/development/01-getting-started/project-structure.md
+++ b/packages/core/docs/development/01-getting-started/project-structure.md
@@ -11,6 +11,8 @@ import ProjectTree from '@site/src/components/MDX/ProjectTree';
 
 An EventCatalog project is a folder of Markdown files that describe and model your architecture.
 
+You can edit these files directly, or use the optional [EventCatalog Editor](/docs/editor/overview) to create, preview, review, and commit catalog content through a visual workflow.
+
 Each resource in your catalog, such as a domain, service, event, command, query, team, or diagram, is represented by a file or folder in your project. EventCatalog reads those files and turns them into a catalog.
 
 You can also bring your own documentation into EventCatalog, such as architecture decision records, guides, onboarding material, or runbooks. Learn more about [bringing your own documentation](/docs/development/bring-your-own-documentation/introduction).

--- a/packages/core/docs/development/bring-your-own-documentation/01-introduction.md
+++ b/packages/core/docs/development/bring-your-own-documentation/01-introduction.md
@@ -9,6 +9,8 @@ description: Bring your own documentation to EventCatalog
 
 EventCatalog allows you to centralise architecture documentation alongside your domains, services, and events — keeping knowledge and context in one place.
 
+You can write this documentation with Markdown and MDX, or use the optional [EventCatalog Editor](/docs/editor/overview) for a visual editing workflow.
+
 Common use cases include:
 
 - Architecture decision records (ADRs)

--- a/packages/core/docs/development/customization/customize-sidebars/00-application-sidebar.md
+++ b/packages/core/docs/development/customization/customize-sidebars/00-application-sidebar.md
@@ -15,9 +15,11 @@ The application sidebar is the sidebar that is rendered on every page in EventCa
 
 ### Show/hide items in the application sidebar
 
+<AddedIn version="3.39.5" />
+
 You can show or hide items in the application sidebar by using the `sidebar` property in your `eventcatalog.config.js` file.
 
-**By default, all items is the sidebar are shown.**
+**By default, all items in the sidebar are shown.**
 
 ```js title="eventcatalog.config.js"
 // rest of the config
@@ -25,6 +27,11 @@ sidebar: [
   {
     id: '/schemas/explorer',
     // This will hide the Schema Explorer
+    visible: false,
+  },
+  {
+    id: '/discover/events',
+    // This will hide the Events item
     visible: false,
   },
 ]
@@ -38,8 +45,41 @@ Options for the `sidebar` property:
 | ID | Description |
 | --- | --- |
 | `/` | The home page icon |
-| `/docs` | The documentation page icon |
-| `/discover` | The discover page icon |
-| `/directory` | The users directory page icon |
+| `/docs/custom` | The custom documentation page |
+| `/discover/domains` | The domains page |
+| `/discover/services` | The services page |
+| `/discover/external-systems` | The external systems page |
+| `/discover/events` | The events page |
+| `/discover/commands` | The commands page |
+| `/discover/queries` | The queries page |
+| `/discover/flows` | The flows page |
+| `/discover/containers` | The data stores page |
+| `/discover/data-products` | The data products page |
+| `/directory/teams` | The teams page |
+| `/directory/users` | The users page |
+| `/settings/general` | The settings page |
 | `/studio` | The EventCatalog Studio icon |
 | `/schemas/explorer` | The schema explorer page |
+| `/schemas/fields` | The schema insights page (SSR only) |
+
+### Use legacy group ids
+
+You can also use legacy group ids to hide all items in a section at once. Setting a group id to `visible: false` hides every item that belongs to that group.
+
+| Legacy ID | Items hidden |
+| --- | --- |
+| `/docs` | `/docs/custom` |
+| `/discover` | All discover items (domains, services, events, commands, queries, flows, data stores, data products, external systems) |
+| `/directory` | `/directory/teams` and `/directory/users` |
+| `/settings` | `/settings/general` |
+
+```js title="eventcatalog.config.js"
+// rest of the config
+sidebar: [
+  {
+    id: '/directory',
+    // This will hide both Teams and Users
+    visible: false,
+  },
+]
+```

--- a/packages/core/docs/editor/00-overview.md
+++ b/packages/core/docs/editor/00-overview.md
@@ -1,0 +1,73 @@
+---
+sidebar_position: 1
+sidebar_label: Overview
+title: EventCatalog Editor
+description: Understand what EventCatalog Editor is, who it is for, and how it fits into your catalog workflow.
+---
+
+EventCatalog Editor is a local visual editor for maintaining an EventCatalog.
+
+It runs on your machine, opens your catalog from disk, lets you edit architecture resources without working directly in Markdown or MDX, and gives you a Git-backed view of the changes before you commit them.
+
+![EventCatalog Editor open on a service resource](./images/editor.png)
+
+## Who the editor is for
+
+The editor is for people who maintain an EventCatalog:
+
+- Architects documenting [domains](/docs/development/guides/domains/introduction), [services](/docs/development/guides/services/introduction), [messages](/docs/development/guides/messages/overview), and [ownership](/docs/owners)
+- Developers keeping resource documentation, schemas, and specifications up to date
+- Analysts, product owners, or domain experts who can improve catalog content but do not want to edit MDX files directly
+
+You still own your catalog as files. The editor makes those files easier to browse, edit, preview, review, and commit.
+
+::::info Need an EventCatalog first?
+
+These docs assume you already have an EventCatalog project. If you are just getting started, create a catalog first with the [EventCatalog installation guide](/docs/development/getting-started/installation), then come back here.
+
+::::
+
+## What the editor does
+
+Use EventCatalog Editor to:
+
+- Open a local EventCatalog project
+- Browse [domains](/docs/development/guides/domains/introduction), [services](/docs/development/guides/services/introduction), [messages](/docs/development/guides/messages/overview), [channels](/docs/development/guides/channels/introduction), [entities](/docs/development/guides/domains/entities/introduction), [data stores](/docs/development/guides/data/introduction), [flows](/docs/development/guides/flows/introduction), [users](/docs/development/guides/owners/users/introduction), and [teams](/docs/development/guides/owners/teams/introduction)
+- Edit documentation in a rich editor or source editor
+- Update common frontmatter fields through forms
+- Add schemas to [events](/docs/development/guides/messages/events/introduction), [commands](/docs/development/guides/messages/commands/introduction), and [queries](/docs/development/guides/messages/queries/introduction)
+- Add OpenAPI, AsyncAPI, and GraphQL specifications to domains and services
+- Preview resources in a running EventCatalog site
+- Inspect local Git changes, view diffs, revert files, and commit work
+- Invite editors through [EventCatalog Cloud](https://eventcatalog.cloud) and assign editor seats
+
+## Local workflow
+
+The editor sits on top of the same files that EventCatalog already uses.
+
+```mermaid
+flowchart LR
+  A[Local EventCatalog files] --> B[EventCatalog Editor]
+  B --> C[Markdown, MDX, schema, and config changes]
+  C --> D[Git changes view]
+  D --> E[Commit locally]
+  E --> F[Your existing review and publishing workflow]
+```
+
+The editor does not replace Git, Markdown, MDX, or your deployment process. It gives catalog maintainers a safer interface for making changes before those changes go through the workflow your team already uses.
+
+## Beta status
+
+EventCatalog Editor is in beta. You can use it today, but some workflows and features may change before general availability.
+
+The editor is a seat-based paid product. Community includes 1 editor seat, Starter includes 3 editor seats, Scale includes 10 editor seats, and Enterprise includes unlimited editor seats. See the [pricing page](/pricing) for current plan details.
+
+If you want to help shape the editor, join the [EventCatalog Discord](https://eventcatalog.dev/discord) or [open an issue in the editor repository](https://github.com/event-catalog/eventcatalog-editor-code/issues).
+
+## Next steps
+
+- Follow the [first edit tutorial](/docs/editor/first-edit).
+- Learn how to [run the editor locally](/docs/editor/how-to/run-locally).
+- Learn how to [use the Flow Editor](/docs/editor/how-to/use-flow-editor).
+- Learn how to [invite editors](/docs/editor/how-to/invite-editors).
+- Understand [how the editor works](/docs/editor/explanation/how-it-works).

--- a/packages/core/docs/editor/01-first-edit.md
+++ b/packages/core/docs/editor/01-first-edit.md
@@ -1,0 +1,124 @@
+---
+sidebar_position: 2
+sidebar_label: First edit tutorial
+title: Make your first edit with EventCatalog Editor
+description: Learn the basic editor workflow by opening a local catalog, changing a resource, previewing it, and reviewing the Git change.
+slug: /editor/first-edit
+---
+
+This tutorial takes you through the first successful editor workflow:
+
+1. Run EventCatalog locally
+2. Run EventCatalog Editor
+3. Open a catalog resource
+4. Make a small documentation change
+5. Preview the resource
+6. Review the Git diff
+7. Publish the change
+
+The goal is not to document a whole architecture. The goal is to learn the editor loop.
+
+::::info Need a catalog?
+
+This tutorial assumes you already have an EventCatalog project on your machine. If you do not, follow the [EventCatalog installation guide](/docs/development/getting-started/installation) first.
+
+::::
+
+## Prerequisites
+
+Before you start, make sure you have:
+
+- Node.js 22 or later
+- Git installed
+- An EventCatalog project containing `eventcatalog.config.js`
+- Access to EventCatalog Editor through [EventCatalog Cloud](https://eventcatalog.cloud)
+- A terminal open in or near your catalog project
+
+If a teammate needs access, an organization admin can [invite them as an editor](/docs/editor/how-to/invite-editors).
+
+Check Node and Git with:
+
+```bash
+node -v
+git --version
+```
+
+## Start your EventCatalog preview
+
+Open a terminal in your EventCatalog project and start EventCatalog:
+
+```bash
+npm run dev
+```
+
+By default, EventCatalog runs at [http://localhost:3000](http://localhost:3000).
+
+The editor can still run without a preview, but preview links are only available when EventCatalog is running locally.
+
+## Start the editor
+
+Open another terminal in the same catalog directory and run:
+
+```bash
+npx @eventcatalog/editor
+```
+
+The editor starts on [http://localhost:3900](http://localhost:3900) and opens your browser.
+
+If the editor asks you to sign in, sign in with [EventCatalog Cloud](https://eventcatalog.cloud) and return to the local editor.
+
+## Open a resource
+
+Choose a resource from the left navigation. A good first edit is a [service](/docs/development/guides/services/introduction), [domain](/docs/development/guides/domains/introduction), [event](/docs/development/guides/messages/events/introduction), [command](/docs/development/guides/messages/commands/introduction), or [query](/docs/development/guides/messages/queries/introduction) that already exists in your catalog.
+
+The editor shows:
+
+- The resource list on the left
+- The resource documentation in the center
+- Metadata and relationship fields around the editor
+
+![Service resource open in EventCatalog Editor](./images/editor.png)
+
+## Make a small change
+
+Change a short paragraph, summary, [owner](/docs/owners), badge, or other low-risk field.
+
+The editor writes changes back to your local catalog files. For example, editing a service updates the matching `index.mdx` file in your catalog.
+
+You can use the rich editor for normal writing, or switch to source mode when you need to work directly with Markdown, MDX, or frontmatter.
+
+## Preview the resource
+
+Use **Open Preview** to view the resource in your running EventCatalog site.
+
+![Open Preview button in EventCatalog Editor](./images/open-preview.png)
+
+Preview opens the page from your local EventCatalog development server. If preview is unavailable, check that EventCatalog is running and that the editor detected the correct preview port.
+
+## Review the change
+
+Open **Changes** from the editor navigation.
+
+The changes page groups local Git changes by EventCatalog resource. Open the changed file to inspect the diff.
+
+![Changes page showing a local Git diff](./images/change-diff.png)
+
+## Publish the change
+
+When the diff looks right, click **Publish** in the editor.
+
+In the beta editor, **Publish** commits your changes locally to Git. It does not deploy your catalog or open a pull request.
+
+After publishing, continue with your team's normal review and release workflow. For example, you might push a branch and open a pull request, or push directly if that is how your catalog is maintained.
+
+## What you learned
+
+You have completed the core editor loop:
+
+- Open a local catalog
+- Edit a resource
+- Preview the resource locally
+- Review the Git diff
+- Publish a local commit
+
+Next, learn how to [edit resources](/docs/editor/how-to/edit-resource), [add schemas and specifications](/docs/editor/how-to/add-schemas-and-specifications), or [review and publish changes](/docs/editor/how-to/review-and-commit-changes).

--- a/packages/core/docs/editor/_category_.json
+++ b/packages/core/docs/editor/_category_.json
@@ -1,0 +1,12 @@
+{
+  "label": "Editor",
+  "position": 2,
+  "collapsible": false,
+  "collapsed": false,
+  "link": {
+    "type": "generated-index",
+    "slug": "editor",
+    "title": "EventCatalog Editor",
+    "description": "Edit, preview, review, and commit EventCatalog documentation from a local visual editor."
+  }
+}

--- a/packages/core/docs/editor/explanation/_category_.json
+++ b/packages/core/docs/editor/explanation/_category_.json
@@ -1,0 +1,11 @@
+{
+  "label": "Explanation",
+  "position": 5,
+  "collapsible": true,
+  "collapsed": false,
+  "link": {
+    "type": "generated-index",
+    "title": "Editor explanation",
+    "description": "Conceptual guides that explain how EventCatalog Editor fits with files, Markdown, MDX, Git, and beta access."
+  }
+}

--- a/packages/core/docs/editor/explanation/beta-status-feedback.md
+++ b/packages/core/docs/editor/explanation/beta-status-feedback.md
@@ -1,0 +1,48 @@
+---
+sidebar_position: 3
+sidebar_label: Beta and feedback
+title: Beta status and feedback
+description: Understand the beta status of EventCatalog Editor and how to give feedback.
+---
+
+EventCatalog Editor is in beta.
+
+You can start using it today, but expect some features, workflows, and interface details to change as the product moves toward general availability.
+
+## What beta means
+
+During beta:
+
+- Some workflows may be incomplete
+- Some resource fields may only be editable in source mode
+- Pull request creation and richer publishing flows may change
+- Documentation and screenshots may lag behind fast-moving features
+
+The editor is ready for real feedback, but not every planned workflow is finished.
+
+## Access and seats
+
+EventCatalog Editor is a seat-based paid product.
+
+Community includes 1 editor seat. Starter includes 3 editor seats. Scale includes 10 editor seats. Enterprise includes unlimited editor seats.
+
+Organization admins can [invite editors](/docs/editor/how-to/invite-editors) through [EventCatalog Cloud](https://eventcatalog.cloud). Admin and editor roles use editor seats; viewer roles are free.
+
+See the [pricing page](/pricing) for current plan details.
+
+## Give feedback
+
+The best feedback is specific:
+
+- What you were trying to document
+- What catalog resource you were editing
+- What worked
+- What was confusing
+- What blocked you
+- What you expected the editor to do
+
+Share feedback in the [EventCatalog Discord](https://eventcatalog.dev/discord) or [open an issue in the editor repository](https://github.com/event-catalog/eventcatalog-editor-code/issues).
+
+## What the beta looks like
+
+![EventCatalog Editor beta interface](../images/editor.png)

--- a/packages/core/docs/editor/explanation/how-it-works.md
+++ b/packages/core/docs/editor/explanation/how-it-works.md
@@ -1,0 +1,49 @@
+---
+sidebar_position: 1
+sidebar_label: How it works
+title: How EventCatalog Editor works
+description: Understand the local architecture and workflow behind EventCatalog Editor.
+---
+
+EventCatalog Editor is local-first.
+
+It starts a small local server, opens a browser UI, reads your EventCatalog project from disk, and writes changes back to the same files.
+
+```mermaid
+flowchart LR
+  A[Browser UI] <--> B[Local editor server]
+  B <--> C[EventCatalog project files]
+  B <--> D[Git repository]
+  B -. detects .-> E[Local EventCatalog preview]
+```
+
+## The editor runs on your machine
+
+The editor binds to your local machine and opens at [http://localhost:3900](http://localhost:3900) by default.
+
+Your catalog stays on disk. Editing a resource changes files in the catalog directory, such as `index.mdx`, schema files, specification files, or `eventcatalog.config.js`.
+
+## The browser talks to the local server
+
+The browser UI does not edit files directly. It talks to the local editor server, which:
+
+- Validates catalog paths
+- Reads resources
+- Writes resource files
+- Manages schema and specification files
+- Reads Git status and diffs
+- Detects local EventCatalog preview URLs
+
+## [EventCatalog Cloud](https://eventcatalog.cloud) controls access
+
+The beta editor uses [EventCatalog Cloud](https://eventcatalog.cloud) for sign-in and editor access.
+
+Organizations in [EventCatalog Cloud](https://eventcatalog.cloud) control which people can open the local editor. Admins and editors can start local editor sessions. Viewers can belong to an organization without using an editor seat, but they cannot open a local editor session.
+
+After sign-in, editing still happens locally. The editor does not become a hosted catalog editor; it remains a local tool pointed at your local catalog files.
+
+## Git remains the review boundary
+
+The editor shows local Git changes, diffs, revert actions, and commits.
+
+It does not replace your team's review and release process. After committing, push and publish the catalog the same way your team already does.

--- a/packages/core/docs/editor/explanation/markdown-mdx-git.md
+++ b/packages/core/docs/editor/explanation/markdown-mdx-git.md
@@ -1,0 +1,58 @@
+---
+sidebar_position: 2
+sidebar_label: Markdown, MDX, and Git
+title: Editor, Markdown, MDX, and Git
+description: Understand how the editor works with EventCatalog's file-based authoring model.
+---
+
+EventCatalog is file-based. The editor keeps that model.
+
+Instead of asking every contributor to edit Markdown, MDX, YAML frontmatter, schemas, and Git diffs by hand, the editor gives them a visual workflow on top of the same project files.
+
+## Markdown and MDX are still the source of truth
+
+Each EventCatalog resource is still represented by files in your catalog.
+
+For example, a [service](/docs/development/guides/services/introduction) might live at:
+
+```txt
+domains/Orders/services/OrderService/index.mdx
+```
+
+When you edit that service in the editor, the editor updates the same file.
+
+## Visual editing is an authoring layer
+
+The editor helps with common tasks:
+
+- Writing documentation
+- Changing summaries and owners
+- Adding badges
+- Modeling relationships
+- Adding schemas and specifications
+- Managing draft status
+
+For advanced content, source mode lets you edit the underlying Markdown, MDX, and frontmatter.
+
+## Git shows exactly what changed
+
+Because the editor writes to files, Git can show the exact change.
+
+That makes the editor useful for contributors who prefer a visual workflow while still giving reviewers the normal file diff.
+
+```mermaid
+flowchart LR
+  A[Visual edit] --> B[MDX and schema files]
+  B --> C[Git diff]
+  C --> D[Commit]
+  D --> E[Review and publish]
+```
+
+## Why this matters
+
+This keeps EventCatalog portable:
+
+- You can still edit files in an IDE
+- You can still review changes in pull requests
+- You can still build and deploy with your existing pipeline
+- You can let non-MDX contributors improve documentation safely

--- a/packages/core/docs/editor/how-to/_category_.json
+++ b/packages/core/docs/editor/how-to/_category_.json
@@ -1,0 +1,11 @@
+{
+  "label": "How-to guides",
+  "position": 3,
+  "collapsible": true,
+  "collapsed": false,
+  "link": {
+    "type": "generated-index",
+    "title": "Editor how-to guides",
+    "description": "Task-focused guides for running EventCatalog Editor and working with catalog changes."
+  }
+}

--- a/packages/core/docs/editor/how-to/add-schemas-and-specifications.md
+++ b/packages/core/docs/editor/how-to/add-schemas-and-specifications.md
@@ -1,0 +1,66 @@
+---
+sidebar_position: 7
+sidebar_label: Add schemas and specifications
+title: Add schemas and specifications
+description: Attach message schemas and API specifications from EventCatalog Editor.
+---
+
+Use schemas and specifications to keep implementation contracts close to the architecture resources they describe.
+
+## Add a schema to a message
+
+Schemas are supported on:
+
+- [Events](/docs/development/guides/messages/events/introduction)
+- [Commands](/docs/development/guides/messages/commands/introduction)
+- [Queries](/docs/development/guides/messages/queries/introduction)
+
+Open the message resource, then use the **Schema** section to add or edit the schema file.
+
+Supported schema formats include:
+
+- JSON Schema
+- Avro
+- Protobuf
+- Other text-based schema files
+
+When you save a schema, the editor writes the schema file into the resource folder and updates the resource metadata so EventCatalog can render it.
+
+If the schema editor does not expose the exact change you need yet, use source mode or edit the schema file directly.
+
+## Add a specification to a domain or service
+
+Specifications are supported on:
+
+- [Domains](/docs/development/guides/domains/introduction)
+- [Services](/docs/development/guides/services/introduction)
+
+Open the domain or service, then use the specifications area to add:
+
+- OpenAPI
+- AsyncAPI
+- GraphQL
+
+The editor writes the specification file into the resource folder and updates the resource `specifications` metadata.
+
+![Service resource showing attached API specifications](../images/editor.png)
+
+## Preview schema and specification changes
+
+Start EventCatalog locally with:
+
+```bash
+npm run dev
+```
+
+Then use **Open Preview** in the editor to check how the schema or specification renders in the catalog.
+
+## When to use source mode
+
+Use source mode when you need to:
+
+- Adjust a custom `SchemaViewer` component
+- Add custom MDX around a schema
+- Edit specification metadata the visual form does not expose yet
+
+For more on schema documentation in EventCatalog, see the [schema documentation guides](/docs/development/guides/schemas/introduction).

--- a/packages/core/docs/editor/how-to/edit-resource.md
+++ b/packages/core/docs/editor/how-to/edit-resource.md
@@ -1,0 +1,88 @@
+---
+sidebar_position: 4
+sidebar_label: Edit a resource
+title: Edit an EventCatalog resource
+description: Update resource documentation, metadata, relationships, and source content in EventCatalog Editor.
+---
+
+Use this guide when you want to update a resource that already exists in your catalog.
+
+## Open the resource
+
+Start the editor and choose a resource from the resource list.
+
+The editor supports common EventCatalog resource types, including [domains](/docs/development/guides/domains/introduction), [services](/docs/development/guides/services/introduction), [events](/docs/development/guides/messages/events/introduction), [commands](/docs/development/guides/messages/commands/introduction), [queries](/docs/development/guides/messages/queries/introduction), [channels](/docs/development/guides/channels/introduction), [entities](/docs/development/guides/domains/entities/introduction), [data stores](/docs/development/guides/data/introduction), [flows](/docs/development/guides/flows/introduction), [users](/docs/development/guides/owners/users/introduction), and [teams](/docs/development/guides/owners/teams/introduction).
+
+![Resource list with a service selected](../images/editor.png)
+
+## Edit the documentation
+
+Use the rich editor to change the resource body.
+
+The rich editor supports common writing blocks such as headings, paragraphs, lists, tables, blockquotes, code blocks, links, and dividers.
+
+Use `/` in an empty paragraph to open the block menu. Slash commands also help you insert EventCatalog components such as diagrams, callouts, steps, tiles, prompts, and resource-aware blocks. Learn more in [Use slash commands](/docs/editor/how-to/use-slash-commands).
+
+![Slash command menu showing EventCatalog components](../images/custom-slash-commands.png)
+
+## Edit resource metadata
+
+Use the resource fields to update common frontmatter values such as:
+
+- Name
+- Summary
+- Owners
+- Badges
+- Repository links
+- Draft status
+- Resource image or icon
+
+Some resource types have extra fields. For example, services can model sent and received messages, and data stores can describe type, technology, access mode, classification, retention, and residency.
+
+## Edit relationships
+
+Use relationship fields to connect resources.
+
+For example:
+
+- Add services to a domain
+- Show messages a service sends or receives
+- Connect services to data stores they read from or write to
+- Connect [owners](/docs/owners) to resources
+
+These fields update the same resource metadata that EventCatalog uses when it renders architecture relationships.
+
+## Create related resources
+
+When a relationship field allows new resources, the editor can create the resource and model how it relates to the current resource.
+
+For example, when creating an event from a service, choose whether the service publishes the event, consumes the event, or only contains the event in its folder.
+
+![Create event dialog showing relationship choices](../images/creating-new-event-modal.png)
+
+## Edit flows
+
+Flow resources include a visual Flow Editor for modeling business processes, user journeys, and architecture workflows.
+
+![Flow editor showing a service node in a business flow](../images/flow-editor.png)
+
+Learn how to [use the Flow Editor](/docs/editor/how-to/use-flow-editor).
+
+## Use source mode
+
+Switch to source mode when you need to edit Markdown, MDX, or frontmatter directly.
+
+![Editor source mode showing Markdown and frontmatter](../images/using-source-mode.png)
+
+Source mode is useful for:
+
+- Checking exact frontmatter
+- Editing custom MDX components
+- Making changes the rich editor does not expose yet
+- Copying content from another file
+
+## Save conflicts
+
+If the file changed on disk after the editor loaded it, the editor protects you from overwriting those changes.
+
+Reload the resource, review the external change, and apply your edit again.

--- a/packages/core/docs/editor/how-to/invite-editors.md
+++ b/packages/core/docs/editor/how-to/invite-editors.md
@@ -1,0 +1,68 @@
+---
+sidebar_position: 3
+sidebar_label: Invite editors
+title: Invite editors to your organization
+description: Add team members in EventCatalog Cloud and assign editor seats so they can use EventCatalog Editor locally.
+---
+
+Use [EventCatalog Cloud](https://eventcatalog.cloud) to manage who can use EventCatalog Editor.
+
+The editor still runs locally on each person's machine. Cloud verifies that the person belongs to your organization and has a role that can open a local editor session.
+
+![Invite team members in EventCatalog Cloud](../images/invite-team-members.png)
+
+## Before you start
+
+You need:
+
+- An [EventCatalog Cloud](https://eventcatalog.cloud) organization
+- Admin access to that organization
+- An available editor seat if you want to invite another admin or editor
+
+If you have not created an organization yet, sign in to [EventCatalog Cloud](https://eventcatalog.cloud) and complete the organization setup first.
+
+## Editor seats by plan
+
+Editor seats control how many people can use EventCatalog Editor for an organization.
+
+- Community includes 1 editor seat
+- Starter includes 3 editor seats
+- Scale includes 10 editor seats
+- Enterprise includes unlimited editor seats
+
+Admins and editors use editor seats. Viewers are free, but viewers cannot open a local editor session.
+
+You can compare plans on the [pricing page](/pricing).
+
+## Invite a team member
+
+1. Sign in to [EventCatalog Cloud](https://eventcatalog.cloud).
+2. Open the organization you want the editor to use.
+3. Go to **Team**.
+4. Enter the team member's email address.
+5. Choose their role.
+6. Click **Invite**.
+
+Invitations expire after 7 days.
+
+Pending invitations for admin and editor roles count toward your editor seat usage. If you run out of editor seats, invite the person as a viewer, cancel an unused pending invitation, change an existing member's role, or upgrade your plan.
+
+## Choose the right role
+
+- Admin can manage the organization, invite members, and use EventCatalog Editor.
+- Editor can use EventCatalog Editor for the organization.
+- Viewer can belong to the organization without using an editor seat.
+
+Use **Editor** for most people who need to maintain catalog content. Use **Admin** when the person also needs to manage organization settings and team access.
+
+## What the invited person does next
+
+After accepting the invitation, the team member can:
+
+1. Clone or open the EventCatalog project locally.
+2. Install catalog dependencies if needed.
+3. [Run EventCatalog Editor locally](/docs/editor/how-to/run-locally).
+4. Sign in with [EventCatalog Cloud](https://eventcatalog.cloud) when the editor asks for access.
+5. Choose the organization if their account belongs to more than one organization.
+
+The editor changes their local files and gives them a Git UI to publish a local commit. It does not upload catalog source files to [EventCatalog Cloud](https://eventcatalog.cloud).

--- a/packages/core/docs/editor/how-to/open-catalog.md
+++ b/packages/core/docs/editor/how-to/open-catalog.md
@@ -1,0 +1,44 @@
+---
+sidebar_position: 2
+sidebar_label: Open a catalog
+title: Open a catalog in the editor
+description: Mount an EventCatalog project from the CLI or from the editor UI.
+---
+
+EventCatalog Editor needs a local catalog directory before it can show resources.
+
+## How the editor finds a catalog
+
+When you run `npx @eventcatalog/editor`, the editor looks for a catalog in this order:
+
+1. The path passed with `--catalog`
+2. The current directory, if it contains `eventcatalog.config.js`
+3. The first child directory containing `eventcatalog.config.js`
+4. The catalog path screen in the browser
+
+## Open a catalog from the CLI
+
+Pass the catalog path:
+
+```bash
+npx @eventcatalog/editor --catalog /path/to/my-catalog
+```
+
+Use an absolute path when possible. It makes it clear which catalog the editor is changing.
+
+## Open a catalog from the browser
+
+If the editor cannot find a catalog automatically, it shows a catalog path screen.
+
+Enter the path to your EventCatalog project and choose **Open**.
+
+## Fix catalog loading errors
+
+If the editor cannot open the catalog, check that:
+
+- The path points to the catalog root
+- The directory contains `eventcatalog.config.js`
+- The config file can be imported by Node.js
+- Dependencies for the catalog are installed
+
+If you are not sure what the catalog root should look like, read the [EventCatalog project structure guide](/docs/development/getting-started/project-structure).

--- a/packages/core/docs/editor/how-to/preview-changes.md
+++ b/packages/core/docs/editor/how-to/preview-changes.md
@@ -1,0 +1,55 @@
+---
+sidebar_position: 8
+sidebar_label: Preview changes
+title: Preview editor changes
+description: Open local EventCatalog preview links from the editor.
+---
+
+Preview lets you check how a resource looks in EventCatalog before committing your changes.
+
+## Start EventCatalog locally
+
+In your catalog project, run:
+
+```bash
+npm run dev
+```
+
+EventCatalog usually runs at [http://localhost:3000](http://localhost:3000).
+
+## Start the editor
+
+In another terminal, run:
+
+```bash
+npx @eventcatalog/editor
+```
+
+The editor checks whether EventCatalog is running locally. When it detects a preview, resource pages show **Open Preview**.
+
+## Use a custom preview port
+
+If EventCatalog is running on a different port, tell the editor:
+
+```bash
+npx @eventcatalog/editor --eventcatalog-port 3001
+```
+
+## Open a preview
+
+Open a resource in the editor and choose **Open Preview**.
+
+The editor opens the matching resource page in the local EventCatalog site.
+
+![Editor header with Open Preview action](../images/header.png)
+
+## Fix missing preview links
+
+If preview is unavailable:
+
+- Check that EventCatalog is running
+- Check the preview port
+- Restart the editor after starting EventCatalog
+- Open the local EventCatalog URL directly to confirm it works
+
+Preview is local. It does not publish your changes.

--- a/packages/core/docs/editor/how-to/revert-local-changes.md
+++ b/packages/core/docs/editor/how-to/revert-local-changes.md
@@ -1,0 +1,43 @@
+---
+sidebar_position: 10
+sidebar_label: Revert local changes
+title: Revert local editor changes
+description: Discard local catalog edits from the editor changes view.
+---
+
+Use revert when you want to discard local edits before committing them.
+
+## Open the Changes page
+
+Choose **Changes** from the editor navigation.
+
+The editor shows modified, added, deleted, renamed, and untracked files when Git change tracking is available.
+
+## Revert one file
+
+Open a changed file and choose **Revert**.
+
+The editor asks for confirmation before it discards the local file change.
+
+![Changes page with revert actions for local edits](../images/change-diff.png)
+
+## Revert a resource group
+
+If a resource has multiple changed files, you can revert the group from the Changes page.
+
+For example, reverting a message resource might discard changes to both:
+
+- `index.mdx`
+- `schema.json`
+
+## What revert does
+
+Revert restores modified and deleted files from Git.
+
+Untracked files are removed from disk.
+
+::::warning Revert cannot be undone by the editor
+
+Only revert files when you are sure you do not need the local edits. If you are unsure, inspect the diff first or commit the work to a temporary branch.
+
+::::

--- a/packages/core/docs/editor/how-to/review-and-commit-changes.md
+++ b/packages/core/docs/editor/how-to/review-and-commit-changes.md
@@ -1,0 +1,57 @@
+---
+sidebar_position: 9
+sidebar_label: Review and publish changes
+title: Review and publish editor changes
+description: Use the editor changes view to inspect local Git changes and publish a local commit.
+---
+
+EventCatalog Editor writes to your local catalog files. Use the **Changes** page to inspect what changed before you publish.
+
+## Open the Changes page
+
+Choose **Changes** from the editor navigation.
+
+If the catalog is a Git repository, the editor shows local changes grouped by EventCatalog resource.
+
+![Changes page with a grouped resource diff](../images/change-diff.png)
+
+## Inspect a file diff
+
+Open a changed file to view the unified diff.
+
+Use the diff to check:
+
+- The intended Markdown or MDX changed
+- Metadata changes are correct
+- Generated schema or specification paths look right
+- Unrelated files were not changed accidentally
+
+## Publish from the editor
+
+When the changes look right, click **Publish** in the editor.
+
+In the beta editor, **Publish** commits your changes locally to Git. It does not deploy your catalog or open a pull request.
+
+Use a short message that describes the catalog change, for example:
+
+```txt
+Document OrderPlaced event schema
+```
+
+## Continue with your team's workflow
+
+After publishing, use your existing Git workflow to share and release the change.
+
+For example:
+
+```bash
+git push
+```
+
+Then open a pull request if your team reviews catalog changes through GitHub or another Git hosting provider.
+
+::::info Pull request creation
+
+Built-in pull request creation is planned, but beta users should continue using their existing Git workflow after publishing local changes.
+
+::::

--- a/packages/core/docs/editor/how-to/run-locally.md
+++ b/packages/core/docs/editor/how-to/run-locally.md
@@ -1,0 +1,71 @@
+---
+sidebar_position: 1
+sidebar_label: Run locally
+title: Run EventCatalog Editor locally
+description: Start EventCatalog Editor against a local EventCatalog project.
+---
+
+Use this guide when you want to start EventCatalog Editor on your machine.
+
+## Prerequisites
+
+You need:
+
+- Node.js 22 or later
+- Git
+- An EventCatalog project containing `eventcatalog.config.js`
+- EventCatalog Editor access through [EventCatalog Cloud](https://eventcatalog.cloud)
+
+## Run from a catalog directory
+
+Open a terminal in your EventCatalog project and run:
+
+```bash
+npx @eventcatalog/editor
+```
+
+The editor starts on [http://localhost:3900](http://localhost:3900).
+
+## Run with an explicit catalog path
+
+If you are not in the catalog directory, pass the catalog path:
+
+```bash
+npx @eventcatalog/editor --catalog /path/to/my-catalog
+```
+
+The directory must contain `eventcatalog.config.js`.
+
+## Choose a different editor port
+
+Use `--port` when port `3900` is already in use:
+
+```bash
+npx @eventcatalog/editor --port 3999
+```
+
+## Connect preview links to a running catalog
+
+The editor looks for a local EventCatalog preview on port `3000` by default.
+
+Start EventCatalog in your catalog project:
+
+```bash
+npm run dev
+```
+
+Then start the editor in another terminal:
+
+```bash
+npx @eventcatalog/editor
+```
+
+If your EventCatalog preview runs on another port, pass it to the editor:
+
+```bash
+npx @eventcatalog/editor --eventcatalog-port 3001
+```
+
+## Stop the editor
+
+Return to the terminal running the editor and press `Ctrl+C`.

--- a/packages/core/docs/editor/how-to/use-flow-editor.md
+++ b/packages/core/docs/editor/how-to/use-flow-editor.md
@@ -1,0 +1,66 @@
+---
+sidebar_position: 5
+sidebar_label: Flow Editor
+title: Use the Flow Editor
+description: Create and update EventCatalog flows visually with EventCatalog Editor.
+---
+
+Use the Flow Editor when you want to document a business process, user journey, or architecture workflow without editing the [flow](/docs/development/guides/flows/introduction) files by hand.
+
+Flow resources are still stored in your local EventCatalog project. The editor gives you a visual way to create and arrange the steps, then writes the change back to your catalog files.
+
+![Flow editor showing a service node in a business flow](../images/flow-editor.png)
+
+## Open a flow
+
+Start EventCatalog Editor and open a flow from the resource list.
+
+If you are creating a new flow, create it from the editor first, then open it from the flow list.
+
+Click the **Flow Editor** tab at the top of the resource to switch from the documentation view into the visual editor.
+
+## Add a step
+
+Use **Add step** or choose an empty node in the flow.
+
+The editor opens a picker so you can choose what kind of node belongs in the flow.
+
+![Flow editor node type picker](../images/flow-editor-pick-a-node.png)
+
+## Choose the right node
+
+Use the node picker to add the resource that best represents the next step.
+
+For example:
+
+- Add a [service](/docs/development/guides/services/introduction) when a system performs work
+- Add an [event](/docs/development/guides/messages/events/introduction) when something has happened
+- Add a [command](/docs/development/guides/messages/commands/introduction) when one system asks another system to do something
+- Add a [query](/docs/development/guides/messages/queries/introduction) when the flow reads information
+
+Use existing catalog resources when they already exist. Create new resources when the flow reveals something that is missing from the catalog.
+
+## Review the flow
+
+After adding steps, read the flow from left to right and check that it tells the story clearly.
+
+Check that:
+
+- The flow starts with the trigger or first meaningful step
+- Each step uses the most accurate resource type
+- Resource names match the language your team uses
+- The flow is clear enough for someone who was not in the design discussion
+
+## Preview the flow
+
+Use **Open Preview** to view the flow in your local EventCatalog site.
+
+Preview helps you check how the flow will look to readers before you publish the local commit.
+
+## Publish the change
+
+Open **Changes** and review the files the Flow Editor changed.
+
+When the diff looks right, click **Publish**. In the beta editor, **Publish** commits your changes locally to Git.
+
+After publishing, continue with your team's normal Git review and release workflow.

--- a/packages/core/docs/editor/how-to/use-slash-commands.md
+++ b/packages/core/docs/editor/how-to/use-slash-commands.md
@@ -1,0 +1,67 @@
+---
+sidebar_position: 6
+sidebar_label: Use slash commands
+title: Use slash commands
+description: Insert Markdown blocks and EventCatalog components from the rich editor.
+---
+
+Slash commands let you add content without remembering Markdown syntax or MDX component names.
+
+Type `/` in an empty paragraph to open the command menu. The menu shows matching blocks, grouped by purpose, with a visual preview of the selected command.
+
+![Slash command menu showing EventCatalog diagram components](../images/custom-slash-commands.png)
+
+## Insert a block
+
+1. Click into the resource documentation.
+2. Start a new empty paragraph.
+3. Type `/`.
+4. Search or scroll to the block you want.
+5. Press `Enter` or click the command.
+
+The editor inserts the matching Markdown or MDX block into the resource.
+
+## Add EventCatalog components
+
+Slash commands are useful for adding EventCatalog-specific components without switching to source mode.
+
+You can insert components such as:
+
+- Node Graph
+- Miro diagram
+- Draw.io diagram
+- Lucid diagram
+- IcePanel diagram
+- [Flow](/docs/development/guides/flows/introduction)
+- Mermaid diagram
+- Entity Map
+- Schema Viewer
+- Steps
+- Tiles
+- Accordion group
+- Prompt
+- Visibility
+- Admonitions such as note, tip, warning, danger, and info
+
+Some commands are available only when they make sense for the current resource. For example, **Schema Viewer** is available for [events](/docs/development/guides/messages/events/introduction), [commands](/docs/development/guides/messages/commands/introduction), and [queries](/docs/development/guides/messages/queries/introduction), while **Entity Map** is available for [domains](/docs/development/guides/domains/introduction).
+
+## Use visual previews
+
+The preview panel shows what the selected command is for before you insert it.
+
+Use this when you are deciding between similar blocks, such as diagram components or callout types.
+
+## Edit the inserted block
+
+After inserting a component, you can usually edit it directly in the rich editor.
+
+If the component needs configuration that is not exposed visually yet, switch to source mode and edit the MDX.
+
+## When to use source mode instead
+
+Use source mode when you need to:
+
+- Paste an existing MDX component
+- Change advanced component attributes
+- Edit custom components that the slash menu does not know about
+- Review the exact Markdown or MDX that will be saved

--- a/packages/core/docs/editor/reference/_category_.json
+++ b/packages/core/docs/editor/reference/_category_.json
@@ -1,0 +1,11 @@
+{
+  "label": "Reference",
+  "position": 4,
+  "collapsible": true,
+  "collapsed": false,
+  "link": {
+    "type": "generated-index",
+    "title": "Editor reference",
+    "description": "Lookup information for EventCatalog Editor commands, supported resources, content support, and troubleshooting."
+  }
+}

--- a/packages/core/docs/editor/reference/cli.md
+++ b/packages/core/docs/editor/reference/cli.md
@@ -1,0 +1,61 @@
+---
+sidebar_position: 1
+sidebar_label: CLI
+title: EventCatalog Editor CLI reference
+description: Command and option reference for running EventCatalog Editor.
+---
+
+Run the editor with:
+
+```bash
+npx @eventcatalog/editor
+```
+
+## Requirements
+
+- Node.js 22 or later
+- Git
+- An EventCatalog directory containing `eventcatalog.config.js`
+
+## Options
+
+| Option | Description | Default |
+| --- | --- | --- |
+| `--catalog <path>` | Path to the EventCatalog root to edit. | Current directory, a detected child catalog, or browser selection |
+| `--port <n>` | Port for the editor server. | `3900` |
+| `--eventcatalog-port <n>` | Port where local EventCatalog preview is running. | `3000` |
+| `--no-open` | Start the editor without opening the browser automatically. | Opens browser |
+| `--help`, `-h` | Show CLI help. |  |
+| `--version`, `-v` | Show the installed editor version. |  |
+
+## Examples
+
+Run from a catalog directory:
+
+```bash
+npx @eventcatalog/editor
+```
+
+Run against a specific catalog:
+
+```bash
+npx @eventcatalog/editor --catalog /Users/me/dev/my-catalog
+```
+
+Use a different editor port:
+
+```bash
+npx @eventcatalog/editor --port 3999
+```
+
+Use a different EventCatalog preview port:
+
+```bash
+npx @eventcatalog/editor --eventcatalog-port 3001
+```
+
+Start without opening a browser:
+
+```bash
+npx @eventcatalog/editor --no-open
+```

--- a/packages/core/docs/editor/reference/supported-content.md
+++ b/packages/core/docs/editor/reference/supported-content.md
@@ -1,0 +1,81 @@
+---
+sidebar_position: 3
+sidebar_label: Supported content
+title: Supported content and MDX
+description: Markdown, MDX, and component support in EventCatalog Editor.
+---
+
+EventCatalog Editor supports rich editing for common Markdown content and source editing for advanced Markdown and MDX.
+
+## Rich editor content
+
+The rich editor supports:
+
+- Headings
+- Paragraphs
+- Bold and italic text
+- Links
+- Bullet lists
+- Numbered lists
+- Blockquotes
+- Code blocks
+- Horizontal dividers
+- Tables
+
+Use `/` in an empty paragraph to open the slash command menu.
+
+![Slash command menu showing component previews](../images/custom-slash-commands.png)
+
+## Slash commands
+
+Slash commands can insert Markdown blocks and EventCatalog components from the rich editor.
+
+Common command groups include:
+
+- Text: headings, paragraphs, and quotes
+- Lists: bullet and ordered lists
+- Advanced: code blocks, dividers, and tables
+- Admonitions: note, tip, warning, danger, and info callouts
+- Diagrams: Node Graph, [Flow](/docs/development/guides/flows/introduction), Mermaid, Miro, Draw.io, Lucid, IcePanel, Entity Map, and Schema Viewer
+- Layout: Steps, Tiles, and Accordion group
+- AI: Prompt and Visibility blocks
+
+Some commands are resource-aware. For example, Schema Viewer appears for [events](/docs/development/guides/messages/events/introduction), [commands](/docs/development/guides/messages/commands/introduction), and [queries](/docs/development/guides/messages/queries/introduction), and Entity Map appears for [domains](/docs/development/guides/domains/introduction).
+
+## Source mode
+
+Use source mode for:
+
+- Frontmatter edits
+- Custom Markdown
+- MDX components
+- Content the rich editor does not expose yet
+
+Source mode edits the full document source.
+
+## MDX components
+
+The editor understands common EventCatalog MDX components and keeps unknown or complex components as blocks so they can round trip through the editor.
+
+Examples of EventCatalog content you may see include:
+
+- `NodeGraph`
+- `EntityMap`
+- `Mermaid`
+- `Steps`
+- `Schema`
+- `SchemaViewer`
+- `MessageTable`
+- `ChannelInformation`
+- `OpenAPI`
+- `AsyncAPI`
+- `Admonition`
+- `ResourceGroupList`
+
+If a component cannot be edited visually yet, use source mode.
+
+## Editor modes
+
+Use the header controls to switch between visual editing and source editing.
+
+![Editor header showing visual and source mode controls](../images/header.png)

--- a/packages/core/docs/editor/reference/supported-resources.md
+++ b/packages/core/docs/editor/reference/supported-resources.md
@@ -1,0 +1,51 @@
+---
+sidebar_position: 2
+sidebar_label: Supported resources
+title: Supported resources
+description: Resource types and capabilities currently supported by EventCatalog Editor.
+---
+
+EventCatalog Editor can browse and edit the main EventCatalog resource types.
+
+| Resource type | Browse | Edit docs | Edit metadata | Create | Delete | Notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| [Domain](/docs/development/guides/domains/introduction) | Yes | Yes | Yes | Yes | Yes | Supports services, messages, entities, specifications, and ubiquitous language |
+| [Service](/docs/development/guides/services/introduction) | Yes | Yes | Yes | Yes | Yes | Supports message relationships, data store relationships, and specifications |
+| [Event](/docs/development/guides/messages/events/introduction) | Yes | Yes | Yes | Yes | Yes | Supports schemas and producer/consumer relationships |
+| [Command](/docs/development/guides/messages/commands/introduction) | Yes | Yes | Yes | Yes | Yes | Supports schemas, operations, and producer/consumer relationships |
+| [Query](/docs/development/guides/messages/queries/introduction) | Yes | Yes | Yes | Yes | Yes | Supports schemas, operations, and producer/consumer relationships |
+| [Channel](/docs/development/guides/channels/introduction) | Yes | Yes | Yes | Yes | Yes | Supports common metadata |
+| [Entity](/docs/development/guides/domains/entities/introduction) | Yes | Yes | Yes | Yes | Yes | Supports common metadata |
+| [Data store](/docs/development/guides/data/introduction) | Yes | Yes | Yes | Yes | Yes | Represented as EventCatalog container resources |
+| [Flow](/docs/development/guides/flows/introduction) | Yes | Yes | Yes | Yes | Yes | Supports flow step editing |
+| [User](/docs/development/guides/owners/users/introduction) | Yes | Yes | Yes | Yes | Yes | Versionless |
+| [Team](/docs/development/guides/owners/teams/introduction) | Yes | Yes | Yes | Yes | Yes | Versionless |
+
+## Schemas
+
+Schemas are supported on:
+
+- [Events](/docs/development/guides/messages/events/introduction)
+- [Commands](/docs/development/guides/messages/commands/introduction)
+- [Queries](/docs/development/guides/messages/queries/introduction)
+
+## Specifications
+
+Specifications are supported on:
+
+- [Domains](/docs/development/guides/domains/introduction)
+- [Services](/docs/development/guides/services/introduction)
+
+Supported specification types:
+
+- OpenAPI
+- AsyncAPI
+- GraphQL
+
+## Versionless resources
+
+Users and teams are versionless in EventCatalog. Other resources use versions.
+
+## Beta limitations
+
+Some advanced resource fields may still require source mode. If a visual field is missing, switch to source mode and edit the underlying Markdown, MDX, or frontmatter directly.

--- a/packages/core/docs/editor/reference/troubleshooting.md
+++ b/packages/core/docs/editor/reference/troubleshooting.md
@@ -1,0 +1,76 @@
+---
+sidebar_position: 4
+sidebar_label: Troubleshooting
+title: Troubleshooting EventCatalog Editor
+description: Fix common issues when running EventCatalog Editor.
+---
+
+## The editor cannot find my catalog
+
+Check that:
+
+- You are running the editor from the catalog directory, or using `--catalog`
+- The directory contains `eventcatalog.config.js`
+- The config file can be loaded by Node.js
+- Catalog dependencies are installed
+
+Run with an explicit path:
+
+```bash
+npx @eventcatalog/editor --catalog /path/to/my-catalog
+```
+
+## I cannot sign in
+
+The editor uses [EventCatalog Cloud](https://eventcatalog.cloud) for access.
+
+If sign-in fails:
+
+- Check your internet connection
+- Try signing out of [EventCatalog Cloud](https://eventcatalog.cloud) and signing in again
+- Restart the local editor
+- Check that your account has editor access
+
+If you see an editor access message, ask an organization admin to [invite you as an editor](/docs/editor/how-to/invite-editors) or change your role to **Editor** or **Admin**. Viewer accounts can sign in to [EventCatalog Cloud](https://eventcatalog.cloud), but they cannot open a local editor session.
+
+## Preview is unavailable
+
+Preview links require a local EventCatalog development server.
+
+Start EventCatalog:
+
+```bash
+npm run dev
+```
+
+Then restart the editor. If your catalog runs on a different port, pass it with `--eventcatalog-port`.
+
+## Changes are not shown
+
+The Changes page uses Git. Check that:
+
+- Your catalog is inside a Git repository
+- Git is installed
+- The files have actually changed on disk
+
+You can also check from a terminal:
+
+```bash
+git status
+```
+
+## A save reports a conflict
+
+A conflict means the file changed on disk after the editor loaded it.
+
+Reload the resource, review the external change, and apply your edit again.
+
+## A visual field is missing
+
+The beta editor does not expose every possible EventCatalog field as a form yet.
+
+Use source mode to edit unsupported frontmatter or MDX directly.
+
+## Get help
+
+Join the [EventCatalog Discord](https://eventcatalog.dev/discord) or [open an issue in the editor repository](https://github.com/event-catalog/eventcatalog-editor-code/issues).

--- a/packages/create-eventcatalog/create-app.ts
+++ b/packages/create-eventcatalog/create-app.ts
@@ -98,12 +98,15 @@ export async function createApp({
 
   // Next steps
   console.log();
-  console.log(`  ${chalk.cyan.bold('next')}  You're all set! Explore your project!`);
+  console.log(`  You're all set! Explore your catalog!`);
   console.log();
-  console.log(`  Enter your project directory using ${chalk.cyan('cd ' + cdpath)}`);
-  console.log(`  Run ${chalk.cyan(`${packageManager} run dev`)} to start the dev server. ${chalk.dim('CTRL+C to stop.')}`);
+  console.log(`    ${chalk.dim('■')} ${chalk.cyan('cd ' + cdpath)}`);
+  console.log(`    ${chalk.dim('■')} Run ${chalk.cyan(`${packageManager} run dev`)} to start the dev server.`);
   console.log();
   console.log(`  ${chalk.dim('Star us on GitHub:')} ${chalk.underline('https://github.com/event-catalog/eventcatalog')}`);
   console.log(`  ${chalk.dim('Join our Discord:')}  ${chalk.underline('https://eventcatalog.dev/discord')}`);
+  console.log();
+  console.log(`  ${chalk.dim('Want a better editing experience?')}`);
+  console.log(`  Run ${chalk.cyan(`${packageManager} run editor`)} to open EventCatalog Editor.`);
   console.log();
 }

--- a/packages/create-eventcatalog/templates/amazon-api-gateway/README-template.md
+++ b/packages/create-eventcatalog/templates/amazon-api-gateway/README-template.md
@@ -1,27 +1,54 @@
-# My Amazon API Gateway Event Catalog
+# Welcome to EventCatalog
 
-Welcome to your new Amazon API Gateway EventCatalog!
+[EventCatalog](https://www.eventcatalog.dev/) is your architecture catalog for distributed systems. This template adds the Amazon API Gateway generator so you can import OpenAPI specs from API Gateway and document how they connect to your domains, services, and teams.
 
-Getting started:
+## Generate Your Catalog
 
-1. Edit the `.env` file to configure your environment variables.
-1. Configure the apis in the `eventcatalog.config.js` file
-1. Run `npm run generate` to import your OpenAPI specs from apigateway and document them.
-1. Run `npm run dev` to start the development server.
-1. Go to localhost:3000 to view your catalog.
+1. Edit `.env` with your AWS settings.
+2. Configure your APIs in `eventcatalog.config.js`.
+3. Import your OpenAPI specs:
 
-### What else can you do?
+```sh
+npm run generate
+```
 
-With the ApiGateway integration you can :
+4. Start the catalog:
 
-- Document your apis
-- Assign your apis to producers and consumers
-- Assign resources to users and teams in your organization
-- Visualize your APIGateway architecture
-- And much more!
+```sh
+npm run dev
+```
 
-The easiest way to get started and dive deeper is to read the [EventCatalog documentation](https://www.eventcatalog.dev/docs/plugins/amazon-apigateway/intro).
+Open [http://localhost:3000](http://localhost:3000) to view your catalog.
 
-### Found a problem?
+## Edit Your Catalog
 
-If you found a problem or have a feature request, please open an issue on [GitHub](https://github.com/event-catalog/generators).
+Your generated resources are docs-as-code. You can enrich them with ownership, domain context, Markdown, examples, and relationships that are not always available in API Gateway.
+
+Prefer a visual workflow? Run `npm run editor` to open the [EventCatalog Editor](https://www.eventcatalog.dev/docs/editor/overview) and browse, create, or update catalog resources through a GitHub-backed UI.
+
+## Keep It in Sync
+
+Run `npm run generate` whenever your API Gateway APIs change. You can also run the generator in CI so your catalog stays aligned with AWS.
+
+With this integration you can:
+
+- Document APIs and OpenAPI specs
+- Assign APIs to producers and consumers
+- Connect resources to users and teams
+- Visualize your API Gateway architecture
+
+## Use AI with Architecture Context
+
+EventCatalog gives AI tools structured context about your domains, services, messages, schemas, owners, and flows. Connect an MCP-compatible tool with the [EventCatalog MCP Server](https://www.eventcatalog.dev/docs/development/guides/ai/using-mcp-server).
+
+## Learn by Task
+
+- [Amazon API Gateway integration docs](https://www.eventcatalog.dev/docs/plugins/amazon-apigateway/intro)
+- [Use the EventCatalog Editor](https://www.eventcatalog.dev/docs/editor/overview)
+- [Document a service](https://www.eventcatalog.dev/docs/development/guides/services)
+- [Add events, commands, and queries](https://www.eventcatalog.dev/docs/development/guides/messages/adding-messages)
+- [Join the community](https://discord.gg/3rjaZMmrAm)
+
+## Found a Problem?
+
+Open an issue on [GitHub](https://github.com/event-catalog/generators).

--- a/packages/create-eventcatalog/templates/asyncapi/README-template.md
+++ b/packages/create-eventcatalog/templates/asyncapi/README-template.md
@@ -1,55 +1,63 @@
-# My Event Catalog
+# Welcome to EventCatalog
 
-Welcome to your new catalog, powered by [EventCatalog](https://www.eventcatalog.dev) — the open-source documentation tool for event-driven architectures.
+[EventCatalog](https://www.eventcatalog.dev/) is your architecture catalog for distributed systems. Use it to document, govern, and discover your services, domains, APIs, events, commands, queries, schemas, teams, and flows in one place.
 
-## Getting Started
+## Start the Catalog
 
 ```sh
 npm run dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) to see your catalog.
+Open [http://localhost:3000](http://localhost:3000) to view your catalog.
 
-You can start editing your catalog by adding **domains**, **services**, and **messages** to this project. Each resource is a folder with an `index.md` file containing frontmatter metadata and markdown content.
+Using `pnpm` or `yarn`? Run the same scripts with the package manager you chose when creating this project.
 
-## What Can You Do?
+## Edit Your Catalog
 
-- **Document services** — define producers and consumers with their schemas
-- **Map events, commands & queries** — capture every message flowing through your system
-- **Organize with domains** — group resources into bounded contexts
-- **Visualize your architecture** — auto-generated diagrams of your services and message flows
-- **Version everything** — track how your architecture evolves over time
-- **Use AI to explore & document** — connect AI tools directly to your catalog
+Your catalog is docs-as-code. Resources live in folders with an `index.mdx` file for frontmatter metadata and Markdown content.
 
-## Use AI with Your Catalog
+Good places to start:
 
-### Skills
+- `domains/` - bounded contexts, business capabilities, and ownership
+- `domains/<domain>/services/` - services, APIs, and message producers or consumers
+- `events/`, `commands/`, and `queries/` - the messages flowing through your system
+- `teams/` and `users/` - who owns each part of the architecture
 
-Let AI agents document your architecture for you. Install [EventCatalog Skills](https://github.com/event-catalog/skills):
+Prefer a visual workflow? Run `npm run editor` to open the [EventCatalog Editor](https://www.eventcatalog.dev/docs/editor/overview) and browse, create, or update catalog resources through a GitHub-backed UI.
+
+## Make Your First Change
+
+1. Add or edit a domain, service, or message.
+2. Run `npm run dev` and check the generated pages and diagrams.
+3. Commit the MDX and schema files to Git.
+
+## Keep It in Sync
+
+Use `npm run generate` with [EventCatalog integrations](https://www.eventcatalog.dev/integrations) to import architecture data from OpenAPI, AsyncAPI, schema registries, EventBridge, GitHub, internal systems, and more.
+
+Run generators locally while you work, or in CI so your catalog stays aligned with the systems it describes.
+
+## Use AI with Architecture Context
+
+EventCatalog gives AI tools structured context about your domains, services, messages, schemas, owners, and flows.
+
+- Connect Claude, Cursor, VS Code, Windsurf, or another MCP-compatible tool with the [EventCatalog MCP Server](https://www.eventcatalog.dev/docs/development/guides/ai/using-mcp-server).
+- Install [EventCatalog Skills](https://github.com/event-catalog/skills) to help agents document services, create domain models, and map business flows:
 
 ```sh
 npx skills add event-catalog/skills
 ```
 
-Skills can generate service documentation, create domain models, and map business flows — all through natural language.
+## Learn by Task
 
-### MCP Server
+- [Create a domain](https://www.eventcatalog.dev/docs/development/guides/domains)
+- [Document a service](https://www.eventcatalog.dev/docs/development/guides/services)
+- [Add events, commands, and queries](https://www.eventcatalog.dev/docs/development/guides/messages/adding-messages)
+- [Use the EventCatalog Editor](https://www.eventcatalog.dev/docs/editor/overview)
+- [Generate from integrations](https://www.eventcatalog.dev/integrations)
+- [Manage your catalog with the SDK](https://www.eventcatalog.dev/docs/development/sdk)
+- [Join the community](https://discord.gg/3rjaZMmrAm)
 
-Connect your catalog to Claude, Cursor, Windsurf, or any MCP-compatible AI tool using the [EventCatalog MCP Server](https://www.eventcatalog.dev/docs/development/guides/ai/using-mcp-server). Ask questions about your architecture and get instant answers.
-
-## Automate Your Catalog
-
-Keep your catalog in sync with your architecture using [EventCatalog integrations](https://www.eventcatalog.dev/integrations). Import services, messages, and schemas from sources like AsyncAPI, OpenAPI, Schema Registries, and more — so your documentation is always up to date.
-
-## Learn More
-
-- [Documentation](https://www.eventcatalog.dev/docs/development/getting-started/introduction) — understand how EventCatalog works
-- [Adding Services](https://www.eventcatalog.dev/docs/development/guides/services) — document your first service
-- [Adding Messages](https://www.eventcatalog.dev/docs/development/guides/messages/adding-messages) — create events, commands, and queries
-- [Adding Domains](https://www.eventcatalog.dev/docs/development/guides/domains) — organize into bounded contexts
-- [SDK](https://www.eventcatalog.dev/docs/development/sdk) — manage your catalog programmatically
-- [Discord](https://discord.gg/3rjaZMmrAm) — join the community
-
-## Found a problem?
+## Found a Problem?
 
 Open an issue on [GitHub](https://github.com/event-catalog/eventcatalog/issues).

--- a/packages/create-eventcatalog/templates/confluent/README-template.md
+++ b/packages/create-eventcatalog/templates/confluent/README-template.md
@@ -1,28 +1,55 @@
-# My Confluent Event Catalog
+# Welcome to EventCatalog
 
-Welcome to your new Confluent Event Catalog!
+[EventCatalog](https://www.eventcatalog.dev/) is your architecture catalog for distributed systems. This template adds the Confluent Schema Registry generator so you can import schemas and topics, then document how they connect to your domains, services, and teams.
 
-Getting started:
+## Generate Your Catalog
 
-1. Edit the `.env` file to configure your environment variables.
-1. Run Confluent Cloud locally, or configure your `schemaRegistryUrl` in the `eventcatalog.config.js` file
-1. Run `npm run generate` to import your schemas from confluent schema registry.
-1. Run `npm run dev` to start the development server.
-1. Go to localhost:3000 to view your catalog.
+1. Edit `.env` with your Confluent settings.
+2. Run Confluent locally, or configure `schemaRegistryUrl` in `eventcatalog.config.js`.
+3. Import your schemas:
 
-### What else can you do?
+```sh
+npm run generate
+```
 
-With the Confluent Schema Registry integration you can :
+4. Start the catalog:
 
-- Document your schemas, topics
-- Assign your schemas to producers and consumers
-- Assign resources to users and teams in your organization
+```sh
+npm run dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) to view your catalog.
+
+## Edit Your Catalog
+
+Your generated resources are docs-as-code. You can enrich them with ownership, domain context, Markdown, examples, and relationships that are not always available in the schema registry.
+
+Prefer a visual workflow? Run `npm run editor` to open the [EventCatalog Editor](https://www.eventcatalog.dev/docs/editor/overview) and browse, create, or update catalog resources through a GitHub-backed UI.
+
+## Keep It in Sync
+
+Run `npm run generate` whenever your schemas or topics change. You can also run the generator in CI so your catalog stays aligned with Confluent.
+
+With this integration you can:
+
+- Document schemas and topics
+- Assign schemas to producers and consumers
+- Connect resources to users and teams
 - Visualize your Kafka architecture
-- Add semantic meaning to your schemas and topics
-- And much more!
+- Add semantic meaning to schemas and topics
 
-The easiest way to get started and dive deeper is to read the [Event Catalog documentation](https://eventcatalog.dev/docs/plugins/confluent-schema-registry/intro).
+## Use AI with Architecture Context
 
-### Found a problem?
+EventCatalog gives AI tools structured context about your domains, services, messages, schemas, owners, and flows. Connect an MCP-compatible tool with the [EventCatalog MCP Server](https://www.eventcatalog.dev/docs/development/guides/ai/using-mcp-server).
 
-If you found a problem or have a feature request, please open an issue on [GitHub](https://github.com/event-catalog/generators).
+## Learn by Task
+
+- [Confluent Schema Registry integration docs](https://eventcatalog.dev/docs/plugins/confluent-schema-registry/intro)
+- [Use the EventCatalog Editor](https://www.eventcatalog.dev/docs/editor/overview)
+- [Document a service](https://www.eventcatalog.dev/docs/development/guides/services)
+- [Add events, commands, and queries](https://www.eventcatalog.dev/docs/development/guides/messages/adding-messages)
+- [Join the community](https://discord.gg/3rjaZMmrAm)
+
+## Found a Problem?
+
+Open an issue on [GitHub](https://github.com/event-catalog/generators).

--- a/packages/create-eventcatalog/templates/default/README-template.md
+++ b/packages/create-eventcatalog/templates/default/README-template.md
@@ -1,55 +1,63 @@
-# My Event Catalog
+# Welcome to EventCatalog
 
-Welcome to your new catalog, powered by [EventCatalog](https://www.eventcatalog.dev) — the open-source documentation tool for event-driven architectures.
+[EventCatalog](https://www.eventcatalog.dev/) is your architecture catalog for distributed systems. Use it to document, govern, and discover your services, domains, APIs, events, commands, queries, schemas, teams, and flows in one place.
 
-## Getting Started
+## Start the Catalog
 
 ```sh
 npm run dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) to see your catalog.
+Open [http://localhost:3000](http://localhost:3000) to view your catalog.
 
-You can start editing your catalog by adding **domains**, **services**, and **messages** to this project. Each resource is a folder with an `index.md` file containing frontmatter metadata and markdown content.
+Using `pnpm` or `yarn`? Run the same scripts with the package manager you chose when creating this project.
 
-## What Can You Do?
+## Edit Your Catalog
 
-- **Document services** — define producers and consumers with their schemas
-- **Map events, commands & queries** — capture every message flowing through your system
-- **Organize with domains** — group resources into bounded contexts
-- **Visualize your architecture** — auto-generated diagrams of your services and message flows
-- **Version everything** — track how your architecture evolves over time
-- **Use AI to explore & document** — connect AI tools directly to your catalog
+Your catalog is docs-as-code. Resources live in folders with an `index.mdx` file for frontmatter metadata and Markdown content.
 
-## Use AI with Your Catalog
+Good places to start:
 
-### Skills
+- `domains/` - bounded contexts, business capabilities, and ownership
+- `domains/<domain>/services/` - services, APIs, and message producers or consumers
+- `events/`, `commands/`, and `queries/` - the messages flowing through your system
+- `teams/` and `users/` - who owns each part of the architecture
 
-Let AI agents document your architecture for you. Install [EventCatalog Skills](https://github.com/event-catalog/skills):
+Prefer a visual workflow? Run `npm run editor` to open the [EventCatalog Editor](https://www.eventcatalog.dev/docs/editor/overview) and browse, create, or update catalog resources through a GitHub-backed UI.
+
+## Make Your First Change
+
+1. Add or edit a domain, service, or message.
+2. Run `npm run dev` and check the generated pages and diagrams.
+3. Commit the MDX and schema files to Git.
+
+## Keep It in Sync
+
+Use `npm run generate` with [EventCatalog integrations](https://www.eventcatalog.dev/integrations) to import architecture data from OpenAPI, AsyncAPI, schema registries, EventBridge, GitHub, internal systems, and more.
+
+Run generators locally while you work, or in CI so your catalog stays aligned with the systems it describes.
+
+## Use AI with Architecture Context
+
+EventCatalog gives AI tools structured context about your domains, services, messages, schemas, owners, and flows.
+
+- Connect Claude, Cursor, VS Code, Windsurf, or another MCP-compatible tool with the [EventCatalog MCP Server](https://www.eventcatalog.dev/docs/development/guides/ai/using-mcp-server).
+- Install [EventCatalog Skills](https://github.com/event-catalog/skills) to help agents document services, create domain models, and map business flows:
 
 ```sh
 npx skills add event-catalog/skills
 ```
 
-Skills can generate service documentation, create domain models, and map business flows — all through natural language.
+## Learn by Task
 
-### MCP Server
+- [Create a domain](https://www.eventcatalog.dev/docs/development/guides/domains)
+- [Document a service](https://www.eventcatalog.dev/docs/development/guides/services)
+- [Add events, commands, and queries](https://www.eventcatalog.dev/docs/development/guides/messages/adding-messages)
+- [Use the EventCatalog Editor](https://www.eventcatalog.dev/docs/editor/overview)
+- [Generate from integrations](https://www.eventcatalog.dev/integrations)
+- [Manage your catalog with the SDK](https://www.eventcatalog.dev/docs/development/sdk)
+- [Join the community](https://discord.gg/3rjaZMmrAm)
 
-Connect your catalog to Claude, Cursor, Windsurf, or any MCP-compatible AI tool using the [EventCatalog MCP Server](https://www.eventcatalog.dev/docs/development/guides/ai/using-mcp-server). Ask questions about your architecture and get instant answers.
-
-## Automate Your Catalog
-
-Keep your catalog in sync with your architecture using [EventCatalog integrations](https://www.eventcatalog.dev/integrations). Import services, messages, and schemas from sources like AsyncAPI, OpenAPI, Schema Registries, and more — so your documentation is always up to date.
-
-## Learn More
-
-- [Documentation](https://www.eventcatalog.dev/docs/development/getting-started/introduction) — understand how EventCatalog works
-- [Adding Services](https://www.eventcatalog.dev/docs/development/guides/services) — document your first service
-- [Adding Messages](https://www.eventcatalog.dev/docs/development/guides/messages/adding-messages) — create events, commands, and queries
-- [Adding Domains](https://www.eventcatalog.dev/docs/development/guides/domains) — organize into bounded contexts
-- [SDK](https://www.eventcatalog.dev/docs/development/sdk) — manage your catalog programmatically
-- [Discord](https://discord.gg/3rjaZMmrAm) — join the community
-
-## Found a problem?
+## Found a Problem?
 
 Open an issue on [GitHub](https://github.com/event-catalog/eventcatalog/issues).

--- a/packages/create-eventcatalog/templates/empty/README-template.md
+++ b/packages/create-eventcatalog/templates/empty/README-template.md
@@ -1,55 +1,63 @@
-# My Event Catalog
+# Welcome to EventCatalog
 
-Welcome to your new catalog, powered by [EventCatalog](https://www.eventcatalog.dev) — the open-source documentation tool for event-driven architectures.
+[EventCatalog](https://www.eventcatalog.dev/) is your architecture catalog for distributed systems. Use it to document, govern, and discover your services, domains, APIs, events, commands, queries, schemas, teams, and flows in one place.
 
-## Getting Started
+## Start the Catalog
 
 ```sh
 npm run dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) to see your catalog.
+Open [http://localhost:3000](http://localhost:3000) to view your catalog.
 
-You can start editing your catalog by adding **domains**, **services**, and **messages** to this project. Each resource is a folder with an `index.md` file containing frontmatter metadata and markdown content.
+Using `pnpm` or `yarn`? Run the same scripts with the package manager you chose when creating this project.
 
-## What Can You Do?
+## Edit Your Catalog
 
-- **Document services** — define producers and consumers with their schemas
-- **Map events, commands & queries** — capture every message flowing through your system
-- **Organize with domains** — group resources into bounded contexts
-- **Visualize your architecture** — auto-generated diagrams of your services and message flows
-- **Version everything** — track how your architecture evolves over time
-- **Use AI to explore & document** — connect AI tools directly to your catalog
+Your catalog is docs-as-code. Resources live in folders with an `index.mdx` file for frontmatter metadata and Markdown content.
 
-## Use AI with Your Catalog
+Good places to start:
 
-### Skills
+- `domains/` - bounded contexts, business capabilities, and ownership
+- `domains/<domain>/services/` - services, APIs, and message producers or consumers
+- `events/`, `commands/`, and `queries/` - the messages flowing through your system
+- `teams/` and `users/` - who owns each part of the architecture
 
-Let AI agents document your architecture for you. Install [EventCatalog Skills](https://github.com/event-catalog/skills):
+Prefer a visual workflow? Run `npm run editor` to open the [EventCatalog Editor](https://www.eventcatalog.dev/docs/editor/overview) and browse, create, or update catalog resources through a GitHub-backed UI.
+
+## Make Your First Change
+
+1. Add or edit a domain, service, or message.
+2. Run `npm run dev` and check the generated pages and diagrams.
+3. Commit the MDX and schema files to Git.
+
+## Keep It in Sync
+
+Use `npm run generate` with [EventCatalog integrations](https://www.eventcatalog.dev/integrations) to import architecture data from OpenAPI, AsyncAPI, schema registries, EventBridge, GitHub, internal systems, and more.
+
+Run generators locally while you work, or in CI so your catalog stays aligned with the systems it describes.
+
+## Use AI with Architecture Context
+
+EventCatalog gives AI tools structured context about your domains, services, messages, schemas, owners, and flows.
+
+- Connect Claude, Cursor, VS Code, Windsurf, or another MCP-compatible tool with the [EventCatalog MCP Server](https://www.eventcatalog.dev/docs/development/guides/ai/using-mcp-server).
+- Install [EventCatalog Skills](https://github.com/event-catalog/skills) to help agents document services, create domain models, and map business flows:
 
 ```sh
 npx skills add event-catalog/skills
 ```
 
-Skills can generate service documentation, create domain models, and map business flows — all through natural language.
+## Learn by Task
 
-### MCP Server
+- [Create a domain](https://www.eventcatalog.dev/docs/development/guides/domains)
+- [Document a service](https://www.eventcatalog.dev/docs/development/guides/services)
+- [Add events, commands, and queries](https://www.eventcatalog.dev/docs/development/guides/messages/adding-messages)
+- [Use the EventCatalog Editor](https://www.eventcatalog.dev/docs/editor/overview)
+- [Generate from integrations](https://www.eventcatalog.dev/integrations)
+- [Manage your catalog with the SDK](https://www.eventcatalog.dev/docs/development/sdk)
+- [Join the community](https://discord.gg/3rjaZMmrAm)
 
-Connect your catalog to Claude, Cursor, Windsurf, or any MCP-compatible AI tool using the [EventCatalog MCP Server](https://www.eventcatalog.dev/docs/development/guides/ai/using-mcp-server). Ask questions about your architecture and get instant answers.
-
-## Automate Your Catalog
-
-Keep your catalog in sync with your architecture using [EventCatalog integrations](https://www.eventcatalog.dev/integrations). Import services, messages, and schemas from sources like AsyncAPI, OpenAPI, Schema Registries, and more — so your documentation is always up to date.
-
-## Learn More
-
-- [Documentation](https://www.eventcatalog.dev/docs/development/getting-started/introduction) — understand how EventCatalog works
-- [Adding Services](https://www.eventcatalog.dev/docs/development/guides/services) — document your first service
-- [Adding Messages](https://www.eventcatalog.dev/docs/development/guides/messages/adding-messages) — create events, commands, and queries
-- [Adding Domains](https://www.eventcatalog.dev/docs/development/guides/domains) — organize into bounded contexts
-- [SDK](https://www.eventcatalog.dev/docs/development/sdk) — manage your catalog programmatically
-- [Discord](https://discord.gg/3rjaZMmrAm) — join the community
-
-## Found a problem?
+## Found a Problem?
 
 Open an issue on [GitHub](https://github.com/event-catalog/eventcatalog/issues).

--- a/packages/create-eventcatalog/templates/eventbridge/README-template.md
+++ b/packages/create-eventcatalog/templates/eventbridge/README-template.md
@@ -1,27 +1,54 @@
-# My EventBridge Event Catalog
+# Welcome to EventCatalog
 
-Welcome to your new EventBridge EventCatalog!
+[EventCatalog](https://www.eventcatalog.dev/) is your architecture catalog for distributed systems. This template adds the EventBridge generator so you can import schemas from Amazon EventBridge and document how they connect to your domains, services, and teams.
 
-Getting started:
+## Generate Your Catalog
 
-1. Edit the `.env` file to configure your environment variables.
-1. Configure the region and schema registry name in the `eventcatalog.config.js` file
-1. Run `npm run generate` to import your schemas from confluent schema registry.
-1. Run `npm run dev` to start the development server.
-1. Go to localhost:3000 to view your catalog.
+1. Edit `.env` with your AWS settings.
+2. Configure the region and schema registry name in `eventcatalog.config.js`.
+3. Import your EventBridge schemas:
 
-### What else can you do?
+```sh
+npm run generate
+```
 
-With the EventBridge integration you can :
+4. Start the catalog:
 
-- Document your schemas
-- Assign your schemas to producers and consumers
-- Assign resources to users and teams in your organization
+```sh
+npm run dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) to view your catalog.
+
+## Edit Your Catalog
+
+Your generated resources are docs-as-code. You can enrich them with ownership, domain context, Markdown, examples, and relationships that are not always available in the source schema.
+
+Prefer a visual workflow? Run `npm run editor` to open the [EventCatalog Editor](https://www.eventcatalog.dev/docs/editor/overview) and browse, create, or update catalog resources through a GitHub-backed UI.
+
+## Keep It in Sync
+
+Run `npm run generate` whenever your EventBridge schemas change. You can also run the generator in CI so your catalog stays aligned with your registry.
+
+With this integration you can:
+
+- Document EventBridge schemas and events
+- Assign schemas to producers and consumers
+- Connect resources to users and teams
 - Visualize your EventBridge architecture
-- And much more!
 
-The easiest way to get started and dive deeper is to read the [EventCatalog documentation](https://www.eventcatalog.dev/docs/plugins/eventbridge/intro).
+## Use AI with Architecture Context
 
-### Found a problem?
+EventCatalog gives AI tools structured context about your domains, services, messages, schemas, owners, and flows. Connect an MCP-compatible tool with the [EventCatalog MCP Server](https://www.eventcatalog.dev/docs/development/guides/ai/using-mcp-server).
 
-If you found a problem or have a feature request, please open an issue on [GitHub](https://github.com/event-catalog/generators).
+## Learn by Task
+
+- [EventBridge integration docs](https://www.eventcatalog.dev/docs/plugins/eventbridge/intro)
+- [Use the EventCatalog Editor](https://www.eventcatalog.dev/docs/editor/overview)
+- [Document a service](https://www.eventcatalog.dev/docs/development/guides/services)
+- [Add events, commands, and queries](https://www.eventcatalog.dev/docs/development/guides/messages/adding-messages)
+- [Join the community](https://discord.gg/3rjaZMmrAm)
+
+## Found a Problem?
+
+Open an issue on [GitHub](https://github.com/event-catalog/generators).

--- a/packages/create-eventcatalog/templates/graphql/README-template.md
+++ b/packages/create-eventcatalog/templates/graphql/README-template.md
@@ -1,55 +1,63 @@
-# My Event Catalog
+# Welcome to EventCatalog
 
-Welcome to your new catalog, powered by [EventCatalog](https://www.eventcatalog.dev) — the open-source documentation tool for event-driven architectures.
+[EventCatalog](https://www.eventcatalog.dev/) is your architecture catalog for distributed systems. Use it to document, govern, and discover your services, domains, APIs, events, commands, queries, schemas, teams, and flows in one place.
 
-## Getting Started
+## Start the Catalog
 
 ```sh
 npm run dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) to see your catalog.
+Open [http://localhost:3000](http://localhost:3000) to view your catalog.
 
-You can start editing your catalog by adding **domains**, **services**, and **messages** to this project. Each resource is a folder with an `index.md` file containing frontmatter metadata and markdown content.
+Using `pnpm` or `yarn`? Run the same scripts with the package manager you chose when creating this project.
 
-## What Can You Do?
+## Edit Your Catalog
 
-- **Document services** — define producers and consumers with their schemas
-- **Map events, commands & queries** — capture every message flowing through your system
-- **Organize with domains** — group resources into bounded contexts
-- **Visualize your architecture** — auto-generated diagrams of your services and message flows
-- **Version everything** — track how your architecture evolves over time
-- **Use AI to explore & document** — connect AI tools directly to your catalog
+Your catalog is docs-as-code. Resources live in folders with an `index.mdx` file for frontmatter metadata and Markdown content.
 
-## Use AI with Your Catalog
+Good places to start:
 
-### Skills
+- `domains/` - bounded contexts, business capabilities, and ownership
+- `domains/<domain>/services/` - services, APIs, and message producers or consumers
+- `events/`, `commands/`, and `queries/` - the messages flowing through your system
+- `teams/` and `users/` - who owns each part of the architecture
 
-Let AI agents document your architecture for you. Install [EventCatalog Skills](https://github.com/event-catalog/skills):
+Prefer a visual workflow? Run `npm run editor` to open the [EventCatalog Editor](https://www.eventcatalog.dev/docs/editor/overview) and browse, create, or update catalog resources through a GitHub-backed UI.
+
+## Make Your First Change
+
+1. Add or edit a domain, service, or message.
+2. Run `npm run dev` and check the generated pages and diagrams.
+3. Commit the MDX and schema files to Git.
+
+## Keep It in Sync
+
+Use `npm run generate` with [EventCatalog integrations](https://www.eventcatalog.dev/integrations) to import architecture data from OpenAPI, AsyncAPI, schema registries, EventBridge, GitHub, internal systems, and more.
+
+Run generators locally while you work, or in CI so your catalog stays aligned with the systems it describes.
+
+## Use AI with Architecture Context
+
+EventCatalog gives AI tools structured context about your domains, services, messages, schemas, owners, and flows.
+
+- Connect Claude, Cursor, VS Code, Windsurf, or another MCP-compatible tool with the [EventCatalog MCP Server](https://www.eventcatalog.dev/docs/development/guides/ai/using-mcp-server).
+- Install [EventCatalog Skills](https://github.com/event-catalog/skills) to help agents document services, create domain models, and map business flows:
 
 ```sh
 npx skills add event-catalog/skills
 ```
 
-Skills can generate service documentation, create domain models, and map business flows — all through natural language.
+## Learn by Task
 
-### MCP Server
+- [Create a domain](https://www.eventcatalog.dev/docs/development/guides/domains)
+- [Document a service](https://www.eventcatalog.dev/docs/development/guides/services)
+- [Add events, commands, and queries](https://www.eventcatalog.dev/docs/development/guides/messages/adding-messages)
+- [Use the EventCatalog Editor](https://www.eventcatalog.dev/docs/editor/overview)
+- [Generate from integrations](https://www.eventcatalog.dev/integrations)
+- [Manage your catalog with the SDK](https://www.eventcatalog.dev/docs/development/sdk)
+- [Join the community](https://discord.gg/3rjaZMmrAm)
 
-Connect your catalog to Claude, Cursor, Windsurf, or any MCP-compatible AI tool using the [EventCatalog MCP Server](https://www.eventcatalog.dev/docs/development/guides/ai/using-mcp-server). Ask questions about your architecture and get instant answers.
-
-## Automate Your Catalog
-
-Keep your catalog in sync with your architecture using [EventCatalog integrations](https://www.eventcatalog.dev/integrations). Import services, messages, and schemas from sources like AsyncAPI, OpenAPI, Schema Registries, and more — so your documentation is always up to date.
-
-## Learn More
-
-- [Documentation](https://www.eventcatalog.dev/docs/development/getting-started/introduction) — understand how EventCatalog works
-- [Adding Services](https://www.eventcatalog.dev/docs/development/guides/services) — document your first service
-- [Adding Messages](https://www.eventcatalog.dev/docs/development/guides/messages/adding-messages) — create events, commands, and queries
-- [Adding Domains](https://www.eventcatalog.dev/docs/development/guides/domains) — organize into bounded contexts
-- [SDK](https://www.eventcatalog.dev/docs/development/sdk) — manage your catalog programmatically
-- [Discord](https://discord.gg/3rjaZMmrAm) — join the community
-
-## Found a problem?
+## Found a Problem?
 
 Open an issue on [GitHub](https://github.com/event-catalog/eventcatalog/issues).

--- a/packages/create-eventcatalog/templates/index.ts
+++ b/packages/create-eventcatalog/templates/index.ts
@@ -48,6 +48,7 @@ export const installTemplate = async ({
     private: true,
     scripts: {
       dev: 'eventcatalog dev',
+      editor: 'npx @eventcatalog/editor@latest',
       build: 'eventcatalog build',
       start: 'eventcatalog start',
       preview: 'eventcatalog preview',

--- a/packages/create-eventcatalog/templates/openapi/README-template.md
+++ b/packages/create-eventcatalog/templates/openapi/README-template.md
@@ -1,59 +1,63 @@
-# My Event Catalog
+# Welcome to EventCatalog
 
-Welcome to your new catalog, powered by [EventCatalog](https://www.eventcatalog.dev) — the open-source documentation tool for event-driven architectures.
+[EventCatalog](https://www.eventcatalog.dev/) is your architecture catalog for distributed systems. Use it to document, govern, and discover your services, domains, APIs, events, commands, queries, schemas, teams, and flows in one place.
 
-## Getting Started
+## Start the Catalog
 
 ```sh
 npm run dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) to see your catalog.
+Open [http://localhost:3000](http://localhost:3000) to view your catalog.
 
-You can start editing your catalog by adding **domains**, **services**, and **messages** to this project. Each resource is a folder with an `index.md` file containing frontmatter metadata and markdown content.
+Using `pnpm` or `yarn`? Run the same scripts with the package manager you chose when creating this project.
 
-## What Can You Do?
+## Edit Your Catalog
 
-- **Document services** — define producers and consumers with their schemas
-- **Map events, commands & queries** — capture every message flowing through your system
-- **Organize with domains** — group resources into bounded contexts
-- **Visualize your architecture** — auto-generated diagrams of your services and message flows
-- **Version everything** — track how your architecture evolves over time
-- **Use AI to explore & document** — connect AI tools directly to your catalog
+Your catalog is docs-as-code. Resources live in folders with an `index.mdx` file for frontmatter metadata and Markdown content.
 
-## Use AI with Your Catalog
+Good places to start:
 
-### Skills
+- `domains/` - bounded contexts, business capabilities, and ownership
+- `domains/<domain>/services/` - services, APIs, and message producers or consumers
+- `events/`, `commands/`, and `queries/` - the messages flowing through your system
+- `teams/` and `users/` - who owns each part of the architecture
 
-Let AI agents document your architecture for you. Install [EventCatalog Skills](https://github.com/event-catalog/skills):
+Prefer a visual workflow? Run `npm run editor` to open the [EventCatalog Editor](https://www.eventcatalog.dev/docs/editor/overview) and browse, create, or update catalog resources through a GitHub-backed UI.
+
+## Make Your First Change
+
+1. Add or edit a domain, service, or message.
+2. Run `npm run dev` and check the generated pages and diagrams.
+3. Commit the MDX and schema files to Git.
+
+## Keep It in Sync
+
+Use `npm run generate` with [EventCatalog integrations](https://www.eventcatalog.dev/integrations) to import architecture data from OpenAPI, AsyncAPI, schema registries, EventBridge, GitHub, internal systems, and more.
+
+Run generators locally while you work, or in CI so your catalog stays aligned with the systems it describes.
+
+## Use AI with Architecture Context
+
+EventCatalog gives AI tools structured context about your domains, services, messages, schemas, owners, and flows.
+
+- Connect Claude, Cursor, VS Code, Windsurf, or another MCP-compatible tool with the [EventCatalog MCP Server](https://www.eventcatalog.dev/docs/development/guides/ai/using-mcp-server).
+- Install [EventCatalog Skills](https://github.com/event-catalog/skills) to help agents document services, create domain models, and map business flows:
 
 ```sh
 npx skills add event-catalog/skills
 ```
 
-Skills can generate service documentation, create domain models, and map business flows — all through natural language.
+## Learn by Task
 
-### MCP Server
+- [Create a domain](https://www.eventcatalog.dev/docs/development/guides/domains)
+- [Document a service](https://www.eventcatalog.dev/docs/development/guides/services)
+- [Add events, commands, and queries](https://www.eventcatalog.dev/docs/development/guides/messages/adding-messages)
+- [Use the EventCatalog Editor](https://www.eventcatalog.dev/docs/editor/overview)
+- [Generate from integrations](https://www.eventcatalog.dev/integrations)
+- [Manage your catalog with the SDK](https://www.eventcatalog.dev/docs/development/sdk)
+- [Join the community](https://discord.gg/3rjaZMmrAm)
 
-Connect your catalog to Claude, Cursor, Windsurf, or any MCP-compatible AI tool using the [EventCatalog MCP Server](https://www.eventcatalog.dev/docs/development/guides/ai/using-mcp-server). Ask questions about your architecture and get instant answers.
-
-## Automate Your Catalog
-
-Keep your catalog in sync with your architecture using [EventCatalog integrations](https://www.eventcatalog.dev/integrations). Import services, messages, and schemas from sources like AsyncAPI, OpenAPI, Confluent Schema Registry, AWS EventBridge, and more — so your documentation is always up to date.
-
-## Automate Your Catalog
-
-Keep your catalog in sync with your architecture using [EventCatalog integrations](https://www.eventcatalog.dev/integrations). Import services, messages, and schemas from sources like AsyncAPI, OpenAPI, Schema Registries, and more — so your documentation is always up to date.
-
-## Learn More
-
-- [Documentation](https://www.eventcatalog.dev/docs/development/getting-started/introduction) — understand how EventCatalog works
-- [Adding Services](https://www.eventcatalog.dev/docs/development/guides/services) — document your first service
-- [Adding Messages](https://www.eventcatalog.dev/docs/development/guides/messages/adding-messages) — create events, commands, and queries
-- [Adding Domains](https://www.eventcatalog.dev/docs/development/guides/domains) — organize into bounded contexts
-- [SDK](https://www.eventcatalog.dev/docs/development/sdk) — manage your catalog programmatically
-- [Discord](https://discord.gg/3rjaZMmrAm) — join the community
-
-## Found a problem?
+## Found a Problem?
 
 Open an issue on [GitHub](https://github.com/event-catalog/eventcatalog/issues).


### PR DESCRIPTION
## What This PR Does

Refreshes the README templates that ship with `create-eventcatalog` to give new users clearer, task-oriented guidance, and updates the CLI completion screen to match. Adds a new `editor` npm script to every template so users can open the EventCatalog Editor straight from a freshly scaffolded project.

## Changes Overview

### Key Changes

- Rewrote README templates across `default`, `empty`, `asyncapi`, `openapi`, `graphql`, `amazon-api-gateway`, `confluent`, and `eventbridge` with a consistent structure: start the catalog, edit your catalog, make your first change, keep it in sync, use AI with architecture context, and learn by task.
- Added an `editor` script (`npx @eventcatalog/editor@latest`) to the generated `package.json` in `templates/index.ts`.
- Tweaked the post-create CLI output in `create-app.ts` to a cleaner bullet style and pointed users at the Editor.
- Picked up Editor docs synced from `website-2` via the pre-commit docs hook.

## How It Works

The `create-eventcatalog` CLI copies a chosen template directory into the user's project and merges a generated `package.json`. The new `editor` script lands in that generated `package.json`, so every newly created catalog can run `npm run editor` (or the user's package manager equivalent) without any manual setup. The README changes are purely content updates inside the template directories.

## Breaking Changes

None. Existing projects are unaffected; only newly scaffolded projects pick up the new templates and the new script.

## Additional Notes

- Patch bump for `@eventcatalog/create-eventcatalog`.
- The Editor docs added under `packages/core/docs/editor/` came from the docs sync hook and reflect the latest content from `website-2`.