### PR TITLE
fix(sdk): use real RegExp in addMessageToChannel path split

### DIFF
--- a/.changeset/fix-addmessagetochannel-regex-split.md
+++ b/.changeset/fix-addmessagetochannel-regex-split.md
@@ -1,0 +1,9 @@
+---
+'@eventcatalog/sdk': patch
+---
+
+Fix `addMessageToChannel` (and its `addEventToChannel` / `addCommandToChannel` / `addQueryToChannel` bindings) corrupting catalog layout.
+
+The function previously split the existing resource path with a template *string* — `` `/[\\/]+${collection}` `` — instead of a real `RegExp`. The literal substring never matched real paths, so `.split()` returned the input unchanged and the resource was rewritten under `<catalog>/<collection>/<id>/index.mdx/<collection>/<id>/index.mdx`, with `index.mdx` becoming a directory.
+
+The fix mirrors the regex form already used in `services.ts` (`new RegExp('[\\\\/]+' + collection)`), so the split matches both POSIX and Windows path separators. A regression test under `addEventToChannel` asserts that the canonical event path stays a file and the duplicate nested path does not exist.

--- a/packages/sdk/src/channels.ts
+++ b/packages/sdk/src/channels.ts
@@ -275,7 +275,7 @@ export const addMessageToChannel =
       throw new Error(`Cannot find message ${id} in the catalog`);
     }
 
-    const path = existingResource.split(`/[\\/]+${collection}`)[0];
+    const path = existingResource.split(new RegExp(`[\\\\/]+${collection}`))[0];
     const pathToResource = join(path, collection);
 
     await rmMessageById(directory)(_message.id, _message.version, true);

--- a/packages/sdk/src/test/channels.test.ts
+++ b/packages/sdk/src/test/channels.test.ts
@@ -735,6 +735,44 @@ describe('Channels SDK', () => {
           })
         ).rejects.toThrowError('Message InventoryCreated with version 0.0.1 not found');
       });
+
+      it('does not create a duplicate nested copy of the event under its own index.mdx', async () => {
+        // Regression test for a path-split bug where the split argument was a
+        // template *string* (`/[\\/]+${collection}`) instead of a real regex.
+        // The literal substring never matched real paths, so split() returned
+        // the whole input and the resource ended up rewritten at
+        // <catalog>/events/<id>/index.mdx/events/<id>/index.mdx — i.e. with
+        // `index.mdx` as a directory. The fix uses a real RegExp matching
+        // both POSIX and Windows separators.
+        await writeChannel(mockChannel);
+        await writeEvent({
+          id: 'InventoryCreated',
+          name: 'Inventory Created',
+          version: '0.0.1',
+          summary: 'This is a summary',
+          markdown: '# Hello world',
+        });
+
+        await addEventToChannel('inventory.{env}.events', {
+          id: 'InventoryCreated',
+          version: '0.0.1',
+          parameters: { env: 'dev' },
+        });
+
+        const canonical = path.join(CATALOG_PATH, 'events', 'InventoryCreated', 'index.mdx');
+        const duplicateNested = path.join(
+          CATALOG_PATH,
+          'events',
+          'InventoryCreated',
+          'index.mdx',
+          'events',
+          'InventoryCreated',
+          'index.mdx'
+        );
+        const indexMdxStat = fs.statSync(canonical);
+        expect(indexMdxStat.isFile()).toBe(true);
+        expect(fs.existsSync(duplicateNested)).toBe(false);
+      });
     });
 
     describe('addCommandToChannel', () => {


### PR DESCRIPTION
Reimplementation of https://github.com/event-catalog/eventcatalog/pull/2567 (original author: @jagreehal).

## What This PR Does

Fixes `addMessageToChannel` (and its `addEventToChannel` / `addCommandToChannel` / `addQueryToChannel` bindings) corrupting catalog layout by rewriting messages into a duplicate nested path, turning `index.mdx` into a directory.

## Changes Overview

### Key Changes

- **`packages/sdk/src/channels.ts`**: replace the template-string split argument with a real `RegExp` so the split actually matches the path separator + collection segment, mirroring the working form in `services.ts`.
- **`packages/sdk/src/test/channels.test.ts`**: add a focused regression test under the existing `addEventToChannel` describe that asserts (a) the canonical `events/<id>/index.mdx` stays a file and (b) the bad nested `events/<id>/index.mdx/events/<id>/index.mdx` path does not exist.
- **`.changeset/fix-addmessagetochannel-regex-split.md`**: patch changeset for `@eventcatalog/sdk`.

## How It Works

`packages/sdk/src/channels.ts:278` previously read:

```ts
const path = existingResource.split(`/[\\/]+${collection}`)[0];
```

The argument to `.split()` is a template *string*, not a `RegExp`. `String.prototype.split` looked for the literal characters `/[\\/]+events` (or `commands`/`queries`), which never appears in real paths, so it returned the whole input unchanged. The downstream `join(path, collection)` then nested a duplicate of the resource under `<orig>/<collection>/<id>/index.mdx`, and the following `writeMessage` created `index.mdx` as a directory.

The equivalent split in `services.ts` already uses a real regex; this PR makes `channels.ts` consistent:

```ts
const path = existingResource.split(new RegExp(`[\\\\/]+${collection}`))[0];
```

The regex matches one-or-more path separators (POSIX `/` or Windows `\`) followed by the collection name, so the parent directory is correctly recovered before re-joining.

## Breaking Changes

None. Happy-path callers see identical behaviour; only the broken duplicate-nesting path is removed. Full SDK suite (`pnpm --filter @eventcatalog/sdk run test`) passes (772/772) including the new regression case.

## Additional Notes

- Skipped the unrelated `@scalar/api-reference-react` bump and `pnpm-lock.yaml` churn that appeared in the upstream PR — those came from a merge with main, not from the fix.
- Credit to @jagreehal for the original investigation and patch in #2567.