### PR TITLE
Fix environment switcher for catalogs hosted under base paths

### DIFF
--- a/.changeset/witty-pandas-jump.md
+++ b/.changeset/witty-pandas-jump.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Fix environment switcher to support catalogs hosted under different base paths. The environment dropdown now matches the current environment by origin and base path, and preserves the in-catalog path, search params, and hash when switching environments.

--- a/packages/connectors/CHANGELOG.md
+++ b/packages/connectors/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Minor Changes
 
 - 3334ab1: Add Microsoft Entra directory connector for syncing users and teams from Microsoft Entra ID (Azure AD).
-
   - `@eventcatalog/connectors`: new `microsoftEntraDirectory` connector export and docs
   - `@eventcatalog/sdk`: `Team`/`User` source now supports an optional `id`, and `User.avatarUrl` is now optional
   - `@eventcatalog/core`: render the Microsoft Entra directory source badge with an Azure icon

--- a/packages/core/eventcatalog/src/components/EnvironmentDropdown.test.ts
+++ b/packages/core/eventcatalog/src/components/EnvironmentDropdown.test.ts
@@ -55,4 +55,10 @@ describe('EnvironmentDropdown', () => {
       'https://example.com/prod/services/foo'
     );
   });
+
+  it('preserves the current path when the current environment is unknown', () => {
+    expect(buildEnvironmentUrl('https://example.com/prod', 'http://localhost:3000/services/foo')).toBe(
+      'https://example.com/prod/services/foo'
+    );
+  });
 });

--- a/packages/core/eventcatalog/src/components/EnvironmentDropdown.test.ts
+++ b/packages/core/eventcatalog/src/components/EnvironmentDropdown.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { buildEnvironmentUrl, findCurrentEnvironment } from './EnvironmentDropdown';
+
+const environments = [
+  {
+    name: 'Development',
+    url: 'https://example.com/event-catalog/dev',
+    shortName: 'Dev',
+  },
+  {
+    name: 'UAT',
+    url: 'https://example.com/event-catalog/uat',
+    shortName: 'UAT',
+  },
+  {
+    name: 'Production',
+    url: 'https://example.com/event-catalog/prod',
+    shortName: 'Prod',
+  },
+];
+
+describe('EnvironmentDropdown', () => {
+  it('finds the current environment when environments share an origin but use different base paths', () => {
+    expect(findCurrentEnvironment(environments, 'https://example.com/event-catalog/uat/services/foo')?.name).toBe('UAT');
+  });
+
+  it('builds environment urls by replacing the current environment base path', () => {
+    expect(
+      buildEnvironmentUrl(
+        'https://example.com/event-catalog/prod',
+        'https://example.com/event-catalog/uat/services/foo',
+        'https://example.com/event-catalog/uat'
+      )
+    ).toBe('https://example.com/event-catalog/prod/services/foo');
+  });
+
+  it('preserves search params and hashes when switching environments', () => {
+    expect(
+      buildEnvironmentUrl(
+        'https://example.com/event-catalog/prod',
+        'https://example.com/event-catalog/uat/services/foo?tab=messages#latest',
+        'https://example.com/event-catalog/uat'
+      )
+    ).toBe('https://example.com/event-catalog/prod/services/foo?tab=messages#latest');
+  });
+
+  it('keeps existing origin based environment switching for root catalogs', () => {
+    expect(
+      buildEnvironmentUrl('https://prod.example.com', 'https://uat.example.com/services/foo', 'https://uat.example.com')
+    ).toBe('https://prod.example.com/services/foo');
+  });
+
+  it('switches from a root catalog to a subpath catalog', () => {
+    expect(buildEnvironmentUrl('https://example.com/prod', 'https://example.com/services/foo', 'https://example.com')).toBe(
+      'https://example.com/prod/services/foo'
+    );
+  });
+});

