### PR TITLE
feat(core): support clickable url on badges

### DIFF
--- a/.changeset/clickable-badge-urls.md
+++ b/.changeset/clickable-badge-urls.md
@@ -1,0 +1,8 @@
+---
+'@eventcatalog/core': patch
+'@eventcatalog/linter': patch
+'@eventcatalog/sdk': patch
+'@eventcatalog/language-server': patch
+---
+
+Add optional `url` support to badges so they can render as clickable links.

--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,4 @@ ec-test/
 
 docs/superpowers/*
 .worktrees/
+.pnpm-store/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -340,6 +340,7 @@ pnpm run format       # Formats all packages
 - The example catalog at `/examples/default` is used when running `pnpm run start:catalog`
 - SSR mode is required for AI Chat and MCP Server features
 - Use `DISABLE_EVENTCATALOG_CACHE=true` env var to disable caching during development
+- When making changes in this repository, check whether the same change or a compatible follow-up is needed in the editor repository at `eventcatalog/eventcatalog-editor`. If no editor change is needed, mention that explicitly in the final response.
 - Run `pnpm run format` before committing changes
 - Never verify the build, the developer will do this themselves
 - SDK test files may get modified during test runs - restore with `git restore packages/sdk/src/test/`

--- a/examples/default/domains/E-Commerce/index.mdx
+++ b/examples/default/domains/E-Commerce/index.mdx
@@ -21,12 +21,10 @@ badges:
     backgroundColor: neutral
     textColor: neutral
     icon: RectangleGroupIcon
-    url: /visualiser/domains/E-Commerce/1.0.0
   - content: Business Critical
     backgroundColor: neutral
     textColor: neutral
     icon: ShieldCheckIcon
-    url: /docs/teams/full-stack
 attachments:
   - url: https://example.com/adr/001 
     title: ADR-001 - Use Kafka for asynchronous messaging

--- a/examples/default/domains/E-Commerce/index.mdx
+++ b/examples/default/domains/E-Commerce/index.mdx
@@ -21,10 +21,12 @@ badges:
     backgroundColor: neutral
     textColor: neutral
     icon: RectangleGroupIcon
+    url: /visualiser/domains/E-Commerce/1.0.0
   - content: Business Critical
     backgroundColor: neutral
     textColor: neutral
     icon: ShieldCheckIcon
+    url: /docs/teams/full-stack
 attachments:
   - url: https://example.com/adr/001 
     title: ADR-001 - Use Kafka for asynchronous messaging

--- a/examples/default/domains/E-Commerce/subdomains/Orders/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Orders/index.mdx
@@ -16,7 +16,6 @@ badges:
     backgroundColor: neutral
     textColor: neutral
     icon: RectangleGroupIcon
-    url: /docs/domains/E-Commerce/1.0.0
 entities:
   - id: Order
   - id: OrderItem

--- a/examples/default/domains/E-Commerce/subdomains/Orders/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Orders/index.mdx
@@ -16,6 +16,7 @@ badges:
     backgroundColor: neutral
     textColor: neutral
     icon: RectangleGroupIcon
+    url: /docs/domains/E-Commerce/1.0.0
 entities:
   - id: Order
   - id: OrderItem

--- a/examples/default/domains/E-Commerce/subdomains/Orders/services/InventoryService/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Orders/services/InventoryService/index.mdx
@@ -63,15 +63,6 @@ readsFrom:
     version: 0.0.1
   - id: inventory-readmodel
     version: 0.0.1
-badges:
-  - content: Domain: Orders
-    backgroundColor: blue
-    textColor: blue
-    url: /docs/domains/Orders/0.0.3
-  - content: Team: Order Management
-    backgroundColor: neutral
-    textColor: neutral
-    url: /docs/teams/order-management
 repository:
   language: JavaScript
   url: 'https://github.com/event-catalog/pretend-shipping-service'

--- a/examples/default/domains/E-Commerce/subdomains/Orders/services/InventoryService/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Orders/services/InventoryService/index.mdx
@@ -63,6 +63,15 @@ readsFrom:
     version: 0.0.1
   - id: inventory-readmodel
     version: 0.0.1
+badges:
+  - content: Domain: Orders
+    backgroundColor: blue
+    textColor: blue
+    url: /docs/domains/Orders/0.0.3
+  - content: Team: Order Management
+    backgroundColor: neutral
+    textColor: neutral
+    url: /docs/teams/order-management
 repository:
   language: JavaScript
   url: 'https://github.com/event-catalog/pretend-shipping-service'

--- a/packages/core/docs/api/03-domain-api.md
+++ b/packages/core/docs/api/03-domain-api.md
@@ -283,6 +283,22 @@ You can also pass any valid CSS color value directly: hex (`#ff0000`), `rgb()`, 
 ---
 ```
 
+#### Link to external URLs
+
+<AddedIn version="3.39.6" />
+
+Add a `url` to a badge to make it render as a clickable link with an external-link icon. When `url` is omitted, the badge renders as a plain label.
+
+```md title="Link badge example"
+---
+  badges:
+    - content: View Runbook
+      url: https://runbooks.example.com/my-domain
+      backgroundColor: blue
+      textColor: white
+---
+```
+
 ### `specifications` {#specifications}
 
 <AddedIn version="2.6.0" />

--- a/packages/core/docs/api/04-service-api.md
+++ b/packages/core/docs/api/04-service-api.md
@@ -263,6 +263,22 @@ You can also pass any valid CSS color value directly: hex (`#ff0000`), `rgb()`, 
 ---
 ```
 
+#### Link to external URLs
+
+<AddedIn version="3.39.6" />
+
+Add a `url` to a badge to make it render as a clickable link with an external-link icon. When `url` is omitted, the badge renders as a plain label.
+
+```md title="Link badge example"
+---
+  badges:
+    - content: View Runbook
+      url: https://runbooks.example.com/my-service
+      backgroundColor: blue
+      textColor: white
+---
+```
+
 ### `specifications` {#specifications}
 
 <AddedIn version="2.39.1" />

--- a/packages/core/docs/api/05-command-api.md
+++ b/packages/core/docs/api/05-command-api.md
@@ -186,6 +186,22 @@ You can also pass any valid CSS color value directly: hex (`#ff0000`), `rgb()`, 
 ---
 ```
 
+#### Link to external URLs
+
+<AddedIn version="3.39.6" />
+
+Add a `url` to a badge to make it render as a clickable link with an external-link icon. When `url` is omitted, the badge renders as a plain label.
+
+```md title="Link badge example"
+---
+  badges:
+    - content: View Runbook
+      url: https://runbooks.example.com/my-command
+      backgroundColor: blue
+      textColor: white
+---
+```
+
 ### `schemaPath` {#schemaPath}
 
 Path to the schema of the message.

--- a/packages/core/docs/api/06-event-api.md
+++ b/packages/core/docs/api/06-event-api.md
@@ -185,6 +185,22 @@ You can also pass any valid CSS color value directly: hex (`#ff0000`), `rgb()`, 
 ---
 ```
 
+#### Link to external URLs
+
+<AddedIn version="3.39.6" />
+
+Add a `url` to a badge to make it render as a clickable link with an external-link icon. When `url` is omitted, the badge renders as a plain label.
+
+```md title="Link badge example"
+---
+  badges:
+    - content: View Runbook
+      url: https://runbooks.example.com/my-event
+      backgroundColor: blue
+      textColor: white
+---
+```
+
 ### `schemaPath` {#schemaPath}
 
 Path to the schema of the message.

--- a/packages/core/docs/api/06-query-api.md
+++ b/packages/core/docs/api/06-query-api.md
@@ -183,6 +183,22 @@ You can also pass any valid CSS color value directly: hex (`#ff0000`), `rgb()`, 
 ---
 ```
 
+#### Link to external URLs
+
+<AddedIn version="3.39.6" />
+
+Add a `url` to a badge to make it render as a clickable link with an external-link icon. When `url` is omitted, the badge renders as a plain label.
+
+```md title="Link badge example"
+---
+  badges:
+    - content: View Runbook
+      url: https://runbooks.example.com/my-query
+      backgroundColor: blue
+      textColor: white
+---
+```
+
 ### `schemaPath` {#schemaPath}
 
 Path to the schema of the message.

--- a/packages/core/docs/api/08-channel-api.md
+++ b/packages/core/docs/api/08-channel-api.md
@@ -251,6 +251,22 @@ You can also pass any valid CSS color value directly: hex (`#ff0000`), `rgb()`, 
 ---
 ```
 
+#### Link to external URLs
+
+<AddedIn version="3.39.6" />
+
+Add a `url` to a badge to make it render as a clickable link with an external-link icon. When `url` is omitted, the badge renders as a plain label.
+
+```md title="Link badge example"
+---
+  badges:
+    - content: View Runbook
+      url: https://runbooks.example.com/my-channel
+      backgroundColor: blue
+      textColor: white
+---
+```
+
 ### `repository` {#repository}
 
 <AddedIn version="2.11.2" />

--- a/packages/core/docs/api/09-flow-api.md
+++ b/packages/core/docs/api/09-flow-api.md
@@ -360,6 +360,22 @@ You can also pass any valid CSS color value directly: hex (`#ff0000`), `rgb()`, 
 ---
 ```
 
+#### Link to external URLs
+
+<AddedIn version="3.39.6" />
+
+Add a `url` to a badge to make it render as a clickable link with an external-link icon. When `url` is omitted, the badge renders as a plain label.
+
+```md title="Link badge example"
+---
+  badges:
+    - content: View Runbook
+      url: https://runbooks.example.com/my-flow
+      backgroundColor: blue
+      textColor: white
+---
+```
+
 ### `editUrl` {#editUrl}
 
 <AddedIn version="2.49.4" />

--- a/packages/core/docs/api/10-entity-api.md
+++ b/packages/core/docs/api/10-entity-api.md
@@ -233,6 +233,21 @@ You can also pass any valid CSS color value directly: hex (`#ff0000`), `rgb()`, 
 ---
 ```
 
+#### Link to external URLs
+
+<AddedIn version="3.39.6" />
+
+Add a `url` to a badge to make it render as a clickable link with an external-link icon. When `url` is omitted, the badge renders as a plain label.
+
+```md title="Link badge example"
+---
+  badges:
+    - content: View Runbook
+      url: https://runbooks.example.com/my-entity
+      backgroundColor: blue
+      textColor: white
+---
+```
 
 ### `editUrl` {#editUrl}
 

--- a/packages/core/docs/api/12-data-product-api.md
+++ b/packages/core/docs/api/12-data-product-api.md
@@ -229,6 +229,7 @@ Badge properties:
 | `content` | `string` | Yes | Text content of the badge |
 | `backgroundColor` | `string` | Yes | Background color (named token or CSS value) |
 | `textColor` | `string` | Yes | Text color (named token or CSS value) |
+| `url` | `string` | No | When set, the badge renders as a clickable link with an external-link icon |
 
 #### Use named colors
 
@@ -239,6 +240,22 @@ Supported names: `slate`, `gray`, `zinc`, `neutral`, `stone`, `red`, `orange`, `
 #### Use any CSS color
 
 You can also pass any valid CSS color value directly: hex (`#ff0000`), `rgb()`, `hsl()`, `oklch()`, or a CSS variable (`var(--my-color)`).
+
+#### Link to external URLs
+
+<AddedIn version="3.39.6" />
+
+Add a `url` to a badge to make it render as a clickable link with an external-link icon. When `url` is omitted, the badge renders as a plain label.
+
+```md title="Link badge example"
+---
+badges:
+  - content: View Runbook
+    url: https://runbooks.example.com/my-data-product
+    backgroundColor: blue
+    textColor: white
+---
+```
 
 ### `repository`
 

--- a/packages/core/eventcatalog/src/components/Badge.astro
+++ b/packages/core/eventcatalog/src/components/Badge.astro
@@ -1,0 +1,50 @@
+---
+import { getBadgeHref, getBadgeStyle } from '@utils/badge-styles';
+import { ArrowTopRightOnSquareIcon } from '@heroicons/react/20/solid';
+
+type Badge = {
+  id?: string;
+  content: string;
+  backgroundColor?: string;
+  textColor?: string;
+  icon?: any;
+  iconComponent?: any;
+  iconURL?: string;
+  class?: string;
+  url?: string;
+};
+
+type Props = {
+  badge: Badge;
+  className?: string;
+};
+
+const { badge, className = '' } = Astro.props;
+const href = getBadgeHref(badge);
+const Icon = badge.icon || badge.iconComponent;
+const classes = `
+  inline-flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm font-medium
+  ${badge.backgroundColor ? 'bg-[rgb(var(--ec-content-hover))]' : 'bg-transparent'} border border-[rgb(var(--ec-page-border))]
+  text-[rgb(var(--ec-page-text))]
+  shadow-xs
+  ${badge.class ? badge.class : ''}
+  ${className}
+`;
+---
+
+{
+  href ? (
+    <a id={badge.id || undefined} href={href} class={classes} style={getBadgeStyle(badge)} title={badge.content}>
+      {Icon && <Icon className="w-4 h-4 flex-shrink-0" />}
+      {badge.iconURL && <img src={badge.iconURL} class="w-4 h-4 flex-shrink-0 opacity-80" alt="" />}
+      <span>{badge.content}</span>
+      <ArrowTopRightOnSquareIcon className="w-3.5 h-3.5 flex-shrink-0 opacity-70" aria-hidden="true" />
+    </a>
+  ) : (
+    <span id={badge.id || undefined} class={classes} style={getBadgeStyle(badge)} title={badge.content}>
+      {Icon && <Icon className="w-4 h-4 flex-shrink-0" />}
+      {badge.iconURL && <img src={badge.iconURL} class="w-4 h-4 flex-shrink-0 opacity-80" alt="" />}
+      <span>{badge.content}</span>
+    </span>
+  )
+}

--- a/packages/core/eventcatalog/src/components/Tables/Discover/DiscoverTable.tsx
+++ b/packages/core/eventcatalog/src/components/Tables/Discover/DiscoverTable.tsx
@@ -52,6 +52,7 @@ export interface DiscoverTableData {
       content: string;
       backgroundColor?: string;
       textColor?: string;
+      url?: string;
     }>;
     producers?: Array<any>;
     consumers?: Array<any>;

--- a/packages/core/eventcatalog/src/components/Tables/Discover/columns.tsx
+++ b/packages/core/eventcatalog/src/components/Tables/Discover/columns.tsx
@@ -1,11 +1,17 @@
 import { createColumnHelper } from '@tanstack/react-table';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { DocumentTextIcon, MapIcon } from '@heroicons/react/24/solid';
-import { ArrowDownIcon, ArrowUpIcon, EllipsisVerticalIcon, StarIcon } from '@heroicons/react/24/outline';
+import {
+  ArrowDownIcon,
+  ArrowTopRightOnSquareIcon,
+  ArrowUpIcon,
+  EllipsisVerticalIcon,
+  StarIcon,
+} from '@heroicons/react/24/outline';
 import { buildUrl } from '@utils/url-builder';
 import { getColorAndIconForCollection } from '@utils/collections/icons';
 import { getCollectionTextColorClass } from '@utils/collection-colors';
-import { getBadgeReactStyle } from '@utils/badge-styles';
+import { getBadgeHref, getBadgeReactStyle } from '@utils/badge-styles';
 import { isIconPath, resolveIconUrl } from '@utils/icon';
 import { useStore } from '@nanostores/react';
 import { favoritesStore, toggleFavorite, type FavoriteItem } from '../../../stores/favorites-store';
@@ -15,7 +21,11 @@ import type { TableConfiguration } from '@types';
 const columnHelper = createColumnHelper<DiscoverTableData>();
 
 // Badge cell component (proper React component to use hooks)
-const BadgesCell = ({ badges }: { badges: Array<{ content: string; backgroundColor?: string; textColor?: string }> }) => {
+const BadgesCell = ({
+  badges,
+}: {
+  badges: Array<{ content: string; backgroundColor?: string; textColor?: string; url?: string }>;
+}) => {
   const [isExpanded, setIsExpanded] = useState(false);
 
   if (!badges || badges.length === 0) return <span className="text-xs text-[rgb(var(--ec-icon-color))]">-</span>;
@@ -25,16 +35,28 @@ const BadgesCell = ({ badges }: { badges: Array<{ content: string; backgroundCol
 
   return (
     <div className="flex flex-col gap-1 items-start">
-      {visibleItems.map((badge, index) => (
-        <span
-          key={`${badge.content}-${index}`}
-          className="inline-flex items-center px-2 py-0.5 text-[11px] font-normal rounded-md max-w-[140px] truncate border border-[rgb(var(--ec-page-border))] text-[rgb(var(--ec-page-text-muted))] bg-transparent"
-          style={getBadgeReactStyle(badge)}
-          title={badge.content}
-        >
-          {badge.content}
-        </span>
-      ))}
+      {visibleItems.map((badge, index) => {
+        const href = getBadgeHref(badge);
+        const className =
+          'inline-flex items-center px-2 py-0.5 text-[11px] font-normal rounded-md max-w-[140px] truncate border border-[rgb(var(--ec-page-border))] text-[rgb(var(--ec-page-text-muted))] bg-transparent';
+
+        return href ? (
+          <a
+            key={`${badge.content}-${index}`}
+            href={href}
+            className={className}
+            style={getBadgeReactStyle(badge)}
+            title={badge.content}
+          >
+            <span className="truncate">{badge.content}</span>
+            <ArrowTopRightOnSquareIcon className="ml-1 h-3 w-3 shrink-0 opacity-70" aria-hidden="true" />
+          </a>
+        ) : (
+          <span key={`${badge.content}-${index}`} className={className} style={getBadgeReactStyle(badge)} title={badge.content}>
+            {badge.content}
+          </span>
+        );
+      })}
       {hiddenCount > 0 && (
         <button onClick={() => setIsExpanded(!isExpanded)} className="text-xs text-[rgb(var(--ec-accent))] hover:underline">
           {isExpanded ? 'less' : `+${hiddenCount}`}

--- a/packages/core/eventcatalog/src/components/Tables/Table.tsx
+++ b/packages/core/eventcatalog/src/components/Tables/Table.tsx
@@ -58,6 +58,7 @@ export type TData<T extends TCollectionTypes> = {
       backgroundColor: string;
       textColor: string;
       icon: any; // Where is it defined?
+      url?: string;
     }>;
     // ---------------------------------------------------------------------------
     // Domains

--- a/packages/core/eventcatalog/src/components/Tables/columns/SharedColumns.tsx
+++ b/packages/core/eventcatalog/src/components/Tables/columns/SharedColumns.tsx
@@ -1,6 +1,7 @@
 import { createColumnHelper } from '@tanstack/react-table';
 import { useState } from 'react';
-import { getBadgeReactStyle } from '@utils/badge-styles';
+import { ArrowTopRightOnSquareIcon } from '@heroicons/react/20/solid';
+import { getBadgeHref, getBadgeReactStyle } from '@utils/badge-styles';
 import { filterByBadge } from '../filters/custom-filters';
 import type { TCollectionTypes, TData } from '../Table';
 import type { TableConfiguration } from '@types';
@@ -24,16 +25,28 @@ export const createBadgesColumn = <T extends { data: Pick<TData<U>['data'], 'bad
 
       return (
         <div className="flex flex-wrap gap-1 items-center">
-          {visibleItems.map((badge, index) => (
-            <span
-              key={`${badge.id}-${index}`}
-              className="inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-md border border-[rgb(var(--ec-accent)/0.5)] text-[rgb(var(--ec-page-text))] bg-transparent"
-              style={getBadgeReactStyle(badge)}
-              title={badge.content}
-            >
-              {badge.content}
-            </span>
-          ))}
+          {visibleItems.map((badge, index) => {
+            const href = getBadgeHref(badge);
+            const className =
+              'inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-md border border-[rgb(var(--ec-accent)/0.5)] text-[rgb(var(--ec-page-text))] bg-transparent';
+
+            return href ? (
+              <a
+                key={`${badge.id}-${index}`}
+                href={href}
+                className={className}
+                style={getBadgeReactStyle(badge)}
+                title={badge.content}
+              >
+                <span>{badge.content}</span>
+                <ArrowTopRightOnSquareIcon className="ml-1 h-3 w-3 shrink-0 opacity-70" aria-hidden="true" />
+              </a>
+            ) : (
+              <span key={`${badge.id}-${index}`} className={className} style={getBadgeReactStyle(badge)} title={badge.content}>
+                {badge.content}
+              </span>
+            );
+          })}
           {hiddenCount > 0 && (
             <button onClick={() => setIsExpanded(!isExpanded)} className="text-xs text-[rgb(var(--ec-accent))] hover:underline">
               {isExpanded ? 'less' : `+${hiddenCount}`}

--- a/packages/core/eventcatalog/src/content.config-shared-collections.ts
+++ b/packages/core/eventcatalog/src/content.config-shared-collections.ts
@@ -6,6 +6,7 @@ export const badge = z.object({
   backgroundColor: z.string(),
   textColor: z.string(),
   icon: z.string().optional(),
+  url: z.string().optional(),
 });
 
 // Create a union type for owners

--- a/packages/core/eventcatalog/src/enterprise/custom-documentation/pages/docs/custom/index.astro
+++ b/packages/core/eventcatalog/src/enterprise/custom-documentation/pages/docs/custom/index.astro
@@ -5,6 +5,7 @@ import config from '@config';
 import { AlignLeftIcon, UserIcon, UsersIcon } from 'lucide-react';
 
 import mdxComponents from '@components/MDX/components';
+import Badge from '@components/Badge.astro';
 
 import { getOwner } from '@utils/collections/owners';
 import { buildUrl, buildEditUrlForResource } from '@utils/url-builder';
@@ -117,24 +118,7 @@ const editUrl =
                 badges && badges.length > 0 && (
                   <div class="flex flex-wrap gap-3 py-2">
                     {badges.map((badge: any) => {
-                      return (
-                        <a href={badge.url || '#'}>
-                          <span
-                            id={badge.id || ''}
-                            class={`
-                              inline-flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm font-medium
-                              bg-[rgb(var(--ec-content-hover))] border border-[rgb(var(--ec-page-border))]
-                              text-[rgb(var(--ec-page-text))]
-                              shadow-xs
-                              ${badge.class ? badge.class : ''}
-                            `}
-                          >
-                            {badge.icon && <badge.icon className="w-4 h-4 flex-shrink-0 text-[rgb(var(--ec-icon-color))]" />}
-                            {badge.iconURL && <img src={badge.iconURL} class="w-4 h-4 flex-shrink-0 opacity-80" alt="" />}
-                            <span>{badge.content}</span>
-                          </span>
-                        </a>
-                      );
+                      return <Badge badge={badge} />;
                     })}
                   </div>
                 )

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/[docType]/[docId]/[docVersion]/index.astro
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/[docType]/[docId]/[docVersion]/index.astro
@@ -5,11 +5,11 @@ import VerticalSideBarLayout from '@layouts/VerticalSideBarLayout.astro';
 import Admonition from '@components/MDX/Admonition';
 import components from '@components/MDX/components';
 import CopyAsMarkdown from '@components/CopyAsMarkdown';
+import Badge from '@components/Badge.astro';
 import { buildUrl } from '@utils/url-builder';
 import { AlignLeftIcon, HistoryIcon } from 'lucide-react';
 import { isEventCatalogChatEnabled, isResourceDocsEnabled } from '@utils/feature';
 import { getIcon } from '@utils/badges';
-import { getBadgeStyle } from '@utils/badge-styles';
 import { collectionToResourceMap } from '@utils/collections/util';
 
 import { Page } from './_index.data';
@@ -80,19 +80,7 @@ const pagefindAttributes =
           {
             badges.length > 0 && (
               <div class="flex flex-wrap gap-3 py-4">
-                {badges.map((badge: any) => (
-                  <span
-                    class={`
-                      inline-flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm font-medium
-                      ${badge.backgroundColor ? 'bg-[rgb(var(--ec-content-hover))]' : 'bg-transparent'} border border-[rgb(var(--ec-page-border))]
-                      text-[rgb(var(--ec-page-text))]
-                    `}
-                    style={getBadgeStyle(badge)}
-                  >
-                    {badge.iconComponent && <badge.iconComponent className="w-4 h-4 flex-shrink-0" />}
-                    <span>{badge.content}</span>
-                  </span>
-                ))}
+                {badges.map((badge: any) => <Badge badge={badge} />)}
               </div>
             )
           }

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/[docType]/[docId]/index.astro
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/[docType]/[docId]/index.astro
@@ -5,11 +5,11 @@ import VerticalSideBarLayout from '@layouts/VerticalSideBarLayout.astro';
 import Admonition from '@components/MDX/Admonition';
 import components from '@components/MDX/components';
 import CopyAsMarkdown from '@components/CopyAsMarkdown';
+import Badge from '@components/Badge.astro';
 import { buildUrl } from '@utils/url-builder';
 import { AlignLeftIcon, HistoryIcon } from 'lucide-react';
 import { isEventCatalogChatEnabled, isResourceDocsEnabled } from '@utils/feature';
 import { getIcon } from '@utils/badges';
-import { getBadgeStyle } from '@utils/badge-styles';
 import { collectionToResourceMap } from '@utils/collections/util';
 
 import { Page } from './_index.data';
@@ -73,19 +73,7 @@ const pagefindAttributes =
             {
               badges.length > 0 && (
                 <div class="flex flex-wrap gap-3 py-4">
-                  {badges.map((badge: any) => (
-                    <span
-                      class={`
-                        inline-flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm font-medium
-                        ${badge.backgroundColor ? 'bg-[rgb(var(--ec-content-hover))]' : 'bg-transparent'} border border-[rgb(var(--ec-page-border))]
-                        text-[rgb(var(--ec-page-text))]
-                      `}
-                      style={getBadgeStyle(badge)}
-                    >
-                      {badge.iconComponent && <badge.iconComponent className="w-4 h-4 flex-shrink-0" />}
-                      <span>{badge.content}</span>
-                    </span>
-                  ))}
+                  {badges.map((badge: any) => <Badge badge={badge} />)}
                 </div>
               )
             }

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/changelog/index.astro
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/changelog/index.astro
@@ -15,10 +15,10 @@ import mdxComponents from '@components/MDX/components';
 import 'diff2html/bundles/css/diff2html.min.css';
 
 import { buildUrl } from '@utils/url-builder';
-import { getBadgeStyle } from '@utils/badge-styles';
 import { getPreviousVersion } from '@utils/collections/util';
 import { getDiffsForCurrentAndPreviousVersion } from '@utils/file-diffs';
 import VerticalSideBarLayout from '@layouts/VerticalSideBarLayout.astro';
+import Badge from '@components/Badge.astro';
 import { ClientRouter } from 'astro:transitions';
 import { isChangelogEnabled } from '@utils/feature';
 
@@ -143,13 +143,7 @@ const badges = [getBadge()];
           badges && (
             <div class="flex flex-wrap py-2 pt-4">
               {badges.map((badge: any) => (
-                <span
-                  class="text-sm font-medium px-2 py-1 rounded-md mr-2 space-x-1 flex items-center bg-transparent border border-[rgb(var(--ec-page-border))]"
-                  style={getBadgeStyle(badge)}
-                >
-                  {badge.icon && <badge.icon className="w-4 h-4 inline-block mr-1" />}
-                  <span>{badge.content}</span>
-                </span>
+                <Badge badge={badge} className="mr-2 px-2 py-1 rounded-md" />
               ))}
             </div>
           )
@@ -195,13 +189,7 @@ const badges = [getBadge()];
                   {log.badges && (
                     <div class="flex flex-wrap">
                       {log.badges.map((badge: any) => (
-                        <span
-                          class="text-sm font-medium px-2 py-1 rounded-md mr-2 space-x-1 flex items-center bg-[rgb(var(--ec-badge-default-bg))] text-[rgb(var(--ec-badge-default-text))]"
-                          style={getBadgeStyle(badge)}
-                        >
-                          {badge.icon && <badge.icon className="w-4 h-4 inline-block mr-1" />}
-                          <span>{badge.content}</span>
-                        </span>
+                        <Badge badge={badge} className="mr-2 px-2 py-1 rounded-md" />
                       ))}
                     </div>
                   )}

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/graphql/[filename].astro
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/graphql/[filename].astro
@@ -7,8 +7,8 @@ import Footer from '@layouts/Footer.astro';
 import { Page } from './_[filename].data';
 import { getAbsoluteFilePathForAstroFile } from '@utils/files';
 import { buildUrl, buildEditUrlForResource } from '@utils/url-builder';
-import { getBadgeStyle } from '@utils/badge-styles';
 import Admonition from '@components/MDX/Admonition';
+import Badge from '@components/Badge.astro';
 
 import { ServerIcon } from '@heroicons/react/24/outline';
 
@@ -83,23 +83,7 @@ const pagefindAttributes =
               badges && badges.length > 0 && (
                 <div class="flex flex-wrap gap-3 py-4">
                   {badges.map((badge: any) => {
-                    return (
-                      <span
-                        id={badge.id || ''}
-                        class={`
-                          inline-flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm font-medium
-                          ${badge.backgroundColor ? 'bg-[rgb(var(--ec-content-hover))]' : 'bg-transparent'} border border-[rgb(var(--ec-page-border))]
-                          text-[rgb(var(--ec-page-text))]
-                          shadow-xs
-                          ${badge.class ? badge.class : ''}
-                        `}
-                        style={getBadgeStyle(badge)}
-                      >
-                        {badge.icon && <badge.icon className="w-4 h-4 flex-shrink-0" />}
-                        {badge.iconURL && <img src={badge.iconURL} class="w-4 h-4 flex-shrink-0 opacity-80" alt="" />}
-                        <span>{badge.content}</span>
-                      </span>
-                    );
+                    return <Badge badge={badge} />;
                   })}
                 </div>
               )

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/index.astro
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/index.astro
@@ -15,6 +15,7 @@ import Admonition from '@components/MDX/Admonition';
 import VersionList from '@components/Lists/VersionList.astro';
 import CopyAsMarkdown from '@components/CopyAsMarkdown';
 import FavoriteButton from '@components/FavoriteButton';
+import Badge from '@components/Badge.astro';
 import { shouldRenderSideBarSection } from '@stores/sidebar-store/builders/shared';
 
 import {
@@ -34,7 +35,6 @@ import { getSpecificationsForService } from '@utils/collections/services';
 import { resourceToCollectionMap, collectionToResourceMap, getDeprecatedDetails } from '@utils/collections/util';
 import { getSchemasFromResource } from '@utils/collections/schemas';
 import { getIcon } from '@utils/badges';
-import { getBadgeStyle } from '@utils/badge-styles';
 import { buildUrl, buildEditUrlForResource } from '@utils/url-builder';
 import { isIconPath, resolveIconUrl } from '@utils/icon';
 import {
@@ -377,23 +377,7 @@ if (!hasCurrentFlowEmbed && !hasCurrentPageNodeGraph) {
               badges && (
                 <div class="flex flex-wrap gap-3 pt-6 pb-2">
                   {badges.map((badge: any) => {
-                    return (
-                      <span
-                        id={badge.id || ''}
-                        class={`
-                          inline-flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm font-medium
-                          ${badge.backgroundColor ? 'bg-[rgb(var(--ec-content-hover))]' : 'bg-transparent'} border border-[rgb(var(--ec-page-border))]
-                          text-[rgb(var(--ec-page-text))]
-                          shadow-xs
-                          ${badge.class ? badge.class : ''}
-                        `}
-                        style={getBadgeStyle(badge)}
-                      >
-                        {badge.icon && <badge.icon className="w-4 h-4 flex-shrink-0" />}
-                        {badge.iconURL && <img src={badge.iconURL} class="w-4 h-4 flex-shrink-0 opacity-80" alt="" />}
-                        <span>{badge.content}</span>
-                      </span>
-                    );
+                    return <Badge badge={badge} />;
                   })}
                 </div>
               )

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/language/[dictionaryId]/index.astro
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/language/[dictionaryId]/index.astro
@@ -1,5 +1,6 @@
 ---
 import RectangleGroupIcon from '@heroicons/react/24/outline/RectangleGroupIcon';
+import Badge from '@components/Badge.astro';
 import Footer from '@layouts/Footer.astro';
 import VerticalSideBarLayout from '@layouts/VerticalSideBarLayout.astro';
 import { buildUrl } from '@utils/url-builder';
@@ -80,17 +81,7 @@ const badges = [
               badges && badges.length > 0 && (
                 <div class="flex flex-wrap gap-3 py-4">
                   {badges.map((badge: any) => {
-                    return (
-                      <span
-                        class="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm font-medium
-                          bg-[rgb(var(--ec-content-hover))] border border-[rgb(var(--ec-page-border))]
-                          text-[rgb(var(--ec-page-text))] shadow-xs"
-                      >
-                        {badge.icon && <badge.icon className="w-4 h-4 flex-shrink-0 text-[rgb(var(--ec-icon-color))]" />}
-                        {badge.iconURL && <img src={badge.iconURL} class="w-4 h-4 flex-shrink-0 opacity-80" alt="" />}
-                        <span>{badge.content}</span>
-                      </span>
-                    );
+                    return <Badge badge={badge} />;
                   })}
                 </div>
               )

--- a/packages/core/eventcatalog/src/utils/__tests__/badge-styles.test.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/badge-styles.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { getBadgeHref } from '../badge-styles';
+
+describe('getBadgeHref', () => {
+  it('returns undefined when a badge has no url', () => {
+    expect(getBadgeHref({})).toBeUndefined();
+  });
+
+  it('builds root-relative badge urls through the catalog url builder', () => {
+    expect(getBadgeHref({ url: '/domains/Payments' })).toBe('/domains/Payments');
+  });
+
+  it('keeps absolute badge urls unchanged', () => {
+    expect(getBadgeHref({ url: 'https://example.com/docs' })).toBe('https://example.com/docs');
+  });
+});

--- a/packages/core/eventcatalog/src/utils/__tests__/badge-styles.test.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/badge-styles.test.ts
@@ -14,8 +14,17 @@ describe('getBadgeHref', () => {
     expect(getBadgeHref({ url: '/domains/Payments' })).toBe('/domains/Payments');
   });
 
-  it('keeps absolute badge urls unchanged', () => {
+  it('keeps safe absolute badge urls unchanged', () => {
     expect(getBadgeHref({ url: 'https://example.com/docs' })).toBe('https://example.com/docs');
+    expect(getBadgeHref({ url: 'http://example.com/docs' })).toBe('http://example.com/docs');
+    expect(getBadgeHref({ url: 'mailto:hello@example.com' })).toBe('mailto:hello@example.com');
+    expect(getBadgeHref({ url: 'tel:+441234567890' })).toBe('tel:+441234567890');
+  });
+
+  it('rejects unsafe absolute badge url schemes', () => {
+    expect(getBadgeHref({ url: 'javascript:alert(1)' })).toBeUndefined();
+    expect(getBadgeHref({ url: 'data:text/html,<script>alert(1)</script>' })).toBeUndefined();
+    expect(getBadgeHref({ url: 'vbscript:msgbox(1)' })).toBeUndefined();
   });
 
   it('does not rebuild badge urls that already include the catalog base url', () => {

--- a/packages/core/eventcatalog/src/utils/__tests__/badge-styles.test.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/badge-styles.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { getBadgeHref } from '../badge-styles';
 
 describe('getBadgeHref', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it('returns undefined when a badge has no url', () => {
     expect(getBadgeHref({})).toBeUndefined();
   });
@@ -12,5 +16,19 @@ describe('getBadgeHref', () => {
 
   it('keeps absolute badge urls unchanged', () => {
     expect(getBadgeHref({ url: 'https://example.com/docs' })).toBe('https://example.com/docs');
+  });
+
+  it('does not rebuild badge urls that already include the catalog base url', () => {
+    vi.stubEnv('BASE_URL', '/catalog/');
+
+    expect(getBadgeHref({ url: '/catalog/docs/services/InventoryService/0.0.2/spec/openapi' })).toBe(
+      '/catalog/docs/services/InventoryService/0.0.2/spec/openapi'
+    );
+  });
+
+  it('still base-prefixes root-relative badge urls without the catalog base url', () => {
+    vi.stubEnv('BASE_URL', '/catalog/');
+
+    expect(getBadgeHref({ url: '/docs/services/InventoryService/0.0.2' })).toBe('/catalog/docs/services/InventoryService/0.0.2');
   });
 });

--- a/packages/core/eventcatalog/src/utils/badge-styles.ts
+++ b/packages/core/eventcatalog/src/utils/badge-styles.ts
@@ -10,6 +10,14 @@ type Badge = {
 
 const ABSOLUTE_OR_PROTOCOL_RELATIVE_URL_PATTERN = /^(?:[a-z][a-z\d+\-.]*:|\/\/)/i;
 
+const isAlreadyBasePrefixed = (url: string) => {
+  const baseUrl = import.meta.env.BASE_URL;
+  if (!baseUrl || baseUrl === '/') return false;
+
+  const normalizedBaseUrl = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
+  return url === normalizedBaseUrl || url.startsWith(`${normalizedBaseUrl}/`);
+};
+
 const NAMED_BADGE_COLOR_KEYS = new Set([
   'slate',
   'gray',
@@ -216,6 +224,7 @@ export const getBadgeHref = (badge: Badge) => {
   const url = badge.url.trim();
   if (!url) return undefined;
   if (ABSOLUTE_OR_PROTOCOL_RELATIVE_URL_PATTERN.test(url) || url.startsWith('#') || url.startsWith('?')) return url;
+  if (isAlreadyBasePrefixed(url)) return url;
   if (url.startsWith('/')) return buildUrl(url);
 
   return url;

--- a/packages/core/eventcatalog/src/utils/badge-styles.ts
+++ b/packages/core/eventcatalog/src/utils/badge-styles.ts
@@ -8,7 +8,9 @@ type Badge = {
   url?: string;
 };
 
-const ABSOLUTE_OR_PROTOCOL_RELATIVE_URL_PATTERN = /^(?:[a-z][a-z\d+\-.]*:|\/\/)/i;
+const URL_SCHEME_PATTERN = /^[a-z][a-z\d+\-.]*:/i;
+const PROTOCOL_RELATIVE_URL_PATTERN = /^\/\//;
+const SAFE_BADGE_URL_SCHEMES = new Set(['http:', 'https:', 'mailto:', 'tel:']);
 
 const isAlreadyBasePrefixed = (url: string) => {
   const baseUrl = import.meta.env.BASE_URL;
@@ -223,7 +225,11 @@ export const getBadgeHref = (badge: Badge) => {
 
   const url = badge.url.trim();
   if (!url) return undefined;
-  if (ABSOLUTE_OR_PROTOCOL_RELATIVE_URL_PATTERN.test(url) || url.startsWith('#') || url.startsWith('?')) return url;
+  if (url.startsWith('#') || url.startsWith('?') || PROTOCOL_RELATIVE_URL_PATTERN.test(url)) return url;
+
+  const scheme = URL_SCHEME_PATTERN.exec(url)?.[0].toLowerCase();
+  if (scheme) return SAFE_BADGE_URL_SCHEMES.has(scheme) ? url : undefined;
+
   if (isAlreadyBasePrefixed(url)) return url;
   if (url.startsWith('/')) return buildUrl(url);
 

--- a/packages/core/eventcatalog/src/utils/badge-styles.ts
+++ b/packages/core/eventcatalog/src/utils/badge-styles.ts
@@ -1,9 +1,14 @@
+import { buildUrl } from './url-builder';
+
 type BadgeColorKind = 'background' | 'text';
 
 type Badge = {
   backgroundColor?: string;
   textColor?: string;
+  url?: string;
 };
+
+const ABSOLUTE_OR_PROTOCOL_RELATIVE_URL_PATTERN = /^(?:[a-z][a-z\d+\-.]*:|\/\/)/i;
 
 const NAMED_BADGE_COLOR_KEYS = new Set([
   'slate',
@@ -203,4 +208,15 @@ export const getBadgeReactStyle = (badge: Badge) => {
     ...(backgroundColor ? { backgroundColor } : {}),
     ...(color ? { color } : {}),
   };
+};
+
+export const getBadgeHref = (badge: Badge) => {
+  if (!badge.url) return undefined;
+
+  const url = badge.url.trim();
+  if (!url) return undefined;
+  if (ABSOLUTE_OR_PROTOCOL_RELATIVE_URL_PATTERN.test(url) || url.startsWith('#') || url.startsWith('?')) return url;
+  if (url.startsWith('/')) return buildUrl(url);
+
+  return url;
 };

--- a/packages/language-server/src/compiler.ts
+++ b/packages/language-server/src/compiler.ts
@@ -276,6 +276,10 @@ function mapAnnotations(annotations: Annotation[]): Record<string, unknown> {
           (a) => isNamedAnnotationArg(a) && a.key === "text",
         ) as NamedAnnotationArg | undefined;
         if (textArg) badge.textColor = String(getAnnotationArgValue(textArg));
+        const urlArg = ann.args.find(
+          (a) => isNamedAnnotationArg(a) && a.key === "url",
+        ) as NamedAnnotationArg | undefined;
+        if (urlArg) badge.url = String(getAnnotationArgValue(urlArg));
         (result.badges as Record<string, string>[]).push(badge);
         break;
       }

--- a/packages/language-server/test/compiler.test.ts
+++ b/packages/language-server/test/compiler.test.ts
@@ -186,7 +186,7 @@ describe("compile", () => {
     const program = await parseProgram(`
       service OrderService {
         version 1.0.0
-        @badge("Core", bg: "#3b82f6", text: "#fff")
+        @badge("Core", bg: "#3b82f6", text: "#fff", url: "/domains/Payments")
       }
     `);
 
@@ -200,6 +200,7 @@ describe("compile", () => {
     expect(svcOutput!.content).toContain('content: "Core"');
     expect(svcOutput!.content).toContain('backgroundColor: "#3b82f6"');
     expect(svcOutput!.content).toContain('textColor: "#fff"');
+    expect(svcOutput!.content).toContain('url: "/domains/Payments"');
   });
 
   it("compiles @note annotation into notes array", async () => {

--- a/packages/linter/src/schemas/common.ts
+++ b/packages/linter/src/schemas/common.ts
@@ -5,6 +5,7 @@ export const badgeSchema = z.object({
   backgroundColor: z.string(),
   textColor: z.string(),
   icon: z.string().optional(),
+  url: z.string().optional(),
 });
 
 export const ownerReferenceSchema = z

--- a/packages/linter/src/types/index.ts
+++ b/packages/linter/src/types/index.ts
@@ -3,7 +3,7 @@ export interface Badge {
   backgroundColor: string;
   textColor: string;
   icon?: string;
-  link?: string;
+  url?: string;
 }
 
 export interface Specification {

--- a/packages/sdk/src/dsl/utils.ts
+++ b/packages/sdk/src/dsl/utils.ts
@@ -30,7 +30,7 @@ interface BaseResource {
   version: string;
   summary?: string;
   owners?: string[];
-  badges?: { content: string; backgroundColor: string; textColor: string }[];
+  badges?: { content: string; backgroundColor: string; textColor: string; url?: string }[];
   deprecated?: boolean | { date?: string; message?: string };
   draft?: boolean | { title?: string; message?: string };
 }

--- a/packages/sdk/src/types.d.ts
+++ b/packages/sdk/src/types.d.ts
@@ -252,6 +252,7 @@ export interface Badge {
   backgroundColor: string;
   textColor: string;
   icon?: string;
+  url?: string;
 }
 
 export interface Changelog {


### PR DESCRIPTION
## What This PR Does

Adds an optional `url` field to badges on every resource that supports them — services, domains, events, commands, queries, channels, flows, entities, and data products. When a badge has a `url`, EventCatalog now renders it as a clickable `<a>` link with an external-link icon. When `url` is omitted, behaviour is unchanged. This unblocks linking badges to runbooks, dashboards, SLOs, or any other external context relevant to the resource.

## Changes Overview

### Key Changes
- New `Badge.astro` component that renders a badge as either `<a>` (when `url` is set) or `<span>` (when not).
- New `getBadgeHref` helper in `packages/core/eventcatalog/src/utils/badge-styles.ts`, with unit tests.
- Astro content collection schema extended so the `badges[]` array accepts an optional `url` string. SDK types, linter schema, and language-server compiler mirror the change.
- Discover tables updated so badges rendered inside table cells respect the new `url` and render as links there too.
- API reference docs updated with a new \"Link to external URLs\" subsection (and a `url` row in the data-product API badge table) for every resource type, all tagged with `<AddedIn version=\"3.39.6\" />`.
- Example catalog updated to demo the feature.
- Changeset: `patch` for `@eventcatalog/core`, `@eventcatalog/sdk`, `@eventcatalog/language-server`, and `@eventcatalog/linter`.

## How It Works

The badge schema in the shared Astro content config now defines `url` as an optional string, so every resource type that already exposed `badges` inherits the new field with no per-collection wiring. At render time, `Badge.astro` checks `getBadgeHref(badge)` and either emits an `<a>` with the existing badge styles plus an external-link icon, or falls back to the previous `<span>` markup. The Discover tables use the same helper so badge linking is consistent between resource pages and list views. SDK, linter, and language-server type definitions were updated in lock-step so DSL authoring tooling validates the new field correctly.

## Breaking Changes

None. `url` is optional everywhere; existing badges continue to render exactly as before.

## Additional Notes

- The docs-updater agent also updated the user-facing docs in the sibling `eventcatalog/website-2` repo (9 files under `docs/api/`) tagged with `<AddedIn version=\"3.39.6\" />`. Those changes live in a separate repository and need a separate PR.
- Guide pages in `website-2` were intentionally left untouched — they only show badges in sample frontmatter and defer field-level documentation to the API reference.