### PR TITLE
feat(core): add oauth bearer token authentication for the mcp server

### DIFF
--- a/.changeset/oauth-mcp-server-protection.md
+++ b/.changeset/oauth-mcp-server-protection.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/core': minor
+---
+
+feat(core): add OAuth Bearer token authentication for the built-in MCP server. EventCatalog now acts as an MCP protected resource server and can require valid access tokens (JWT) on `/docs/mcp`, with protected resource metadata served at `/.well-known/oauth-protected-resource`.

--- a/packages/core/docs/development/ask-your-architecture/03-mcp-server/getting-started.md
+++ b/packages/core/docs/development/ask-your-architecture/03-mcp-server/getting-started.md
@@ -45,6 +45,78 @@ Visit the endpoint in your browser to verify. It returns available tools and res
 }
 ```
 
+### Protect with OAuth
+
+<AddedIn version="3.40.0" />
+
+The built-in MCP server can be protected with OAuth Bearer tokens, following the MCP authorization specification for HTTP transports.
+
+EventCatalog acts as the OAuth protected resource server for `/docs/mcp`. Your identity provider or authorization server remains responsible for user login, consent, client registration, `/authorize`, `/oauth/token`, and token refresh.
+
+Configure MCP authorization in `eventcatalog.config.js`:
+
+```js title="eventcatalog.config.js"
+module.exports = {
+  output: 'server',
+  mcp: {
+    auth: {
+      enabled: true,
+      resource: 'https://your-eventcatalog.com/docs/mcp',
+      authorizationServers: ['https://auth.example.com'],
+      issuer: 'https://auth.example.com',
+      audience: 'https://your-eventcatalog.com/docs/mcp',
+      requiredScopes: ['catalog:read'],
+      jwksUri: 'https://auth.example.com/.well-known/jwks.json',
+    },
+  },
+};
+```
+
+When enabled, EventCatalog serves protected resource metadata at `/.well-known/oauth-protected-resource`. Unauthenticated MCP clients receive a `401 Unauthorized` response with a `WWW-Authenticate` header pointing at that document. MCP clients then obtain an access token from the advertised authorization server and call `/docs/mcp` with:
+
+```http
+Authorization: Bearer <access-token>
+```
+
+The access token must be valid, unexpired, issued by the configured issuer, intended for the configured audience, and include all required scopes.
+
+#### Key signing options
+
+Choose one of the following strategies for token validation:
+
+| Strategy | Config fields |
+|---|---|
+| JWKS endpoint (recommended) | `jwksUri` |
+| Inline asymmetric public key | `publicKey` or `publicKeyEnvVar` |
+| Symmetric shared secret | `sharedSecret` or `sharedSecretEnvVar` |
+
+Prefer `publicKeyEnvVar` or `sharedSecretEnvVar` over inline values to avoid committing secrets to source control.
+
+#### All options
+
+| Field | Required | Description |
+|---|---|---|
+| `enabled` | Yes | Enables OAuth Bearer token validation |
+| `resource` | No | Absolute URL of the MCP resource. Set this explicitly when behind a proxy |
+| `protectedResourceMetadataUrl` | No | URL for the protected resource metadata document. Defaults to `/.well-known/oauth-protected-resource` |
+| `authorizationServers` | No | Authorization server URLs advertised to MCP clients |
+| `issuer` | No | Expected token issuer (`iss` claim) |
+| `audience` | No | Expected token audience (`aud` claim). Defaults to `resource` |
+| `requiredScopes` | No | Scopes every token must include |
+| `jwksUri` | No | JWKS endpoint for asymmetric JWT validation |
+| `publicKey` | No | Inline public key for asymmetric JWT validation |
+| `publicKeyEnvVar` | No | Environment variable containing the public key |
+| `sharedSecret` | No | Inline shared secret for symmetric JWT validation |
+| `sharedSecretEnvVar` | No | Environment variable containing the shared secret |
+
+:::note Existing website authentication
+The `auth.enabled` and `eventcatalog.auth.js` settings protect the EventCatalog website with browser sessions. MCP authorization is separate because MCP clients authenticate with Bearer tokens, not browser cookies.
+:::
+
+:::tip Authorization server discovery
+EventCatalog serves `/.well-known/oauth-protected-resource` for MCP client discovery. It does not serve `/.well-known/oauth-authorization-server`, `/authorize`, or `/oauth/token` -- those endpoints must be provided by the authorization server listed in `authorizationServers`. If your MCP client expects those endpoints on the catalog host, proxy the authorization server behind that host with your load balancer or reverse proxy.
+:::
+
 ### Connect clients
 
 <details>

--- a/packages/core/eventcatalog/src/__tests__/middleware-auth.spec.ts
+++ b/packages/core/eventcatalog/src/__tests__/middleware-auth.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { findMatchingRule, getPublicRoutes, matchesPattern } from '../enterprise/auth/middleware/middleware-auth';
+import { findMatchingRule, getPublicRoutes, isMcpRoute, matchesPattern } from '../enterprise/auth/middleware/middleware-auth';
 
 // Note:
 describe('middleware-auth', () => {
@@ -144,6 +144,20 @@ describe('middleware-auth', () => {
       expect(getPublicRoutes(false)).not.toContain('/docs/llm/schemas.txt');
       expect(getPublicRoutes(false)).not.toContain('/docs/llm/llms.txt');
       expect(getPublicRoutes(false)).not.toContain('/docs/llm/llms-full.txt');
+    });
+  });
+
+  describe('isMcpRoute', () => {
+    it('matches the MCP endpoint and child paths only', () => {
+      expect(isMcpRoute('/docs/mcp')).toBe(true);
+      expect(isMcpRoute('/docs/mcp/')).toBe(true);
+      expect(isMcpRoute('/docs/mcp/messages')).toBe(true);
+    });
+
+    it('does not match routes that only share the same prefix', () => {
+      expect(isMcpRoute('/docs/mcp-anything')).toBe(false);
+      expect(isMcpRoute('/docs/mcpany')).toBe(false);
+      expect(isMcpRoute('/docs/mcp.v1')).toBe(false);
     });
   });
 });

--- a/packages/core/eventcatalog/src/enterprise/auth/middleware/middleware-auth.ts
+++ b/packages/core/eventcatalog/src/enterprise/auth/middleware/middleware-auth.ts
@@ -6,7 +6,7 @@
 // src/middleware/auth.ts
 import type { MiddlewareHandler } from 'astro';
 import { getSession } from 'auth-astro/server';
-import { isAuthEnabled } from '@utils/feature';
+import { isAuthEnabled, isEventCatalogMCPAuthEnabled } from '@utils/feature';
 import jwt from 'jsonwebtoken';
 import { isLLMSTxtEnabled } from '@utils/feature';
 
@@ -97,6 +97,10 @@ export function getPublicRoutes(isLLMSTextEnabled: boolean) {
   ];
 }
 
+export function isMcpRoute(pathname: string) {
+  return pathname === '/docs/mcp' || pathname.startsWith('/docs/mcp/');
+}
+
 export const authMiddleware: MiddlewareHandler = async (context, next) => {
   const { request, redirect, locals } = context;
   const url = new URL(request.url);
@@ -118,6 +122,7 @@ export const authMiddleware: MiddlewareHandler = async (context, next) => {
 
   if (
     pathname.startsWith('/_') ||
+    (isEventCatalogMCPAuthEnabled() && isMcpRoute(pathname)) ||
     systemRoutes.some((route) => pathname.startsWith(route)) ||
     pathname.startsWith('/.well-known/') ||
     publicRoutes.some((route) => pathname.startsWith(route)) ||

--- a/packages/core/eventcatalog/src/enterprise/feature.ts
+++ b/packages/core/eventcatalog/src/enterprise/feature.ts
@@ -66,6 +66,8 @@ export const isDiagramComparisonEnabled = () => isEventCatalogScaleEnabled();
 
 export const isEventCatalogMCPEnabled = () => isEventCatalogScaleEnabled() && isSSR();
 
+export const isEventCatalogMCPAuthEnabled = () => isEventCatalogMCPEnabled() && (config?.mcp?.auth?.enabled ?? false);
+
 export const isIntegrationsEnabled = () => isEventCatalogScaleEnabled();
 
 export const isExportPDFEnabled = () => true;

--- a/packages/core/eventcatalog/src/enterprise/integrations/eventcatalog-features.ts
+++ b/packages/core/eventcatalog/src/enterprise/integrations/eventcatalog-features.ts
@@ -12,6 +12,7 @@ import {
   isEventCatalogScaleEnabled,
   isEventCatalogStarterEnabled,
   isEventCatalogMCPEnabled,
+  isEventCatalogMCPAuthEnabled,
   isFullCatalogAPIEnabled,
   isDevMode,
   isIntegrationsEnabled,
@@ -69,6 +70,17 @@ export default function eventCatalogIntegration(): AstroIntegration {
           params.injectRoute({
             pattern: '/docs/mcp/[...path]',
             entrypoint: path.join(catalogDirectory, 'src/enterprise/mcp/mcp-server.ts'),
+          });
+        }
+
+        if (isEventCatalogMCPAuthEnabled()) {
+          params.injectRoute({
+            pattern: '/.well-known/oauth-protected-resource',
+            entrypoint: path.join(catalogDirectory, 'src/enterprise/mcp/oauth-protected-resource.ts'),
+          });
+          params.injectRoute({
+            pattern: '/.well-known/oauth-protected-resource/[...path]',
+            entrypoint: path.join(catalogDirectory, 'src/enterprise/mcp/oauth-protected-resource.ts'),
           });
         }
 

--- a/packages/core/eventcatalog/src/enterprise/mcp/__tests__/mcp-auth.spec.ts
+++ b/packages/core/eventcatalog/src/enterprise/mcp/__tests__/mcp-auth.spec.ts
@@ -1,0 +1,102 @@
+/**
+ * Licensed under the EventCatalog Commercial License.
+ * See /packages/core/eventcatalog/src/enterprise/LICENSE
+ */
+
+import { describe, expect, it } from 'vitest';
+import jwt from 'jsonwebtoken';
+import {
+  createWwwAuthenticateHeader,
+  getMcpProtectedResourceMetadata,
+  type McpAuthConfig,
+  validateMcpRequest,
+} from '../mcp-auth';
+
+const authConfig: McpAuthConfig = {
+  enabled: true,
+  resource: 'https://catalog.example.com/docs/mcp',
+  authorizationServers: ['https://auth.example.com'],
+  issuer: 'https://auth.example.com',
+  audience: 'https://catalog.example.com/docs/mcp',
+  requiredScopes: ['catalog:read'],
+  sharedSecret: 'test-secret',
+};
+
+const createRequest = (token?: string) =>
+  new Request('https://catalog.example.com/docs/mcp', {
+    method: 'POST',
+    headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+  });
+
+const createToken = (overrides: Partial<McpAuthConfig> = {}, payload: Record<string, unknown> = {}) =>
+  jwt.sign({ scope: 'catalog:read', ...payload }, authConfig.sharedSecret!, {
+    issuer: overrides.issuer ?? authConfig.issuer,
+    audience: overrides.audience ?? authConfig.audience,
+    expiresIn: '1h',
+  });
+
+describe('MCP OAuth protected resource metadata', () => {
+  it('returns undefined when MCP auth is disabled', () => {
+    const request = createRequest();
+    expect(getMcpProtectedResourceMetadata(request, { enabled: false })).toBeUndefined();
+  });
+
+  it('returns protected resource metadata for MCP clients', () => {
+    const request = createRequest();
+
+    expect(getMcpProtectedResourceMetadata(request, authConfig)).toEqual({
+      resource: 'https://catalog.example.com/docs/mcp',
+      authorization_servers: ['https://auth.example.com'],
+      scopes_supported: ['catalog:read'],
+    });
+  });
+});
+
+describe('MCP Bearer token validation', () => {
+  it('allows requests when MCP auth is disabled', async () => {
+    const result = await validateMcpRequest(createRequest(), { enabled: false });
+    expect(result.ok).toBe(true);
+  });
+
+  it('returns a 401 challenge when the Bearer token is missing', async () => {
+    const result = await validateMcpRequest(createRequest(), authConfig);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+
+    expect(result.status).toBe(401);
+    expect(createWwwAuthenticateHeader(result)).toContain(
+      'resource_metadata="https://catalog.example.com/.well-known/oauth-protected-resource"'
+    );
+    expect(createWwwAuthenticateHeader(result)).toContain('scope="catalog:read"');
+  });
+
+  it('accepts a valid JWT access token', async () => {
+    const token = createToken();
+    const result = await validateMcpRequest(createRequest(token), authConfig);
+
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects a token with the wrong audience', async () => {
+    const token = createToken({ audience: 'https://api.github.com' });
+    const result = await validateMcpRequest(createRequest(token), authConfig);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+
+    expect(result.status).toBe(401);
+    expect(result.error).toBe('invalid_token');
+  });
+
+  it('returns 403 when the token is valid but missing required scopes', async () => {
+    const token = createToken({}, { scope: 'profile:read' });
+    const result = await validateMcpRequest(createRequest(token), authConfig);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+
+    expect(result.status).toBe(403);
+    expect(result.error).toBe('insufficient_scope');
+  });
+});

--- a/packages/core/eventcatalog/src/enterprise/mcp/__tests__/mcp-auth.spec.ts
+++ b/packages/core/eventcatalog/src/enterprise/mcp/__tests__/mcp-auth.spec.ts
@@ -78,6 +78,21 @@ describe('MCP Bearer token validation', () => {
     expect(result.ok).toBe(true);
   });
 
+  it('accepts the Bearer scheme regardless of case', async () => {
+    const token = createToken();
+    const lowercase = new Request('https://catalog.example.com/docs/mcp', {
+      method: 'POST',
+      headers: { Authorization: `bearer ${token}` },
+    });
+    const mixedCase = new Request('https://catalog.example.com/docs/mcp', {
+      method: 'POST',
+      headers: { Authorization: `BeArEr ${token}` },
+    });
+
+    expect((await validateMcpRequest(lowercase, authConfig)).ok).toBe(true);
+    expect((await validateMcpRequest(mixedCase, authConfig)).ok).toBe(true);
+  });
+
   it('rejects a token with the wrong audience', async () => {
     const token = createToken({ audience: 'https://api.github.com' });
     const result = await validateMcpRequest(createRequest(token), authConfig);

--- a/packages/core/eventcatalog/src/enterprise/mcp/__tests__/mcp-server.spec.ts
+++ b/packages/core/eventcatalog/src/enterprise/mcp/__tests__/mcp-server.spec.ts
@@ -80,6 +80,7 @@ vi.mock('@utils/feature', () => ({
   isSSR: vi.fn(() => true),
   isEventCatalogScaleEnabled: vi.fn(() => true),
   isEventCatalogMCPEnabled: vi.fn(() => true),
+  isEventCatalogMCPAuthEnabled: vi.fn(() => false),
 }));
 
 // Mock getSchemasFromResource

--- a/packages/core/eventcatalog/src/enterprise/mcp/mcp-auth.ts
+++ b/packages/core/eventcatalog/src/enterprise/mcp/mcp-auth.ts
@@ -102,8 +102,9 @@ export async function validateMcpRequest(
   const metadataUrl = getMcpProtectedResourceMetadataUrl(request, authConfig);
   const requiredScopes = getMcpRequiredScopes(authConfig);
   const authHeader = request.headers.get('Authorization');
+  const bearerMatch = authHeader?.match(/^Bearer\s+(.*)$/i);
 
-  if (!authHeader?.startsWith('Bearer ')) {
+  if (!bearerMatch) {
     return {
       ok: false,
       status: 401,
@@ -114,7 +115,7 @@ export async function validateMcpRequest(
     };
   }
 
-  const token = authHeader.slice('Bearer '.length).trim();
+  const token = bearerMatch[1].trim();
 
   if (!token) {
     return {

--- a/packages/core/eventcatalog/src/enterprise/mcp/mcp-auth.ts
+++ b/packages/core/eventcatalog/src/enterprise/mcp/mcp-auth.ts
@@ -1,0 +1,265 @@
+/**
+ * Licensed under the EventCatalog Commercial License.
+ * See /packages/core/eventcatalog/src/enterprise/LICENSE
+ */
+
+import jwt, { type Algorithm, type JwtPayload } from 'jsonwebtoken';
+import { createPublicKey, type JsonWebKey, type KeyObject } from 'node:crypto';
+import config from '../../../eventcatalog.config.js';
+import type { Config } from '../../../../src/eventcatalog.config';
+
+type ConfiguredMcpAuth = NonNullable<NonNullable<Config['mcp']>['auth']>;
+
+export type McpAuthConfig = ConfiguredMcpAuth;
+
+type TokenClaims = JwtPayload & {
+  scope?: string;
+  scp?: string[];
+};
+
+type JwksKey = JsonWebKey & {
+  kid?: string;
+};
+
+type AuthFailure = {
+  ok: false;
+  status: 401 | 403;
+  error: string;
+  description: string;
+  requiredScopes: string[];
+  metadataUrl: string;
+};
+
+export type McpAuthResult =
+  | {
+      ok: true;
+      claims?: TokenClaims;
+    }
+  | AuthFailure;
+
+const jwksCache = new Map<string, { expiresAt: number; keys: JwksKey[] }>();
+
+const quote = (value: string) => `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+
+export const getMcpAuthConfig = (): McpAuthConfig | undefined => config?.mcp?.auth;
+
+export const isMcpAuthEnabled = (
+  authConfig: McpAuthConfig | undefined = getMcpAuthConfig()
+): authConfig is McpAuthConfig & { enabled: true } => authConfig?.enabled === true;
+
+export function getMcpResourceUrl(request: Request, authConfig: McpAuthConfig | undefined = getMcpAuthConfig()) {
+  if (authConfig?.resource) return authConfig.resource;
+  return new URL('/docs/mcp', request.url).href;
+}
+
+export function getMcpProtectedResourceMetadataUrl(request: Request, authConfig: McpAuthConfig | undefined = getMcpAuthConfig()) {
+  if (authConfig?.protectedResourceMetadataUrl) return authConfig.protectedResourceMetadataUrl;
+  return new URL('/.well-known/oauth-protected-resource', request.url).href;
+}
+
+export function getMcpRequiredScopes(authConfig: McpAuthConfig | undefined = getMcpAuthConfig()) {
+  return authConfig?.requiredScopes ?? [];
+}
+
+export function getMcpProtectedResourceMetadata(request: Request, authConfig: McpAuthConfig | undefined = getMcpAuthConfig()) {
+  if (!isMcpAuthEnabled(authConfig)) return undefined;
+
+  return {
+    resource: getMcpResourceUrl(request, authConfig),
+    authorization_servers: authConfig?.authorizationServers ?? [],
+    scopes_supported: getMcpRequiredScopes(authConfig),
+  };
+}
+
+export function createWwwAuthenticateHeader(failure: AuthFailure) {
+  const params = [
+    `realm=${quote('mcp')}`,
+    `resource_metadata=${quote(failure.metadataUrl)}`,
+    failure.requiredScopes.length > 0 ? `scope=${quote(failure.requiredScopes.join(' '))}` : undefined,
+    failure.error ? `error=${quote(failure.error)}` : undefined,
+    failure.description ? `error_description=${quote(failure.description)}` : undefined,
+  ].filter(Boolean);
+
+  return `Bearer ${params.join(', ')}`;
+}
+
+export function createMcpAuthErrorResponse(failure: AuthFailure) {
+  return new Response(JSON.stringify({ error: failure.error, message: failure.description }), {
+    status: failure.status,
+    headers: {
+      'Content-Type': 'application/json',
+      'WWW-Authenticate': createWwwAuthenticateHeader(failure),
+    },
+  });
+}
+
+export async function validateMcpRequest(
+  request: Request,
+  authConfig: McpAuthConfig | undefined = getMcpAuthConfig()
+): Promise<McpAuthResult> {
+  if (!isMcpAuthEnabled(authConfig)) return { ok: true };
+
+  const metadataUrl = getMcpProtectedResourceMetadataUrl(request, authConfig);
+  const requiredScopes = getMcpRequiredScopes(authConfig);
+  const authHeader = request.headers.get('Authorization');
+
+  if (!authHeader?.startsWith('Bearer ')) {
+    return {
+      ok: false,
+      status: 401,
+      error: 'invalid_token',
+      description: 'Missing Bearer access token',
+      requiredScopes,
+      metadataUrl,
+    };
+  }
+
+  const token = authHeader.slice('Bearer '.length).trim();
+
+  if (!token) {
+    return {
+      ok: false,
+      status: 401,
+      error: 'invalid_token',
+      description: 'Missing Bearer access token',
+      requiredScopes,
+      metadataUrl,
+    };
+  }
+
+  try {
+    const claims = await verifyAccessToken(token, request, authConfig);
+    const missingScopes = getMissingScopes(claims, requiredScopes);
+
+    if (missingScopes.length > 0) {
+      return {
+        ok: false,
+        status: 403,
+        error: 'insufficient_scope',
+        description: `Missing required scope${missingScopes.length > 1 ? 's' : ''}: ${missingScopes.join(' ')}`,
+        requiredScopes,
+        metadataUrl,
+      };
+    }
+
+    return { ok: true, claims };
+  } catch {
+    return {
+      ok: false,
+      status: 401,
+      error: 'invalid_token',
+      description: 'Invalid or expired Bearer access token',
+      requiredScopes,
+      metadataUrl,
+    };
+  }
+}
+
+async function verifyAccessToken(token: string, request: Request, authConfig: McpAuthConfig): Promise<TokenClaims> {
+  const decoded = jwt.decode(token, { complete: true });
+  const algorithm = decoded && typeof decoded === 'object' ? (decoded.header.alg as Algorithm | undefined) : undefined;
+
+  if (!algorithm || algorithm === 'none') {
+    throw new Error('Unsupported JWT algorithm');
+  }
+
+  const key = await getVerificationKey(token, authConfig);
+  const audience = getJwtAudience(authConfig.audience ?? getMcpResourceUrl(request, authConfig));
+
+  const payload = jwt.verify(token, key, {
+    audience,
+    issuer: authConfig.issuer,
+    algorithms: [algorithm],
+    clockTolerance: 5,
+  });
+
+  if (!payload || typeof payload === 'string') {
+    throw new Error('Invalid JWT payload');
+  }
+
+  return payload as TokenClaims;
+}
+
+async function getVerificationKey(token: string, authConfig: McpAuthConfig): Promise<string | Buffer | KeyObject> {
+  const sharedSecret = getConfiguredValue(authConfig.sharedSecret, authConfig.sharedSecretEnvVar);
+  if (sharedSecret) return sharedSecret;
+
+  const publicKey = getConfiguredValue(authConfig.publicKey, authConfig.publicKeyEnvVar);
+  if (publicKey) return publicKey;
+
+  if (authConfig.jwksUri) {
+    return getJwksVerificationKey(token, authConfig.jwksUri);
+  }
+
+  throw new Error('MCP auth requires jwksUri, publicKey, publicKeyEnvVar, sharedSecret, or sharedSecretEnvVar');
+}
+
+function getConfiguredValue(value: string | undefined, envVar: string | undefined) {
+  if (value) return value;
+  if (envVar) return process.env[envVar];
+  return undefined;
+}
+
+async function getJwksVerificationKey(token: string, jwksUri: string) {
+  const decoded = jwt.decode(token, { complete: true });
+  const kid = decoded && typeof decoded === 'object' ? decoded.header.kid : undefined;
+  const keys = await getJwksKeys(jwksUri);
+  const jwk = keys.find((key) => (kid ? key.kid === kid : keys.length === 1));
+
+  if (!jwk) {
+    throw new Error('No matching JWKS key found for token');
+  }
+
+  return createPublicKey({ key: jwk, format: 'jwk' });
+}
+
+function getJwtAudience(audience: string | string[]) {
+  if (Array.isArray(audience)) {
+    if (audience.length === 0) return undefined;
+    return audience as [string, ...string[]];
+  }
+
+  return audience;
+}
+
+async function getJwksKeys(jwksUri: string): Promise<JwksKey[]> {
+  const cached = jwksCache.get(jwksUri);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.keys;
+  }
+
+  const response = await fetch(jwksUri, {
+    headers: {
+      Accept: 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch JWKS: ${response.status}`);
+  }
+
+  const body = (await response.json()) as { keys?: JwksKey[] };
+  const keys = body.keys ?? [];
+  jwksCache.set(jwksUri, { keys, expiresAt: Date.now() + 5 * 60 * 1000 });
+  return keys;
+}
+
+function getMissingScopes(claims: TokenClaims, requiredScopes: string[]) {
+  if (requiredScopes.length === 0) return [];
+
+  const scopes = new Set<string>();
+
+  if (typeof claims.scope === 'string') {
+    for (const scope of claims.scope.split(/\s+/)) {
+      if (scope) scopes.add(scope);
+    }
+  }
+
+  if (Array.isArray(claims.scp)) {
+    for (const scope of claims.scp) {
+      scopes.add(scope);
+    }
+  }
+
+  return requiredScopes.filter((scope) => !scopes.has(scope));
+}

--- a/packages/core/eventcatalog/src/enterprise/mcp/mcp-server.ts
+++ b/packages/core/eventcatalog/src/enterprise/mcp/mcp-server.ts
@@ -32,6 +32,7 @@ import {
   toolDescriptions,
 } from '@enterprise/tools/catalog-tools';
 import { getCollection } from 'astro:content';
+import { createMcpAuthErrorResponse, validateMcpRequest } from './mcp-auth';
 
 const catalogDirectory = process.env.PROJECT_DIR || process.cwd();
 
@@ -462,6 +463,12 @@ const mcpResources = [
 
 // Health check endpoint
 app.get('/', async (c: Context) => {
+  const auth = await validateMcpRequest(c.req.raw);
+
+  if (!auth.ok) {
+    return createMcpAuthErrorResponse(auth);
+  }
+
   return c.json({
     name: 'EventCatalog MCP Server',
     version: '1.0.0',
@@ -475,6 +482,12 @@ app.get('/', async (c: Context) => {
 // MCP protocol endpoint - handles POST requests for MCP protocol
 app.post('/', async (c: Context) => {
   try {
+    const auth = await validateMcpRequest(c.req.raw);
+
+    if (!auth.ok) {
+      return createMcpAuthErrorResponse(auth);
+    }
+
     // Create fresh server and transport per request — the MCP SDK's
     // WebStandardStreamableHTTPServerTransport is single-use in stateless
     // mode: it sets _hasHandledRequest=true after the first call and throws

--- a/packages/core/eventcatalog/src/enterprise/mcp/oauth-protected-resource.ts
+++ b/packages/core/eventcatalog/src/enterprise/mcp/oauth-protected-resource.ts
@@ -1,0 +1,25 @@
+/**
+ * Licensed under the EventCatalog Commercial License.
+ * See /packages/core/eventcatalog/src/enterprise/LICENSE
+ */
+
+import type { APIRoute } from 'astro';
+import { getMcpProtectedResourceMetadata } from './mcp-auth';
+
+export const GET: APIRoute = async ({ request }) => {
+  const metadata = getMcpProtectedResourceMetadata(request);
+
+  if (!metadata) {
+    return new Response(JSON.stringify({ error: 'mcp_auth_not_configured' }), {
+      status: 404,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  return new Response(JSON.stringify(metadata, null, 2), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+};
+
+export const prerender = false;

--- a/packages/core/eventcatalog/src/utils/feature.ts
+++ b/packages/core/eventcatalog/src/utils/feature.ts
@@ -29,6 +29,7 @@ export {
   isCustomStylesEnabled,
   isDiagramComparisonEnabled,
   isEventCatalogMCPEnabled,
+  isEventCatalogMCPAuthEnabled,
   isIntegrationsEnabled,
   isExportPDFEnabled,
 } from '../enterprise/feature';

--- a/packages/core/src/eventcatalog.config.ts
+++ b/packages/core/src/eventcatalog.config.ts
@@ -55,6 +55,49 @@ type AuthConfig = {
   enabled: boolean;
 };
 
+type McpAuthConfig = {
+  /**
+   * Require OAuth Bearer tokens for the built-in MCP server.
+   * EventCatalog acts as the MCP protected resource server; the
+   * configured authorization server remains responsible for login,
+   * consent, token issuance, and client registration.
+   */
+  enabled?: boolean;
+  /**
+   * Absolute URL for the MCP resource. Defaults to the request origin
+   * plus `/docs/mcp`, but production deployments behind proxies should
+   * set this explicitly.
+   */
+  resource?: string;
+  /**
+   * Optional absolute URL for the OAuth Protected Resource Metadata
+   * document. Defaults to `/.well-known/oauth-protected-resource`.
+   */
+  protectedResourceMetadataUrl?: string;
+  /** Authorization server issuer/base URLs advertised to MCP clients. */
+  authorizationServers?: string[];
+  /** Expected token issuer (`iss`). */
+  issuer?: string;
+  /** Expected token audience (`aud`). Defaults to `resource`. */
+  audience?: string | string[];
+  /** Scopes required to call the MCP server. */
+  requiredScopes?: string[];
+  /** JWKS endpoint used to validate asymmetric JWT access tokens. */
+  jwksUri?: string;
+  /** Inline public key for asymmetric JWT validation. */
+  publicKey?: string;
+  /** Environment variable containing the public key. */
+  publicKeyEnvVar?: string;
+  /** Inline shared secret for symmetric JWT validation. Prefer `sharedSecretEnvVar`. */
+  sharedSecret?: string;
+  /** Environment variable containing the shared secret. */
+  sharedSecretEnvVar?: string;
+};
+
+type McpConfig = {
+  auth?: McpAuthConfig;
+};
+
 type GA4Config = {
   measurementId: string;
 };
@@ -105,6 +148,7 @@ export interface Config {
    */
   theme?: CatalogTheme;
   auth?: AuthConfig;
+  mcp?: McpConfig;
   rss?: {
     enabled: boolean;
     limit: number;

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -25,7 +25,6 @@
 - 8f724a7: feat: add `externalSystem` flag to services for modelling third-party integrations
 
   Services can now set `externalSystem: true` in their frontmatter to be rendered as external systems. This changes their presentation without changing their capabilities — they still send and receive messages, have owners, and support specifications like any other service.
-
   - Visualiser: external services render purple with a Globe icon and an "External System" badge
   - Sidebar (root): a dedicated "External Systems" section lists externals; the regular "Services" section excludes them
   - Sidebar (domain): externals appear under a new "External Integrations" group, separate from "Services In Domain"


### PR DESCRIPTION
Closes #2123

## What This PR Does

Adds OAuth 2.0 Bearer token authentication for EventCatalog's built-in MCP server at `/docs/mcp`, following the MCP authorization specification for HTTP transports. EventCatalog now acts as an OAuth **protected resource server**: it validates incoming access tokens but does not issue them — login, consent, client registration, and token issuance remain the responsibility of the user's existing authorization server. Unauthenticated MCP clients receive a `401` with a `WWW-Authenticate` header that points them at the protected resource metadata document, so spec-compliant MCP clients can complete the authorization handshake automatically.

## Changes Overview

### Key Changes

- **New config surface** (`packages/core/src/eventcatalog.config.ts`): `mcp.auth` block on `Config`, with `enabled`, `resource`, `protectedResourceMetadataUrl`, `authorizationServers`, `issuer`, `audience`, `requiredScopes`, `jwksUri`, `publicKey` / `publicKeyEnvVar`, and `sharedSecret` / `sharedSecretEnvVar`.
- **Feature gate** (`packages/core/eventcatalog/src/enterprise/feature.ts`): new `isEventCatalogMCPAuthEnabled()` — requires Scale plan + SSR + `mcp.auth.enabled = true`. Re-exported via `@utils/feature`.
- **Token validation** (`packages/core/eventcatalog/src/enterprise/mcp/mcp-auth.ts`): validates Bearer JWTs against the configured JWKS / public key / shared secret, checks issuer, audience, expiry, and required scopes, and returns structured `WWW-Authenticate` error responses on failure.
- **MCP endpoints** (`packages/core/eventcatalog/src/enterprise/mcp/mcp-server.ts`): both `GET /` (health) and `POST /` (MCP protocol) now call `validateMcpRequest` and short-circuit with `createMcpAuthErrorResponse` when auth fails.
- **Protected resource metadata** (`packages/core/eventcatalog/src/enterprise/mcp/oauth-protected-resource.ts`): new route serving `/.well-known/oauth-protected-resource`, injected by the Astro integration when MCP auth is enabled.
- **Middleware exclusion** (`packages/core/eventcatalog/src/enterprise/auth/middleware/middleware-auth.ts`): MCP routes (`/docs/mcp`, `/docs/mcp/*`) are skipped by the existing browser-session auth middleware when MCP auth is enabled, since MCP clients use Bearer tokens rather than cookies.
- **Tests**: new `mcp-auth.spec.ts` covering the validation matrix, plus updates to `middleware-auth.spec.ts` and `mcp-server.spec.ts` for the new branching.
- **Docs**: "Protect the MCP server with OAuth" section added to the in-repo docs and to `website-2`, tagged with `<AddedIn version="3.40.0" />`.

## How It Works

1. The user sets `mcp.auth.enabled = true` in `eventcatalog.config.js` and points it at their authorization server's JWKS endpoint (or supplies a public key / shared secret).
2. The Astro integration injects the `/.well-known/oauth-protected-resource` route, and the auth middleware learns to skip `/docs/mcp` routes so it doesn't redirect MCP clients to the login page.
3. On every MCP request, the server pulls the `Authorization: Bearer <jwt>` header, verifies the signature against the configured key material, and checks `iss`, `aud`, `exp`, and `scope` against the configured values.
4. On failure, the server returns `401` with a `WWW-Authenticate: Bearer resource_metadata="..."` header pointing at the protected resource metadata document, which advertises the configured authorization servers. Spec-compliant MCP clients then run the authorization code flow against the user's IdP and retry with a valid token.

The browser-session auth (`auth.enabled` / `eventcatalog.auth.js`) is unchanged and continues to gate the EventCatalog UI. The two auth surfaces are deliberately separate — they protect different transports for different client types.

## Breaking Changes

None. The feature is opt-in via `mcp.auth.enabled` and is gated by the Scale plan + SSR. Existing MCP deployments that don't set `mcp.auth` continue to behave as before.

## Additional Notes

- Docs were also updated in the sibling repo `eventcatalog/website-2` (`docs/development/ask-your-architecture/03-mcp-server/getting-started.md`). Those need to be committed and PR'd separately.
- Requires Scale plan and SSR (`output: 'server'`).
- The token validator supports JWKS, asymmetric public keys (inline or via env var), and symmetric shared secrets — env-var forms are recommended over inline.