### PR TITLE
fix(visualiser): prevent prose styles from breaking node graph rendering

### DIFF
--- a/.changeset/quiet-otters-graph.md
+++ b/.changeset/quiet-otters-graph.md
@@ -1,0 +1,6 @@
+---
+'@eventcatalog/core': patch
+'@eventcatalog/visualiser': patch
+---
+
+fix node graph styling when rendered inside prose containers and prevent prose styles from affecting visualiser images

--- a/examples/default/domains/E-Commerce/subdomains/Orders/agents/InventoryRebalancingAgent/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Orders/agents/InventoryRebalancingAgent/index.mdx
@@ -38,6 +38,8 @@ The Inventory Rebalancing Agent supports the [[domain|Orders]] domain when the c
 
 It receives [[event|OutOfStock]] and [[event|InventoryAdjusted]] so it can recommend whether operations should transfer stock, split a shipment, backorder the order, or notify the customer.
 
+<NodeGraph />
+
 ## Tools
 
 <AgentTools />

--- a/examples/default/domains/E-Commerce/subdomains/Orders/agents/OrderSupportAgent/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Orders/agents/OrderSupportAgent/index.mdx
@@ -37,6 +37,8 @@ The Order Support Agent helps the support team answer order questions without ma
 
 It belongs to the [[domain|Orders]] domain and works alongside [[service|OrdersService]], [[service|NotificationService]], and [[service|ShippingService]].
 
+<NodeGraph />
+
 ## Tools
 
 <AgentTools />

--- a/examples/default/domains/E-Commerce/subdomains/Payment/agents/FraudReviewAgent/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Payment/agents/FraudReviewAgent/index.mdx
@@ -39,6 +39,8 @@ The Fraud Review Agent supports the [[domain|Payment]] domain by reviewing risky
 
 It receives [[event|PaymentInitiated]], [[event|RiskScoreCalculated]], and [[event|FraudDetected]] from payment and fraud detection services. It uses risk profile tooling to explain why a payment was flagged and recommend whether payment processing should continue.
 
+<NodeGraph />
+
 ## Tools
 
 <AgentTools />

--- a/examples/default/domains/E-Commerce/subdomains/Payment/agents/RefundPolicyAgent/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Payment/agents/RefundPolicyAgent/index.mdx
@@ -39,6 +39,8 @@ The Refund Policy Agent helps support teams make consistent refund decisions wit
 
 It receives [[event|PaymentProcessed]], [[event|PaymentFailed]], and [[event|FraudDetected]] so it can explain whether a refund should be approved, rejected, or escalated for manual review.
 
+<NodeGraph />
+
 ## Tools
 
 <AgentTools />

--- a/packages/core/eventcatalog/src/components/MDX/NodeGraph/NodeGraphPortal.tsx
+++ b/packages/core/eventcatalog/src/components/MDX/NodeGraph/NodeGraphPortal.tsx
@@ -1,7 +1,7 @@
 const NodeGraphPortal = (props: any) => {
   return (
     <div
-      className="h-[30em] my-6 mb-12 w-full relative border! border-[rgb(var(--ec-page-border))]! rounded-md overflow-hidden"
+      className="not-prose h-[30em] my-6 mb-12 w-full relative border! border-[rgb(var(--ec-page-border))]! rounded-md overflow-hidden"
       id={`${props.id}-portal`}
       style={{
         maxHeight: props.maxHeight ? `${props.maxHeight}em` : `30em`,

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -37,7 +37,6 @@
 - 8f724a7: feat: add `externalSystem` flag to services for modelling third-party integrations
 
   Services can now set `externalSystem: true` in their frontmatter to be rendered as external systems. This changes their presentation without changing their capabilities — they still send and receive messages, have owners, and support specifications like any other service.
-
   - Visualiser: external services render purple with a Globe icon and an "External System" badge
   - Sidebar (root): a dedicated "External Systems" section lists externals; the regular "Services" section excludes them
   - Sidebar (domain): externals appear under a new "External Integrations" group, separate from "Services In Domain"

--- a/packages/visualiser/src/components/NodeGraphPortal.tsx
+++ b/packages/visualiser/src/components/NodeGraphPortal.tsx
@@ -1,7 +1,7 @@
 const NodeGraphPortal = (props: any) => {
   return (
     <div
-      className="h-[30em] my-6 mb-12 w-full relative border border-gray-200 rounded-md"
+      className="not-prose h-[30em] my-6 mb-12 w-full relative border border-gray-200 rounded-md"
       id={`${props.id}-portal`}
       style={{
         maxHeight: props.maxHeight ? `${props.maxHeight}em` : `30em`,

--- a/packages/visualiser/src/styles-core.css
+++ b/packages/visualiser/src/styles-core.css
@@ -123,6 +123,11 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
+.eventcatalog-visualizer img {
+  margin: 0;
+  background-color: transparent;
+}
+
 /*
  * Scoped dark mode overrides for the visualizer.
  * Higher specificity ensures these win over the consuming app's

--- a/packages/visualiser/src/styles.css
+++ b/packages/visualiser/src/styles.css
@@ -123,6 +123,11 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
+.eventcatalog-visualizer img {
+  margin: 0;
+  background-color: transparent;
+}
+
 /*
  * Scoped dark mode overrides for the visualizer.
  * Higher specificity ensures these win over the consuming app's


### PR DESCRIPTION
## What This PR Does

Fixes visual regressions in the node graph (visualiser) when it's rendered inside MDX content that has Tailwind `prose` styles applied. Prose typography rules were leaking into the React Flow container and into images rendered by visualiser nodes, causing unwanted margins and backgrounds.

## Changes Overview

### Key Changes

- Add `not-prose` to the `NodeGraphPortal` wrapper in both `@eventcatalog/core` and `@eventcatalog/visualiser` so the React Flow container is isolated from surrounding prose styles.
- Reset `margin` and `background-color` on `img` elements inside `.eventcatalog-visualizer` (in both `styles.css` and `styles-core.css`) so node images render cleanly inside prose contexts.
- Add `<NodeGraph />` to the example agent pages (`OrderSupportAgent`, `InventoryRebalancingAgent`, `FraudReviewAgent`, `RefundPolicyAgent`) so the rendering can be verified in the default catalog.

## How It Works

Tailwind's `prose` plugin applies generous typography rules (margins, image backgrounds, etc.) to descendant elements. When the visualiser's portal is dropped inside a prose container in MDX, those rules cascade into the React Flow node images and the portal wrapper itself. Adding `not-prose` opts the portal subtree out, and the scoped `img` reset is a defence-in-depth fix for any visualiser usage that doesn't go through the portal.

## Breaking Changes

None.

## Additional Notes

- Patch release for `@eventcatalog/core` and `@eventcatalog/visualiser`.
- The example MDX edits surface the regression in the default catalog and act as a smoke test for the fix.