### PR TITLE
fix(core): type toolsRaw as any[] in services node graph

### DIFF
--- a/.changeset/swift-otters-type.md
+++ b/.changeset/swift-otters-type.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Fix implicit any type on tool parameter in services node graph

--- a/packages/core/eventcatalog/src/utils/node-graphs/services-node-graph.ts
+++ b/packages/core/eventcatalog/src/utils/node-graphs/services-node-graph.ts
@@ -215,7 +215,7 @@ export const getNodesAndEdges = async ({
   const sendsRaw = service?.data.sends || [];
   const writesToRaw = service?.data.writesTo || [];
   const readsFromRaw = service?.data.readsFrom || [];
-  const toolsRaw = collection === 'agents' ? (service?.data as any).tools || [] : [];
+  const toolsRaw: any[] = collection === 'agents' ? (service?.data as any).tools || [] : [];
 
   const receivesHydrated = receivesRaw
     .map((message) => findInMap(messageMap, message.id, message.version))


### PR DESCRIPTION
## What This PR Does

Fixes a TypeScript type-check failure in `packages/core` caused by an implicit `any` type on the `tool` parameter inside the agents branch of `services-node-graph.ts`. The `toolsRaw` array is now explicitly typed as `any[]` so `forEach` can infer the parameter type.

## Changes Overview

### Key Changes
- `packages/core/eventcatalog/src/utils/node-graphs/services-node-graph.ts`: typed `toolsRaw` as `any[]` so `tool` no longer trips `ts(7006)` in `pnpm run check`.

## How It Works

`toolsRaw` was previously inferred as `any` (from the `(service?.data as any).tools || []` expression) which then propagated as `any` to the `forEach` callback parameter and tripped strict-mode diagnostics. Annotating the local as `any[]` keeps the same runtime behaviour but gives `forEach` an array signature to infer against.

## Breaking Changes

None.

## Additional Notes

- `pnpm run check` now reports 0 errors across 450 files.
- No user-facing behaviour change; docs were not updated.