### PR TITLE
feat(connectors): add directory connectors for syncing users and teams

### DIFF
--- a/.changeset/swift-connectors-arrive.md
+++ b/.changeset/swift-connectors-arrive.md
@@ -1,0 +1,7 @@
+---
+'@eventcatalog/core': minor
+'@eventcatalog/connectors': minor
+'@eventcatalog/sdk': minor
+---
+
+Add directory connectors for syncing users and teams from external sources (e.g. GitHub organizations) into EventCatalog collections. Introduces the new `@eventcatalog/connectors` package and `directory.sources` configuration in `eventcatalog.config`.

--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Package Core
         run: pnpm pack
         working-directory: packages/core
+      - name: Package Connectors
+        run: pnpm pack
+        working-directory: packages/connectors
       - name: Package Visualiser
         run: pnpm pack
         working-directory: packages/visualiser
@@ -53,6 +56,7 @@ jobs:
           mv packages/sdk/*.tgz sdk-package.tgz
           mv packages/cli/*.tgz cli-package.tgz
           mv packages/core/*.tgz core-package.tgz
+          mv packages/connectors/*.tgz connectors-package.tgz
           mv packages/visualiser/*.tgz visualiser-package.tgz
           mv packages/language-server/*.tgz language-server-package.tgz
       - name: Upload package artifacts
@@ -63,6 +67,7 @@ jobs:
             sdk-package.tgz
             cli-package.tgz
             core-package.tgz
+            connectors-package.tgz
             visualiser-package.tgz
             language-server-package.tgz
 
@@ -92,7 +97,7 @@ jobs:
           name: eventcatalog-packages-artifact
       - name: Install @eventcatalog packages
         working-directory: examples/default/
-        run: npm install --prefer-offline ../../sdk-package.tgz ../../core-package.tgz ../../visualiser-package.tgz
+        run: npm install --prefer-offline ../../sdk-package.tgz ../../core-package.tgz ../../connectors-package.tgz ../../visualiser-package.tgz
       - name: Build EventCatalog
         working-directory: examples/default/
         run: npx eventcatalog build

--- a/examples/default/package.json
+++ b/examples/default/package.json
@@ -3,6 +3,7 @@
     "version": "0.1.0",
     "private": true,
     "dependencies": {
+        "@eventcatalog/connectors": "workspace:*",
         "@eventcatalog/core": "workspace:*"
     }
 }

--- a/packages/connectors/README.md
+++ b/packages/connectors/README.md
@@ -11,7 +11,7 @@ export default {
     sources: [
       githubDirectory({
         org: "acme",
-        teams: true,
+        teams: ["platform", "architecture"],
         users: true,
         token: process.env.GITHUB_TOKEN,
       }),

--- a/packages/connectors/README.md
+++ b/packages/connectors/README.md
@@ -1,0 +1,60 @@
+# @eventcatalog/connectors
+
+Connectors for syncing external systems into EventCatalog.
+
+```js
+// eventcatalog.config.js
+import { githubDirectory } from "@eventcatalog/connectors";
+
+export default {
+  directory: {
+    sources: [
+      githubDirectory({
+        org: "acme",
+        teams: true,
+        users: true,
+        token: process.env.GITHUB_TOKEN,
+      }),
+    ],
+  },
+};
+```
+
+External directory sources require EventCatalog Scale when loaded by EventCatalog.
+
+Custom directory sources can use the same contract:
+
+```js
+import { defineDirectorySource } from "@eventcatalog/connectors";
+
+export const companyDirectory = defineDirectorySource({
+  type: "directory",
+  name: "company-directory",
+
+  async loadTeams() {
+    return [
+      {
+        id: "platform",
+        name: "Platform",
+        members: ["alice"],
+        source: {
+          provider: "company-directory",
+        },
+      },
+    ];
+  },
+
+  async loadUsers() {
+    return [
+      {
+        id: "alice",
+        name: "Alice",
+        avatarUrl: "https://example.com/alice.png",
+        source: {
+          provider: "company-directory",
+        },
+      },
+    ];
+  },
+});
+```

--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@eventcatalog/connectors",
+  "version": "0.0.1",
+  "description": "Connectors for syncing external systems into EventCatalog Collections",
+  "scripts": {
+    "build": "tsup",
+    "build:bin": "tsup",
+    "test": "vitest --run",
+    "test:ci": "vitest --run",
+    "format": "prettier --write .",
+    "format:diff": "prettier --list-different ."
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "eventcatalog",
+    "connectors",
+    "github",
+    "directory"
+  ],
+  "author": "",
+  "license": "MIT",
+  "files": [
+    "dist",
+    "package.json"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
+    }
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "devDependencies": {
+    "@types/node": "^20.14.10",
+    "prettier": "^3.3.3",
+    "tsup": "^8.1.0",
+    "typescript": "^5.5.3",
+    "vitest": "^3.2.4"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/event-catalog/eventcatalog"
+  }
+}

--- a/packages/connectors/src/github-directory.test.ts
+++ b/packages/connectors/src/github-directory.test.ts
@@ -9,18 +9,16 @@ describe("githubDirectory", () => {
     vi.stubGlobal("fetch", fetchMock);
   });
 
-  it("loads teams and their members from a GitHub organization", async () => {
+  it("loads configured teams and their members from a GitHub organization", async () => {
     fetchMock
       .mockResolvedValueOnce(
-        jsonResponse([
-          {
-            id: 123,
-            name: "Platform",
-            slug: "platform",
-            description: "Platform team",
-            html_url: "https://github.com/orgs/acme/teams/platform",
-          },
-        ]),
+        jsonResponse({
+          id: 123,
+          name: "Platform",
+          slug: "platform",
+          description: "Platform team",
+          html_url: "https://github.com/orgs/acme/teams/platform",
+        }),
       )
       .mockResolvedValueOnce(
         jsonResponse([
@@ -36,6 +34,7 @@ describe("githubDirectory", () => {
     const source = githubDirectory({
       org: "acme",
       token: "github-token",
+      teams: ["platform"],
     });
 
     await expect(source.loadTeams?.()).resolves.toEqual([
@@ -84,7 +83,7 @@ describe("githubDirectory", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(fetchMock).toHaveBeenNthCalledWith(
       1,
-      "https://api.github.com/orgs/acme/teams?per_page=100",
+      "https://api.github.com/orgs/acme/teams/platform?per_page=100",
       expect.objectContaining({
         headers: expect.objectContaining({
           authorization: "Bearer github-token",
@@ -99,29 +98,30 @@ describe("githubDirectory", () => {
     );
   });
 
-  it("filters teams by slug and avoids loading members when users are disabled", async () => {
-    fetchMock.mockResolvedValueOnce(
-      jsonResponse([
-        {
+  it("loads only configured teams and avoids loading members when users are disabled", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
           id: 123,
           name: "Platform",
           slug: "platform",
           description: null,
           html_url: "https://github.com/orgs/acme/teams/platform",
-        },
-        {
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
           id: 789,
           name: "Product",
           slug: "product",
           description: null,
           html_url: "https://github.com/orgs/acme/teams/product",
-        },
-      ]),
-    );
+        }),
+      );
 
     const source = githubDirectory({
       org: "acme",
-      teams: ["platform"],
+      teams: ["platform", "product"],
       users: false,
     });
 
@@ -145,26 +145,63 @@ describe("githubDirectory", () => {
           url: "https://github.com/orgs/acme/teams/platform",
         },
       },
+      {
+        id: "product",
+        name: "Product",
+        summary: undefined,
+        markdown: [
+          ":::note",
+          "This team is synced from GitHub and is read-only in EventCatalog.",
+          "",
+          "Manage the team and its members in GitHub.",
+          "",
+          "[View team on GitHub](https://github.com/orgs/acme/teams/product)",
+          ":::",
+        ].join("\n"),
+        source: {
+          provider: "github",
+          id: "789",
+          url: "https://github.com/orgs/acme/teams/product",
+        },
+      },
     ]);
     await expect(source.loadUsers?.()).resolves.toEqual([]);
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://api.github.com/orgs/acme/teams/platform?per_page=100",
+      expect.any(Object),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://api.github.com/orgs/acme/teams/product?per_page=100",
+      expect.any(Object),
+    );
   });
 
-  it("follows GitHub pagination links", async () => {
+  it("follows GitHub pagination links for team members", async () => {
     fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          id: 123,
+          name: "Platform",
+          slug: "platform",
+          description: null,
+          html_url: "https://github.com/orgs/acme/teams/platform",
+        }),
+      )
       .mockResolvedValueOnce(
         jsonResponse(
           [
             {
-              id: 123,
-              name: "Platform",
-              slug: "platform",
-              description: null,
-              html_url: "https://github.com/orgs/acme/teams/platform",
+              id: 456,
+              login: "jane",
+              avatar_url: "https://avatars.githubusercontent.com/u/456",
+              html_url: "https://github.com/jane",
             },
           ],
           {
-            link: '<https://api.github.com/orgs/acme/teams?page=2&per_page=100>; rel="next"',
+            link: '<https://api.github.com/orgs/acme/teams/platform/members?page=2&per_page=100>; rel="next"',
           },
         ),
       )
@@ -172,24 +209,33 @@ describe("githubDirectory", () => {
         jsonResponse([
           {
             id: 789,
-            name: "Product",
-            slug: "product",
-            description: null,
-            html_url: "https://github.com/orgs/acme/teams/product",
+            login: "john",
+            avatar_url: "https://avatars.githubusercontent.com/u/789",
+            html_url: "https://github.com/john",
           },
         ]),
       );
 
     const source = githubDirectory({
       org: "acme",
-      users: false,
+      teams: ["platform"],
     });
 
-    await expect(source.loadTeams?.()).resolves.toHaveLength(2);
+    await expect(source.loadUsers?.()).resolves.toHaveLength(2);
     expect(fetchMock).toHaveBeenNthCalledWith(
-      2,
-      "https://api.github.com/orgs/acme/teams?page=2&per_page=100",
+      3,
+      "https://api.github.com/orgs/acme/teams/platform/members?page=2&per_page=100",
       expect.any(Object),
+    );
+  });
+
+  it("requires explicit team slugs", () => {
+    expect(() =>
+      githubDirectory({
+        org: "acme",
+      } as never),
+    ).toThrow(
+      'GitHub directory connector requires at least one team slug. Set teams: ["platform"].',
     );
   });
 
@@ -203,6 +249,7 @@ describe("githubDirectory", () => {
 
     const source = githubDirectory({
       org: "acme",
+      teams: ["platform"],
       users: false,
     });
 

--- a/packages/connectors/src/github-directory.test.ts
+++ b/packages/connectors/src/github-directory.test.ts
@@ -1,0 +1,222 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { githubDirectory } from "./github-directory";
+
+const fetchMock = vi.fn();
+
+describe("githubDirectory", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  it("loads teams and their members from a GitHub organization", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse([
+          {
+            id: 123,
+            name: "Platform",
+            slug: "platform",
+            description: "Platform team",
+            html_url: "https://github.com/orgs/acme/teams/platform",
+          },
+        ]),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse([
+          {
+            id: 456,
+            login: "jane",
+            avatar_url: "https://avatars.githubusercontent.com/u/456",
+            html_url: "https://github.com/jane",
+          },
+        ]),
+      );
+
+    const source = githubDirectory({
+      org: "acme",
+      token: "github-token",
+    });
+
+    await expect(source.loadTeams?.()).resolves.toEqual([
+      {
+        id: "platform",
+        name: "Platform",
+        summary: "Platform team",
+        members: ["jane"],
+        markdown: [
+          ":::note",
+          "This team is synced from GitHub and is read-only in EventCatalog.",
+          "",
+          "Manage the team and its members in GitHub.",
+          "",
+          "[View team on GitHub](https://github.com/orgs/acme/teams/platform)",
+          ":::",
+        ].join("\n"),
+        source: {
+          provider: "github",
+          id: "123",
+          url: "https://github.com/orgs/acme/teams/platform",
+        },
+      },
+    ]);
+    await expect(source.loadUsers?.()).resolves.toEqual([
+      {
+        id: "jane",
+        name: "jane",
+        avatarUrl: "https://avatars.githubusercontent.com/u/456",
+        markdown: [
+          ":::note",
+          "This user is synced from GitHub and is read-only in EventCatalog.",
+          "",
+          "Manage profile details and team membership in GitHub.",
+          "",
+          "[View user on GitHub](https://github.com/jane)",
+          ":::",
+        ].join("\n"),
+        source: {
+          provider: "github",
+          id: "456",
+          url: "https://github.com/jane",
+        },
+      },
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://api.github.com/orgs/acme/teams?per_page=100",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          authorization: "Bearer github-token",
+          "x-github-api-version": "2022-11-28",
+        }),
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://api.github.com/orgs/acme/teams/platform/members?per_page=100",
+      expect.any(Object),
+    );
+  });
+
+  it("filters teams by slug and avoids loading members when users are disabled", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse([
+        {
+          id: 123,
+          name: "Platform",
+          slug: "platform",
+          description: null,
+          html_url: "https://github.com/orgs/acme/teams/platform",
+        },
+        {
+          id: 789,
+          name: "Product",
+          slug: "product",
+          description: null,
+          html_url: "https://github.com/orgs/acme/teams/product",
+        },
+      ]),
+    );
+
+    const source = githubDirectory({
+      org: "acme",
+      teams: ["platform"],
+      users: false,
+    });
+
+    await expect(source.loadTeams?.()).resolves.toEqual([
+      {
+        id: "platform",
+        name: "Platform",
+        summary: undefined,
+        markdown: [
+          ":::note",
+          "This team is synced from GitHub and is read-only in EventCatalog.",
+          "",
+          "Manage the team and its members in GitHub.",
+          "",
+          "[View team on GitHub](https://github.com/orgs/acme/teams/platform)",
+          ":::",
+        ].join("\n"),
+        source: {
+          provider: "github",
+          id: "123",
+          url: "https://github.com/orgs/acme/teams/platform",
+        },
+      },
+    ]);
+    await expect(source.loadUsers?.()).resolves.toEqual([]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("follows GitHub pagination links", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse(
+          [
+            {
+              id: 123,
+              name: "Platform",
+              slug: "platform",
+              description: null,
+              html_url: "https://github.com/orgs/acme/teams/platform",
+            },
+          ],
+          {
+            link: '<https://api.github.com/orgs/acme/teams?page=2&per_page=100>; rel="next"',
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse([
+          {
+            id: 789,
+            name: "Product",
+            slug: "product",
+            description: null,
+            html_url: "https://github.com/orgs/acme/teams/product",
+          },
+        ]),
+      );
+
+    const source = githubDirectory({
+      org: "acme",
+      users: false,
+    });
+
+    await expect(source.loadTeams?.()).resolves.toHaveLength(2);
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://api.github.com/orgs/acme/teams?page=2&per_page=100",
+      expect.any(Object),
+    );
+  });
+
+  it("throws with the GitHub response body when a request fails", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response("Requires authentication", {
+        status: 401,
+        statusText: "Unauthorized",
+      }),
+    );
+
+    const source = githubDirectory({
+      org: "acme",
+      users: false,
+    });
+
+    await expect(source.loadTeams?.()).rejects.toThrow(
+      "GitHub directory connector failed (401 Unauthorized): Requires authentication",
+    );
+  });
+});
+
+const jsonResponse = (body: unknown, headers?: HeadersInit) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: {
+      "content-type": "application/json",
+      ...headers,
+    },
+  });

--- a/packages/connectors/src/github-directory.ts
+++ b/packages/connectors/src/github-directory.ts
@@ -1,0 +1,239 @@
+import {
+  defineDirectorySource,
+  type DirectorySource,
+  type DirectoryTeam,
+  type DirectoryUser,
+} from "./types";
+
+type GitHubDirectoryOptions = {
+  org: string;
+  token?: string;
+  teams?: true | string[];
+  users?: boolean;
+  baseUrl?: string;
+};
+
+type GitHubTeam = {
+  id: number;
+  name: string;
+  slug: string;
+  description: string | null;
+  html_url: string;
+};
+
+type GitHubUser = {
+  id: number;
+  login: string;
+  avatar_url: string;
+  html_url: string;
+};
+
+type GitHubDirectoryData = {
+  teams: DirectoryTeam[];
+  users: DirectoryUser[];
+};
+
+const GITHUB_API_VERSION = "2022-11-28";
+
+export const githubDirectory = (
+  options: GitHubDirectoryOptions,
+): DirectorySource => {
+  let cachedData: Promise<GitHubDirectoryData> | undefined;
+
+  const load = () => {
+    cachedData = cachedData ?? loadGitHubDirectory(options);
+    return cachedData;
+  };
+
+  return defineDirectorySource({
+    type: "directory",
+    name: `github:${options.org}`,
+    cacheKey: createGitHubDirectoryCacheKey(options),
+    loadTeams: async () => {
+      const data = await load();
+      return data.teams;
+    },
+    loadUsers: async () => {
+      const data = await load();
+      return data.users;
+    },
+  });
+};
+
+const createGitHubDirectoryCacheKey = (options: GitHubDirectoryOptions) => {
+  const teams =
+    options.teams === true || options.teams === undefined
+      ? "all"
+      : [...options.teams].sort().join(",");
+  const users = options.users !== false ? "true" : "false";
+  const baseUrl = options.baseUrl ?? "https://api.github.com";
+
+  return `github:${baseUrl}:${options.org}:teams=${teams}:users=${users}`;
+};
+
+const loadGitHubDirectory = async (
+  options: GitHubDirectoryOptions,
+): Promise<GitHubDirectoryData> => {
+  const teams = await loadGitHubTeams(options);
+  const shouldLoadUsers = options.users !== false;
+
+  if (!shouldLoadUsers) {
+    return { teams, users: [] };
+  }
+
+  const usersById = new Map<string, DirectoryUser>();
+  const teamsWithMembers: DirectoryTeam[] = [];
+
+  for (const team of teams) {
+    const members = await loadGitHubTeamMembers(options, team.id);
+
+    for (const member of members) {
+      usersById.set(member.id, member);
+    }
+
+    teamsWithMembers.push({
+      ...team,
+      members: members.map((member) => member.id),
+    });
+  }
+
+  return {
+    teams: teamsWithMembers,
+    users: Array.from(usersById.values()),
+  };
+};
+
+const loadGitHubTeams = async (
+  options: GitHubDirectoryOptions,
+): Promise<DirectoryTeam[]> => {
+  const teams = await paginate<GitHubTeam>(
+    options,
+    `/orgs/${encodeURIComponent(options.org)}/teams`,
+  );
+  const configuredTeams =
+    options.teams === undefined || options.teams === true
+      ? undefined
+      : new Set(options.teams);
+
+  return teams
+    .filter((team) => !configuredTeams || configuredTeams.has(team.slug))
+    .map((team) => ({
+      id: team.slug,
+      name: team.name,
+      summary: team.description ?? undefined,
+      markdown: createGitHubSyncedMarkdown("team", team.html_url),
+      source: {
+        provider: "github",
+        id: String(team.id),
+        url: team.html_url,
+      },
+    }));
+};
+
+const loadGitHubTeamMembers = async (
+  options: GitHubDirectoryOptions,
+  teamSlug: string,
+): Promise<DirectoryUser[]> => {
+  const members = await paginate<GitHubUser>(
+    options,
+    `/orgs/${encodeURIComponent(options.org)}/teams/${encodeURIComponent(teamSlug)}/members`,
+  );
+
+  return members.map((member) => ({
+    id: member.login,
+    name: member.login,
+    avatarUrl: member.avatar_url,
+    markdown: createGitHubSyncedMarkdown("user", member.html_url),
+    source: {
+      provider: "github",
+      id: String(member.id),
+      url: member.html_url,
+    },
+  }));
+};
+
+const createGitHubSyncedMarkdown = (type: "team" | "user", url: string) => {
+  if (type === "team") {
+    return [
+      ":::note",
+      "This team is synced from GitHub and is read-only in EventCatalog.",
+      "",
+      "Manage the team and its members in GitHub.",
+      "",
+      `[View team on GitHub](${url})`,
+      ":::",
+    ].join("\n");
+  }
+
+  return [
+    ":::note",
+    "This user is synced from GitHub and is read-only in EventCatalog.",
+    "",
+    "Manage profile details and team membership in GitHub.",
+    "",
+    `[View user on GitHub](${url})`,
+    ":::",
+  ].join("\n");
+};
+
+const paginate = async <T>(
+  options: GitHubDirectoryOptions,
+  pathname: string,
+): Promise<T[]> => {
+  const results: T[] = [];
+  let url: string | undefined = buildGitHubUrl(options, pathname);
+
+  while (url) {
+    const response = await githubRequest<T[]>(options, url);
+    results.push(...response.data);
+    url = getNextPageUrl(response.headers.get("link"));
+  }
+
+  return results;
+};
+
+const githubRequest = async <T>(
+  options: GitHubDirectoryOptions,
+  url: string,
+): Promise<{ data: T; headers: Headers }> => {
+  const response = await fetch(url, {
+    headers: {
+      accept: "application/vnd.github+json",
+      "x-github-api-version": GITHUB_API_VERSION,
+      "user-agent": "@eventcatalog/connectors",
+      ...(options.token ? { authorization: `Bearer ${options.token}` } : {}),
+    },
+  });
+
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(
+      `GitHub directory connector failed (${response.status} ${response.statusText}): ${message}`,
+    );
+  }
+
+  return {
+    data: (await response.json()) as T,
+    headers: response.headers,
+  };
+};
+
+const buildGitHubUrl = (options: GitHubDirectoryOptions, pathname: string) => {
+  const baseUrl = options.baseUrl ?? "https://api.github.com";
+  const normalizedBaseUrl = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
+  const normalizedPathname = pathname.replace(/^\//u, "");
+  const url = new URL(normalizedPathname, normalizedBaseUrl);
+  url.searchParams.set("per_page", "100");
+  return url.toString();
+};
+
+const getNextPageUrl = (linkHeader: string | null) => {
+  if (!linkHeader) return undefined;
+
+  const nextLink = linkHeader
+    .split(",")
+    .find((link) => link.includes('rel="next"'));
+  const match = nextLink?.match(/<([^>]+)>/);
+
+  return match?.[1];
+};

--- a/packages/connectors/src/github-directory.ts
+++ b/packages/connectors/src/github-directory.ts
@@ -8,7 +8,7 @@ import {
 type GitHubDirectoryOptions = {
   org: string;
   token?: string;
-  teams?: true | string[];
+  teams: string[];
   users?: boolean;
   baseUrl?: string;
 };
@@ -38,6 +38,12 @@ const GITHUB_API_VERSION = "2022-11-28";
 export const githubDirectory = (
   options: GitHubDirectoryOptions,
 ): DirectorySource => {
+  if (!Array.isArray(options.teams) || options.teams.length === 0) {
+    throw new Error(
+      'GitHub directory connector requires at least one team slug. Set teams: ["platform"].',
+    );
+  }
+
   let cachedData: Promise<GitHubDirectoryData> | undefined;
 
   const load = () => {
@@ -48,7 +54,6 @@ export const githubDirectory = (
   return defineDirectorySource({
     type: "directory",
     name: `github:${options.org}`,
-    cacheKey: createGitHubDirectoryCacheKey(options),
     loadTeams: async () => {
       const data = await load();
       return data.teams;
@@ -58,17 +63,6 @@ export const githubDirectory = (
       return data.users;
     },
   });
-};
-
-const createGitHubDirectoryCacheKey = (options: GitHubDirectoryOptions) => {
-  const teams =
-    options.teams === true || options.teams === undefined
-      ? "all"
-      : [...options.teams].sort().join(",");
-  const users = options.users !== false ? "true" : "false";
-  const baseUrl = options.baseUrl ?? "https://api.github.com";
-
-  return `github:${baseUrl}:${options.org}:teams=${teams}:users=${users}`;
 };
 
 const loadGitHubDirectory = async (
@@ -106,28 +100,38 @@ const loadGitHubDirectory = async (
 const loadGitHubTeams = async (
   options: GitHubDirectoryOptions,
 ): Promise<DirectoryTeam[]> => {
-  const teams = await paginate<GitHubTeam>(
-    options,
-    `/orgs/${encodeURIComponent(options.org)}/teams`,
-  );
-  const configuredTeams =
-    options.teams === undefined || options.teams === true
-      ? undefined
-      : new Set(options.teams);
+  const teams: GitHubTeam[] = [];
 
-  return teams
-    .filter((team) => !configuredTeams || configuredTeams.has(team.slug))
-    .map((team) => ({
-      id: team.slug,
-      name: team.name,
-      summary: team.description ?? undefined,
-      markdown: createGitHubSyncedMarkdown("team", team.html_url),
-      source: {
-        provider: "github",
-        id: String(team.id),
-        url: team.html_url,
-      },
-    }));
+  for (const teamSlug of options.teams) {
+    teams.push(await loadGitHubTeam(options, teamSlug));
+  }
+
+  return teams.map((team) => ({
+    id: team.slug,
+    name: team.name,
+    summary: team.description ?? undefined,
+    markdown: createGitHubSyncedMarkdown("team", team.html_url),
+    source: {
+      provider: "github",
+      id: String(team.id),
+      url: team.html_url,
+    },
+  }));
+};
+
+const loadGitHubTeam = async (
+  options: GitHubDirectoryOptions,
+  teamSlug: string,
+) => {
+  const response = await githubRequest<GitHubTeam>(
+    options,
+    buildGitHubUrl(
+      options,
+      `/orgs/${encodeURIComponent(options.org)}/teams/${encodeURIComponent(teamSlug)}`,
+    ),
+  );
+
+  return response.data;
 };
 
 const loadGitHubTeamMembers = async (

--- a/packages/connectors/src/index.ts
+++ b/packages/connectors/src/index.ts
@@ -1,0 +1,8 @@
+export { githubDirectory } from "./github-directory";
+export { defineDirectorySource } from "./types";
+export type {
+  DirectoryEntrySource,
+  DirectorySource,
+  DirectoryTeam,
+  DirectoryUser,
+} from "./types";

--- a/packages/connectors/src/types.ts
+++ b/packages/connectors/src/types.ts
@@ -1,0 +1,75 @@
+/**
+ * Describes where a generated directory entry came from.
+ *
+ * EventCatalog uses the provider to show source badges and to treat generated
+ * resources as externally managed.
+ */
+export type DirectoryEntrySource = {
+  /** Provider identifier, for example `github`, `okta`, or `ldap`. */
+  provider: string;
+  /** Optional provider-specific identifier for the external resource. */
+  id?: string;
+  /** Optional URL back to the resource in the external provider. */
+  url?: string;
+  [key: string]: unknown;
+};
+
+/**
+ * User returned by a directory source.
+ *
+ * Directory users are synced as read-only EventCatalog users and can be
+ * referenced by teams through their `id`.
+ */
+export type DirectoryUser = {
+  id: string;
+  name: string;
+  avatarUrl: string;
+  role?: string;
+  email?: string;
+  markdown?: string;
+  source?: DirectoryEntrySource;
+  [key: string]: unknown;
+};
+
+/**
+ * Team returned by a directory source.
+ *
+ * Directory teams are synced as read-only EventCatalog teams.
+ */
+export type DirectoryTeam = {
+  id: string;
+  name: string;
+  summary?: string;
+  /** User IDs for members of this team. */
+  members?: string[];
+  email?: string;
+  markdown?: string;
+  source?: DirectoryEntrySource;
+  [key: string]: unknown;
+};
+
+/**
+ * Loads users and/or teams from an external directory provider.
+ *
+ * EventCatalog calls these loaders during content sync, writes the returned
+ * entries into Astro collections, and mirrors them into the generated
+ * `.eventcatalog/store/directory.json` file for SDK/editor reads.
+ */
+export type DirectorySource = {
+  type: "directory";
+  /** Stable source identifier, usually `<provider>:<account-or-org>`. */
+  name: string;
+  /** Optional stable cache key for this source configuration. */
+  cacheKey?: string;
+  /** Load users from the external directory. */
+  loadUsers?: () => Promise<DirectoryUser[]>;
+  /** Load teams from the external directory. */
+  loadTeams?: () => Promise<DirectoryTeam[]>;
+};
+
+/**
+ * Defines a custom directory source with type inference for connector authors.
+ */
+export const defineDirectorySource = <TSource extends DirectorySource>(
+  source: TSource,
+) => source;

