### PR TITLE
Catalog analytics tracking

### DIFF
--- a/.changeset/swift-otters-ingest.md
+++ b/.changeset/swift-otters-ingest.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Update the default cloud analytics ingest endpoint to https://api.ecingest.dev/v1/analytics/ingest

--- a/examples/default/eventcatalog.config.js
+++ b/examples/default/eventcatalog.config.js
@@ -39,6 +39,15 @@ export default {
     type: 'indexed'
   },
 
+  cloud: {
+    analytics: {
+      enabled: true,
+      trackingId: 'ec_pSHjUPcG_IC-rA33',
+      writeKey: 'ecwk_DDxi5JHmfKahvl7kbNvGcfeMgNOpfMTU',
+      endpoint: 'https://eventcatalog-analytics.dave-c96.workers.dev/v1/analytics/ingest',
+    }
+  },
+
   navigation: {
     pages: [
       {

--- a/examples/default/eventcatalog.config.js
+++ b/examples/default/eventcatalog.config.js
@@ -38,16 +38,6 @@ export default {
   search: {
     type: 'indexed'
   },
-
-  cloud: {
-    analytics: {
-      enabled: true,
-      trackingId: 'ec_pSHjUPcG_IC-rA33',
-      writeKey: 'ecwk_DDxi5JHmfKahvl7kbNvGcfeMgNOpfMTU',
-      endpoint: 'https://eventcatalog-analytics.dave-c96.workers.dev/v1/analytics/ingest',
-    }
-  },
-
   navigation: {
     pages: [
       {

--- a/packages/core/docs/api/03-domain-api.md
+++ b/packages/core/docs/api/03-domain-api.md
@@ -283,6 +283,22 @@ You can also pass any valid CSS color value directly: hex (`#ff0000`), `rgb()`, 
 ---
 ```
 
+#### Link to external URLs
+
+<AddedIn version="3.39.6" />
+
+Add a `url` to a badge to make it render as a clickable link with an external-link icon. When `url` is omitted, the badge renders as a plain label.
+
+```md title="Link badge example"
+---
+  badges:
+    - content: View Runbook
+      url: https://runbooks.example.com/my-domain
+      backgroundColor: blue
+      textColor: white
+---
+```
+
 ### `specifications` {#specifications}
 
 <AddedIn version="2.6.0" />

--- a/packages/core/docs/api/04-service-api.md
+++ b/packages/core/docs/api/04-service-api.md
@@ -263,6 +263,22 @@ You can also pass any valid CSS color value directly: hex (`#ff0000`), `rgb()`, 
 ---
 ```
 
+#### Link to external URLs
+
+<AddedIn version="3.39.6" />
+
+Add a `url` to a badge to make it render as a clickable link with an external-link icon. When `url` is omitted, the badge renders as a plain label.
+
+```md title="Link badge example"
+---
+  badges:
+    - content: View Runbook
+      url: https://runbooks.example.com/my-service
+      backgroundColor: blue
+      textColor: white
+---
+```
+
 ### `specifications` {#specifications}
 
 <AddedIn version="2.39.1" />

--- a/packages/core/docs/api/05-command-api.md
+++ b/packages/core/docs/api/05-command-api.md
@@ -186,6 +186,22 @@ You can also pass any valid CSS color value directly: hex (`#ff0000`), `rgb()`, 
 ---
 ```
 
+#### Link to external URLs
+
+<AddedIn version="3.39.6" />
+
+Add a `url` to a badge to make it render as a clickable link with an external-link icon. When `url` is omitted, the badge renders as a plain label.
+
+```md title="Link badge example"
+---
+  badges:
+    - content: View Runbook
+      url: https://runbooks.example.com/my-command
+      backgroundColor: blue
+      textColor: white
+---
+```
+
 ### `schemaPath` {#schemaPath}
 
 Path to the schema of the message.

--- a/packages/core/docs/api/06-event-api.md
+++ b/packages/core/docs/api/06-event-api.md
@@ -185,6 +185,22 @@ You can also pass any valid CSS color value directly: hex (`#ff0000`), `rgb()`, 
 ---
 ```
 
+#### Link to external URLs
+
+<AddedIn version="3.39.6" />
+
+Add a `url` to a badge to make it render as a clickable link with an external-link icon. When `url` is omitted, the badge renders as a plain label.
+
+```md title="Link badge example"
+---
+  badges:
+    - content: View Runbook
+      url: https://runbooks.example.com/my-event
+      backgroundColor: blue
+      textColor: white
+---
+```
+
 ### `schemaPath` {#schemaPath}
 
 Path to the schema of the message.

--- a/packages/core/docs/api/06-query-api.md
+++ b/packages/core/docs/api/06-query-api.md
@@ -183,6 +183,22 @@ You can also pass any valid CSS color value directly: hex (`#ff0000`), `rgb()`, 
 ---
 ```
 
+#### Link to external URLs
+
+<AddedIn version="3.39.6" />
+
+Add a `url` to a badge to make it render as a clickable link with an external-link icon. When `url` is omitted, the badge renders as a plain label.
+
+```md title="Link badge example"
+---
+  badges:
+    - content: View Runbook
+      url: https://runbooks.example.com/my-query
+      backgroundColor: blue
+      textColor: white
+---
+```
+
 ### `schemaPath` {#schemaPath}
 
 Path to the schema of the message.

--- a/packages/core/docs/api/08-channel-api.md
+++ b/packages/core/docs/api/08-channel-api.md
@@ -251,6 +251,22 @@ You can also pass any valid CSS color value directly: hex (`#ff0000`), `rgb()`, 
 ---
 ```
 
+#### Link to external URLs
+
+<AddedIn version="3.39.6" />
+
+Add a `url` to a badge to make it render as a clickable link with an external-link icon. When `url` is omitted, the badge renders as a plain label.
+
+```md title="Link badge example"
+---
+  badges:
+    - content: View Runbook
+      url: https://runbooks.example.com/my-channel
+      backgroundColor: blue
+      textColor: white
+---
+```
+
 ### `repository` {#repository}
 
 <AddedIn version="2.11.2" />

--- a/packages/core/docs/api/09-flow-api.md
+++ b/packages/core/docs/api/09-flow-api.md
@@ -360,6 +360,22 @@ You can also pass any valid CSS color value directly: hex (`#ff0000`), `rgb()`, 
 ---
 ```
 
+#### Link to external URLs
+
+<AddedIn version="3.39.6" />
+
+Add a `url` to a badge to make it render as a clickable link with an external-link icon. When `url` is omitted, the badge renders as a plain label.
+
+```md title="Link badge example"
+---
+  badges:
+    - content: View Runbook
+      url: https://runbooks.example.com/my-flow
+      backgroundColor: blue
+      textColor: white
+---
+```
+
 ### `editUrl` {#editUrl}
 
 <AddedIn version="2.49.4" />

--- a/packages/core/docs/api/10-entity-api.md
+++ b/packages/core/docs/api/10-entity-api.md
@@ -233,6 +233,21 @@ You can also pass any valid CSS color value directly: hex (`#ff0000`), `rgb()`, 
 ---
 ```
 
+#### Link to external URLs
+
+<AddedIn version="3.39.6" />
+
+Add a `url` to a badge to make it render as a clickable link with an external-link icon. When `url` is omitted, the badge renders as a plain label.
+
+```md title="Link badge example"
+---
+  badges:
+    - content: View Runbook
+      url: https://runbooks.example.com/my-entity
+      backgroundColor: blue
+      textColor: white
+---
+```
 
 ### `editUrl` {#editUrl}
 

--- a/packages/core/docs/api/12-data-product-api.md
+++ b/packages/core/docs/api/12-data-product-api.md
@@ -229,6 +229,7 @@ Badge properties:
 | `content` | `string` | Yes | Text content of the badge |
 | `backgroundColor` | `string` | Yes | Background color (named token or CSS value) |
 | `textColor` | `string` | Yes | Text color (named token or CSS value) |
+| `url` | `string` | No | When set, the badge renders as a clickable link with an external-link icon |
 
 #### Use named colors
 
@@ -239,6 +240,22 @@ Supported names: `slate`, `gray`, `zinc`, `neutral`, `stone`, `red`, `orange`, `
 #### Use any CSS color
 
 You can also pass any valid CSS color value directly: hex (`#ff0000`), `rgb()`, `hsl()`, `oklch()`, or a CSS variable (`var(--my-color)`).
+
+#### Link to external URLs
+
+<AddedIn version="3.39.6" />
+
+Add a `url` to a badge to make it render as a clickable link with an external-link icon. When `url` is omitted, the badge renders as a plain label.
+
+```md title="Link badge example"
+---
+badges:
+  - content: View Runbook
+    url: https://runbooks.example.com/my-data-product
+    backgroundColor: blue
+    textColor: white
+---
+```
 
 ### `repository`
 

--- a/packages/core/docs/development/ask-your-architecture/03-mcp-server/getting-started.md
+++ b/packages/core/docs/development/ask-your-architecture/03-mcp-server/getting-started.md
@@ -45,6 +45,78 @@ Visit the endpoint in your browser to verify. It returns available tools and res
 }
 ```
 
+### Protect with OAuth
+
+<AddedIn version="3.40.0" />
+
+The built-in MCP server can be protected with OAuth Bearer tokens, following the MCP authorization specification for HTTP transports.
+
+EventCatalog acts as the OAuth protected resource server for `/docs/mcp`. Your identity provider or authorization server remains responsible for user login, consent, client registration, `/authorize`, `/oauth/token`, and token refresh.
+
+Configure MCP authorization in `eventcatalog.config.js`:
+
+```js title="eventcatalog.config.js"
+module.exports = {
+  output: 'server',
+  mcp: {
+    auth: {
+      enabled: true,
+      resource: 'https://your-eventcatalog.com/docs/mcp',
+      authorizationServers: ['https://auth.example.com'],
+      issuer: 'https://auth.example.com',
+      audience: 'https://your-eventcatalog.com/docs/mcp',
+      requiredScopes: ['catalog:read'],
+      jwksUri: 'https://auth.example.com/.well-known/jwks.json',
+    },
+  },
+};
+```
+
+When enabled, EventCatalog serves protected resource metadata at `/.well-known/oauth-protected-resource`. Unauthenticated MCP clients receive a `401 Unauthorized` response with a `WWW-Authenticate` header pointing at that document. MCP clients then obtain an access token from the advertised authorization server and call `/docs/mcp` with:
+
+```http
+Authorization: Bearer <access-token>
+```
+
+The access token must be valid, unexpired, issued by the configured issuer, intended for the configured audience, and include all required scopes.
+
+#### Key signing options
+
+Choose one of the following strategies for token validation:
+
+| Strategy | Config fields |
+|---|---|
+| JWKS endpoint (recommended) | `jwksUri` |
+| Inline asymmetric public key | `publicKey` or `publicKeyEnvVar` |
+| Symmetric shared secret | `sharedSecret` or `sharedSecretEnvVar` |
+
+Prefer `publicKeyEnvVar` or `sharedSecretEnvVar` over inline values to avoid committing secrets to source control.
+
+#### All options
+
+| Field | Required | Description |
+|---|---|---|
+| `enabled` | Yes | Enables OAuth Bearer token validation |
+| `resource` | No | Absolute URL of the MCP resource. Set this explicitly when behind a proxy |
+| `protectedResourceMetadataUrl` | No | URL for the protected resource metadata document. Defaults to `/.well-known/oauth-protected-resource` |
+| `authorizationServers` | No | Authorization server URLs advertised to MCP clients |
+| `issuer` | No | Expected token issuer (`iss` claim) |
+| `audience` | No | Expected token audience (`aud` claim). Defaults to `resource` |
+| `requiredScopes` | No | Scopes every token must include |
+| `jwksUri` | No | JWKS endpoint for asymmetric JWT validation |
+| `publicKey` | No | Inline public key for asymmetric JWT validation |
+| `publicKeyEnvVar` | No | Environment variable containing the public key |
+| `sharedSecret` | No | Inline shared secret for symmetric JWT validation |
+| `sharedSecretEnvVar` | No | Environment variable containing the shared secret |
+
+:::note Existing website authentication
+The `auth.enabled` and `eventcatalog.auth.js` settings protect the EventCatalog website with browser sessions. MCP authorization is separate because MCP clients authenticate with Bearer tokens, not browser cookies.
+:::
+
+:::tip Authorization server discovery
+EventCatalog serves `/.well-known/oauth-protected-resource` for MCP client discovery. It does not serve `/.well-known/oauth-authorization-server`, `/authorize`, or `/oauth/token` -- those endpoints must be provided by the authorization server listed in `authorizationServers`. If your MCP client expects those endpoints on the catalog host, proxy the authorization server behind that host with your load balancer or reverse proxy.
+:::
+
 ### Connect clients
 
 <details>

--- a/packages/core/eventcatalog/src/enterprise/analytics/components/AnalyticsHead.astro
+++ b/packages/core/eventcatalog/src/enterprise/analytics/components/AnalyticsHead.astro
@@ -3,11 +3,15 @@ import config from '@config';
 import { isIntegrationsEnabled } from '@utils/feature';
 
 const integrations = config.integrations;
+const cloudAnalytics = config.cloud?.analytics;
 const enabled = isIntegrationsEnabled() && integrations;
 const hasProviders = enabled && (integrations?.ga4 || integrations?.gtm || integrations?.posthog);
 const debug = integrations?.debug ?? false;
+const cloudDebug = cloudAnalytics?.debug ?? debug;
+const cloudAnalyticsEndpoint = cloudAnalytics?.endpoint || 'https://eventcatalog.cloud/v1/analytics/ingest';
+const isCloudAnalyticsEnabled = cloudAnalytics?.enabled === true && !!cloudAnalytics?.trackingId;
 // Render the manager if there are providers OR if debug mode is on (so users can verify the pipeline)
-const shouldRender = enabled && (hasProviders || debug);
+const shouldRender = isCloudAnalyticsEnabled || (enabled && (hasProviders || debug));
 
 // Build script contents in frontmatter to avoid Prettier/JSX parsing issues with braces in inline scripts
 const ga4ConfigScript = integrations?.ga4
@@ -35,6 +39,7 @@ posthog.init(${posthogApiKey}, {api_host: ${posthogApiHost}, person_profiles: 'i
 const hasGA4 = !!integrations?.ga4;
 const hasGTM = !!integrations?.gtm;
 const hasPostHog = !!integrations?.posthog;
+const hasCloudAnalytics = !!isCloudAnalyticsEnabled;
 
 const managerScript = `(function() {
 function AnalyticsManager(opts) {
@@ -57,6 +62,28 @@ AnalyticsManager.prototype.pageView = function(url, props) {
     try { this.adapters[i].pageView(url, props); } catch(e) {}
   }
 };
+function createId(prefix) {
+  var bytes = new Uint8Array(16);
+  if (window.crypto && window.crypto.getRandomValues) {
+    window.crypto.getRandomValues(bytes);
+  } else {
+    for (var i = 0; i < bytes.length; i++) bytes[i] = Math.floor(Math.random() * 256);
+  }
+  return prefix + '_' + Array.prototype.map.call(bytes, function(byte) {
+    return byte.toString(16).padStart(2, '0');
+  }).join('');
+}
+function getStoredId(storage, key, prefix) {
+  try {
+    var existing = storage.getItem(key);
+    if (existing) return existing;
+    var id = createId(prefix);
+    storage.setItem(key, id);
+    return id;
+  } catch(e) {
+    return createId(prefix);
+  }
+}
 var manager = new AnalyticsManager({ debug: ${debug} });
 ${
   hasGA4
@@ -82,6 +109,56 @@ ${
   name: 'posthog',
   track: function(event, props) { if (window.posthog) window.posthog.capture(event, props); },
   pageView: function(url, props) { if (window.posthog) window.posthog.capture('$pageview', Object.assign({ '$current_url': url }, props || {})); }
+});`
+    : ''
+}
+${
+  hasCloudAnalytics
+    ? `var eventCatalogCloudLastPath;
+manager.register({
+  name: 'eventcatalog-cloud',
+  track: function(event, props) {
+    if (event !== 'catalog.page_viewed' && event !== 'catalog.built' && event !== 'catalog.resource_inventory_reported') return;
+
+    var payload = Object.assign({
+      trackingId: ${JSON.stringify(cloudAnalytics?.trackingId || '')},
+      event: event,
+      anonymousId: getStoredId(window.localStorage, 'eventcatalog-cloud-anonymous-id', 'anon'),
+      sessionId: getStoredId(window.sessionStorage, 'eventcatalog-cloud-session-id', 'sess'),
+      timestamp: new Date().toISOString()
+    }, props || {});
+
+    var body = JSON.stringify(payload);
+    if (${cloudDebug}) console.log('[EventCatalog Cloud Analytics] track: ' + event, payload);
+
+    try {
+      fetch(${JSON.stringify(cloudAnalyticsEndpoint)}, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: body,
+        keepalive: true,
+        credentials: 'omit'
+      }).catch(function() {});
+    } catch(e) {}
+  },
+  pageView: function(url, props) {
+    props = props || {};
+    var path = props.url || url || window.location.pathname;
+    var payload = {
+      path: path,
+      section: props.section || undefined,
+      referrer: eventCatalogCloudLastPath || document.referrer || undefined
+    };
+    if (props.resource_type && props.resource_id) {
+      payload.resource = {
+        type: props.resource_type,
+        id: props.resource_id,
+        version: props.resource_version || undefined
+      };
+    }
+    eventCatalogCloudLastPath = path;
+    this.track('catalog.page_viewed', payload);
+  }
 });`
     : ''
 }

--- a/packages/core/eventcatalog/src/enterprise/analytics/components/AnalyticsHead.astro
+++ b/packages/core/eventcatalog/src/enterprise/analytics/components/AnalyticsHead.astro
@@ -8,7 +8,7 @@ const enabled = isIntegrationsEnabled() && integrations;
 const hasProviders = enabled && (integrations?.ga4 || integrations?.gtm || integrations?.posthog);
 const debug = integrations?.debug ?? false;
 const cloudDebug = cloudAnalytics?.debug ?? debug;
-const cloudAnalyticsEndpoint = cloudAnalytics?.endpoint || 'https://eventcatalog.cloud/v1/analytics/ingest';
+const cloudAnalyticsEndpoint = cloudAnalytics?.endpoint || 'https://api.ecingest.dev/v1/analytics/ingest';
 const isCloudAnalyticsEnabled = cloudAnalytics?.enabled === true && !!cloudAnalytics?.trackingId;
 // Render the manager if there are providers OR if debug mode is on (so users can verify the pipeline)
 const shouldRender = isCloudAnalyticsEnabled || (enabled && (hasProviders || debug));

--- a/packages/core/eventcatalog/src/enterprise/analytics/components/AnalyticsTracker.astro
+++ b/packages/core/eventcatalog/src/enterprise/analytics/components/AnalyticsTracker.astro
@@ -3,10 +3,12 @@ import config from '@config';
 import { isIntegrationsEnabled } from '@utils/feature';
 
 const integrations = config.integrations;
+const cloudAnalytics = config.cloud?.analytics;
 const enabled = isIntegrationsEnabled() && integrations;
 const hasProviders = enabled && (integrations?.ga4 || integrations?.gtm || integrations?.posthog);
 const debug = integrations?.debug ?? false;
-const shouldRender = enabled && (hasProviders || debug);
+const isCloudAnalyticsEnabled = cloudAnalytics?.enabled === true && !!cloudAnalytics?.trackingId;
+const shouldRender = isCloudAnalyticsEnabled || (enabled && (hasProviders || debug));
 
 const base = (config.base || '/').replace(/\/$/, '');
 const baseJson = JSON.stringify(base);

--- a/packages/core/src/analytics/log-build.js
+++ b/packages/core/src/analytics/log-build.js
@@ -11,7 +11,7 @@ const getFeatures = async (configFile) => {
   };
 };
 
-const CLOUD_ANALYTICS_ENDPOINT = 'https://eventcatalog.cloud/v1/analytics/ingest';
+const CLOUD_ANALYTICS_ENDPOINT = 'https://api.ecingest.dev/v1/analytics/ingest';
 
 const toCloudResourceCounts = (counts) => ({
   domains: counts.domains || 0,

--- a/packages/core/src/analytics/log-build.js
+++ b/packages/core/src/analytics/log-build.js
@@ -11,6 +11,46 @@ const getFeatures = async (configFile) => {
   };
 };
 
+const CLOUD_ANALYTICS_ENDPOINT = 'https://eventcatalog.cloud/v1/analytics/ingest';
+
+const toCloudResourceCounts = (counts) => ({
+  domains: counts.domains || 0,
+  services: counts.services || 0,
+  events: counts.events || 0,
+  commands: counts.commands || 0,
+  queries: counts.queries || 0,
+  flows: counts.flows || 0,
+  channels: counts.channels || 0,
+  entities: counts.entities || 0,
+  containers: counts.containers || 0,
+  dataProducts: counts['data-products'] || 0,
+  teams: counts.teams || 0,
+  users: counts.users || 0,
+  designs: counts.designs || 0,
+  diagrams: counts.diagrams || 0,
+  ubiquitousLanguages: counts.ubiquitousLanguages || 0,
+});
+
+const reportCloudResourceInventory = async (configFile, resourceCounts) => {
+  const analytics = configFile.cloud?.analytics;
+  if (!analytics?.enabled || !analytics.trackingId || !analytics.writeKey) return;
+
+  const endpoint = analytics.endpoint || CLOUD_ANALYTICS_ENDPOINT;
+  await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-EventCatalog-Analytics-Key': analytics.writeKey,
+    },
+    body: JSON.stringify({
+      trackingId: analytics.trackingId,
+      event: 'catalog.resource_inventory_reported',
+      timestamp: new Date().toISOString(),
+      counts: toCloudResourceCounts(resourceCounts),
+    }),
+  });
+};
+
 /**
  *
  * @param {string} projectDir
@@ -38,6 +78,8 @@ const main = async (projectDir, { isEventCatalogStarterEnabled, isEventCatalogSc
 
     const features = await getFeatures(configFile);
     const resourceCounts = await countResources(projectDir);
+
+    await reportCloudResourceInventory(configFile, resourceCounts);
 
     await raiseEvent({
       command: 'build',

--- a/packages/core/src/eventcatalog.config.ts
+++ b/packages/core/src/eventcatalog.config.ts
@@ -68,6 +68,18 @@ type PostHogConfig = {
   apiHost?: string;
 };
 
+type EventCatalogCloudAnalyticsConfig = {
+  enabled: boolean;
+  trackingId: string;
+  writeKey?: string;
+  endpoint?: string;
+  debug?: boolean;
+};
+
+type EventCatalogCloudConfig = {
+  analytics?: EventCatalogCloudAnalyticsConfig;
+};
+
 type IntegrationsConfig = {
   ga4?: GA4Config;
   gtm?: GTMConfig;
@@ -216,6 +228,7 @@ export interface Config {
   queries?: {
     tableConfiguration?: TableConfiguration;
   };
+  cloud?: EventCatalogCloudConfig;
   integrations?: IntegrationsConfig;
   scalarConfiguration?: ScalarConfiguration;
 }


### PR DESCRIPTION
## What This PR Does

Adds cloud analytics tracking for EventCatalog catalogs and configures the default ingest endpoint. Catalogs can now send anonymous build/usage analytics to the EventCatalog cloud ingest service when `cloud.analytics` is enabled in the config.

## Changes Overview

### Key Changes
- Add catalog analytics tracking via `AnalyticsHead.astro` and `AnalyticsTracker.astro`
- Add build-time analytics logging in `src/analytics/log-build.js` (resource counts)
- Extend `eventcatalog.config.ts` with the `cloud.analytics` config schema
- Set the default cloud analytics ingest endpoint to `https://api.ecingest.dev/v1/analytics/ingest`

## How It Works

When `cloud.analytics.enabled` is `true` and a `trackingId` is set, the catalog renders the analytics manager in the page head and posts events to the configured ingest endpoint. The endpoint defaults to `https://api.ecingest.dev/v1/analytics/ingest` and can be overridden via `cloud.analytics.endpoint`. Build-time resource counts are logged via `log-build.js`.

## Breaking Changes

None. Analytics is opt-in via config.

## Additional Notes

- The default ingest endpoint was updated to `https://api.ecingest.dev/v1/analytics/ingest`.
- The committed `packages/core/docs/*` changes are auto-synced from the `website-2` repo by the pre-commit hook.