### PR TITLE
Show full resource name tooltips on truncated visualiser nodes

### DIFF
--- a/.changeset/clever-otters-truncate.md
+++ b/.changeset/clever-otters-truncate.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/visualiser": patch
+---
+
+Visualiser nodes now show a tooltip with the full resource name on hover when the name is truncated.

--- a/packages/visualiser/src/nodes/Custom.tsx
+++ b/packages/visualiser/src/nodes/Custom.tsx
@@ -4,6 +4,7 @@ import * as Icons from "@heroicons/react/24/solid";
 import * as ContextMenu from "@radix-ui/react-context-menu";
 import { HIDDEN_HANDLE_STYLE } from "./OwnerIndicator";
 import { EMPTY_ARRAY, EMPTY_OBJECT, LINE_CLAMP_STYLE } from "./shared-styles";
+import { TruncatedResourceName } from "./TruncatedResourceName";
 import { usePortalContainer } from "../context/PortalContainerContext";
 
 type MenuItem = {
@@ -298,9 +299,13 @@ export default memo(function CustomNode({ data, selected }: any) {
 
           <div className="px-3 pt-3.5 pb-2.5">
             <div className="flex items-center gap-2">
-              <span className="text-[13px] font-semibold leading-snug text-[rgb(var(--ec-page-text))] truncate">
+              <TruncatedResourceName
+                value={title}
+                tooltipBorderColor={palette.pillBorder}
+                className="text-[13px] font-semibold leading-snug text-[rgb(var(--ec-page-text))] truncate"
+              >
                 {title}
-              </span>
+              </TruncatedResourceName>
             </div>
 
             {mode === "full" && summary && (

--- a/packages/visualiser/src/nodes/DataProduct.tsx
+++ b/packages/visualiser/src/nodes/DataProduct.tsx
@@ -10,6 +10,7 @@ import {
   useDarkMode,
 } from "./shared-styles";
 import { CustomIcon, isIconPath } from "../utils/custom-icon";
+import { TruncatedResourceName } from "./TruncatedResourceName";
 
 function GlowHandle({ side }: { side: "left" | "right" }) {
   return (
@@ -151,7 +152,10 @@ function PostItDataProduct(props: DataProductNode) {
               }
             />
           )}
-          <div
+          <TruncatedResourceName
+            as="div"
+            value={name}
+            tooltipBorderColor="#6366f1"
             className={classNames(
               "text-[13px] font-bold leading-snug min-w-0 truncate",
               deprecated
@@ -160,7 +164,7 @@ function PostItDataProduct(props: DataProductNode) {
             )}
           >
             {name}
-          </div>
+          </TruncatedResourceName>
         </div>
 
         {/* Version */}
@@ -262,9 +266,13 @@ function DefaultDataProduct(props: DataProductNode) {
             />
           )}
           <div className="flex items-baseline gap-1 min-w-0">
-            <span className="text-[13px] font-semibold leading-snug text-[rgb(var(--ec-page-text))] truncate">
+            <TruncatedResourceName
+              value={name}
+              tooltipBorderColor="#6366f1"
+              className="text-[13px] font-semibold leading-snug text-[rgb(var(--ec-page-text))] truncate"
+            >
               {name}
-            </span>
+            </TruncatedResourceName>
             {version && (
               <span className="text-[10px] font-normal text-[rgb(var(--ec-page-text-muted))] shrink-0">
                 (v{version})

--- a/packages/visualiser/src/nodes/Entity.tsx
+++ b/packages/visualiser/src/nodes/Entity.tsx
@@ -9,6 +9,7 @@ import {
   HANDLE_RIGHT_OFFSET_STYLE,
   EMPTY_ARRAY,
 } from "./shared-styles";
+import { TruncatedResourceName } from "./TruncatedResourceName";
 
 interface EntityData {
   id: string;
@@ -93,15 +94,19 @@ export default memo(function EntityNode({
               externalToDomain ? "bg-amber-500/20" : "bg-blue-500/15",
             )}
           >
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-2 min-w-0">
               {Icon && (
                 <Icon className="w-4 h-4 text-[rgb(var(--ec-page-text-muted))]" />
               )}
-              <span className="font-semibold text-[rgb(var(--ec-page-text))] text-sm">
+              <TruncatedResourceName
+                value={name}
+                tooltipBorderColor={externalToDomain ? "#f59e0b" : "#60a5fa"}
+                className="font-semibold text-[rgb(var(--ec-page-text))] text-sm truncate"
+              >
                 {name}
-              </span>
+              </TruncatedResourceName>
               {aggregateRoot && (
-                <span className="text-xs bg-amber-500/20 text-amber-600 dark:text-amber-400 px-1.5 py-0.5 rounded font-medium">
+                <span className="text-xs bg-amber-500/20 text-amber-600 dark:text-amber-400 px-1.5 py-0.5 rounded font-medium shrink-0">
                   AR
                 </span>
               )}

--- a/packages/visualiser/src/nodes/Flow.tsx
+++ b/packages/visualiser/src/nodes/Flow.tsx
@@ -11,6 +11,7 @@ import {
   TINY_FONT_STYLE,
   EMPTY_ARRAY,
 } from "./shared-styles";
+import { TruncatedResourceName } from "./TruncatedResourceName";
 
 interface FlowData {
   id: string;
@@ -111,7 +112,7 @@ export default memo(function FlowNode({
                 </span>
               )}
             </div>
-            <div className="p-1 flex-1">
+            <div className="p-1 flex-1 min-w-0">
               {targetPosition && (
                 <Handle type="target" position={targetPosition} />
               )}
@@ -125,9 +126,14 @@ export default memo(function FlowNode({
                     : "",
                 )}
               >
-                <span className="text-xs font-bold block pt-0.5 pb-0.5">
+                <TruncatedResourceName
+                  as="div"
+                  value={name}
+                  tooltipBorderColor="#14b8a6"
+                  className="text-xs font-bold truncate pt-0.5 pb-0.5"
+                >
                   {name}
-                </span>
+                </TruncatedResourceName>
                 <div className="flex justify-between">
                   <span className="text-[10px] font-light block pt-0.5 pb-0.5 ">
                     v{version}

--- a/packages/visualiser/src/nodes/FlowExpandedNode.tsx
+++ b/packages/visualiser/src/nodes/FlowExpandedNode.tsx
@@ -1,5 +1,6 @@
 import { memo } from "react";
 import { Workflow, Minimize2 } from "lucide-react";
+import { TruncatedResourceName } from "./TruncatedResourceName";
 
 export type FlowExpandedNodeData = {
   flowName?: string;
@@ -59,6 +60,7 @@ const HEADER_CONTENT_STYLE: React.CSSProperties = {
   justifyContent: "space-between",
   height: "100%",
   padding: "0 12px 0 14px",
+  gap: 12,
 };
 
 const FLOW_NAME_STYLE: React.CSSProperties = {
@@ -107,8 +109,22 @@ export default memo(function FlowExpandedNode({
         </div>
 
         <div style={HEADER_CONTENT_STYLE}>
-          <div style={{ display: "flex", alignItems: "center" }}>
-            <span style={FLOW_NAME_STYLE}>{flowName || "Flow"}</span>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              minWidth: 0,
+              flex: 1,
+            }}
+          >
+            <TruncatedResourceName
+              value={flowName || "Flow"}
+              tooltipBorderColor="#14b8a6"
+              className="truncate"
+              style={FLOW_NAME_STYLE}
+            >
+              {flowName || "Flow"}
+            </TruncatedResourceName>
             {version && <span style={VERSION_STYLE}>v{version}</span>}
           </div>
 

--- a/packages/visualiser/src/nodes/GroupNode.tsx
+++ b/packages/visualiser/src/nodes/GroupNode.tsx
@@ -1,6 +1,7 @@
 import { memo } from "react";
 import type { NodeProps } from "@xyflow/react";
 import { BoxesIcon } from "lucide-react";
+import { TruncatedResourceName } from "./TruncatedResourceName";
 
 export type GroupNodeData = {
   mode: string;
@@ -65,12 +66,14 @@ const GROUP_BANNER_CONTENT_STYLE = {
   justifyContent: "center" as const,
   height: "100%",
   padding: "0 40px",
+  minWidth: 0,
 } as const;
 
 const GROUP_BANNER_INNER_STYLE = {
   display: "flex",
   alignItems: "center" as const,
   gap: 8,
+  minWidth: 0,
 } as const;
 
 const GROUP_DOMAIN_NAME_STYLE = {
@@ -115,9 +118,14 @@ export default memo(function GroupNode({ data }: NodeProps) {
         {/* Banner text content */}
         <div style={GROUP_BANNER_CONTENT_STYLE}>
           <div style={GROUP_BANNER_INNER_STYLE}>
-            <span style={GROUP_DOMAIN_NAME_STYLE}>
+            <TruncatedResourceName
+              value={domain?.name || "Domain"}
+              tooltipBorderColor="#7c3aed"
+              className="truncate"
+              style={GROUP_DOMAIN_NAME_STYLE}
+            >
               {domain?.name || "Domain"}
-            </span>
+            </TruncatedResourceName>
             {domain?.version && (
               <span style={GROUP_VERSION_STYLE}>v{domain.version}</span>
             )}

--- a/packages/visualiser/src/nodes/Step.tsx
+++ b/packages/visualiser/src/nodes/Step.tsx
@@ -2,6 +2,7 @@ import { memo } from "react";
 import { Handle, Position } from "@xyflow/react";
 import { HIDDEN_HANDLE_STYLE } from "./OwnerIndicator";
 import { NODE_WIDTH_STYLE, ROTATED_LABEL_STYLE } from "./shared-styles";
+import { TruncatedResourceName } from "./TruncatedResourceName";
 
 interface Data {
   title: string;
@@ -49,7 +50,7 @@ export default memo(function StepNode({
           </span>
         )}
       </div>
-      <div className="p-1 flex-1">
+      <div className="p-1 flex-1 min-w-0">
         <Handle
           type="target"
           position={targetPosition || Position.Left}
@@ -62,8 +63,15 @@ export default memo(function StepNode({
         />
 
         {!summary && (
-          <div className="h-full flex items-center">
-            <span className="text-sm font-bold block pb-0.5">{title}</span>
+          <div className="h-full flex items-center min-w-0">
+            <TruncatedResourceName
+              as="div"
+              value={title}
+              tooltipBorderColor="#60a5fa"
+              className="text-sm font-bold truncate pb-0.5"
+            >
+              {title}
+            </TruncatedResourceName>
           </div>
         )}
 
@@ -76,7 +84,14 @@ export default memo(function StepNode({
                   : "",
               )}
             >
-              <span className="text-xs font-bold block pb-0.5">{title}</span>
+              <TruncatedResourceName
+                as="div"
+                value={title}
+                tooltipBorderColor="#60a5fa"
+                className="text-xs font-bold truncate pb-0.5"
+              >
+                {title}
+              </TruncatedResourceName>
             </div>
             {mode === "full" && (
               <div className="divide-y divide-[rgb(var(--ec-page-border))] ">

--- a/packages/visualiser/src/nodes/TruncatedResourceName.tsx
+++ b/packages/visualiser/src/nodes/TruncatedResourceName.tsx
@@ -1,0 +1,75 @@
+import {
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+} from "react";
+
+type TruncatedResourceNameProps = {
+  as?: "div" | "span";
+  children: ReactNode;
+  className?: string;
+  style?: CSSProperties;
+  tooltipBorderColor?: string;
+  value: string;
+};
+
+export function TruncatedResourceName({
+  as: Component = "span",
+  children,
+  className,
+  style,
+  tooltipBorderColor = "rgb(var(--ec-page-border))",
+  value,
+}: TruncatedResourceNameProps) {
+  const ref = useRef<HTMLSpanElement>(null);
+  const [isTruncated, setIsTruncated] = useState(false);
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+
+    const updateTruncation = () => {
+      setIsTruncated(element.scrollWidth > element.clientWidth);
+    };
+
+    updateTruncation();
+
+    if (typeof ResizeObserver === "undefined") {
+      window.addEventListener("resize", updateTruncation);
+      return () => window.removeEventListener("resize", updateTruncation);
+    }
+
+    const observer = new ResizeObserver(updateTruncation);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [value]);
+
+  return (
+    <Component className="ec-truncated-resource-name group relative min-w-0 max-w-full flex-1">
+      <span
+        ref={ref}
+        className={`block min-w-0 ${className || ""}`}
+        style={style}
+      >
+        {children}
+      </span>
+      {isTruncated && (
+        <span
+          className="ec-truncated-resource-name-tooltip pointer-events-none absolute left-1/2 bottom-full z-[9999] mb-4 hidden w-max max-w-[320px] -translate-x-1/2 rounded-md border-2 bg-slate-950 px-2.5 py-1.5 text-[11px] font-medium leading-snug text-white shadow-lg group-hover:block group-focus-within:block"
+          style={{ borderColor: tooltipBorderColor }}
+        >
+          <span className="block whitespace-normal break-words">{value}</span>
+          <span
+            className="absolute left-1/2 top-full h-2 w-2 -translate-x-1/2 -translate-y-1/2 rotate-45 border-b border-r bg-slate-950"
+            style={{
+              borderBottomColor: tooltipBorderColor,
+              borderRightColor: tooltipBorderColor,
+            }}
+          />
+        </span>
+      )}
+    </Component>
+  );
+}

--- a/packages/visualiser/src/nodes/User.tsx
+++ b/packages/visualiser/src/nodes/User.tsx
@@ -2,6 +2,7 @@ import { memo } from "react";
 import { UserIcon } from "@heroicons/react/20/solid";
 import { Handle } from "@xyflow/react";
 import { NODE_WIDTH_STYLE, ROTATED_LABEL_STYLE } from "./shared-styles";
+import { TruncatedResourceName } from "./TruncatedResourceName";
 
 interface Data {
   title: string;
@@ -37,6 +38,7 @@ export default memo(function UserNode({
   } = data as Data;
 
   const { summary, actor: { name } = {} } = step;
+  const displayName = name || step.name || step.title || "Actor";
 
   return (
     <div
@@ -62,15 +64,20 @@ export default memo(function UserNode({
           </span>
         )}
       </div>
-      <div className="p-1 flex-1">
+      <div className="p-1 flex-1 min-w-0">
         {targetPosition && <Handle type="target" position={targetPosition} />}
         {sourcePosition && <Handle type="source" position={sourcePosition} />}
 
         {(!summary || mode !== "full") && (
-          <div className="h-full ">
-            <span className="text-sm font-bold block pb-0.5 w-full">
-              {name}
-            </span>
+          <div className="h-full min-w-0">
+            <TruncatedResourceName
+              as="div"
+              value={displayName}
+              tooltipBorderColor="#eab308"
+              className="text-sm font-bold truncate pb-0.5"
+            >
+              {displayName}
+            </TruncatedResourceName>
             {mode === "simple" && (
               <div className="w-full text-right">
                 <span className=" w-full text-[10px] text-[rgb(var(--ec-page-text-muted))] font-light block pt-0.5 pb-0.5 ">
@@ -90,7 +97,14 @@ export default memo(function UserNode({
                   : "",
               )}
             >
-              <span className="text-xs font-bold block pb-0.5">{name}</span>
+              <TruncatedResourceName
+                as="div"
+                value={displayName}
+                tooltipBorderColor="#eab308"
+                className="text-xs font-bold truncate pb-0.5"
+              >
+                {displayName}
+              </TruncatedResourceName>
             </div>
             {mode === "full" && (
               <div className="divide-y divide-[rgb(var(--ec-page-border))] ">

--- a/packages/visualiser/src/nodes/actor/ActorNode.tsx
+++ b/packages/visualiser/src/nodes/actor/ActorNode.tsx
@@ -9,6 +9,7 @@ import {
   FOLDED_CORNER_SHADOW_STYLE,
   useDarkMode,
 } from "../shared-styles";
+import { TruncatedResourceName } from "../TruncatedResourceName";
 
 function GlowHandle({ side }: { side: "left" | "right" }) {
   return (
@@ -120,14 +121,17 @@ function PostItActor(props: ActorNode) {
           )}
         </div>
 
-        <div
+        <TruncatedResourceName
+          as="div"
+          value={name}
+          tooltipBorderColor="#eab308"
           className={classNames(
-            "text-[13px] font-bold leading-snug",
+            "text-[13px] font-bold leading-snug truncate",
             deprecated ? "text-yellow-950/40 line-through" : "text-yellow-950",
           )}
         >
           {name}
-        </div>
+        </TruncatedResourceName>
 
         {mode === "full" && summary && (
           <div
@@ -205,9 +209,14 @@ function DefaultActor(props: ActorNode) {
 
       <div className="px-3 pt-3.5 pb-2.5">
         {/* Name */}
-        <span className="text-[13px] font-semibold leading-snug text-[rgb(var(--ec-page-text))]">
+        <TruncatedResourceName
+          as="div"
+          value={name}
+          tooltipBorderColor="#eab308"
+          className="text-[13px] font-semibold leading-snug text-[rgb(var(--ec-page-text))] truncate"
+        >
           {name}
-        </span>
+        </TruncatedResourceName>
 
         {/* Summary */}
         {mode === "full" && summary && (

--- a/packages/visualiser/src/nodes/channel/ChannelNode.tsx
+++ b/packages/visualiser/src/nodes/channel/ChannelNode.tsx
@@ -14,6 +14,7 @@ import {
   useDarkMode,
 } from "../shared-styles";
 import { CustomIcon, isIconPath } from "../../utils/custom-icon";
+import { TruncatedResourceName } from "../TruncatedResourceName";
 
 import { memo, useMemo } from "react";
 
@@ -228,14 +229,17 @@ function PostItChannel(props: ChannelNode) {
             />
           )}
           <div className="flex items-baseline gap-1.5 min-w-0">
-            <div
+            <TruncatedResourceName
+              as="div"
+              value={name}
+              tooltipBorderColor="#6b7280"
               className={classNames(
                 "text-[13px] font-bold leading-snug truncate",
                 deprecated ? "text-gray-950/40 line-through" : "text-gray-950",
               )}
             >
               {name}
-            </div>
+            </TruncatedResourceName>
             {version && (
               <span className="text-[9px] text-gray-900/30 font-medium shrink-0">
                 v{version}
@@ -379,9 +383,13 @@ function DefaultChannel(props: ChannelNode) {
             />
           )}
           <div className="flex items-baseline gap-1.5 min-w-0">
-            <span className="text-[13px] font-semibold leading-snug text-[rgb(var(--ec-page-text))] truncate">
+            <TruncatedResourceName
+              value={name}
+              tooltipBorderColor="#6b7280"
+              className="text-[13px] font-semibold leading-snug text-[rgb(var(--ec-page-text))] truncate"
+            >
               {name}
-            </span>
+            </TruncatedResourceName>
             {version && (
               <span
                 className="text-[9px] font-normal shrink-0"

--- a/packages/visualiser/src/nodes/command/CommandNode.tsx
+++ b/packages/visualiser/src/nodes/command/CommandNode.tsx
@@ -15,6 +15,7 @@ import {
   FOLDED_CORNER_SHADOW_STYLE,
   useDarkMode,
 } from "../shared-styles";
+import { TruncatedResourceName } from "../TruncatedResourceName";
 
 const GlowHandle = memo(function GlowHandle({
   side,
@@ -144,14 +145,17 @@ function PostItCommand(props: CommandNode) {
               }
             />
           )}
-          <div
+          <TruncatedResourceName
+            as="div"
+            value={name}
+            tooltipBorderColor="#3b82f6"
             className={classNames(
               "text-[13px] font-bold leading-snug min-w-0 truncate",
               deprecated ? "text-blue-950/40 line-through" : "text-blue-950",
             )}
           >
             {name}
-          </div>
+          </TruncatedResourceName>
         </div>
 
         {version && (
@@ -285,9 +289,13 @@ function DefaultCommand(props: CommandNode) {
               />
             )}
             <div className="flex items-baseline gap-1 min-w-0">
-              <span className="text-[13px] font-semibold leading-snug text-[rgb(var(--ec-page-text))] truncate">
+              <TruncatedResourceName
+                value={name}
+                tooltipBorderColor="#3b82f6"
+                className="text-[13px] font-semibold leading-snug text-[rgb(var(--ec-page-text))] truncate"
+              >
                 {name}
-              </span>
+              </TruncatedResourceName>
               {version && (
                 <span className="text-[10px] font-normal text-[rgb(var(--ec-page-text-muted))] shrink-0">
                   (v{version})

--- a/packages/visualiser/src/nodes/data/DataNode.tsx
+++ b/packages/visualiser/src/nodes/data/DataNode.tsx
@@ -15,6 +15,7 @@ import {
   useDarkMode,
 } from "../shared-styles";
 import { CustomIcon, isIconPath } from "../../utils/custom-icon";
+import { TruncatedResourceName } from "../TruncatedResourceName";
 
 function GlowHandle({ side }: { side: "left" | "right" }) {
   return (
@@ -174,7 +175,10 @@ function PostItData(props: DataNode) {
               }
             />
           )}
-          <div
+          <TruncatedResourceName
+            as="div"
+            value={name}
+            tooltipBorderColor="#6366f1"
             className={classNames(
               "text-[13px] font-bold leading-snug min-w-0 truncate",
               deprecated
@@ -183,7 +187,7 @@ function PostItData(props: DataNode) {
             )}
           >
             {name}
-          </div>
+          </TruncatedResourceName>
         </div>
 
         {/* Version */}
@@ -307,9 +311,13 @@ function DefaultData(props: DataNode) {
             />
           )}
           <div className="flex items-baseline gap-1 min-w-0">
-            <span className="text-[13px] font-semibold leading-snug text-[rgb(var(--ec-page-text))] truncate">
+            <TruncatedResourceName
+              value={name}
+              tooltipBorderColor="#6366f1"
+              className="text-[13px] font-semibold leading-snug text-[rgb(var(--ec-page-text))] truncate"
+            >
               {name}
-            </span>
+            </TruncatedResourceName>
             {version && (
               <span className="text-[10px] font-normal text-[rgb(var(--ec-page-text-muted))] shrink-0">
                 (v{version})

--- a/packages/visualiser/src/nodes/event/EventNode.tsx
+++ b/packages/visualiser/src/nodes/event/EventNode.tsx
@@ -15,6 +15,7 @@ import {
   useDarkMode,
 } from "../shared-styles";
 import { CustomIcon, isIconPath } from "../../utils/custom-icon";
+import { TruncatedResourceName } from "../TruncatedResourceName";
 
 const GlowHandle = memo(function GlowHandle({
   side,
@@ -145,7 +146,10 @@ function PostItEvent(props: EventNode) {
               }
             />
           )}
-          <div
+          <TruncatedResourceName
+            as="div"
+            value={name}
+            tooltipBorderColor="#f97316"
             className={classNames(
               "text-[13px] font-bold leading-snug min-w-0 truncate",
               deprecated
@@ -154,7 +158,7 @@ function PostItEvent(props: EventNode) {
             )}
           >
             {name}
-          </div>
+          </TruncatedResourceName>
         </div>
 
         {/* Version */}
@@ -287,9 +291,13 @@ function DefaultEvent(props: EventNode) {
               />
             )}
             <div className="flex items-baseline gap-1 min-w-0">
-              <span className="text-[13px] font-semibold leading-snug text-[rgb(var(--ec-page-text))] truncate">
+              <TruncatedResourceName
+                value={name}
+                tooltipBorderColor="#f97316"
+                className="text-[13px] font-semibold leading-snug text-[rgb(var(--ec-page-text))] truncate"
+              >
                 {name}
-              </span>
+              </TruncatedResourceName>
               {version && (
                 <span
                   className="text-[10px] font-normal shrink-0"

--- a/packages/visualiser/src/nodes/external-system/ExternalSystem.tsx
+++ b/packages/visualiser/src/nodes/external-system/ExternalSystem.tsx
@@ -12,6 +12,7 @@ import {
   FOLDED_CORNER_SHADOW_STYLE,
   useDarkMode,
 } from "../shared-styles";
+import { TruncatedResourceName } from "../TruncatedResourceName";
 
 function GlowHandle({ side }: { side: "left" | "right" }) {
   return (
@@ -126,14 +127,17 @@ function PostItExternalSystem(props: ExternalSystemNode) {
           )}
         </div>
 
-        <div
+        <TruncatedResourceName
+          as="div"
+          value={name}
+          tooltipBorderColor="#a855f7"
           className={classNames(
-            "text-[13px] font-bold leading-snug",
+            "text-[13px] font-bold leading-snug truncate",
             deprecated ? "text-purple-950/40 line-through" : "text-purple-950",
           )}
         >
           {name}
-        </div>
+        </TruncatedResourceName>
 
         {version && (
           <div className="text-[9px] text-purple-900/40 font-semibold mt-0.5">
@@ -218,10 +222,14 @@ function DefaultExternalSystem(props: ExternalSystemNode) {
 
       <div className="px-3 pt-3.5 pb-2.5">
         {/* Name + version */}
-        <div className="flex items-baseline gap-1">
-          <span className="text-[13px] font-semibold leading-snug text-[rgb(var(--ec-page-text))]">
+        <div className="flex items-baseline gap-1 min-w-0">
+          <TruncatedResourceName
+            value={name}
+            tooltipBorderColor="#a855f7"
+            className="text-[13px] font-semibold leading-snug text-[rgb(var(--ec-page-text))] truncate"
+          >
             {name}
-          </span>
+          </TruncatedResourceName>
           {version && (
             <span className="text-[10px] font-normal text-[rgb(var(--ec-page-text-muted))] shrink-0">
               (v{version})

--- a/packages/visualiser/src/nodes/message-group/MessageGroupExpandedNode.tsx
+++ b/packages/visualiser/src/nodes/message-group/MessageGroupExpandedNode.tsx
@@ -1,5 +1,6 @@
 import { memo } from "react";
 import { Layers, Minimize2 } from "lucide-react";
+import { TruncatedResourceName } from "../TruncatedResourceName";
 
 export type MessageGroupExpandedNodeData = {
   groupName: string;
@@ -56,6 +57,7 @@ const HEADER_CONTENT_STYLE: React.CSSProperties = {
   justifyContent: "space-between",
   height: "100%",
   padding: "0 12px 0 14px",
+  gap: 12,
 };
 
 const GROUP_NAME_STYLE: React.CSSProperties = {
@@ -104,8 +106,22 @@ export default memo(function MessageGroupExpandedNode({
         </div>
 
         <div style={HEADER_CONTENT_STYLE}>
-          <div style={{ display: "flex", alignItems: "center" }}>
-            <span style={GROUP_NAME_STYLE}>{groupName || "Group"}</span>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              minWidth: 0,
+              flex: 1,
+            }}
+          >
+            <TruncatedResourceName
+              value={groupName || "Group"}
+              tooltipBorderColor="#8b5cf6"
+              className="truncate"
+              style={GROUP_NAME_STYLE}
+            >
+              {groupName || "Group"}
+            </TruncatedResourceName>
           </div>
 
           <button

--- a/packages/visualiser/src/nodes/message-group/MessageGroupNode.tsx
+++ b/packages/visualiser/src/nodes/message-group/MessageGroupNode.tsx
@@ -3,6 +3,7 @@ import { Layers, Zap, Terminal, HelpCircle, Maximize2 } from "lucide-react";
 import { Node, Handle, Position, useNodeConnections } from "@xyflow/react";
 import { HIDDEN_HANDLE_STYLE } from "../OwnerIndicator";
 import { useDarkMode } from "../shared-styles";
+import { TruncatedResourceName } from "../TruncatedResourceName";
 
 export type MessageGroupNodeData = {
   mode?: string;
@@ -140,9 +141,14 @@ export default memo(function MessageGroupNode(props: MessageGroupNode) {
         </div>
 
         <div className="px-3 pt-3.5 pb-2.5">
-          <div className="text-[13px] font-semibold leading-snug text-[rgb(var(--ec-page-text))]">
+          <TruncatedResourceName
+            as="div"
+            value={groupName}
+            tooltipBorderColor="#8b5cf6"
+            className="text-[13px] font-semibold leading-snug text-[rgb(var(--ec-page-text))] truncate"
+          >
             {groupName}
-          </div>
+          </TruncatedResourceName>
 
           <div className="mt-1.5 flex items-center gap-2">
             <span

--- a/packages/visualiser/src/nodes/note/NoteNode.tsx
+++ b/packages/visualiser/src/nodes/note/NoteNode.tsx
@@ -31,6 +31,7 @@ const AVAILABLE_COLORS = {
     text: "text-yellow-900",
     placeholder: "placeholder-yellow-600",
     selectedRing: "ring-yellow-500",
+    tooltipBorderColor: "#facc15",
   },
   blue: {
     bg: "bg-blue-200",
@@ -38,6 +39,7 @@ const AVAILABLE_COLORS = {
     text: "text-blue-900",
     placeholder: "placeholder-blue-600",
     selectedRing: "ring-blue-500",
+    tooltipBorderColor: "#60a5fa",
   },
   green: {
     bg: "bg-green-200",
@@ -45,6 +47,7 @@ const AVAILABLE_COLORS = {
     text: "text-green-900",
     placeholder: "placeholder-green-600",
     selectedRing: "ring-green-500",
+    tooltipBorderColor: "#4ade80",
   },
   pink: {
     bg: "bg-pink-200",
@@ -52,6 +55,7 @@ const AVAILABLE_COLORS = {
     text: "text-pink-900",
     placeholder: "placeholder-pink-600",
     selectedRing: "ring-pink-500",
+    tooltipBorderColor: "#f472b6",
   },
   purple: {
     bg: "bg-purple-200",
@@ -59,6 +63,7 @@ const AVAILABLE_COLORS = {
     text: "text-purple-900",
     placeholder: "placeholder-purple-600",
     selectedRing: "ring-purple-500",
+    tooltipBorderColor: "#c084fc",
   },
   gray: {
     bg: "bg-gray-200",
@@ -66,6 +71,7 @@ const AVAILABLE_COLORS = {
     text: "text-gray-900",
     placeholder: "placeholder-gray-600",
     selectedRing: "ring-gray-500",
+    tooltipBorderColor: "#9ca3af",
   },
 } as const;
 
@@ -86,7 +92,9 @@ export default memo(function NoteNodeComponent({
   const [currentText, setCurrentText] = useState(
     data.text || "Double-click to edit...",
   );
+  const [isTextOverflowing, setIsTextOverflowing] = useState(false);
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
+  const displayRef = useRef<HTMLDivElement>(null);
 
   const currentColorName = (data.color as ColorName) || "yellow";
   const colorClasses =
@@ -135,6 +143,26 @@ export default memo(function NoteNodeComponent({
       textAreaRef.current.select();
     }
   }, [isEditing]);
+
+  useEffect(() => {
+    const element = displayRef.current;
+    if (!element || isEditing) return;
+
+    const updateOverflow = () => {
+      setIsTextOverflowing(element.scrollHeight > element.clientHeight);
+    };
+
+    updateOverflow();
+
+    if (typeof ResizeObserver === "undefined") {
+      window.addEventListener("resize", updateOverflow);
+      return () => window.removeEventListener("resize", updateOverflow);
+    }
+
+    const observer = new ResizeObserver(updateOverflow);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [currentText, isEditing]);
 
   const handleDoubleClick = useCallback(() => {
     if (!readOnly) {
@@ -248,12 +276,32 @@ export default memo(function NoteNodeComponent({
             placeholder="Enter text..."
           />
         ) : (
-          <div
-            className="whitespace-pre-wrap break-words w-full h-full overflow-y-auto custom-scrollbar text-[10px]"
-            dangerouslySetInnerHTML={{
-              __html: formatText(currentText),
-            }}
-          />
+          <>
+            <div
+              ref={displayRef}
+              className="whitespace-pre-wrap break-words w-full h-full overflow-y-auto custom-scrollbar text-[10px]"
+              dangerouslySetInnerHTML={{
+                __html: formatText(currentText),
+              }}
+            />
+            {isTextOverflowing && (
+              <div
+                className="pointer-events-none absolute left-1/2 bottom-full z-[9999] mb-4 hidden w-max max-w-[320px] -translate-x-1/2 rounded-md border bg-slate-950 px-2.5 py-1.5 text-[11px] font-medium leading-snug text-white shadow-lg group-hover:block"
+                style={{ borderColor: colorClasses.tooltipBorderColor }}
+              >
+                <span className="block whitespace-pre-wrap break-words">
+                  {currentText}
+                </span>
+                <span
+                  className="absolute left-1/2 top-full h-2 w-2 -translate-x-1/2 -translate-y-1/2 rotate-45 border-b border-r bg-slate-950"
+                  style={{
+                    borderBottomColor: colorClasses.tooltipBorderColor,
+                    borderRightColor: colorClasses.tooltipBorderColor,
+                  }}
+                />
+              </div>
+            )}
+          </>
         )}
 
         {/* PostIt folded corner effect */}

--- a/packages/visualiser/src/nodes/query/QueryNode.tsx
+++ b/packages/visualiser/src/nodes/query/QueryNode.tsx
@@ -15,6 +15,7 @@ import {
   FOLDED_CORNER_SHADOW_STYLE,
   useDarkMode,
 } from "../shared-styles";
+import { TruncatedResourceName } from "../TruncatedResourceName";
 
 const GlowHandle = memo(function GlowHandle({
   side,
@@ -141,14 +142,17 @@ function PostItQuery(props: QueryNode) {
               }
             />
           )}
-          <div
+          <TruncatedResourceName
+            as="div"
+            value={name}
+            tooltipBorderColor="#22c55e"
             className={classNames(
               "text-[13px] font-bold leading-snug min-w-0 truncate",
               deprecated ? "text-green-950/40 line-through" : "text-green-950",
             )}
           >
             {name}
-          </div>
+          </TruncatedResourceName>
         </div>
 
         {version && (
@@ -282,9 +286,13 @@ function DefaultQuery(props: QueryNode) {
               />
             )}
             <div className="flex items-baseline gap-1 min-w-0">
-              <span className="text-[13px] font-semibold leading-snug text-[rgb(var(--ec-page-text))] truncate">
+              <TruncatedResourceName
+                value={name}
+                tooltipBorderColor="#22c55e"
+                className="text-[13px] font-semibold leading-snug text-[rgb(var(--ec-page-text))] truncate"
+              >
                 {name}
-              </span>
+              </TruncatedResourceName>
               {version && (
                 <span className="text-[10px] font-normal text-[rgb(var(--ec-page-text-muted))] shrink-0">
                   (v{version})

--- a/packages/visualiser/src/nodes/service/ServiceNode.tsx
+++ b/packages/visualiser/src/nodes/service/ServiceNode.tsx
@@ -15,6 +15,7 @@ import {
   FOLDED_CORNER_SHADOW_STYLE,
   useDarkMode,
 } from "../shared-styles";
+import { TruncatedResourceName } from "../TruncatedResourceName";
 
 const SPEC_LABELS: Record<string, string> = {
   openapi: "OpenAPI",
@@ -208,6 +209,7 @@ type PostItPalette = {
   nameTextDeprecated: string;
   versionClass: string;
   summaryClass: string;
+  tooltipBorderColor: string;
 };
 
 const POST_IT_SERVICE: PostItPalette = {
@@ -224,6 +226,7 @@ const POST_IT_SERVICE: PostItPalette = {
   versionClass: "text-[9px] text-pink-900/40 font-semibold mt-0.5",
   summaryClass:
     "mt-2 pt-1.5 border-t border-pink-900/10 text-[9px] text-pink-950/60 leading-relaxed overflow-hidden",
+  tooltipBorderColor: "#ec4899",
 };
 
 const POST_IT_EXTERNAL: PostItPalette = {
@@ -241,6 +244,7 @@ const POST_IT_EXTERNAL: PostItPalette = {
   versionClass: "text-[9px] text-purple-900/40 font-semibold mt-0.5",
   summaryClass:
     "mt-2 pt-1.5 border-t border-purple-900/10 text-[9px] text-purple-950/60 leading-relaxed overflow-hidden",
+  tooltipBorderColor: "#a855f7",
 };
 
 type DefaultPalette = {
@@ -258,6 +262,7 @@ type DefaultPalette = {
   ownerAccent: string;
   ownerBorder: string;
   ownerIcon: string;
+  tooltipBorderColor: string;
 };
 
 const DEFAULT_SERVICE: DefaultPalette = {
@@ -275,6 +280,7 @@ const DEFAULT_SERVICE: DefaultPalette = {
   ownerAccent: "bg-pink-400",
   ownerBorder: "rgba(236,72,153,0.08)",
   ownerIcon: "text-pink-300",
+  tooltipBorderColor: "#ec4899",
 };
 
 const DEFAULT_EXTERNAL: DefaultPalette = {
@@ -292,6 +298,7 @@ const DEFAULT_EXTERNAL: DefaultPalette = {
   ownerAccent: "bg-purple-400",
   ownerBorder: "rgba(168,85,247,0.08)",
   ownerIcon: "text-purple-300",
+  tooltipBorderColor: "#a855f7",
 };
 
 type ServiceNodeData = EventCatalogResource & {
@@ -399,14 +406,17 @@ function PostItService(props: ServiceNode) {
               }
             />
           )}
-          <div
+          <TruncatedResourceName
+            as="div"
+            value={name}
+            tooltipBorderColor={p.tooltipBorderColor}
             className={classNames(
               "text-[13px] font-bold leading-snug min-w-0 truncate",
               deprecated ? p.nameTextDeprecated : p.nameText,
             )}
           >
             {name}
-          </div>
+          </TruncatedResourceName>
         </div>
 
         {version && <div className={p.versionClass}>v{version}</div>}
@@ -528,9 +538,13 @@ function DefaultService(props: ServiceNode) {
             />
           )}
           <div className="flex items-baseline gap-1 min-w-0">
-            <span className="text-[13px] font-semibold leading-snug text-[rgb(var(--ec-page-text))] truncate">
+            <TruncatedResourceName
+              value={name}
+              tooltipBorderColor={p.tooltipBorderColor}
+              className="text-[13px] font-semibold leading-snug text-[rgb(var(--ec-page-text))] truncate"
+            >
               {name}
-            </span>
+            </TruncatedResourceName>
             {version && (
               <span className="text-[10px] font-normal text-[rgb(var(--ec-page-text-muted))] shrink-0">
                 (v{version})

--- a/packages/visualiser/src/styles-core.css
+++ b/packages/visualiser/src/styles-core.css
@@ -224,6 +224,10 @@
   cursor: pointer;
 }
 
+.react-flow__node:hover .ec-truncated-resource-name-tooltip {
+  display: block;
+}
+
 /* Smooth transition when expanding/collapsing message groups */
 .ec-animating-layout .react-flow__node {
   transition: transform 0.35s cubic-bezier(0.4, 0, 0.2, 1);


### PR DESCRIPTION
## What This PR Does

Resource names in the visualiser are truncated to fit inside their nodes, which previously made long names unreadable. This PR adds a hover tooltip that reveals the full name, but only when the name is actually truncated. It introduces a shared `TruncatedResourceName` component and wires it into every node type.

## Changes Overview

### Key Changes

- Add new `TruncatedResourceName` component (`packages/visualiser/src/nodes/TruncatedResourceName.tsx`) that detects truncation via `ResizeObserver` (with a window-resize fallback) and renders a tooltip with the full value on hover/focus.
- Replace the plain name `div`/`span` in every node type with `TruncatedResourceName`, passing the node-specific accent colour as `tooltipBorderColor`.
- Add a CSS rule in `styles-core.css` so the tooltip also shows on `.react-flow__node:hover`.

### Node types updated

Custom, DataProduct, Entity, Flow, FlowExpandedNode, GroupNode, Step, User, ActorNode, ChannelNode, CommandNode, DataNode, EventNode, ExternalSystem, MessageGroupNode, MessageGroupExpandedNode, NoteNode, QueryNode, ServiceNode.

## How It Works

`TruncatedResourceName` renders the name inside a `min-w-0` flex container with the existing `truncate` styling. A `ResizeObserver` on the inner span compares `scrollWidth` to `clientWidth`; when the text overflows, an absolutely-positioned tooltip becomes available and is revealed on hover/focus. The tooltip border colour matches each node's accent so it reads as part of that node. When the name fits, no tooltip is rendered.

## Breaking Changes

None. Purely additive — node markup and styling are unchanged when names fit.

## Additional Notes

- Tooltip visibility is driven both by the component's own `group-hover`/`group-focus-within` classes and a React Flow node-hover CSS rule for robustness.