--- a/packages/connectors/src/types.ts
+++ b/packages/connectors/src/types.ts
@@ -59,8 +59,6 @@ export type DirectorySource = {
   type: "directory";
   /** Stable source identifier, usually `<provider>:<account-or-org>`. */
   name: string;
-  /** Optional stable cache key for this source configuration. */
-  cacheKey?: string;
   /** Load users from the external directory. */
   loadUsers?: () => Promise<DirectoryUser[]>;
   /** Load teams from the external directory. */

--- a/packages/connectors/tsconfig.json
+++ b/packages/connectors/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  }
+}

--- a/packages/connectors/tsup.config.ts
+++ b/packages/connectors/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  target: "es2020",
+  format: ["cjs", "esm"],
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+  dts: true,
+  entry: {
+    index: "src/index.ts",
+  },
+  outDir: "dist",
+  shims: true,
+});

--- a/packages/core/eventcatalog/astro.config.mjs
+++ b/packages/core/eventcatalog/astro.config.mjs
@@ -37,6 +37,9 @@ const expressiveCodeConfig = {
   },
 };
 
+const markdownRemarkPlugins = [remarkDirective, remarkDirectives, remarkComment, mermaid, plantuml];
+const mdxRemarkPlugins = [...markdownRemarkPlugins, remarkResourceRef];
+
 // https://astro.build/config
 export default defineConfig({
   base,
@@ -66,6 +69,11 @@ export default defineConfig({
   // https://docs.astro.build/en/reference/configuration-reference/#trailingslash
   trailingSlash: config.trailingSlash === true ? 'always' : 'ignore',
 
+  markdown: {
+    remarkPlugins: markdownRemarkPlugins,
+    gfm: true,
+  },
+
   // just turn this off for all users (for now...)
   devToolbar: { enabled: false },
   integrations: [
@@ -76,7 +84,7 @@ export default defineConfig({
     mdx({
       // https://docs.astro.build/en/guides/integrations-guide/mdx/#optimize
       optimize: config.mdxOptimize || false,
-      remarkPlugins: [remarkDirective, remarkDirectives, remarkComment, mermaid, plantuml, remarkResourceRef],
+      remarkPlugins: mdxRemarkPlugins,
       rehypePlugins: [
         [
           rehypeExpressiveCode,

--- a/packages/core/eventcatalog/src/components/FieldsExplorer/FieldNodeGraph.tsx
+++ b/packages/core/eventcatalog/src/components/FieldsExplorer/FieldNodeGraph.tsx
@@ -15,8 +15,8 @@ import {
   Event as EventNodeComponent,
   Command as CommandNodeComponent,
   Query as QueryNodeComponent,
-  Service as ServiceNodeComponent,
   Field as FieldNodeComponent,
+  nodeComponents,
 } from '@eventcatalog/visualiser';
 import { X, ChevronDown, ChevronRight, Search, AlertTriangle } from 'lucide-react';
 import { BoltIcon, ChatBubbleLeftIcon, MagnifyingGlassIcon, ServerIcon } from '@heroicons/react/24/solid';
@@ -88,7 +88,7 @@ function wrapWithContextMenu(Component: React.ComponentType<any>) {
 // and the catalog means these MemoExoticComponents don't match ComponentType<any>
 // unless we widen once here.
 const nodeTypes = {
-  service: wrapWithContextMenu(ServiceNodeComponent as unknown as React.ComponentType<any>),
+  service: wrapWithContextMenu(nodeComponents.service as unknown as React.ComponentType<any>),
   event: wrapWithContextMenu(EventNodeComponent as unknown as React.ComponentType<any>),
   command: wrapWithContextMenu(CommandNodeComponent as unknown as React.ComponentType<any>),
   query: wrapWithContextMenu(QueryNodeComponent as unknown as React.ComponentType<any>),

--- a/packages/core/eventcatalog/src/components/Tables/Table.tsx
+++ b/packages/core/eventcatalog/src/components/Tables/Table.tsx
@@ -51,6 +51,10 @@ export type TData<T extends TCollectionTypes> = {
     name: string;
     summary: string;
     version: string;
+    source?: {
+      provider: string;
+      url?: string;
+    };
     latestVersion?: string; // Defined on getter collection utility
     draft?: boolean | { title?: string; message: string }; // Draft property from base schema
     badges?: Array<{

--- a/packages/core/eventcatalog/src/components/Tables/columns/DirectorySourceColumn.tsx
+++ b/packages/core/eventcatalog/src/components/Tables/columns/DirectorySourceColumn.tsx
@@ -1,0 +1,49 @@
+import { FileText, Github } from 'lucide-react';
+
+type DirectorySource = {
+  provider: string;
+  url?: string;
+};
+
+export const DirectorySourceCell = ({ source }: { source?: DirectorySource }) => {
+  if (source?.provider === 'github') {
+    const icon = (
+      <Github className="h-4 w-4 text-[rgb(var(--ec-icon-color))] transition-colors group-hover/source:text-[rgb(var(--ec-page-text))]" />
+    );
+
+    if (source.url) {
+      return (
+        <a
+          href={source.url}
+          target="_blank"
+          rel="noreferrer"
+          className="group/source inline-flex h-7 w-7 items-center justify-center rounded-md border border-[rgb(var(--ec-page-border))] bg-[rgb(var(--ec-page-bg)/0.35)] transition-colors hover:bg-[rgb(var(--ec-content-hover))]"
+          title="Synced from GitHub"
+          aria-label="Synced from GitHub"
+        >
+          {icon}
+        </a>
+      );
+    }
+
+    return (
+      <span
+        className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-[rgb(var(--ec-page-border))] bg-[rgb(var(--ec-page-bg)/0.35)]"
+        title="Synced from GitHub"
+        aria-label="Synced from GitHub"
+      >
+        {icon}
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-[rgb(var(--ec-page-border))] bg-[rgb(var(--ec-page-bg)/0.35)] text-[rgb(var(--ec-icon-color))]"
+      title="Synced to local file"
+      aria-label="Synced to local file"
+    >
+      <FileText className="h-4 w-4" />
+    </span>
+  );
+};

--- a/packages/core/eventcatalog/src/components/Tables/columns/TeamsTableColumns.tsx
+++ b/packages/core/eventcatalog/src/components/Tables/columns/TeamsTableColumns.tsx
@@ -7,6 +7,7 @@ import type { CollectionUserTypes } from '@types';
 import type { TableConfiguration } from '@types';
 import { getColorAndIconForCollection } from '@utils/collections/icons';
 import { getCollectionTextColorClass } from '@utils/collection-colors';
+import { DirectorySourceCell } from './DirectorySourceColumn';
 const columnHelper = createColumnHelper<TData<CollectionUserTypes>>();
 
 const CollectionListCell = ({
@@ -79,6 +80,16 @@ export const columns = (tableConfiguration: TableConfiguration) => [
       filteredItemHasVersion: false,
     },
     filterFn: filterByName,
+  }),
+
+  columnHelper.accessor('data.source', {
+    id: 'source',
+    header: () => <span>{tableConfiguration.columns?.source?.label || 'Source'}</span>,
+    cell: (info) => <DirectorySourceCell source={info.getValue() as { provider: string; url?: string } | undefined} />,
+    meta: {
+      showFilter: false,
+      className: 'w-[96px]',
+    },
   }),
 
   columnHelper.accessor(

--- a/packages/core/eventcatalog/src/components/Tables/columns/UserTableColumns.tsx
+++ b/packages/core/eventcatalog/src/components/Tables/columns/UserTableColumns.tsx
@@ -7,6 +7,7 @@ import type { CollectionUserTypes } from '@types';
 import type { TableConfiguration } from '@types';
 import { getColorAndIconForCollection } from '@utils/collections/icons';
 import { getCollectionTextColorClass } from '@utils/collection-colors';
+import { DirectorySourceCell } from './DirectorySourceColumn';
 const columnHelper = createColumnHelper<TData<CollectionUserTypes>>();
 
 const CollectionListCell = ({
@@ -82,6 +83,16 @@ export const columns = (tableConfiguration: TableConfiguration) => [
       filteredItemHasVersion: false,
     },
     filterFn: filterByName,
+  }),
+
+  columnHelper.accessor('data.source', {
+    id: 'source',
+    header: () => <span>{tableConfiguration.columns?.source?.label || 'Source'}</span>,
+    cell: (info) => <DirectorySourceCell source={info.getValue() as { provider: string; url?: string } | undefined} />,
+    meta: {
+      showFilter: false,
+      className: 'w-[96px]',
+    },
   }),
 
   columnHelper.accessor('data.role', {

--- a/packages/core/eventcatalog/src/content.config.ts
+++ b/packages/core/eventcatalog/src/content.config.ts
@@ -7,6 +7,8 @@ import { badge, ownerReference } from './content.config-shared-collections';
 import { ADR_STATUS_VALUES } from './utils/collections/adr-constants';
 import fs from 'fs';
 import path from 'path';
+import { userTeamDirectoryLoader } from './enterprise/directory/user-team-directory';
+import config from '@config';
 
 // Enterprise Collections
 import { customPagesSchema, resourceDocsSchema, resourceDocCategoriesSchema } from './enterprise/collections';
@@ -100,6 +102,11 @@ const resourcePointer = z.object({
   id: z.string(),
   version: z.string().optional().default('latest'),
   type: z.enum(['agent', 'service', 'event', 'command', 'query', 'flow', 'channel', 'domain', 'user', 'team', 'container']),
+});
+
+const directoryEntrySource = z.object({
+  provider: z.string(),
+  url: z.string().optional(),
 });
 
 const changelogs = defineCollection({
@@ -876,10 +883,15 @@ const entities = defineCollection({
 });
 
 const users = defineCollection({
-  loader: glob({
-    pattern: withIgnoredBuildArtifacts('users/*.(md|mdx)'),
-    base: projectDirBase,
-    generateId: ({ data }) => data.id as string,
+  loader: userTeamDirectoryLoader({
+    collection: 'users',
+    sources: config.directory?.sources,
+    conflictStrategy: config.directory?.conflictStrategy,
+    local: {
+      pattern: withIgnoredBuildArtifacts('users/*.(md|mdx)'),
+      base: projectDirBase,
+      generateId: ({ data }) => data.id as string,
+    },
   }),
   schema: z.object({
     id: z.string(),
@@ -887,6 +899,8 @@ const users = defineCollection({
     avatarUrl: z.string(),
     role: z.string().optional(),
     hidden: z.boolean().optional(),
+    source: directoryEntrySource.optional(),
+    readOnly: z.boolean().optional(),
     email: z.string().optional(),
     slackDirectMessageUrl: z.string().optional(),
     msTeamsDirectMessageUrl: z.string().optional(),
@@ -901,10 +915,15 @@ const users = defineCollection({
 });
 
 const teams = defineCollection({
-  loader: glob({
-    pattern: withIgnoredBuildArtifacts('teams/*.(md|mdx)'),
-    base: projectDirBase,
-    generateId: ({ data }) => data.id as string,
+  loader: userTeamDirectoryLoader({
+    collection: 'teams',
+    sources: config.directory?.sources,
+    conflictStrategy: config.directory?.conflictStrategy,
+    local: {
+      pattern: withIgnoredBuildArtifacts('teams/*.(md|mdx)'),
+      base: projectDirBase,
+      generateId: ({ data }) => data.id as string,
+    },
   }),
   schema: z.object({
     id: z.string(),
@@ -912,6 +931,8 @@ const teams = defineCollection({
     summary: z.string().optional(),
     email: z.string().optional(),
     hidden: z.boolean().optional(),
+    source: directoryEntrySource.optional(),
+    readOnly: z.boolean().optional(),
     slackDirectMessageUrl: z.string().optional(),
     msTeamsDirectMessageUrl: z.string().optional(),
     members: z.array(reference('users')).optional(),

--- a/packages/core/eventcatalog/src/enterprise/directory/user-team-directory.spec.ts
+++ b/packages/core/eventcatalog/src/enterprise/directory/user-team-directory.spec.ts
@@ -119,6 +119,7 @@ describe('userTeamDirectoryLoader', () => {
               markdown: '# Jane',
               source: {
                 provider: 'github',
+                id: 'github-user-123',
                 url: 'https://github.com/jane',
               },
             },
@@ -137,6 +138,7 @@ describe('userTeamDirectoryLoader', () => {
         avatarUrl: 'https://example.com/jane.png',
         source: {
           provider: 'github',
+          id: 'github-user-123',
           url: 'https://github.com/jane',
         },
         readOnly: true,
@@ -150,6 +152,7 @@ describe('userTeamDirectoryLoader', () => {
         avatarUrl: 'https://example.com/jane.png',
         source: {
           provider: 'github',
+          id: 'github-user-123',
           url: 'https://github.com/jane',
         },
         readOnly: true,
@@ -171,6 +174,7 @@ describe('userTeamDirectoryLoader', () => {
         avatarUrl: 'https://example.com/jane.png',
         source: {
           provider: 'github',
+          id: 'github-user-123',
           url: 'https://github.com/jane',
         },
         readOnly: true,
@@ -336,6 +340,7 @@ describe('userTeamDirectoryLoader', () => {
               markdown: '# Core Maintainers',
               source: {
                 provider: 'github',
+                id: 'github-team-123',
                 url: 'https://github.com/orgs/event-catalog/teams/core-maintainers',
               },
             },
@@ -360,6 +365,7 @@ describe('userTeamDirectoryLoader', () => {
               readOnly: true,
               source: {
                 provider: 'github',
+                id: 'github-team-123',
                 url: 'https://github.com/orgs/event-catalog/teams/core-maintainers',
               },
             },
@@ -367,6 +373,86 @@ describe('userTeamDirectoryLoader', () => {
         },
       });
       expect(store.generatedAt).toEqual(expect.any(String));
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('deduplicates synced store entries when source-wins replaces an earlier directory source entry', async () => {
+    isEventCatalogScaleEnabled.mockReturnValue(true);
+    const context = createContext();
+    const tempDir = await mkdtemp(path.join(tmpdir(), 'eventcatalog-directory-store-'));
+    const storePath = path.join(tempDir, '.eventcatalog', 'store', 'directory.json');
+    const loader = userTeamDirectoryLoader({
+      collection: 'users',
+      local: {
+        pattern: 'users/*.(md|mdx)',
+        base: tempDir,
+      },
+      conflictStrategy: 'source-wins',
+      storePath,
+      sources: [
+        {
+          type: 'directory',
+          name: 'github:first',
+          loadUsers: async () => [
+            {
+              id: 'jane',
+              name: 'Jane From First Source',
+              markdown: 'First source Jane',
+              source: {
+                provider: 'github',
+                id: 'first-source-jane',
+              },
+            },
+          ],
+        },
+        {
+          type: 'directory',
+          name: 'github:second',
+          loadUsers: async () => [
+            {
+              id: 'jane',
+              name: 'Jane From Second Source',
+              markdown: 'Second source Jane',
+              source: {
+                provider: 'github',
+                id: 'second-source-jane',
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    try {
+      await loader.load(context as never);
+
+      const store = JSON.parse(await readFile(storePath, 'utf8'));
+      expect(store.resources.users).toEqual([
+        {
+          id: 'jane',
+          name: 'Jane From Second Source',
+          markdown: 'Second source Jane',
+          readOnly: true,
+          source: {
+            provider: 'github',
+            id: 'second-source-jane',
+          },
+        },
+      ]);
+      expect(context.store.get('jane')).toMatchObject({
+        data: {
+          id: 'jane',
+          name: 'Jane From Second Source',
+          source: {
+            provider: 'github',
+            id: 'second-source-jane',
+          },
+          readOnly: true,
+        },
+        body: 'Second source Jane',
+      });
     } finally {
       await rm(tempDir, { recursive: true, force: true });
     }

--- a/packages/core/eventcatalog/src/enterprise/directory/user-team-directory.spec.ts
+++ b/packages/core/eventcatalog/src/enterprise/directory/user-team-directory.spec.ts
@@ -265,16 +265,25 @@ describe('userTeamDirectoryLoader', () => {
     );
   });
 
-  it('uses cached source entries on subsequent loads', async () => {
+  it('refreshes source entries on subsequent loads', async () => {
     isEventCatalogScaleEnabled.mockReturnValue(true);
     const context = createContext();
-    const loadUsers = vi.fn(async () => [
-      {
-        id: 'jane',
-        name: 'Jane Doe',
-        avatarUrl: 'https://example.com/jane.png',
-      },
-    ]);
+    const loadUsers = vi
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          id: 'jane',
+          name: 'Jane Doe',
+          avatarUrl: 'https://example.com/jane.png',
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: 'jane',
+          name: 'Jane Updated',
+          avatarUrl: 'https://example.com/jane-updated.png',
+        },
+      ]);
     const loader = userTeamDirectoryLoader({
       collection: 'users',
       local: {
@@ -286,7 +295,6 @@ describe('userTeamDirectoryLoader', () => {
         {
           type: 'directory',
           name: 'test-source',
-          cacheKey: 'test-cache',
           loadUsers,
         },
       ],
@@ -296,8 +304,13 @@ describe('userTeamDirectoryLoader', () => {
     context.store.clear();
     await loader.load(context as never);
 
-    expect(loadUsers).toHaveBeenCalledTimes(1);
-    expect(consoleLog).toHaveBeenCalledWith(expect.stringContaining('Using cached users from directory source "test-source"'));
+    expect(loadUsers).toHaveBeenCalledTimes(2);
+    expect(context.store.get('jane')).toMatchObject({
+      data: {
+        name: 'Jane Updated',
+        avatarUrl: 'https://example.com/jane-updated.png',
+      },
+    });
   });
 
   it('writes synced source entries to the EventCatalog directory store', async () => {

--- a/packages/core/eventcatalog/src/enterprise/directory/user-team-directory.spec.ts
+++ b/packages/core/eventcatalog/src/enterprise/directory/user-team-directory.spec.ts
@@ -1,0 +1,428 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+const localLoad = vi.fn();
+const isEventCatalogScaleEnabled = vi.fn();
+const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+vi.mock('astro/loaders', () => ({
+  glob: vi.fn(() => ({
+    name: 'mock-glob-loader',
+    load: localLoad,
+  })),
+}));
+
+vi.mock('../feature', () => ({
+  isEventCatalogScaleEnabled: () => isEventCatalogScaleEnabled(),
+}));
+
+import { userTeamDirectoryLoader } from './user-team-directory';
+
+const createContentStore = () => {
+  const entries = new Map<string, unknown>();
+
+  return {
+    has: (id: string) => entries.has(id),
+    set: (entry: { id: string; [key: string]: unknown }) => entries.set(entry.id, entry),
+    get: (id: string) => entries.get(id),
+    clear: () => entries.clear(),
+  };
+};
+
+const createContext = () => ({
+  store: createContentStore(),
+  meta: new Map<string, string>(),
+  parseData: vi.fn(async ({ data }) => data),
+  renderMarkdown: vi.fn(async (markdown) => ({
+    html: `<p>${markdown}</p>`,
+    metadata: {
+      headings: [],
+      localImagePaths: [],
+      remoteImagePaths: [],
+      frontmatter: {},
+      imagePaths: [],
+    },
+  })),
+  generateDigest: vi.fn((data) => JSON.stringify(data)),
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+});
+
+describe('userTeamDirectoryLoader', () => {
+  beforeEach(() => {
+    localLoad.mockReset();
+    isEventCatalogScaleEnabled.mockReset();
+    isEventCatalogScaleEnabled.mockReturnValue(false);
+    consoleLog.mockClear();
+  });
+
+  it('loads local users without requiring EventCatalog Scale when no directory sources are configured', async () => {
+    const context = createContext();
+    const loader = userTeamDirectoryLoader({
+      collection: 'users',
+      local: {
+        pattern: 'users/*.(md|mdx)',
+        base: '/catalog',
+      },
+    });
+
+    await loader.load(context as never);
+
+    expect(localLoad).toHaveBeenCalledWith(context);
+    expect(isEventCatalogScaleEnabled).not.toHaveBeenCalled();
+  });
+
+  it('requires EventCatalog Scale when directory sources are configured', async () => {
+    const context = createContext();
+    const loader = userTeamDirectoryLoader({
+      collection: 'users',
+      local: {
+        pattern: 'users/*.(md|mdx)',
+        base: '/catalog',
+      },
+      storePath: false,
+      sources: [
+        {
+          type: 'directory',
+          name: 'test-source',
+          loadUsers: async () => [],
+        },
+      ],
+    });
+
+    await expect(loader.load(context as never)).rejects.toThrow('Directory sources require EventCatalog Scale.');
+  });
+
+  it('loads users from configured directory sources', async () => {
+    isEventCatalogScaleEnabled.mockReturnValue(true);
+    const context = createContext();
+    const loader = userTeamDirectoryLoader({
+      collection: 'users',
+      local: {
+        pattern: 'users/*.(md|mdx)',
+        base: '/catalog',
+      },
+      storePath: false,
+      sources: [
+        {
+          type: 'directory',
+          name: 'test-source',
+          loadUsers: async () => [
+            {
+              id: 'jane',
+              name: 'Jane Doe',
+              avatarUrl: 'https://example.com/jane.png',
+              markdown: '# Jane',
+              source: {
+                provider: 'github',
+                url: 'https://github.com/jane',
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    await loader.load(context as never);
+
+    expect(context.parseData).toHaveBeenCalledWith({
+      id: 'jane',
+      data: {
+        id: 'jane',
+        name: 'Jane Doe',
+        avatarUrl: 'https://example.com/jane.png',
+        source: {
+          provider: 'github',
+          url: 'https://github.com/jane',
+        },
+        readOnly: true,
+      },
+    });
+    expect(context.store.get('jane')).toEqual({
+      id: 'jane',
+      data: {
+        id: 'jane',
+        name: 'Jane Doe',
+        avatarUrl: 'https://example.com/jane.png',
+        source: {
+          provider: 'github',
+          url: 'https://github.com/jane',
+        },
+        readOnly: true,
+      },
+      body: '# Jane',
+      rendered: {
+        html: '<p># Jane</p>',
+        metadata: {
+          headings: [],
+          localImagePaths: [],
+          remoteImagePaths: [],
+          frontmatter: {},
+          imagePaths: [],
+        },
+      },
+      digest: JSON.stringify({
+        id: 'jane',
+        name: 'Jane Doe',
+        avatarUrl: 'https://example.com/jane.png',
+        source: {
+          provider: 'github',
+          url: 'https://github.com/jane',
+        },
+        readOnly: true,
+        body: '# Jane',
+      }),
+    });
+    expect(consoleLog).toHaveBeenCalledWith(expect.stringContaining('Loading users from directory source "test-source"'));
+    expect(consoleLog).toHaveBeenCalledWith(expect.stringContaining('Synced 1 users from directory source "test-source"'));
+  });
+
+  it('keeps local entries when the conflict strategy is local-wins', async () => {
+    isEventCatalogScaleEnabled.mockReturnValue(true);
+    const context = createContext();
+    context.store.set({
+      id: 'jane',
+      data: {
+        id: 'jane',
+        name: 'Local Jane',
+      },
+    });
+    const loader = userTeamDirectoryLoader({
+      collection: 'users',
+      local: {
+        pattern: 'users/*.(md|mdx)',
+        base: '/catalog',
+      },
+      storePath: false,
+      sources: [
+        {
+          type: 'directory',
+          name: 'test-source',
+          loadUsers: async () => [
+            {
+              id: 'jane',
+              name: 'Source Jane',
+              avatarUrl: 'https://example.com/jane.png',
+            },
+          ],
+        },
+      ],
+    });
+
+    await loader.load(context as never);
+
+    expect(context.store.get('jane')).toEqual({
+      id: 'jane',
+      data: {
+        id: 'jane',
+        name: 'Local Jane',
+      },
+    });
+    expect(consoleLog).toHaveBeenCalledWith(
+      expect.stringContaining('Synced 0 users from directory source "test-source" (1 skipped due to local conflicts)')
+    );
+  });
+
+  it('throws when the conflict strategy is error and a source returns a local id', async () => {
+    isEventCatalogScaleEnabled.mockReturnValue(true);
+    const context = createContext();
+    context.store.set({
+      id: 'jane',
+      data: {
+        id: 'jane',
+        name: 'Local Jane',
+      },
+    });
+    const loader = userTeamDirectoryLoader({
+      collection: 'users',
+      local: {
+        pattern: 'users/*.(md|mdx)',
+        base: '/catalog',
+      },
+      conflictStrategy: 'error',
+      storePath: false,
+      sources: [
+        {
+          type: 'directory',
+          name: 'test-source',
+          loadUsers: async () => [
+            {
+              id: 'jane',
+              name: 'Source Jane',
+              avatarUrl: 'https://example.com/jane.png',
+            },
+          ],
+        },
+      ],
+    });
+
+    await expect(loader.load(context as never)).rejects.toThrow(
+      'Directory source "test-source" returned duplicate users id "jane".'
+    );
+  });
+
+  it('uses cached source entries on subsequent loads', async () => {
+    isEventCatalogScaleEnabled.mockReturnValue(true);
+    const context = createContext();
+    const loadUsers = vi.fn(async () => [
+      {
+        id: 'jane',
+        name: 'Jane Doe',
+        avatarUrl: 'https://example.com/jane.png',
+      },
+    ]);
+    const loader = userTeamDirectoryLoader({
+      collection: 'users',
+      local: {
+        pattern: 'users/*.(md|mdx)',
+        base: '/catalog',
+      },
+      storePath: false,
+      sources: [
+        {
+          type: 'directory',
+          name: 'test-source',
+          cacheKey: 'test-cache',
+          loadUsers,
+        },
+      ],
+    });
+
+    await loader.load(context as never);
+    context.store.clear();
+    await loader.load(context as never);
+
+    expect(loadUsers).toHaveBeenCalledTimes(1);
+    expect(consoleLog).toHaveBeenCalledWith(expect.stringContaining('Using cached users from directory source "test-source"'));
+  });
+
+  it('writes synced source entries to the EventCatalog directory store', async () => {
+    isEventCatalogScaleEnabled.mockReturnValue(true);
+    const context = createContext();
+    const tempDir = await mkdtemp(path.join(tmpdir(), 'eventcatalog-directory-store-'));
+    const storePath = path.join(tempDir, '.eventcatalog', 'store', 'directory.json');
+    const loader = userTeamDirectoryLoader({
+      collection: 'teams',
+      local: {
+        pattern: 'teams/*.(md|mdx)',
+        base: tempDir,
+      },
+      storePath,
+      sources: [
+        {
+          type: 'directory',
+          name: 'github:event-catalog',
+          loadTeams: async () => [
+            {
+              id: 'core-maintainers',
+              name: 'Core Maintainers',
+              markdown: '# Core Maintainers',
+              source: {
+                provider: 'github',
+                url: 'https://github.com/orgs/event-catalog/teams/core-maintainers',
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    try {
+      await loader.load(context as never);
+
+      const store = JSON.parse(await readFile(storePath, 'utf8'));
+      expect(store).toMatchObject({
+        version: '1',
+        resources: {
+          users: [],
+          teams: [
+            {
+              id: 'core-maintainers',
+              name: 'Core Maintainers',
+              markdown: '# Core Maintainers',
+              readOnly: true,
+              source: {
+                provider: 'github',
+                url: 'https://github.com/orgs/event-catalog/teams/core-maintainers',
+              },
+            },
+          ],
+        },
+      });
+      expect(store.generatedAt).toEqual(expect.any(String));
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('clears an existing directory store collection when sources are removed', async () => {
+    const context = createContext();
+    const tempDir = await mkdtemp(path.join(tmpdir(), 'eventcatalog-directory-store-'));
+    const storePath = path.join(tempDir, '.eventcatalog', 'store', 'directory.json');
+    const loader = userTeamDirectoryLoader({
+      collection: 'users',
+      local: {
+        pattern: 'users/*.(md|mdx)',
+        base: tempDir,
+      },
+      storePath,
+    });
+
+    try {
+      await mkdir(path.dirname(storePath), { recursive: true });
+      await writeFile(
+        storePath,
+        JSON.stringify({
+          version: '1',
+          generatedAt: '2026-05-27T00:00:00.000Z',
+          resources: {
+            users: [
+              {
+                id: 'stale-user',
+                name: 'Stale User',
+                markdown: 'Stale directory user',
+                readOnly: true,
+                source: {
+                  provider: 'github',
+                },
+              },
+            ],
+            teams: [
+              {
+                id: 'existing-team',
+                name: 'Existing Team',
+                markdown: 'Existing directory team',
+                readOnly: true,
+                source: {
+                  provider: 'github',
+                },
+              },
+            ],
+          },
+        })
+      );
+
+      await loader.load(context as never);
+
+      const store = JSON.parse(await readFile(storePath, 'utf8'));
+      expect(store.resources.users).toEqual([]);
+      expect(store.resources.teams).toEqual([
+        {
+          id: 'existing-team',
+          name: 'Existing Team',
+          markdown: 'Existing directory team',
+          readOnly: true,
+          source: {
+            provider: 'github',
+          },
+        },
+      ]);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/eventcatalog/src/enterprise/directory/user-team-directory.ts
+++ b/packages/core/eventcatalog/src/enterprise/directory/user-team-directory.ts
@@ -23,7 +23,6 @@ type DirectoryEntry = {
 type DirectorySource = {
   type: 'directory';
   name: string;
-  cacheKey?: string;
   loadUsers?: () => Promise<DirectoryEntry[]>;
   loadTeams?: () => Promise<DirectoryEntry[]>;
 };
@@ -82,7 +81,7 @@ export const userTeamDirectoryLoader = ({
 
       for (const source of sources) {
         logDirectoryInfo(`Loading ${collection} from directory source "${source.name}"`);
-        const entries = await loadSourceEntries({ source, collection, loadEntries, context });
+        const entries = await loadSourceEntries({ source, loadEntries });
         let syncedEntries = 0;
         let skippedEntries = 0;
 
@@ -139,36 +138,13 @@ export const userTeamDirectoryLoader = ({
 
 const loadSourceEntries = async ({
   source,
-  collection,
   loadEntries,
-  context,
 }: {
   source: DirectorySource;
-  collection: UserTeamCollection;
   loadEntries: 'loadUsers' | 'loadTeams';
-  context: Parameters<Loader['load']>[0];
 }) => {
-  const cacheKey = getSourceCacheKey(source, collection);
-  const cachedEntries = context.meta.get(cacheKey);
-
-  if (cachedEntries) {
-    try {
-      logDirectoryInfo(`Using cached ${collection} from directory source "${source.name}"`);
-      return JSON.parse(cachedEntries) as DirectoryEntry[];
-    } catch {
-      context.meta.delete(cacheKey);
-      context.logger.warn(`Ignoring invalid cache for ${collection} from directory source "${source.name}"`);
-    }
-  }
-
-  const entries = (await source[loadEntries]?.()) ?? [];
-  context.meta.set(cacheKey, JSON.stringify(entries));
-
-  return entries;
+  return (await source[loadEntries]?.()) ?? [];
 };
-
-const getSourceCacheKey = (source: DirectorySource, collection: UserTeamCollection) =>
-  `directory:${collection}:${source.cacheKey ?? source.name}`;
 
 const getSourceProvider = (source: DirectorySource) => source.name.split(':')[0] || source.name;
 

--- a/packages/core/eventcatalog/src/enterprise/directory/user-team-directory.ts
+++ b/packages/core/eventcatalog/src/enterprise/directory/user-team-directory.ts
@@ -41,9 +41,8 @@ type DirectoryStoreResource = DirectoryEntry & {
   id: string;
   markdown: string;
   readOnly: true;
-  source: {
+  source: NonNullable<DirectoryEntry['source']> & {
     provider: string;
-    url?: string;
   };
 };
 
@@ -77,7 +76,7 @@ export const userTeamDirectoryLoader = ({
       }
 
       const loadEntries = collection === 'users' ? 'loadUsers' : 'loadTeams';
-      const syncedDirectoryStoreResources: DirectoryStoreResource[] = [];
+      const syncedDirectoryStoreResources = new Map<string, DirectoryStoreResource>();
 
       for (const source of sources) {
         logDirectoryInfo(`Loading ${collection} from directory source "${source.name}"`);
@@ -108,7 +107,7 @@ export const userTeamDirectoryLoader = ({
             id: entry.id,
             data,
           });
-          syncedDirectoryStoreResources.push({
+          syncedDirectoryStoreResources.set(entry.id, {
             ...data,
             markdown: body,
             readOnly: true,
@@ -131,7 +130,7 @@ export const userTeamDirectoryLoader = ({
         );
       }
 
-      await directoryStore?.writeCollection(collection, syncedDirectoryStoreResources);
+      await directoryStore?.writeCollection(collection, Array.from(syncedDirectoryStoreResources.values()));
     },
   };
 };
@@ -152,8 +151,8 @@ const withDirectoryEntrySource = (entryData: Omit<DirectoryEntry, 'markdown'>, s
   const entrySource = entryData.source as DirectoryEntry['source'] | undefined;
   const provider = entrySource?.provider ?? getSourceProvider(source);
   const sourceData = {
+    ...entrySource,
     provider,
-    ...(entrySource?.url ? { url: entrySource.url } : {}),
   };
 
   return {

--- a/packages/core/eventcatalog/src/enterprise/directory/user-team-directory.ts
+++ b/packages/core/eventcatalog/src/enterprise/directory/user-team-directory.ts
@@ -1,0 +1,216 @@
+import { glob, type Loader } from 'astro/loaders';
+import pc from 'picocolors';
+import { isEventCatalogScaleEnabled } from '../feature';
+import { EventCatalogStore } from '../../stores/eventcatalog-store';
+
+const colors = pc.createColors(true);
+
+type UserTeamCollection = 'users' | 'teams';
+type GlobOptions = Parameters<typeof glob>[0];
+
+type DirectoryEntry = {
+  id: string;
+  markdown?: string;
+  readOnly?: boolean;
+  source?: {
+    provider?: string;
+    url?: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+};
+
+type DirectorySource = {
+  type: 'directory';
+  name: string;
+  cacheKey?: string;
+  loadUsers?: () => Promise<DirectoryEntry[]>;
+  loadTeams?: () => Promise<DirectoryEntry[]>;
+};
+
+type DirectoryConflictStrategy = 'local-wins' | 'source-wins' | 'error';
+
+type UserTeamDirectoryLoaderOptions = {
+  collection: UserTeamCollection;
+  local: GlobOptions;
+  sources?: DirectorySource[];
+  conflictStrategy?: DirectoryConflictStrategy;
+  storePath?: string | false;
+};
+
+type DirectoryStoreResource = DirectoryEntry & {
+  id: string;
+  markdown: string;
+  readOnly: true;
+  source: {
+    provider: string;
+    url?: string;
+  };
+};
+
+type DirectoryStoreResources = {
+  users: DirectoryStoreResource[];
+  teams: DirectoryStoreResource[];
+};
+
+export const userTeamDirectoryLoader = ({
+  collection,
+  local,
+  sources = [],
+  conflictStrategy = 'local-wins',
+  storePath,
+}: UserTeamDirectoryLoaderOptions): Loader => {
+  const localLoader = glob(local);
+  const directoryStore = createDirectoryStore({ base: local.base, storePath });
+
+  return {
+    name: `eventcatalog-${collection}-directory-loader`,
+    load: async (context) => {
+      await localLoader.load(context);
+
+      if (sources.length === 0) {
+        await directoryStore?.clearCollectionIfStoreExists(collection);
+        return;
+      }
+
+      if (!isEventCatalogScaleEnabled()) {
+        throw new Error('Directory sources require EventCatalog Scale.');
+      }
+
+      const loadEntries = collection === 'users' ? 'loadUsers' : 'loadTeams';
+      const syncedDirectoryStoreResources: DirectoryStoreResource[] = [];
+
+      for (const source of sources) {
+        logDirectoryInfo(`Loading ${collection} from directory source "${source.name}"`);
+        const entries = await loadSourceEntries({ source, collection, loadEntries, context });
+        let syncedEntries = 0;
+        let skippedEntries = 0;
+
+        for (const entry of entries) {
+          if (context.store.has(entry.id)) {
+            if (conflictStrategy === 'local-wins') {
+              skippedEntries += 1;
+              continue;
+            }
+            if (conflictStrategy === 'error') {
+              throw new Error(`Directory source "${source.name}" returned duplicate ${collection} id "${entry.id}".`);
+            }
+          }
+
+          const { markdown, ...entryData } = entry;
+          const data = {
+            ...withDirectoryEntrySource(entryData, source),
+            id: entry.id,
+            readOnly: true,
+          };
+          const body = markdown ?? '';
+          const rendered = body ? await context.renderMarkdown(body) : undefined;
+          const parsedData = await context.parseData({
+            id: entry.id,
+            data,
+          });
+          syncedDirectoryStoreResources.push({
+            ...data,
+            markdown: body,
+            readOnly: true,
+          });
+
+          context.store.set({
+            id: entry.id,
+            data: parsedData,
+            body,
+            digest: context.generateDigest({ ...data, body }),
+            rendered,
+          });
+          syncedEntries += 1;
+        }
+
+        logDirectoryInfo(
+          `Synced ${syncedEntries} ${collection} from directory source "${source.name}"${
+            skippedEntries > 0 ? ` (${skippedEntries} skipped due to local conflicts)` : ''
+          }`
+        );
+      }
+
+      await directoryStore?.writeCollection(collection, syncedDirectoryStoreResources);
+    },
+  };
+};
+
+const loadSourceEntries = async ({
+  source,
+  collection,
+  loadEntries,
+  context,
+}: {
+  source: DirectorySource;
+  collection: UserTeamCollection;
+  loadEntries: 'loadUsers' | 'loadTeams';
+  context: Parameters<Loader['load']>[0];
+}) => {
+  const cacheKey = getSourceCacheKey(source, collection);
+  const cachedEntries = context.meta.get(cacheKey);
+
+  if (cachedEntries) {
+    try {
+      logDirectoryInfo(`Using cached ${collection} from directory source "${source.name}"`);
+      return JSON.parse(cachedEntries) as DirectoryEntry[];
+    } catch {
+      context.meta.delete(cacheKey);
+      context.logger.warn(`Ignoring invalid cache for ${collection} from directory source "${source.name}"`);
+    }
+  }
+
+  const entries = (await source[loadEntries]?.()) ?? [];
+  context.meta.set(cacheKey, JSON.stringify(entries));
+
+  return entries;
+};
+
+const getSourceCacheKey = (source: DirectorySource, collection: UserTeamCollection) =>
+  `directory:${collection}:${source.cacheKey ?? source.name}`;
+
+const getSourceProvider = (source: DirectorySource) => source.name.split(':')[0] || source.name;
+
+const withDirectoryEntrySource = (entryData: Omit<DirectoryEntry, 'markdown'>, source: DirectorySource) => {
+  const entrySource = entryData.source as DirectoryEntry['source'] | undefined;
+  const provider = entrySource?.provider ?? getSourceProvider(source);
+  const sourceData = {
+    provider,
+    ...(entrySource?.url ? { url: entrySource.url } : {}),
+  };
+
+  return {
+    ...entryData,
+    source: sourceData,
+  };
+};
+
+const getDirectoryStorePath = (base: GlobOptions['base']) => {
+  if (!base || typeof base !== 'string') return undefined;
+  return EventCatalogStore.getStorePath(base, 'directory');
+};
+
+const createDirectoryStore = ({ base, storePath }: { base: GlobOptions['base']; storePath?: string | false }) => {
+  if (storePath === false) return undefined;
+
+  const resolvedStorePath = storePath ?? getDirectoryStorePath(base);
+  if (!resolvedStorePath) return undefined;
+
+  return new EventCatalogStore<DirectoryStoreResources>({
+    storePath: resolvedStorePath,
+    resources: {
+      users: [],
+      teams: [],
+    },
+  });
+};
+
+const getTimestamp = () => {
+  const now = new Date();
+  return now.toLocaleTimeString('en-US', { hour12: false });
+};
+
+const logDirectoryInfo = (message: string) => {
+  console.log(`${colors.dim(getTimestamp())} ${colors.blue('[directory]')} ${message}`);
+};

--- a/packages/core/eventcatalog/src/pages/directory/[type]/index.astro
+++ b/packages/core/eventcatalog/src/pages/directory/[type]/index.astro
@@ -33,6 +33,8 @@ function mapToItem(i: any) {
           id: d.data.id,
           name: d.data.name,
           // @ts-ignore
+          source: d.data?.source,
+          // @ts-ignore
           role: d.data?.role,
           // @ts-ignore
           avatarUrl: d.data?.avatarUrl,

--- a/packages/core/eventcatalog/src/pages/docs/teams/[id]/index.astro
+++ b/packages/core/eventcatalog/src/pages/docs/teams/[id]/index.astro
@@ -7,6 +7,7 @@ import type { CollectionEntry } from 'astro:content';
 import OwnersList from '@components/Lists/OwnersList';
 import PillListFlat from '@components/Lists/PillListFlat';
 import EnvelopeIcon from '@heroicons/react/16/solid/EnvelopeIcon';
+import { Github } from 'lucide-react';
 import { formatAdrStatus } from '@utils/collections/adrs';
 import { buildUrl } from '@utils/url-builder';
 import VerticalSideBarLayout from '@layouts/VerticalSideBarLayout.astro';
@@ -78,6 +79,9 @@ const ownedAdrsList = adrs.map((p) => ({
 }));
 
 const pageTitle = `Team | ${props.data.name}`;
+const source = props.data.source;
+const sourceLabel = source?.provider === 'github' ? 'GitHub' : source?.provider;
+const sourceTitle = sourceLabel ? `Synced from ${sourceLabel}` : undefined;
 ---
 
 <VerticalSideBarLayout title={pageTitle} description={props.data.summary}>
@@ -92,11 +96,6 @@ const pageTitle = `Team | ${props.data.name}`;
           <div class="flex justify-start">
             <div class="flex flex-col justify-between space-y-3">
               <div>
-                <span
-                  class="inline-flex items-center px-2.5 py-0.5 rounded-md text-xs font-medium bg-[rgb(var(--ec-content-hover))] text-[rgb(var(--ec-page-text-muted))] mb-2"
-                >
-                  Team
-                </span>
                 <h2 class="text-3xl font-bold text-[rgb(var(--ec-page-text))]">{props.data.name}</h2>
               </div>
               {
@@ -138,6 +137,31 @@ const pageTitle = `Team | ${props.data.name}`;
                       <img src={buildUrl('/icons/ms-teams.svg', true)} class="w-4 h-4" alt="Teams" />
                       <span>Teams</span>
                     </a>
+                  )
+                }
+                {
+                  source && sourceLabel && source.url && (
+                    <a
+                      href={source.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      title={sourceTitle}
+                      class="inline-flex items-center gap-1.5 text-sm text-[rgb(var(--ec-page-text-muted))] hover:text-[rgb(var(--ec-page-text))] transition-colors"
+                    >
+                      {source.provider === 'github' && <Github className="w-4 h-4 text-[rgb(var(--ec-icon-color))]" />}
+                      <span>{sourceLabel}</span>
+                    </a>
+                  )
+                }
+                {
+                  source && sourceLabel && !source.url && (
+                    <span
+                      title={sourceTitle}
+                      class="inline-flex items-center gap-1.5 text-sm text-[rgb(var(--ec-page-text-muted))]"
+                    >
+                      {source.provider === 'github' && <Github className="w-4 h-4 text-[rgb(var(--ec-icon-color))]" />}
+                      <span>{sourceLabel}</span>
+                    </span>
                   )
                 }
               </div>

--- a/packages/core/eventcatalog/src/pages/docs/users/[id]/index.astro
+++ b/packages/core/eventcatalog/src/pages/docs/users/[id]/index.astro
@@ -7,6 +7,7 @@ import type { CollectionEntry } from 'astro:content';
 import OwnersList from '@components/Lists/OwnersList';
 import PillListFlat from '@components/Lists/PillListFlat';
 import EnvelopeIcon from '@heroicons/react/16/solid/EnvelopeIcon';
+import { Github } from 'lucide-react';
 import { formatAdrStatus } from '@utils/collections/adrs';
 import { buildUrl } from '@utils/url-builder';
 import VerticalSideBarLayout from '@layouts/VerticalSideBarLayout.astro';
@@ -75,6 +76,9 @@ const associatedTeams = teams.map((o) => ({
 }));
 
 const pageTitle = `User | ${props.data.name}`;
+const source = props.data.source;
+const sourceLabel = source?.provider === 'github' ? 'GitHub' : source?.provider;
+const sourceTitle = sourceLabel ? `Synced from ${sourceLabel}` : undefined;
 ---
 
 <VerticalSideBarLayout title={pageTitle}>
@@ -139,6 +143,31 @@ const pageTitle = `User | ${props.data.name}`;
                       <img src={buildUrl('/icons/ms-teams.svg', true)} class="w-4 h-4" alt="Teams" />
                       <span>Teams</span>
                     </a>
+                  )
+                }
+                {
+                  source && sourceLabel && source.url && (
+                    <a
+                      href={source.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      title={sourceTitle}
+                      class="inline-flex items-center gap-1.5 text-sm text-[rgb(var(--ec-page-text-muted))] hover:text-[rgb(var(--ec-page-text))] transition-colors"
+                    >
+                      {source.provider === 'github' && <Github className="w-4 h-4 text-[rgb(var(--ec-icon-color))]" />}
+                      <span>{sourceLabel}</span>
+                    </a>
+                  )
+                }
+                {
+                  source && sourceLabel && !source.url && (
+                    <span
+                      title={sourceTitle}
+                      class="inline-flex items-center gap-1.5 text-sm text-[rgb(var(--ec-page-text-muted))]"
+                    >
+                      {source.provider === 'github' && <Github className="w-4 h-4 text-[rgb(var(--ec-icon-color))]" />}
+                      <span>{sourceLabel}</span>
+                    </span>
                   )
                 }
               </div>

--- a/packages/core/eventcatalog/src/stores/eventcatalog-store.spec.ts
+++ b/packages/core/eventcatalog/src/stores/eventcatalog-store.spec.ts
@@ -1,0 +1,60 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { EventCatalogStore } from './eventcatalog-store';
+
+type TestStoreResources = {
+  users: { id: string; name: string }[];
+  teams: { id: string; name: string }[];
+};
+
+describe('EventCatalogStore', () => {
+  it('writes one collection while preserving the rest of the store', async () => {
+    const tempDir = await mkdtemp(path.join(tmpdir(), 'eventcatalog-store-'));
+    const storePath = EventCatalogStore.getStorePath(tempDir, 'directory');
+    const store = new EventCatalogStore<TestStoreResources>({
+      storePath,
+      resources: {
+        users: [],
+        teams: [],
+      },
+    });
+
+    try {
+      await store.writeCollection('teams', [{ id: 'platform', name: 'Platform' }]);
+      await store.writeCollection('users', [{ id: 'jane', name: 'Jane' }]);
+
+      const stored = JSON.parse(await readFile(storePath, 'utf8'));
+      expect(stored).toMatchObject({
+        version: '1',
+        resources: {
+          users: [{ id: 'jane', name: 'Jane' }],
+          teams: [{ id: 'platform', name: 'Platform' }],
+        },
+      });
+      expect(stored.generatedAt).toEqual(expect.any(String));
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not create a store file when clearing a collection that has not been generated', async () => {
+    const tempDir = await mkdtemp(path.join(tmpdir(), 'eventcatalog-store-'));
+    const storePath = EventCatalogStore.getStorePath(tempDir, 'directory');
+    const store = new EventCatalogStore<TestStoreResources>({
+      storePath,
+      resources: {
+        users: [],
+        teams: [],
+      },
+    });
+
+    try {
+      await store.clearCollectionIfStoreExists('users');
+      expect(await store.exists()).toBe(false);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/eventcatalog/src/stores/eventcatalog-store.ts
+++ b/packages/core/eventcatalog/src/stores/eventcatalog-store.ts
@@ -1,0 +1,103 @@
+import { access, mkdir, readFile, rename, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+type StoreResource = {
+  id: string;
+};
+
+type StoreResources<TResources> = {
+  [K in keyof TResources]: StoreResource[];
+};
+
+type EventCatalogStoreFile<TResources> = {
+  version: '1';
+  generatedAt: string;
+  resources: TResources;
+};
+
+type EventCatalogStoreOptions<TResources> = {
+  storePath: string;
+  resources: TResources;
+};
+
+const writeQueues = new Map<string, Promise<void>>();
+
+export class EventCatalogStore<TResources extends StoreResources<TResources>> {
+  static getStorePath(projectDir: string, name: string) {
+    return path.join(projectDir, '.eventcatalog', 'store', `${name}.json`);
+  }
+
+  constructor(private options: EventCatalogStoreOptions<TResources>) {}
+
+  async exists() {
+    try {
+      await access(this.options.storePath);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async read(): Promise<EventCatalogStoreFile<TResources>> {
+    try {
+      const store = JSON.parse(await readFile(this.options.storePath, 'utf8')) as Partial<EventCatalogStoreFile<TResources>>;
+      return {
+        version: '1',
+        generatedAt: store.generatedAt ?? new Date().toISOString(),
+        resources: this.normalizeResources(store.resources),
+      };
+    } catch {
+      return this.createEmptyStore();
+    }
+  }
+
+  async writeCollection<TKey extends keyof TResources & string>(collection: TKey, resources: TResources[TKey]) {
+    await this.queueWrite(async () => {
+      const store = await this.read();
+      store.generatedAt = new Date().toISOString();
+      store.resources[collection] = [...resources].sort((a, b) => a.id.localeCompare(b.id)) as TResources[TKey];
+
+      await this.write(store);
+    });
+  }
+
+  async clearCollectionIfStoreExists<TKey extends keyof TResources & string>(collection: TKey) {
+    if (!(await this.exists())) return;
+    await this.writeCollection(collection, [] as unknown as TResources[TKey]);
+  }
+
+  private createEmptyStore(): EventCatalogStoreFile<TResources> {
+    return {
+      version: '1',
+      generatedAt: new Date().toISOString(),
+      resources: this.normalizeResources(),
+    };
+  }
+
+  private normalizeResources(resources?: Partial<TResources>): TResources {
+    const normalized = {} as TResources;
+
+    for (const collection of Object.keys(this.options.resources) as (keyof TResources & string)[]) {
+      const value = resources?.[collection];
+      normalized[collection] = (
+        Array.isArray(value) ? value : [...this.options.resources[collection]]
+      ) as TResources[typeof collection];
+    }
+
+    return normalized;
+  }
+
+  private async write(store: EventCatalogStoreFile<TResources>) {
+    await mkdir(path.dirname(this.options.storePath), { recursive: true });
+    await writeFile(`${this.options.storePath}.tmp`, `${JSON.stringify(store, null, 2)}\n`);
+    await rename(`${this.options.storePath}.tmp`, this.options.storePath);
+  }
+
+  private async queueWrite(write: () => Promise<void>) {
+    const previousWrite = writeQueues.get(this.options.storePath) ?? Promise.resolve();
+    const nextWrite = previousWrite.catch(() => undefined).then(write);
+
+    writeQueues.set(this.options.storePath, nextWrite);
+    await nextWrite;
+  }
+}

--- a/packages/core/scripts/start-catalog-locally.js
+++ b/packages/core/scripts/start-catalog-locally.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { join } from 'node:path';
 import { execSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
 
 async function main() {
   const __dirname = import.meta.dirname;
@@ -10,6 +11,11 @@ async function main() {
 
   const catalogDir = join(__dirname, '../eventcatalog/');
   const projectDIR = join(__dirname, `../../../examples/${catalog}`);
+  const connectorsPackage = join(__dirname, '../../connectors/package.json');
+
+  if (existsSync(connectorsPackage)) {
+    execSync('pnpm --filter @eventcatalog/connectors run build:bin', { stdio: 'inherit' });
+  }
 
   execSync('pnpm run build:bin', { stdio: 'inherit' });
 

--- a/packages/core/src/__tests__/eventcatalog-config-file-utils.spec.ts
+++ b/packages/core/src/__tests__/eventcatalog-config-file-utils.spec.ts
@@ -108,6 +108,51 @@ describe('catalog-to-astro-content-directory', () => {
       const configFile = path.join(CATALOG_DIR, 'eventcatalog.config.mjs');
       expect(existsSync(configFile)).toBe(false);
     });
+
+    it('resolves packages imported by temporary config files from the project dependency tree', async () => {
+      const packageDirectory = path.join(CATALOG_DIR, 'node_modules', '@eventcatalog', 'connectors');
+      const configFile = path.join(CATALOG_DIR, 'eventcatalog.config.js');
+
+      await fs.mkdir(packageDirectory, { recursive: true });
+      await fs.writeFile(
+        path.join(packageDirectory, 'package.json'),
+        JSON.stringify({
+          name: '@eventcatalog/connectors',
+          type: 'module',
+          exports: './index.js',
+        })
+      );
+      await fs.writeFile(
+        path.join(packageDirectory, 'index.js'),
+        "export const githubDirectory = () => ({ type: 'directory', name: 'github:test' });"
+      );
+      await fs.writeFile(
+        configFile,
+        `
+          import { githubDirectory } from '@eventcatalog/connectors';
+
+          export default {
+            title: 'Package Import Test',
+            directory: {
+              sources: [githubDirectory()],
+            },
+          };
+        `
+      );
+
+      try {
+        const config = await getEventCatalogConfigFile(CATALOG_DIR);
+
+        expect(config).toEqual({
+          title: 'Package Import Test',
+          directory: {
+            sources: [{ type: 'directory', name: 'github:test' }],
+          },
+        });
+      } finally {
+        await fs.rm(path.join(CATALOG_DIR, 'node_modules'), { recursive: true, force: true });
+      }
+    });
   });
 
   describe('writeEventCatalogConfigFile', () => {

--- a/packages/core/src/analytics/log-build.js
+++ b/packages/core/src/analytics/log-build.js
@@ -11,6 +11,32 @@ const getFeatures = async (configFile) => {
   };
 };
 
+const getDirectoryProvider = (source) => {
+  if (!source?.name || typeof source.name !== 'string') return 'unknown';
+  return source.name.split(':')[0] || 'unknown';
+};
+
+const serializeDirectorySources = (configFile) => {
+  const sources = configFile.directory?.sources;
+  if (!Array.isArray(sources) || sources.length === 0) return 'none';
+
+  const providerCounts = sources.reduce((counts, source) => {
+    const provider = getDirectoryProvider(source);
+    counts[provider] = (counts[provider] || 0) + 1;
+    return counts;
+  }, {});
+
+  const providers = Object.keys(providerCounts)
+    .sort()
+    .map((provider) => `${provider}:${providerCounts[provider]}`)
+    .join(',');
+
+  const hasUsers = sources.some((source) => typeof source?.loadUsers === 'function');
+  const hasTeams = sources.some((source) => typeof source?.loadTeams === 'function');
+
+  return `sources:${sources.length},providers:${providers},users:${hasUsers},teams:${hasTeams}`;
+};
+
 const CLOUD_ANALYTICS_ENDPOINT = 'https://api.ecingest.dev/v1/analytics/ingest';
 
 const toCloudResourceCounts = (counts) => ({
@@ -91,6 +117,7 @@ const main = async (projectDir, { isEventCatalogStarterEnabled, isEventCatalogSc
       features: Object.keys(features)
         .map((feature) => `${feature}:${features[feature]}`)
         .join(','),
+      directorySources: serializeDirectorySources(configFile),
       resources: serializeCounts(resourceCounts),
     });
   } catch (error) {

--- a/packages/core/src/eventcatalog-config-file-utils.js
+++ b/packages/core/src/eventcatalog-config-file-utils.js
@@ -1,4 +1,4 @@
-import { readFile, writeFile, rm, copyFile, mkdtemp } from 'node:fs/promises';
+import { readFile, writeFile, rm, copyFile, mkdtemp, symlink } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { v4 as uuidV4 } from 'uuid';
@@ -13,6 +13,48 @@ export async function cleanup(projectDirectory) {
   }
 }
 
+const findNodeModulesDirectory = (directory) => {
+  let currentDirectory = directory;
+
+  while (true) {
+    const nodeModulesDirectory = path.join(currentDirectory, 'node_modules');
+
+    if (existsSync(nodeModulesDirectory)) {
+      return nodeModulesDirectory;
+    }
+
+    const parentDirectory = path.dirname(currentDirectory);
+
+    if (parentDirectory === currentDirectory) {
+      return undefined;
+    }
+
+    currentDirectory = parentDirectory;
+  }
+};
+
+const linkNodeModulesIntoTempDirectory = async ({ projectDirectory, tempDir }) => {
+  const nodeModulesDirectory = findNodeModulesDirectory(projectDirectory);
+
+  if (!nodeModulesDirectory) {
+    return;
+  }
+
+  await symlink(nodeModulesDirectory, path.join(tempDir, 'node_modules'), 'dir');
+};
+
+const createTemporaryConfigDirectory = async (projectDirectory) => {
+  const nodeModulesDirectory = findNodeModulesDirectory(projectDirectory);
+
+  if (nodeModulesDirectory) {
+    return mkdtemp(path.join(nodeModulesDirectory, '.eventcatalog-config-'));
+  }
+
+  const tempDir = await mkdtemp(path.join(tmpdir(), 'eventcatalog-config-'));
+  await linkNodeModulesIntoTempDirectory({ projectDirectory, tempDir });
+  return tempDir;
+};
+
 export const getEventCatalogConfigFile = async (projectDirectory) => {
   let tempDir;
 
@@ -26,7 +68,7 @@ export const getEventCatalogConfigFile = async (projectDirectory) => {
       // Importing CommonJS config via ESM import requires an .mjs file.
       // Keep this temp copy outside the project directory so Astro/Vite
       // file watchers do not trigger a dev-server restart during startup.
-      tempDir = await mkdtemp(path.join(tmpdir(), 'eventcatalog-config-'));
+      tempDir = await createTemporaryConfigDirectory(projectDirectory);
       configFilePath = path.join(tempDir, 'eventcatalog.config.mjs');
       await copyFile(path.join(projectDirectory, 'eventcatalog.config.js'), configFilePath);
     }

--- a/packages/core/src/eventcatalog.config.ts
+++ b/packages/core/src/eventcatalog.config.ts
@@ -65,7 +65,6 @@ type DirectoryEntry = {
 type DirectorySource = {
   type: 'directory';
   name: string;
-  cacheKey?: string;
   loadUsers?: () => Promise<DirectoryEntry[]>;
   loadTeams?: () => Promise<DirectoryEntry[]>;
 };

--- a/packages/core/src/eventcatalog.config.ts
+++ b/packages/core/src/eventcatalog.config.ts
@@ -56,6 +56,34 @@ type NavigationPage = string | PagesConfiguration;
 
 type GeneratorConfig = string | Record<string, unknown> | [string, Record<string, unknown>];
 
+type DirectoryEntry = {
+  id: string;
+  markdown?: string;
+  [key: string]: unknown;
+};
+
+type DirectorySource = {
+  type: 'directory';
+  name: string;
+  cacheKey?: string;
+  loadUsers?: () => Promise<DirectoryEntry[]>;
+  loadTeams?: () => Promise<DirectoryEntry[]>;
+};
+
+type DirectoryConfig = {
+  /**
+   * External sources that sync users and teams into EventCatalog.
+   * Requires EventCatalog Scale.
+   */
+  sources?: DirectorySource[];
+  /**
+   * Controls what happens when a local Markdown user/team and an external source
+   * return the same id.
+   * @default 'local-wins'
+   */
+  conflictStrategy?: 'local-wins' | 'source-wins' | 'error';
+};
+
 type AuthConfig = {
   enabled: boolean;
 };
@@ -217,6 +245,7 @@ export interface Config {
     services?: ResourceDependency[];
     domains?: ResourceDependency[];
   };
+  directory?: DirectoryConfig;
   mermaid?: {
     maxTextSize?: number;
     iconPacks?: string[];

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -47,7 +47,6 @@
 - 8f724a7: feat: add `externalSystem` flag to services for modelling third-party integrations
 
   Services can now set `externalSystem: true` in their frontmatter to be rendered as external systems. This changes their presentation without changing their capabilities — they still send and receive messages, have owners, and support specifications like any other service.
-
   - Visualiser: external services render purple with a Globe icon and an "External System" badge
   - Sidebar (root): a dedicated "External Systems" section lists externals; the regular "Services" section excludes them
   - Sidebar (domain): externals appear under a new "External Integrations" group, separate from "Services In Domain"

--- a/packages/sdk/src/internal/directory-store.ts
+++ b/packages/sdk/src/internal/directory-store.ts
@@ -1,0 +1,62 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+type DirectoryStoreResource = {
+  id: string;
+  markdown?: string;
+  [key: string]: unknown;
+};
+
+type DirectoryStore = {
+  version: string;
+  generatedAt?: string;
+  resources?: {
+    users?: DirectoryStoreResource[];
+    teams?: DirectoryStoreResource[];
+  };
+};
+
+type DirectoryStoreCollection = 'users' | 'teams';
+
+const DIRECTORY_STORE_PATH = path.join('.eventcatalog', 'store', 'directory.json');
+
+const getCatalogRoot = (catalogDir: string, collection: DirectoryStoreCollection) => {
+  return path.basename(catalogDir) === collection ? path.dirname(catalogDir) : catalogDir;
+};
+
+export const getDirectoryStorePath = (catalogDir: string, collection: DirectoryStoreCollection) => {
+  return path.join(getCatalogRoot(catalogDir, collection), DIRECTORY_STORE_PATH);
+};
+
+type ResourceWithId = {
+  id: string;
+};
+
+export const readDirectoryStoreResources = <T extends ResourceWithId>(
+  catalogDir: string,
+  collection: DirectoryStoreCollection
+): T[] => {
+  const storePath = getDirectoryStorePath(catalogDir, collection);
+  if (!fs.existsSync(storePath)) return [];
+
+  try {
+    const store = JSON.parse(fs.readFileSync(storePath, 'utf8')) as DirectoryStore;
+    const resources = store.resources?.[collection];
+    return Array.isArray(resources) ? (resources as unknown as T[]) : [];
+  } catch {
+    return [];
+  }
+};
+
+export const readDirectoryStoreResource = <T extends ResourceWithId>(
+  catalogDir: string,
+  collection: DirectoryStoreCollection,
+  id: string
+): T | undefined => {
+  return readDirectoryStoreResources<T>(catalogDir, collection).find((resource) => resource.id === id);
+};
+
+export const mergeDirectoryStoreResources = <T extends ResourceWithId>(local: T[], directory: T[]) => {
+  const localIds = new Set(local.map((resource) => resource.id));
+  return [...local, ...directory.filter((resource) => !localIds.has(resource.id))];
+};

--- a/packages/sdk/src/teams.ts
+++ b/packages/sdk/src/teams.ts
@@ -7,6 +7,11 @@ import { getFiles, invalidateFileCache } from './internal/utils';
 import { getResource } from './internal/resources';
 import path from 'node:path';
 import { getUser, getUsers } from './users';
+import {
+  mergeDirectoryStoreResources,
+  readDirectoryStoreResource,
+  readDirectoryStoreResources,
+} from './internal/directory-store';
 
 /**
  * Returns a team from EventCatalog.
@@ -28,7 +33,7 @@ export const getTeam =
   async (id: string): Promise<Team | undefined> => {
     const files = await getFiles(`${catalogDir}/${id}.{md,mdx}`);
 
-    if (files.length == 0) return undefined;
+    if (files.length == 0) return readDirectoryStoreResource<Team>(catalogDir, 'teams', id);
     const file = files[0];
 
     const { data, content } = matter.read(file);
@@ -58,9 +63,7 @@ export const getTeams =
   (catalogDir: string) =>
   async (options?: {}): Promise<Team[]> => {
     const files = await getFiles(`${catalogDir}/*.{md,mdx}`);
-    if (files.length === 0) return [];
-
-    return files.map((file) => {
+    const localTeams = files.map((file) => {
       const { data, content } = matter.read(file);
       return {
         ...data,
@@ -69,6 +72,8 @@ export const getTeams =
         markdown: content.trim(),
       } as Team;
     });
+
+    return mergeDirectoryStoreResources(localTeams, readDirectoryStoreResources<Team>(catalogDir, 'teams'));
   };
 
 /**

--- a/packages/sdk/src/test/teams.test.ts
+++ b/packages/sdk/src/test/teams.test.ts
@@ -39,6 +39,47 @@ describe('Teams SDK', () => {
     it('returns undefined when the team is not found', async () => {
       await expect(await getTeam('unknown-team')).toEqual(undefined);
     });
+
+    it('returns a team from the EventCatalog directory store when no local file exists', async () => {
+      fs.mkdirSync(path.join(CATALOG_PATH, '.eventcatalog', 'store'), { recursive: true });
+      fs.writeFileSync(
+        path.join(CATALOG_PATH, '.eventcatalog', 'store', 'directory.json'),
+        JSON.stringify({
+          version: '1',
+          generatedAt: '2026-05-27T00:00:00.000Z',
+          resources: {
+            users: [],
+            teams: [
+              {
+                id: 'core-maintainers',
+                name: 'Core Maintainers',
+                members: ['github-user'],
+                markdown: 'This team is synced from GitHub',
+                readOnly: true,
+                source: {
+                  provider: 'github',
+                  url: 'https://github.com/orgs/event-catalog/teams/core-maintainers',
+                },
+              },
+            ],
+          },
+        })
+      );
+
+      const team = await getTeam('core-maintainers');
+
+      expect(team).toEqual({
+        id: 'core-maintainers',
+        name: 'Core Maintainers',
+        members: ['github-user'],
+        markdown: 'This team is synced from GitHub',
+        readOnly: true,
+        source: {
+          provider: 'github',
+          url: 'https://github.com/orgs/event-catalog/teams/core-maintainers',
+        },
+      });
+    });
   });
 
   describe('getTeams', () => {
@@ -67,6 +108,67 @@ describe('Teams SDK', () => {
           id: 'eventcatalog-core-team',
           name: 'Eventcatalog Core Team',
           markdown: 'This is the core team for Eventcatalog',
+        },
+      ]);
+    });
+
+    it('merges teams from the EventCatalog directory store after local teams', async () => {
+      await writeTeam({
+        id: 'local-team',
+        name: 'Local Team',
+        markdown: 'This is a local team',
+      });
+
+      fs.mkdirSync(path.join(CATALOG_PATH, '.eventcatalog', 'store'), { recursive: true });
+      fs.writeFileSync(
+        path.join(CATALOG_PATH, '.eventcatalog', 'store', 'directory.json'),
+        JSON.stringify({
+          version: '1',
+          generatedAt: '2026-05-27T00:00:00.000Z',
+          resources: {
+            users: [],
+            teams: [
+              {
+                id: 'local-team',
+                name: 'Directory Local Team',
+                markdown: 'This duplicate should be ignored',
+                readOnly: true,
+                source: {
+                  provider: 'github',
+                },
+              },
+              {
+                id: 'core-maintainers',
+                name: 'Core Maintainers',
+                markdown: 'This team is synced from GitHub',
+                readOnly: true,
+                source: {
+                  provider: 'github',
+                  url: 'https://github.com/orgs/event-catalog/teams/core-maintainers',
+                },
+              },
+            ],
+          },
+        })
+      );
+
+      const teams = await getTeams();
+
+      expect(teams).toEqual([
+        {
+          id: 'local-team',
+          name: 'Local Team',
+          markdown: 'This is a local team',
+        },
+        {
+          id: 'core-maintainers',
+          name: 'Core Maintainers',
+          markdown: 'This team is synced from GitHub',
+          readOnly: true,
+          source: {
+            provider: 'github',
+            url: 'https://github.com/orgs/event-catalog/teams/core-maintainers',
+          },
         },
       ]);
     });
@@ -126,7 +228,7 @@ describe('Teams SDK', () => {
       const team = await getTeam('eventcatalog-core-team');
 
       expect(fs.existsSync(path.join(CATALOG_PATH, 'teams', 'eventcatalog-core-team.mdx'))).toBe(true);
-      expect(team.name).toBe('Eventcatalog Core Team Overridden');
+      expect(team?.name).toBe('Eventcatalog Core Team Overridden');
     });
   });
 
@@ -199,6 +301,79 @@ describe('Teams SDK', () => {
       const owners = await getOwnersForResource('InventoryService');
 
       expect(owners).toEqual([]);
+    });
+
+    it('resolves owners from the EventCatalog directory store', async () => {
+      fs.mkdirSync(path.join(CATALOG_PATH, '.eventcatalog', 'store'), { recursive: true });
+      fs.writeFileSync(
+        path.join(CATALOG_PATH, '.eventcatalog', 'store', 'directory.json'),
+        JSON.stringify({
+          version: '1',
+          generatedAt: '2026-05-27T00:00:00.000Z',
+          resources: {
+            users: [
+              {
+                id: 'github-user',
+                name: 'github-user',
+                avatarUrl: 'https://example.com/avatar.png',
+                markdown: 'This user is synced from GitHub',
+                readOnly: true,
+                source: {
+                  provider: 'github',
+                  url: 'https://github.com/github-user',
+                },
+              },
+            ],
+            teams: [
+              {
+                id: 'core-maintainers',
+                name: 'Core Maintainers',
+                markdown: 'This team is synced from GitHub',
+                readOnly: true,
+                source: {
+                  provider: 'github',
+                  url: 'https://github.com/orgs/event-catalog/teams/core-maintainers',
+                },
+              },
+            ],
+          },
+        })
+      );
+
+      await writeService({
+        id: 'InventoryService',
+        name: 'Inventory Service',
+        version: '0.0.1',
+        summary: 'Service that handles the inventory',
+        markdown: 'This is the inventory service',
+        owners: ['core-maintainers', 'github-user'],
+      });
+
+      const owners = await getOwnersForResource('InventoryService');
+
+      expect(owners).toEqual([
+        {
+          id: 'core-maintainers',
+          name: 'Core Maintainers',
+          markdown: 'This team is synced from GitHub',
+          readOnly: true,
+          source: {
+            provider: 'github',
+            url: 'https://github.com/orgs/event-catalog/teams/core-maintainers',
+          },
+        },
+        {
+          id: 'github-user',
+          name: 'github-user',
+          avatarUrl: 'https://example.com/avatar.png',
+          markdown: 'This user is synced from GitHub',
+          readOnly: true,
+          source: {
+            provider: 'github',
+            url: 'https://github.com/github-user',
+          },
+        },
+      ]);
     });
   });
 });

--- a/packages/sdk/src/test/users.test.ts
+++ b/packages/sdk/src/test/users.test.ts
@@ -41,6 +41,47 @@ describe('Users SDK', () => {
     it('returns undefined when the user is not found', async () => {
       await expect(await getUser('unknown-user')).toEqual(undefined);
     });
+
+    it('returns a user from the EventCatalog directory store when no local file exists', async () => {
+      fs.mkdirSync(path.join(CATALOG_PATH, '.eventcatalog', 'store'), { recursive: true });
+      fs.writeFileSync(
+        path.join(CATALOG_PATH, '.eventcatalog', 'store', 'directory.json'),
+        JSON.stringify({
+          version: '1',
+          generatedAt: '2026-05-27T00:00:00.000Z',
+          resources: {
+            users: [
+              {
+                id: 'github-user',
+                name: 'github-user',
+                avatarUrl: 'https://example.com/avatar.png',
+                markdown: 'This user is synced from GitHub',
+                readOnly: true,
+                source: {
+                  provider: 'github',
+                  url: 'https://github.com/github-user',
+                },
+              },
+            ],
+            teams: [],
+          },
+        })
+      );
+
+      const user = await getUser('github-user');
+
+      expect(user).toEqual({
+        id: 'github-user',
+        name: 'github-user',
+        avatarUrl: 'https://example.com/avatar.png',
+        markdown: 'This user is synced from GitHub',
+        readOnly: true,
+        source: {
+          provider: 'github',
+          url: 'https://github.com/github-user',
+        },
+      });
+    });
   });
 
   describe('getUsers', () => {
@@ -73,6 +114,72 @@ describe('Users SDK', () => {
           name: 'Eventcatalog Core User',
           markdown: 'This is the core user for Eventcatalog',
           avatarUrl: 'https://pbs.twimg.com/profile_images/1262283153563140096/DYRDqKg6_400x400.png',
+        },
+      ]);
+    });
+
+    it('merges users from the EventCatalog directory store after local users', async () => {
+      await writeUser({
+        id: 'local-user',
+        name: 'Local User',
+        markdown: 'This is a local user',
+        avatarUrl: 'https://example.com/local.png',
+      });
+
+      fs.mkdirSync(path.join(CATALOG_PATH, '.eventcatalog', 'store'), { recursive: true });
+      fs.writeFileSync(
+        path.join(CATALOG_PATH, '.eventcatalog', 'store', 'directory.json'),
+        JSON.stringify({
+          version: '1',
+          generatedAt: '2026-05-27T00:00:00.000Z',
+          resources: {
+            users: [
+              {
+                id: 'local-user',
+                name: 'Directory Local User',
+                avatarUrl: 'https://example.com/directory-local.png',
+                markdown: 'This duplicate should be ignored',
+                readOnly: true,
+                source: {
+                  provider: 'github',
+                },
+              },
+              {
+                id: 'github-user',
+                name: 'github-user',
+                avatarUrl: 'https://example.com/avatar.png',
+                markdown: 'This user is synced from GitHub',
+                readOnly: true,
+                source: {
+                  provider: 'github',
+                  url: 'https://github.com/github-user',
+                },
+              },
+            ],
+            teams: [],
+          },
+        })
+      );
+
+      const users = await getUsers();
+
+      expect(users).toEqual([
+        {
+          id: 'local-user',
+          name: 'Local User',
+          markdown: 'This is a local user',
+          avatarUrl: 'https://example.com/local.png',
+        },
+        {
+          id: 'github-user',
+          name: 'github-user',
+          avatarUrl: 'https://example.com/avatar.png',
+          markdown: 'This user is synced from GitHub',
+          readOnly: true,
+          source: {
+            provider: 'github',
+            url: 'https://github.com/github-user',
+          },
         },
       ]);
     });

--- a/packages/sdk/src/types.d.ts
+++ b/packages/sdk/src/types.d.ts
@@ -261,8 +261,13 @@ export interface Team {
   summary?: string;
   email?: string;
   hidden?: boolean;
+  source?: {
+    provider: string;
+    url?: string;
+  };
+  readOnly?: boolean;
   slackDirectMessageUrl?: string;
-  members?: User[];
+  members?: User[] | string[];
   ownedCommands?: Command[];
   ownedServices?: Service[];
   ownedEvents?: Event[];
@@ -275,6 +280,11 @@ export interface User {
   avatarUrl: string;
   role?: string;
   hidden?: boolean;
+  source?: {
+    provider: string;
+    url?: string;
+  };
+  readOnly?: boolean;
   email?: string;
   slackDirectMessageUrl?: string;
   ownedServices?: Service[];

--- a/packages/sdk/src/users.ts
+++ b/packages/sdk/src/users.ts
@@ -4,6 +4,11 @@ import { join } from 'node:path';
 import type { User } from './types';
 import matter from 'gray-matter';
 import { getFiles, invalidateFileCache } from './internal/utils';
+import {
+  mergeDirectoryStoreResources,
+  readDirectoryStoreResource,
+  readDirectoryStoreResources,
+} from './internal/directory-store';
 
 /**
  * Returns a user from EventCatalog.
@@ -25,7 +30,7 @@ export const getUser =
   async (id: string): Promise<User | undefined> => {
     const files = await getFiles(`${catalogDir}/${id}.{md,mdx}`);
 
-    if (files.length == 0) return undefined;
+    if (files.length == 0) return readDirectoryStoreResource<User>(catalogDir, 'users', id);
     const file = files[0];
 
     const { data, content } = matter.read(file);
@@ -56,9 +61,7 @@ export const getUsers =
   (catalogDir: string) =>
   async (options?: {}): Promise<User[]> => {
     const files = await getFiles(`${catalogDir}/users/*.{md,mdx}`);
-    if (files.length === 0) return [];
-
-    return files.map((file) => {
+    const localUsers = files.map((file) => {
       const { data, content } = matter.read(file);
       return {
         ...data,
@@ -68,6 +71,8 @@ export const getUsers =
         markdown: content.trim(),
       } as User;
     });
+
+    return mergeDirectoryStoreResources(localUsers, readDirectoryStoreResources<User>(catalogDir, 'users'));
   };
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,6 +94,24 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.19)(jiti@2.6.1)(jsdom@27.0.0(postcss@8.5.9))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
 
+  packages/connectors:
+    devDependencies:
+      '@types/node':
+        specifier: ^20.14.10
+        version: 20.19.19
+      prettier:
+        specifier: ^3.3.3
+        version: 3.6.2
+      tsup:
+        specifier: ^8.1.0
+        version: 8.5.0(jiti@2.6.1)(postcss@8.5.9)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: ^5.5.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.19)(jiti@2.6.1)(jsdom@27.0.0(postcss@8.5.9))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+
   packages/core:
     dependencies:
       '@ai-sdk/react':


### PR DESCRIPTION
Closes #2538

## What This PR Does

Introduces a new `@eventcatalog/connectors` package and a `directory.sources` configuration option in `eventcatalog.config`. Catalogs can now sync users and teams from external sources (initially GitHub organizations) directly into the `users` and `teams` collections, alongside any locally-defined ones. External entries are marked as read-only and display their source provider in the directory UI.

## Changes Overview

### Key Changes

- New `@eventcatalog/connectors` package with a `githubDirectory()` connector and a `defineDirectorySource()` helper for building custom directory sources.
- New `directory.sources` option in `eventcatalog.config` plus a `conflictStrategy` for resolving overlaps between local and remote entries.
- Astro content collections for `users` and `teams` now load from a combined local + remote loader (`userTeamDirectoryLoader`) and gained `source` and `readOnly` schema fields.
- New `DirectorySourceColumn` column in the teams and users tables to show where each entry came from.
- New SDK directory store (`packages/sdk/src/internal/directory-store.ts`) and SDK type updates so `addTeam` / `addUser` are aware of source-backed entries.
- New `eventcatalog-store` (nanostore) for sharing directory state across components, with tests.
- Tests added for the GitHub connector, the directory loader, the directory store, and SDK team/user behavior.

## How It Works

The `userTeamDirectoryLoader` wraps Astro's `glob` loader. When `directory.sources` is configured, it calls each source's `loadUsers()` / `loadTeams()` method, merges the results with locally-defined markdown entries, and applies the configured `conflictStrategy` when IDs collide. Each entry carries a `source: { provider, url? }` field and a `readOnly` flag so the UI can render appropriate badges and disable edit paths.

The GitHub connector uses the GitHub REST API (via a provided token) to fetch organization teams, team members, and user profiles, then maps them onto EventCatalog's directory schema.

External directory sources require the Scale plan when consumed by core, but the connectors package itself is open and can be used to build custom sources via `defineDirectorySource`.

## Breaking Changes

None. Existing catalogs that do not configure `directory.sources` continue to load users and teams from local markdown only.

## Additional Notes

- The `@eventcatalog/connectors` package ships at `0.0.1` and is the first of what will be a family of connectors.
- Follow-ups: additional providers (e.g. Okta, Google Workspace), and richer conflict reporting in the build output.