--- a/packages/core/eventcatalog/src/components/EnvironmentDropdown.tsx
+++ b/packages/core/eventcatalog/src/components/EnvironmentDropdown.tsx
@@ -38,11 +38,12 @@ export const findCurrentEnvironment = (environments: Environment[], currentHref:
 export const buildEnvironmentUrl = (environmentUrl: string, currentHref: string, currentEnvironmentUrl?: string) => {
   const currentUrl = new URL(currentHref);
   const targetUrl = new URL(environmentUrl, currentUrl.href);
-  const currentEnvironmentUrlObject = currentEnvironmentUrl ? new URL(currentEnvironmentUrl, currentUrl.href) : currentUrl;
-  const currentBasePathname = stripTrailingSlash(currentEnvironmentUrlObject.pathname);
   const targetBasePathname = stripTrailingSlash(targetUrl.pathname);
+  const currentBasePathname = currentEnvironmentUrl
+    ? stripTrailingSlash(new URL(currentEnvironmentUrl, currentUrl.href).pathname)
+    : undefined;
   const pathWithinEnvironment =
-    startsWithPath(currentUrl.pathname, currentBasePathname) && currentBasePathname !== '/'
+    currentBasePathname && currentBasePathname !== '/' && startsWithPath(currentUrl.pathname, currentBasePathname)
       ? currentUrl.pathname.slice(currentBasePathname.length)
       : currentUrl.pathname;
 

--- a/packages/core/eventcatalog/src/components/EnvironmentDropdown.tsx
+++ b/packages/core/eventcatalog/src/components/EnvironmentDropdown.tsx
@@ -11,20 +11,55 @@ interface EnvironmentDropdownProps {
   environments: Environment[];
 }
 
+const stripTrailingSlash = (pathname: string) => pathname.replace(/\/$/, '') || '/';
+
+const startsWithPath = (pathname: string, basePathname: string) =>
+  basePathname === '/' || pathname === basePathname || pathname.startsWith(`${basePathname}/`);
+
+export const findCurrentEnvironment = (environments: Environment[], currentHref: string) => {
+  const currentUrl = new URL(currentHref);
+
+  return (
+    environments
+      .filter((env) => {
+        const envUrl = new URL(env.url, currentUrl.href);
+        const envPathname = stripTrailingSlash(envUrl.pathname);
+
+        return envUrl.origin === currentUrl.origin && startsWithPath(currentUrl.pathname, envPathname);
+      })
+      .sort(
+        (a, b) =>
+          stripTrailingSlash(new URL(b.url, currentUrl.href).pathname).length -
+          stripTrailingSlash(new URL(a.url, currentUrl.href).pathname).length
+      )[0] || null
+  );
+};
+
+export const buildEnvironmentUrl = (environmentUrl: string, currentHref: string, currentEnvironmentUrl?: string) => {
+  const currentUrl = new URL(currentHref);
+  const targetUrl = new URL(environmentUrl, currentUrl.href);
+  const currentEnvironmentUrlObject = currentEnvironmentUrl ? new URL(currentEnvironmentUrl, currentUrl.href) : currentUrl;
+  const currentBasePathname = stripTrailingSlash(currentEnvironmentUrlObject.pathname);
+  const targetBasePathname = stripTrailingSlash(targetUrl.pathname);
+  const pathWithinEnvironment =
+    startsWithPath(currentUrl.pathname, currentBasePathname) && currentBasePathname !== '/'
+      ? currentUrl.pathname.slice(currentBasePathname.length)
+      : currentUrl.pathname;
+
+  targetUrl.pathname = `${targetBasePathname}${pathWithinEnvironment}`.replace(/\/+/g, '/');
+  targetUrl.search = currentUrl.search;
+  targetUrl.hash = currentUrl.hash;
+
+  return targetUrl.toString();
+};
+
 export const EnvironmentDropdown: React.FC<EnvironmentDropdownProps> = ({ environments }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [currentEnvironment, setCurrentEnvironment] = useState<Environment | null>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    // Check if current URL matches any environment
-    const currentUrl = window.location.origin;
-    const matchedEnv = environments.find((env) => {
-      // Normalize URLs for comparison
-      const envUrl = new URL(env.url).origin;
-      return envUrl === currentUrl;
-    });
-    setCurrentEnvironment(matchedEnv || null);
+    setCurrentEnvironment(findCurrentEnvironment(environments, window.location.href));
   }, [environments]);
 
   useEffect(() => {
@@ -99,11 +134,7 @@ export const EnvironmentDropdown: React.FC<EnvironmentDropdownProps> = ({ enviro
               href={env.url}
               onClick={(e) => {
                 e.preventDefault();
-                // Construct the full URL with the current path when clicked
-                const currentPath = window.location.pathname + window.location.search + window.location.hash;
-                const targetUrl = new URL(env.url);
-                targetUrl.pathname = currentPath;
-                window.location.href = targetUrl.toString();
+                window.location.href = buildEnvironmentUrl(env.url, window.location.href, currentEnvironment?.url);
               }}
               className={`block rounded-xl px-3 py-3 transition-colors ${
                 isCurrentEnv

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Patch Changes
 
 - 3334ab1: Add Microsoft Entra directory connector for syncing users and teams from Microsoft Entra ID (Azure AD).
-
   - `@eventcatalog/connectors`: new `microsoftEntraDirectory` connector export and docs
   - `@eventcatalog/sdk`: `Team`/`User` source now supports an optional `id`, and `User.avatarUrl` is now optional
   - `@eventcatalog/core`: render the Microsoft Entra directory source badge with an Azure icon
@@ -63,7 +62,6 @@
 - 8f724a7: feat: add `externalSystem` flag to services for modelling third-party integrations
 
   Services can now set `externalSystem: true` in their frontmatter to be rendered as external systems. This changes their presentation without changing their capabilities — they still send and receive messages, have owners, and support specifications like any other service.
-
   - Visualiser: external services render purple with a Globe icon and an "External System" badge
   - Sidebar (root): a dedicated "External Systems" section lists externals; the regular "Services" section excludes them
   - Sidebar (domain): externals appear under a new "External Integrations" group, separate from "Services In Domain"


### PR DESCRIPTION
## What This PR Does

The environment dropdown previously matched and switched environments using only the URL origin. This broke when multiple environments are served from the same origin but under different base paths (e.g. `https://example.com/event-catalog/uat` vs `.../prod`). This PR makes the dropdown base-path aware so the current environment is detected correctly and switching preserves the user's location within the catalog.

## Changes Overview

### Key Changes

- Add `findCurrentEnvironment` helper that matches an environment by origin **and** base path, picking the most specific (longest) matching path.
- Add `buildEnvironmentUrl` helper that swaps the current environment's base path for the target environment's, preserving the in-catalog path, search params, and hash.
- Update `EnvironmentDropdown` to use these helpers instead of origin-only comparison.
- Add unit tests covering shared-origin/different-base-path matching, base-path swapping, search/hash preservation, and root-to-subpath (and vice versa) switching.

## How It Works

`findCurrentEnvironment` resolves each environment URL against the current href, keeps those whose origin matches and whose base path is a prefix of the current path, then sorts by base-path length to select the most specific match.

`buildEnvironmentUrl` strips the current environment's base path from the current pathname to get the path *within* the catalog, then prefixes the target environment's base path. Trailing slashes are normalized and duplicate slashes collapsed. Search params and hash are carried over unchanged.

## Breaking Changes

None.

## Additional Notes

No corresponding change is needed in the editor repository (`eventcatalog/eventcatalog-editor`) — this is core-only UI behavior.