### PR TITLE
chore(deps): replace axios with native fetch in analytics

### DIFF
--- a/.changeset/swift-otters-fetch.md
+++ b/.changeset/swift-otters-fetch.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+chore(deps): replace axios with native fetch in analytics

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -91,7 +91,6 @@
     "astro-expressive-code": "^0.41.7",
     "astro-seo": "^0.8.4",
     "auth-astro": "^4.2.0",
-    "axios": "^1.15.2",
     "boxen": "^8.0.1",
     "commander": "^12.1.0",
     "concurrently": "^8.2.2",

--- a/packages/core/src/analytics/analytics.js
+++ b/packages/core/src/analytics/analytics.js
@@ -1,4 +1,3 @@
-import axios from 'axios';
 import os from 'os';
 import { VERSION } from '../constants';
 
@@ -22,7 +21,15 @@ async function raiseEvent(eventData) {
   };
 
   try {
-    await axios.post(url, payload, { headers });
+    const response = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to raise analytics event: ${response.status}`);
+    }
   } catch (error) {
     // swallow the error
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,9 +210,6 @@ importers:
       auth-astro:
         specifier: ^4.2.0
         version: 4.2.0(@auth/core@0.37.4)(astro@6.3.1(@types/node@20.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.52.4)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
-      axios:
-        specifier: ^1.15.2
-        version: 1.15.2
       boxen:
         specifier: ^8.0.1
         version: 8.0.1
@@ -3923,6 +3920,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unhead/vue@2.1.13':
     resolution: {integrity: sha512-HYy0shaHRnLNW9r85gppO8IiGz0ONWVV3zGdlT8CQ0tbTwixznJCIiyqV4BSV1aIF1jJIye0pd1p/k6Eab8Z/A==}
@@ -14002,7 +14000,8 @@ snapshots:
     dependencies:
       retry: 0.12.0
 
-  asynckit@0.4.0: {}
+  asynckit@0.4.0:
+    optional: true
 
   atomically@2.0.3:
     dependencies:
@@ -14028,6 +14027,7 @@ snapshots:
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
+    optional: true
 
   axobject-query@4.1.0: {}
 
@@ -14341,6 +14341,7 @@ snapshots:
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
+    optional: true
 
   comma-separated-tokens@1.0.8: {}
 
@@ -14795,7 +14796,8 @@ snapshots:
     dependencies:
       robust-predicates: 3.0.2
 
-  delayed-stream@1.0.0: {}
+  delayed-stream@1.0.0:
+    optional: true
 
   depd@2.0.0: {}
 
@@ -15331,7 +15333,8 @@ snapshots:
     dependencies:
       tabbable: 6.4.0
 
-  follow-redirects@1.15.11: {}
+  follow-redirects@1.15.11:
+    optional: true
 
   fontace@0.4.1:
     dependencies:
@@ -15359,6 +15362,7 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.2
       mime-types: 2.1.35
+    optional: true
 
   format@0.2.2: {}
 
@@ -17159,13 +17163,15 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
-  mime-db@1.52.0: {}
+  mime-db@1.52.0:
+    optional: true
 
   mime-db@1.54.0: {}
 
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+    optional: true
 
   mime-types@3.0.2:
     dependencies:
@@ -17800,7 +17806,8 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
-  proxy-from-env@2.1.0: {}
+  proxy-from-env@2.1.0:
+    optional: true
 
   pump@3.0.3:
     dependencies:


### PR DESCRIPTION
Refs https://github.com/event-catalog/eventcatalog/pull/2570

## What This PR Does

Removes the `axios` dependency from `@eventcatalog/core` and replaces its single usage in the analytics module with the platform-native `fetch` API. This shrinks the dependency tree and aligns `packages/core` with `packages/create-eventcatalog/templates/analytics.ts`, which already uses `fetch`.

## Changes Overview

### Key Changes
- Drop `axios` from `packages/core/package.json` dependencies.
- Rewrite `packages/core/src/analytics/analytics.js` `raiseEvent` to use `fetch` with explicit non-OK response handling (still swallowed by the outer `try/catch`).
- Regenerate `pnpm-lock.yaml` (axios and its transitives — `follow-redirects`, `form-data`, `proxy-from-env`, `combined-stream`, `delayed-stream`, `asynckit`, `mime-db`, `mime-types` — are now `optional: true` only).

## How It Works

`raiseEvent` previously called `axios.post(url, payload, { headers })`. It now calls `fetch(url, { method: 'POST', headers, body: JSON.stringify(payload) })` and throws on a non-OK response so the existing outer `try/catch` continues to swallow failures silently — preserving the "analytics never breaks the CLI" contract.

Node 18+ ships `fetch` globally, which matches EventCatalog's supported Node range, so no polyfill is required.

## Breaking Changes

None. Analytics behavior is unchanged from the caller's perspective.

## Additional Notes

- Credit to the original PR author of https://github.com/event-catalog/eventcatalog/pull/2570 for the idea and approach.
- No user-facing docs change required.