### PR TITLE
Add git schema source and external schema references

### DIFF
--- a/.changeset/swift-otters-gather.md
+++ b/.changeset/swift-otters-gather.md
@@ -1,5 +1,6 @@
 ---
 "@eventcatalog/core": patch
+"@eventcatalog/connectors": patch
 ---
 
 Add support for external schema sources, including a new git schema source connector. Messages can now reference schemas by `ref` resolved through configurable schema sources, and the sidebar reflects the resolved schema format.

--- a/.changeset/swift-otters-gather.md
+++ b/.changeset/swift-otters-gather.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Add support for external schema sources, including a new git schema source connector. Messages can now reference schemas by `ref` resolved through configurable schema sources, and the sidebar reflects the resolved schema format.

--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -45,5 +45,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/event-catalog/eventcatalog"
+  },
+  "dependencies": {
+    "simple-git": "^3.36.0"
   }
 }

--- a/packages/connectors/src/git-schema-source.test.ts
+++ b/packages/connectors/src/git-schema-source.test.ts
@@ -1,0 +1,169 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { gitSchemaSource } from "./git-schema-source";
+
+const { cloneMock } = vi.hoisted(() => ({
+  cloneMock: vi.fn(),
+}));
+
+vi.mock("simple-git", () => ({
+  default: vi.fn(() => ({
+    clone: cloneMock,
+  })),
+}));
+
+describe("gitSchemaSource", () => {
+  beforeEach(() => {
+    cloneMock.mockReset();
+  });
+
+  it("resolves schemas from a configured git source", async () => {
+    cloneMock.mockImplementationOnce(async (_url: string, target: string) => {
+      const schemaDir = path.join(target, "schemas", "events");
+      await mkdir(schemaDir, { recursive: true });
+      await writeFile(
+        path.join(schemaDir, "OrderPlaced.schema.json"),
+        '{"type":"object"}',
+      );
+    });
+
+    const source = gitSchemaSource({
+      name: "contracts",
+      url: "https://github.com/acme/schema-contracts.git",
+      ref: "main",
+      directory: "schemas",
+      token: "github-token",
+    });
+
+    await expect(
+      source.resolve("git://contracts/events/OrderPlaced.schema.json"),
+    ).resolves.toEqual({
+      id: "git://contracts/events/OrderPlaced.schema.json",
+      name: "OrderPlaced.schema.json",
+      format: "jsonschema",
+      content: '{"type":"object"}',
+      source: {
+        provider: "git",
+        id: "contracts:events/OrderPlaced.schema.json",
+        url: "https://github.com/acme/schema-contracts.git",
+        ref: "main",
+        path: "schemas/events/OrderPlaced.schema.json",
+      },
+    });
+
+    expect(
+      source.canResolve("git://contracts/events/OrderPlaced.schema.json"),
+    ).toBe(true);
+    expect(
+      source.canResolve("git://other/events/OrderPlaced.schema.json"),
+    ).toBe(false);
+    expect(cloneMock).toHaveBeenCalledWith(
+      "https://github-token:x-oauth-basic@github.com/acme/schema-contracts.git",
+      expect.any(String),
+      {
+        "--branch": "main",
+        "--depth": 1,
+        "--single-branch": null,
+      },
+    );
+  });
+
+  it("reuses the checkout for multiple schema resolutions", async () => {
+    cloneMock.mockImplementationOnce(async (_url: string, target: string) => {
+      const schemaDir = path.join(target, "schemas", "events");
+      await mkdir(schemaDir, { recursive: true });
+      await writeFile(
+        path.join(schemaDir, "OrderPlaced.schema.json"),
+        '{"type":"object"}',
+      );
+      await writeFile(
+        path.join(schemaDir, "OrderCancelled.avsc"),
+        '{"type":"record"}',
+      );
+    });
+
+    const source = gitSchemaSource({
+      name: "contracts",
+      url: "https://github.com/acme/schema-contracts.git",
+      directory: "schemas",
+    });
+
+    await expect(
+      source.resolve("git://contracts/events/OrderPlaced.schema.json"),
+    ).resolves.toMatchObject({
+      format: "jsonschema",
+    });
+    await expect(
+      source.resolve("git://contracts/events/OrderCancelled.avsc"),
+    ).resolves.toMatchObject({
+      format: "avro",
+    });
+
+    expect(cloneMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports a clear error when the schema file does not exist in the checkout", async () => {
+    cloneMock.mockImplementationOnce(async (_url: string, target: string) => {
+      await mkdir(path.join(target, "schemas", "events"), { recursive: true });
+    });
+
+    const source = gitSchemaSource({
+      name: "contracts",
+      url: "https://github.com/acme/schema-contracts.git",
+      ref: "main",
+      directory: "schemas",
+    });
+
+    await expect(
+      source.resolve("git://contracts/events/Missing.schema.json"),
+    ).rejects.toThrow(
+      'Git schema source "contracts" could not find schema file "schemas/events/Missing.schema.json" in "https://github.com/acme/schema-contracts.git" at ref "main".',
+    );
+  });
+
+  it("requires a valid git schema ref", async () => {
+    const source = gitSchemaSource({
+      name: "contracts",
+      url: "https://github.com/acme/schema-contracts.git",
+    });
+
+    await expect(
+      source.resolve("github://contracts/events/OrderPlaced.schema.json"),
+    ).rejects.toThrow(
+      'Invalid git schema ref "github://contracts/events/OrderPlaced.schema.json". Expected git://<source-name>/<path>.',
+    );
+  });
+
+  it("prevents schema refs escaping the checked out source directory", async () => {
+    cloneMock.mockResolvedValueOnce(undefined);
+
+    const source = gitSchemaSource({
+      name: "contracts",
+      url: "https://github.com/acme/schema-contracts.git",
+      directory: "..",
+    });
+
+    await expect(
+      source.resolve("git://contracts/package.json"),
+    ).rejects.toThrow(
+      'Schema path "../package.json" resolves outside the git schema source directory.',
+    );
+  });
+
+  it("requires a source name and repository url", () => {
+    expect(() =>
+      gitSchemaSource({
+        name: "",
+        url: "https://github.com/acme/schema-contracts.git",
+      }),
+    ).toThrow("Git schema source requires a name.");
+
+    expect(() =>
+      gitSchemaSource({
+        name: "contracts",
+        url: "",
+      }),
+    ).toThrow("Git schema source requires a repository url.");
+  });
+});

--- a/packages/connectors/src/git-schema-source.test.ts
+++ b/packages/connectors/src/git-schema-source.test.ts
@@ -31,7 +31,7 @@ describe("gitSchemaSource", () => {
     const source = gitSchemaSource({
       name: "contracts",
       url: "https://github.com/acme/schema-contracts.git",
-      ref: "main",
+      branch: "main",
       directory: "schemas",
       token: "github-token",
     });
@@ -47,7 +47,7 @@ describe("gitSchemaSource", () => {
         provider: "git",
         id: "contracts:events/OrderPlaced.schema.json",
         url: "https://github.com/acme/schema-contracts.git",
-        ref: "main",
+        branch: "main",
         path: "schemas/events/OrderPlaced.schema.json",
       },
     });
@@ -111,14 +111,14 @@ describe("gitSchemaSource", () => {
     const source = gitSchemaSource({
       name: "contracts",
       url: "https://github.com/acme/schema-contracts.git",
-      ref: "main",
+      branch: "main",
       directory: "schemas",
     });
 
     await expect(
       source.resolve("git://contracts/events/Missing.schema.json"),
     ).rejects.toThrow(
-      'Git schema source "contracts" could not find schema file "schemas/events/Missing.schema.json" in "https://github.com/acme/schema-contracts.git" at ref "main".',
+      'Git schema source "contracts" could not find schema file "schemas/events/Missing.schema.json" in "https://github.com/acme/schema-contracts.git" on branch "main".',
     );
   });
 

--- a/packages/connectors/src/git-schema-source.ts
+++ b/packages/connectors/src/git-schema-source.ts
@@ -1,0 +1,185 @@
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import simpleGit from "simple-git";
+import {
+  defineSchemaSource,
+  type SchemaEntry,
+  type SchemaSource,
+} from "./types";
+
+type GitSchemaSourceOptions = {
+  /**
+   * Stable source name used in schema refs, for example:
+   * `git://contracts/events/OrderPlaced.schema.json`.
+   */
+  name: string;
+  /** Git repository URL. Supports any URL your local git can clone. */
+  url: string;
+  /** Branch, tag, or ref to clone. */
+  ref?: string;
+  /** Optional directory inside the repository that contains schemas. */
+  directory?: string;
+  /** Optional HTTPS token. SSH auth is handled by the local git environment. */
+  token?: string;
+};
+
+const getSchemaFormat = (filePath: string) => {
+  const extension = path.extname(filePath).replace(".", "").toLowerCase();
+
+  if (extension === "avsc" || extension === "avro") return "avro";
+  if (extension === "proto") return "protobuf";
+  if (extension === "json") return "jsonschema";
+  if (extension === "yaml" || extension === "yml") return "yaml";
+
+  return extension || "unknown";
+};
+
+const parseGitSchemaRef = (ref: string) => {
+  let url: URL;
+
+  try {
+    url = new URL(ref);
+  } catch {
+    throw new Error(
+      `Invalid git schema ref "${ref}". Expected git://<source-name>/<path>.`,
+    );
+  }
+
+  if (url.protocol !== "git:") {
+    throw new Error(
+      `Invalid git schema ref "${ref}". Expected git://<source-name>/<path>.`,
+    );
+  }
+
+  const filePath = decodeURIComponent(url.pathname.replace(/^\//, ""));
+
+  if (!url.hostname || !filePath) {
+    throw new Error(
+      `Invalid git schema ref "${ref}". Expected git://<source-name>/<path>.`,
+    );
+  }
+
+  if (filePath.split(/[\\/]/).includes("..")) {
+    throw new Error(
+      `Schema path "${filePath}" resolves outside the git schema source directory.`,
+    );
+  }
+
+  return {
+    sourceName: url.hostname,
+    filePath,
+  };
+};
+
+const addTokenToHttpsUrl = (url: string, token?: string) => {
+  if (!token || !url.startsWith("https://")) return url;
+
+  const parsed = new URL(url);
+  parsed.username = token;
+  parsed.password = "x-oauth-basic";
+  return parsed.toString();
+};
+
+const resolveInside = (basePath: string, ...segments: string[]) => {
+  const base = path.resolve(basePath);
+  const resolved = path.resolve(base, ...segments);
+
+  if (resolved !== base && !resolved.startsWith(`${base}${path.sep}`)) {
+    throw new Error(
+      `Schema path "${segments.join("/")}" resolves outside the git schema source directory.`,
+    );
+  }
+
+  return resolved;
+};
+
+const isNodeFileNotFoundError = (
+  error: unknown,
+): error is NodeJS.ErrnoException => {
+  return error instanceof Error && "code" in error && error.code === "ENOENT";
+};
+
+export const gitSchemaSource = (
+  options: GitSchemaSourceOptions,
+): SchemaSource => {
+  if (!options.name) {
+    throw new Error("Git schema source requires a name.");
+  }
+
+  if (!options.url) {
+    throw new Error("Git schema source requires a repository url.");
+  }
+
+  const ref = options.ref ?? "main";
+  const directory = options.directory ?? "";
+  let checkoutPath: Promise<string> | undefined;
+
+  const checkout = async () => {
+    checkoutPath =
+      checkoutPath ??
+      (async () => {
+        const target = await mkdtemp(
+          path.join(tmpdir(), "eventcatalog-schema-git-"),
+        );
+        await simpleGit().clone(
+          addTokenToHttpsUrl(options.url, options.token),
+          target,
+          {
+            "--branch": ref,
+            "--depth": 1,
+            "--single-branch": null,
+          },
+        );
+        return target;
+      })();
+
+    return checkoutPath;
+  };
+
+  return defineSchemaSource({
+    type: "schemas",
+    name: options.name,
+    canResolve: (id) => {
+      if (!id.startsWith("git://")) return false;
+      return parseGitSchemaRef(id).sourceName === options.name;
+    },
+    resolve: async (id): Promise<SchemaEntry | undefined> => {
+      const { sourceName, filePath } = parseGitSchemaRef(id);
+      if (sourceName !== options.name) return undefined;
+
+      const repositoryPath = await checkout();
+      const schemaPath = resolveInside(repositoryPath, directory, filePath);
+      let content: string;
+
+      try {
+        content = await readFile(schemaPath, "utf8");
+      } catch (error) {
+        if (isNodeFileNotFoundError(error)) {
+          const schemaSourcePath = [directory, filePath]
+            .filter(Boolean)
+            .join("/");
+          throw new Error(
+            `Git schema source "${options.name}" could not find schema file "${schemaSourcePath}" in "${options.url}" at ref "${ref}".`,
+          );
+        }
+
+        throw error;
+      }
+
+      return {
+        id,
+        name: path.basename(filePath),
+        format: getSchemaFormat(filePath),
+        content,
+        source: {
+          provider: "git",
+          id: `${options.name}:${filePath}`,
+          url: options.url,
+          ref,
+          path: [directory, filePath].filter(Boolean).join("/"),
+        },
+      };
+    },
+  });
+};

--- a/packages/connectors/src/git-schema-source.ts
+++ b/packages/connectors/src/git-schema-source.ts
@@ -16,8 +16,8 @@ type GitSchemaSourceOptions = {
   name: string;
   /** Git repository URL. Supports any URL your local git can clone. */
   url: string;
-  /** Branch, tag, or ref to clone. */
-  ref?: string;
+  /** Branch to clone. */
+  branch?: string;
   /** Optional directory inside the repository that contains schemas. */
   directory?: string;
   /** Optional HTTPS token. SSH auth is handled by the local git environment. */
@@ -111,7 +111,7 @@ export const gitSchemaSource = (
     throw new Error("Git schema source requires a repository url.");
   }
 
-  const ref = options.ref ?? "main";
+  const branch = options.branch ?? "main";
   const directory = options.directory ?? "";
   let checkoutPath: Promise<string> | undefined;
 
@@ -126,7 +126,7 @@ export const gitSchemaSource = (
           addTokenToHttpsUrl(options.url, options.token),
           target,
           {
-            "--branch": ref,
+            "--branch": branch,
             "--depth": 1,
             "--single-branch": null,
           },
@@ -160,7 +160,7 @@ export const gitSchemaSource = (
             .filter(Boolean)
             .join("/");
           throw new Error(
-            `Git schema source "${options.name}" could not find schema file "${schemaSourcePath}" in "${options.url}" at ref "${ref}".`,
+            `Git schema source "${options.name}" could not find schema file "${schemaSourcePath}" in "${options.url}" on branch "${branch}".`,
           );
         }
 
@@ -176,7 +176,7 @@ export const gitSchemaSource = (
           provider: "git",
           id: `${options.name}:${filePath}`,
           url: options.url,
-          ref,
+          branch,
           path: [directory, filePath].filter(Boolean).join("/"),
         },
       };

--- a/packages/connectors/src/index.ts
+++ b/packages/connectors/src/index.ts
@@ -1,9 +1,14 @@
 export { githubDirectory } from "./github-directory";
 export { microsoftEntraDirectory } from "./microsoft-entra-directory";
-export { defineDirectorySource } from "./types";
+export { gitSchemaSource } from "./git-schema-source";
+export { defineDirectorySource, defineSchemaSource } from "./types";
 export type {
   DirectoryEntrySource,
   DirectorySource,
   DirectoryTeam,
   DirectoryUser,
+  SchemaEntry,
+  SchemaEntrySource,
+  SchemaResolveContext,
+  SchemaSource,
 } from "./types";

--- a/packages/connectors/src/types.ts
+++ b/packages/connectors/src/types.ts
@@ -71,3 +71,62 @@ export type DirectorySource = {
 export const defineDirectorySource = <TSource extends DirectorySource>(
   source: TSource,
 ) => source;
+
+/**
+ * Describes where a synced schema came from.
+ */
+export type SchemaEntrySource = {
+  /** Provider identifier, for example `git`, `github`, `confluent`, or `eventbridge`. */
+  provider: string;
+  /** Optional provider-specific identifier for the external schema. */
+  id?: string;
+  /** Optional URL back to the schema source. */
+  url?: string;
+  /** Optional version/ref/branch for versioned sources. */
+  ref?: string;
+  /** Optional path inside the source. */
+  path?: string;
+  [key: string]: unknown;
+};
+
+/**
+ * Schema returned by an external schema source.
+ */
+export type SchemaEntry = {
+  id: string;
+  name?: string;
+  format?: string;
+  content: string;
+  source: SchemaEntrySource;
+};
+
+export type SchemaResolveContext = {
+  /** Absolute path to the message file that referenced the schema. */
+  messageFilePath?: string;
+};
+
+/**
+ * Loads schemas from an external source.
+ *
+ * EventCatalog calls schema sources during content sync to resolve schema
+ * references from messages into generated schema collection entries.
+ */
+export type SchemaSource = {
+  type: "schemas";
+  /** Stable source identifier used in schema refs, for example `contracts`. */
+  name: string;
+  /** Returns true when this source can resolve the given schema ref. */
+  canResolve: (ref: string) => boolean;
+  /** Resolves a schema ref into schema content and source metadata. */
+  resolve: (
+    ref: string,
+    context?: SchemaResolveContext,
+  ) => Promise<SchemaEntry | undefined>;
+};
+
+/**
+ * Defines a custom schema source with type inference for connector authors.
+ */
+export const defineSchemaSource = <TSource extends SchemaSource>(
+  source: TSource,
+) => source;

--- a/packages/connectors/src/types.ts
+++ b/packages/connectors/src/types.ts
@@ -84,6 +84,8 @@ export type SchemaEntrySource = {
   url?: string;
   /** Optional version/ref/branch for versioned sources. */
   ref?: string;
+  /** Optional branch for git-backed schema sources. */
+  branch?: string;
   /** Optional path inside the source. */
   path?: string;
   [key: string]: unknown;

--- a/packages/core/eventcatalog/src/components/MDX/SchemaViewer/SchemaViewerPortal.tsx
+++ b/packages/core/eventcatalog/src/components/MDX/SchemaViewer/SchemaViewerPortal.tsx
@@ -2,10 +2,11 @@ const SchemaViewerPortal = (props: any) => {
   // Convert string props to booleans (MDX passes strings)
   const expandBool = props.expand === true || props.expand === 'true';
   const searchBool = props.search !== false && props.search !== 'false';
+  const schemaKey = props.file || 'default';
 
   return (
     <div
-      id={`${props.id}-${props.file}-SchemaViewer-portal`}
+      id={`${props.id}-${schemaKey}-SchemaViewer-portal`}
       data-expand={expandBool ? 'true' : 'false'}
       data-max-height={props.maxHeight}
       data-search={searchBool ? 'true' : 'false'}

--- a/packages/core/eventcatalog/src/components/MDX/SchemaViewer/SchemaViewerPortal.tsx
+++ b/packages/core/eventcatalog/src/components/MDX/SchemaViewer/SchemaViewerPortal.tsx
@@ -2,11 +2,10 @@ const SchemaViewerPortal = (props: any) => {
   // Convert string props to booleans (MDX passes strings)
   const expandBool = props.expand === true || props.expand === 'true';
   const searchBool = props.search !== false && props.search !== 'false';
-  const schemaKey = props.file || 'default';
 
   return (
     <div
-      id={`${props.id}-${schemaKey}-SchemaViewer-portal`}
+      data-schema-viewer-portal-id={props.id}
       data-expand={expandBool ? 'true' : 'false'}
       data-max-height={props.maxHeight}
       data-search={searchBool ? 'true' : 'false'}

--- a/packages/core/eventcatalog/src/components/MDX/SchemaViewer/SchemaViewerRoot.astro
+++ b/packages/core/eventcatalog/src/components/MDX/SchemaViewer/SchemaViewerRoot.astro
@@ -37,8 +37,10 @@ try {
           <div>
             {schema.exists && (
               <div
-                id={`${schema.id}-${schema.schemaKey}-SchemaViewer-client`}
+                id={`${schema.id}-${schema.index}-SchemaViewer-client`}
                 class="not-prose my-4"
+                data-schema-viewer-client-id={schema.id}
+                data-schema-viewer-index={schema.index}
                 data-expand={schema.expand ? 'true' : 'false'}
                 data-search={schema.search !== false ? 'true' : 'false'}
               >
@@ -90,9 +92,9 @@ try {
   // and then we can move the SchemaViewerClient to that container?
 
   function moveSchemaViewerToPortal(schema) {
-    const portalId = `${schema.id}-${schema.schemaKey}-SchemaViewer-portal`;
-    const schemaViewerContainer = document.getElementById(portalId);
-    const schemaViewerClient = document.getElementById(`${schema.id}-${schema.schemaKey}-SchemaViewer-client`);
+    const schemaViewerContainers = document.querySelectorAll(`[data-schema-viewer-portal-id="${schema.id}"]`);
+    const schemaViewerContainer = schemaViewerContainers[schema.index];
+    const schemaViewerClient = document.getElementById(`${schema.id}-${schema.index}-SchemaViewer-client`);
 
     if (schemaViewerContainer && schemaViewerClient) {
       // Get attributes from the portal

--- a/packages/core/eventcatalog/src/components/MDX/SchemaViewer/SchemaViewerRoot.astro
+++ b/packages/core/eventcatalog/src/components/MDX/SchemaViewer/SchemaViewerRoot.astro
@@ -1,13 +1,13 @@
 ---
-const { id, filePath } = Astro.props;
+const { id, filePath, collection, version } = Astro.props;
 import fs from 'node:fs/promises';
-import { existsSync } from 'fs';
-import yaml from 'js-yaml';
+import { getCollection } from 'astro:content';
 import JSONSchemaViewer from '@components/SchemaExplorer/JSONSchemaViewer';
 import AvroSchemaViewer from '@components/SchemaExplorer/AvroSchemaViewer';
 import Admonition from '../Admonition';
 import { getMDXComponentsByName } from '@utils/markdown';
-import { getAbsoluteFilePathForAstroFile, resolveProjectPath, isAvroSchema } from '@utils/files';
+import { resolveProjectPath } from '@utils/files';
+import { resolveSchemaViewer } from './schema-viewer-utils';
 
 let schemas = [];
 
@@ -15,45 +15,11 @@ try {
   const absoluteFilePath = resolveProjectPath(filePath);
   const file = await fs.readFile(absoluteFilePath, 'utf-8');
   const schemaViewers = getMDXComponentsByName(file, 'SchemaViewer');
+  const collectionSchemas = collection && version ? await getCollection('schemas') : [];
 
-  // Loop around all the possible SchemaViewers in the file.
-  const getAllComponents = schemaViewers.map(async (schemaViewerProps: any, index: number) => {
-    const schemaPath = getAbsoluteFilePathForAstroFile(filePath, schemaViewerProps.file);
-    const exists = existsSync(schemaPath);
-    let schema;
-    let render = true;
-    let isAvro = false;
-
-    if (exists) {
-      // Check if this is an Avro schema file
-      isAvro = isAvroSchema(schemaPath);
-
-      // Load the schema for the component
-      schema = await fs.readFile(schemaPath, 'utf-8');
-
-      if (schemaPath.endsWith('.yml') || schemaPath.endsWith('.yaml')) {
-        schema = yaml.load(schema);
-      } else {
-        schema = JSON.parse(schema);
-
-        // For non-Avro schemas, let JSON schema control if the component should be rendered
-        if (!isAvro && schema['x-eventcatalog-render-schema-viewer'] !== undefined) {
-          render = schema['x-eventcatalog-render-schema-viewer'];
-        }
-      }
-    }
-
-    return {
-      id: schemaViewerProps.id || id,
-      exists,
-      schema,
-      schemaPath,
-      isAvroSchema: isAvro,
-      ...schemaViewerProps,
-      render,
-      index,
-    };
-  });
+  const getAllComponents = schemaViewers.map((schemaViewerProps: any, index: number) =>
+    resolveSchemaViewer({ id, version, collection, filePath, schemaViewerProps, collectionSchemas, index })
+  );
 
   schemas = await Promise.all(getAllComponents);
 } catch (error) {
@@ -71,7 +37,7 @@ try {
           <div>
             {schema.exists && (
               <div
-                id={`${schema.id}-${schema.file}-SchemaViewer-client`}
+                id={`${schema.id}-${schema.schemaKey}-SchemaViewer-client`}
                 class="not-prose my-4"
                 data-expand={schema.expand ? 'true' : 'false'}
                 data-search={schema.search !== false ? 'true' : 'false'}
@@ -105,7 +71,11 @@ try {
               <Admonition type="warning">
                 <div>
                   <span class="block font-bold">{`<SchemaViewer/>`} failed to load</span>
-                  <span class="block">Tried to load schema from {schema.schemaPath}, but no schema can be found</span>
+                  <span class="block">
+                    {schema.parseError
+                      ? `Tried to parse schema from ${schema.schemaPath}, but it failed: ${schema.parseError}`
+                      : `Tried to load schema from ${schema.schemaPath || schema.file || 'the message schema collection'}, but no schema can be found`}
+                  </span>
                 </div>
               </Admonition>
             )}
@@ -120,9 +90,9 @@ try {
   // and then we can move the SchemaViewerClient to that container?
 
   function moveSchemaViewerToPortal(schema) {
-    const portalId = `${schema.id}-${schema.file}-SchemaViewer-portal`;
+    const portalId = `${schema.id}-${schema.schemaKey}-SchemaViewer-portal`;
     const schemaViewerContainer = document.getElementById(portalId);
-    const schemaViewerClient = document.getElementById(`${schema.id}-${schema.file}-SchemaViewer-client`);
+    const schemaViewerClient = document.getElementById(`${schema.id}-${schema.schemaKey}-SchemaViewer-client`);
 
     if (schemaViewerContainer && schemaViewerClient) {
       // Get attributes from the portal

--- a/packages/core/eventcatalog/src/components/MDX/SchemaViewer/schema-viewer-utils.spec.ts
+++ b/packages/core/eventcatalog/src/components/MDX/SchemaViewer/schema-viewer-utils.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { resolveSchemaViewer } from './schema-viewer-utils';
+
+const currentMessageSchema = {
+  id: 'schema:events:OrderPlaced:1.0.0:git://contracts/events/OrderPlaced.schema.json',
+  data: {
+    ref: 'git://contracts/events/OrderPlaced.schema.json',
+    format: 'jsonschema',
+    content: '{"type":"object","title":"OrderPlaced"}',
+    default: true,
+    message: {
+      collection: 'events',
+      id: 'OrderPlaced',
+      version: '1.0.0',
+    },
+  },
+};
+
+describe('resolveSchemaViewer', () => {
+  it('uses the current message default schema when no file is set', async () => {
+    const schema = await resolveSchemaViewer({
+      id: 'OrderPlaced',
+      version: '1.0.0',
+      collection: 'events',
+      filePath: 'events/OrderPlaced/index.mdx',
+      schemaViewerProps: {},
+      collectionSchemas: [currentMessageSchema],
+      index: 0,
+    });
+
+    expect(schema.exists).toBe(true);
+    expect(schema.schema.title).toBe('OrderPlaced');
+    expect(schema.schemaPath).toBe('git://contracts/events/OrderPlaced.schema.json');
+  });
+
+  it('does not use the schema collection when a file is set and missing', async () => {
+    const schema = await resolveSchemaViewer({
+      id: 'OrderPlaced',
+      version: '1.0.0',
+      collection: 'events',
+      filePath: 'events/OrderPlaced/index.mdx',
+      schemaViewerProps: {
+        file: 'missing-schema.json',
+      },
+      collectionSchemas: [currentMessageSchema],
+      index: 0,
+    });
+
+    expect(schema.exists).toBe(false);
+    expect(schema.schema).toBeUndefined();
+    expect(schema.schemaKey).toBe('missing-schema.json');
+  });
+});

--- a/packages/core/eventcatalog/src/components/MDX/SchemaViewer/schema-viewer-utils.ts
+++ b/packages/core/eventcatalog/src/components/MDX/SchemaViewer/schema-viewer-utils.ts
@@ -1,0 +1,133 @@
+import { readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { load as loadYaml } from 'js-yaml';
+import { getAbsoluteFilePathForAstroFile, isAvroSchema } from '../../../utils/files';
+
+type SchemaViewerProps = {
+  id?: string;
+  file?: string;
+  [key: string]: any;
+};
+
+type CollectionSchema = {
+  id: string;
+  data: {
+    content?: string;
+    file?: string;
+    filePath?: string;
+    ref?: string;
+    format?: string;
+    default?: boolean;
+    source?: {
+      path?: string;
+      branch?: string;
+    };
+    message?: {
+      collection: string;
+      id: string;
+      version: string;
+    };
+  };
+};
+
+type ResolveSchemaViewerOptions = {
+  id: string;
+  version?: string;
+  collection?: string;
+  filePath: string;
+  schemaViewerProps: SchemaViewerProps;
+  collectionSchemas: CollectionSchema[];
+  index: number;
+};
+
+export const getSchemaViewerKey = (schemaViewerProps: SchemaViewerProps) => schemaViewerProps.file || 'default';
+
+const isYamlSchema = (schemaPath?: string, format?: string) =>
+  schemaPath?.endsWith('.yml') || schemaPath?.endsWith('.yaml') || format === 'yaml';
+
+const isAvroSchemaReference = (schemaPath?: string, format?: string) =>
+  format === 'avro' || (schemaPath ? isAvroSchema(schemaPath) : false);
+
+const parseSchemaContent = (content: string, schemaPath?: string, format?: string) => {
+  if (isYamlSchema(schemaPath, format)) return loadYaml(content);
+  return JSON.parse(content);
+};
+
+const shouldRenderSchema = (schema: any, isAvro: boolean) => {
+  if (isAvro) return true;
+  return schema?.['x-eventcatalog-render-schema-viewer'] !== undefined ? schema['x-eventcatalog-render-schema-viewer'] : true;
+};
+
+const getCollectionSchemaForViewer = ({
+  collectionSchemas,
+  collection,
+  id,
+  version,
+}: Pick<ResolveSchemaViewerOptions, 'collectionSchemas' | 'collection' | 'id' | 'version'>) => {
+  if (!collection || !version) return undefined;
+
+  const resourceSchemas = collectionSchemas.filter((schema) => {
+    const message = schema.data.message;
+    if (!message) return false;
+    return message.collection === collection && message.id === id && message.version === version;
+  });
+
+  return resourceSchemas.find((schema) => schema.data.default) || resourceSchemas[0];
+};
+
+const getCollectionSchemaPath = (schema?: CollectionSchema) =>
+  schema?.data.filePath || schema?.data.file || schema?.data.source?.path || schema?.data.ref;
+
+export const resolveSchemaViewer = async ({
+  id,
+  version,
+  collection,
+  filePath,
+  schemaViewerProps,
+  collectionSchemas,
+  index,
+}: ResolveSchemaViewerOptions) => {
+  const schemaKey = getSchemaViewerKey(schemaViewerProps);
+  const localSchemaPath = schemaViewerProps.file ? getAbsoluteFilePathForAstroFile(filePath, schemaViewerProps.file) : undefined;
+  const localSchemaExists = localSchemaPath ? existsSync(localSchemaPath) : false;
+
+  let schema;
+  let render = true;
+  let isAvro = false;
+  let schemaPath = localSchemaPath;
+  let parseError;
+
+  if (localSchemaExists && localSchemaPath) {
+    isAvro = isAvroSchema(localSchemaPath);
+    const content = await readFile(localSchemaPath, 'utf-8');
+    schema = parseSchemaContent(content, localSchemaPath);
+    render = shouldRenderSchema(schema, isAvro);
+  } else if (!schemaViewerProps.file) {
+    const collectionSchema = getCollectionSchemaForViewer({ collectionSchemas, collection, id, version });
+    const content = collectionSchema?.data.content;
+    schemaPath = getCollectionSchemaPath(collectionSchema);
+
+    if (content) {
+      try {
+        isAvro = isAvroSchemaReference(schemaPath, collectionSchema?.data.format);
+        schema = parseSchemaContent(content, schemaPath, collectionSchema?.data.format);
+        render = shouldRenderSchema(schema, isAvro);
+      } catch (error) {
+        parseError = error instanceof Error ? error.message : 'Unknown parsing error';
+      }
+    }
+  }
+
+  return {
+    id: schemaViewerProps.id || id,
+    exists: localSchemaExists || schema !== undefined,
+    schema,
+    schemaPath,
+    schemaKey,
+    isAvroSchema: isAvro,
+    parseError,
+    ...schemaViewerProps,
+    render,
+    index,
+  };
+};

--- a/packages/core/eventcatalog/src/content.config.ts
+++ b/packages/core/eventcatalog/src/content.config.ts
@@ -1045,6 +1045,7 @@ const schemas = defineCollection({
         path: z.string().optional(),
         url: z.string().optional(),
         ref: z.string().optional(),
+        branch: z.string().optional(),
       }),
       readOnly: z.boolean().optional(),
     })

--- a/packages/core/eventcatalog/src/content.config.ts
+++ b/packages/core/eventcatalog/src/content.config.ts
@@ -1024,6 +1024,7 @@ const schemas = defineCollection({
   schema: z
     .object({
       format: z.string(),
+      schemaId: z.string().optional(),
       ref: z.string().optional(),
       content: z.string().optional(),
       file: z.string().optional(),

--- a/packages/core/eventcatalog/src/content.config.ts
+++ b/packages/core/eventcatalog/src/content.config.ts
@@ -71,6 +71,7 @@ const channelPointer = z
 
 const schemaPointer = z.object({
   id: z.string().optional(),
+  ref: z.string().optional(),
   file: z.string().optional(),
   path: z.string().optional(),
   name: z.string().optional(),
@@ -1018,10 +1019,12 @@ const schemas = defineCollection({
       ]) as string[],
       base: projectDirBase,
     },
+    sources: config.schemas?.sources ?? [],
   }),
   schema: z
     .object({
       format: z.string(),
+      ref: z.string().optional(),
       content: z.string().optional(),
       file: z.string().optional(),
       filePath: z.string().optional(),
@@ -1038,8 +1041,10 @@ const schemas = defineCollection({
       }),
       source: z.object({
         provider: z.string(),
+        id: z.string().optional(),
         path: z.string().optional(),
         url: z.string().optional(),
+        ref: z.string().optional(),
       }),
       readOnly: z.boolean().optional(),
     })

--- a/packages/core/eventcatalog/src/enterprise/tools/__tests__/catalog-tools.mocks.ts
+++ b/packages/core/eventcatalog/src/enterprise/tools/__tests__/catalog-tools.mocks.ts
@@ -520,6 +520,37 @@ export const mockDiagrams = [
 ];
 
 // ============================================
+// Mock Schemas
+// ============================================
+export const mockSchemas = [
+  {
+    id: 'file://schemas/OrderCreated.schema.json',
+    collection: 'schemas',
+    body: '{"type":"object","title":"OrderCreated"}',
+    data: {
+      id: 'file://schemas/OrderCreated.schema.json',
+      ref: 'file://schemas/OrderCreated.schema.json',
+      name: 'OrderCreated.schema.json',
+      format: 'jsonschema',
+      content: '{"type":"object","title":"OrderCreated"}',
+      source: {
+        provider: 'file',
+        path: 'schemas/OrderCreated.schema.json',
+      },
+      message: {
+        collection: 'events',
+        id: 'OrderCreated',
+        name: 'Order Created',
+        version: '1.0.0',
+        summary: 'Fired when an order is created',
+        owners: ['order-team'],
+      },
+      latest: true,
+    },
+  },
+];
+
+// ============================================
 // Helper to get all mocks by collection
 // ============================================
 export const mockCollections: Record<string, any[]> = {
@@ -534,6 +565,7 @@ export const mockCollections: Record<string, any[]> = {
   entities: mockEntities,
   containers: mockContainers,
   diagrams: mockDiagrams,
+  schemas: mockSchemas,
   teams: mockTeams,
   users: mockUsers,
   ubiquitousLanguages: mockUbiquitousLanguages,

--- a/packages/core/eventcatalog/src/enterprise/tools/__tests__/catalog-tools.spec.ts
+++ b/packages/core/eventcatalog/src/enterprise/tools/__tests__/catalog-tools.spec.ts
@@ -776,11 +776,34 @@ describe('getSchemaForResource', () => {
     vi.mocked(getSchemasFromResource).mockReset();
   });
 
-  it('returns schema with format and code', async () => {
+  it('returns message schemas from the generated schemas collection', async () => {
+    const result = await getSchemaForResource({
+      resourceId: 'OrderCreated',
+      resourceVersion: '1.0.0',
+      resourceCollection: 'events',
+    });
+
+    expect(result).toEqual([
+      {
+        id: 'file://schemas/OrderCreated.schema.json',
+        name: 'OrderCreated.schema.json',
+        ref: 'file://schemas/OrderCreated.schema.json',
+        format: 'jsonschema',
+        source: {
+          provider: 'file',
+          path: 'schemas/OrderCreated.schema.json',
+        },
+        code: '{"type":"object","title":"OrderCreated"}',
+      },
+    ]);
+    expect(getSchemasFromResource).not.toHaveBeenCalled();
+  });
+
+  it('falls back to legacy resource schema files when no generated schema entry exists', async () => {
     vi.mocked(getSchemasFromResource).mockResolvedValue([{ url: '/path/to/schema.json', format: 'json-schema' }]);
 
     const result = await getSchemaForResource({
-      resourceId: 'OrderCreated',
+      resourceId: 'PaymentProcessed',
       resourceVersion: '1.0.0',
       resourceCollection: 'events',
     });
@@ -796,7 +819,7 @@ describe('getSchemaForResource', () => {
     vi.mocked(getSchemasFromResource).mockResolvedValue([]);
 
     const result = await getSchemaForResource({
-      resourceId: 'OrderCreated',
+      resourceId: 'PaymentProcessed',
       resourceVersion: '1.0.0',
       resourceCollection: 'events',
     });

--- a/packages/core/eventcatalog/src/enterprise/tools/catalog-tools.ts
+++ b/packages/core/eventcatalog/src/enterprise/tools/catalog-tools.ts
@@ -28,6 +28,8 @@ import { getNodesAndEdges as getNodesAndEdgesForContainer } from '@utils/node-gr
 import { convertToMermaid } from '@utils/node-graphs/export-mermaid';
 import config from '@config';
 
+const MESSAGE_COLLECTIONS = new Set(['events', 'commands', 'queries']);
+
 // ============================================
 // Pagination utilities
 // ============================================
@@ -224,6 +226,27 @@ export async function getSchemaForResource(params: { resourceId: string; resourc
     return {
       error: `Resource not found with id ${params.resourceId} and version ${params.resourceVersion} and collection ${params.resourceCollection}`,
     };
+  }
+
+  if (MESSAGE_COLLECTIONS.has(params.resourceCollection)) {
+    const schemaEntries = await getCollection('schemas');
+    const schemas = schemaEntries.filter(
+      (schema) =>
+        schema.data.message.collection === params.resourceCollection &&
+        schema.data.message.id === params.resourceId &&
+        schema.data.message.version === params.resourceVersion
+    );
+
+    if (schemas.length > 0) {
+      return schemas.map((schema) => ({
+        id: schema.id,
+        name: schema.data.name,
+        ref: schema.data.ref,
+        format: schema.data.format,
+        source: schema.data.source,
+        code: schema.data.content || '',
+      }));
+    }
   }
 
   const schema = await getSchemasFromResource(resource);

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/index.astro
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/index.astro
@@ -565,7 +565,7 @@ if (!isAdrPage && !hasCurrentFlowEmbed && !hasCurrentPageNodeGraph) {
         <div data-pagefind-ignore>
           <!-- @ts-ignore -->
           <!-- <SchemaViewer id={props.data.id} catalog={props.catalog} filePath={props.filePath} /> -->
-          <SchemaViewer id={props.data.id} filePath={props.filePath} />
+          <SchemaViewer id={props.data.id} version={props.data.version} collection={props.collection} filePath={props.filePath} />
 
           {
             nodeGraphs.length > 0 &&

--- a/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/sidebar-builder.spec.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/sidebar-builder.spec.ts
@@ -2185,6 +2185,49 @@ describe('getNestedSideBarData', () => {
       });
     });
 
+    describe('API & Contracts section', () => {
+      it('lists a schema link when the message declares schemas', async () => {
+        const { writeEvent } = utils(CATALOG_FOLDER);
+        await writeEvent({
+          id: 'PaymentProcessed',
+          name: 'Payment Processed',
+          version: '0.0.1',
+          markdown: 'Payment Processed',
+          schemas: [{ ref: 'git://contracts/events/PaymentProcessed.schema.json' }],
+        });
+
+        const navigationData = await getNestedSideBarData();
+        const messageNode = getNavigationConfigurationByKey('event:PaymentProcessed:0.0.1', navigationData);
+        expect(messageNode).toHaveNavigationLink({
+          type: 'item',
+          title: 'Schema (JSON)',
+          href: '/schemas/events/PaymentProcessed/0.0.1',
+        });
+      });
+
+      it('uses a generic schemas label when the message declares multiple schemas', async () => {
+        const { writeEvent } = utils(CATALOG_FOLDER);
+        await writeEvent({
+          id: 'PaymentProcessed',
+          name: 'Payment Processed',
+          version: '0.0.1',
+          markdown: 'Payment Processed',
+          schemas: [
+            { ref: 'git://contracts/events/PaymentProcessed.schema.json' },
+            { ref: 'git://contracts/events/PaymentProcessed.schema.avsc' },
+          ],
+        });
+
+        const navigationData = await getNestedSideBarData();
+        const messageNode = getNavigationConfigurationByKey('event:PaymentProcessed:0.0.1', navigationData);
+        expect(messageNode).toHaveNavigationLink({
+          type: 'item',
+          title: 'Schemas',
+          href: '/schemas/events/PaymentProcessed/0.0.1',
+        });
+      });
+    });
+
     describe('architecture & design section', () => {
       it('the visualizer link is always listed in the navigation item', async () => {
         const { writeEvent } = utils(CATALOG_FOLDER);
@@ -2238,6 +2281,32 @@ describe('getNestedSideBarData', () => {
           version: '0.0.1',
           markdown: 'Payment Processed',
           schemaPath: 'schema.json',
+        });
+        await writeService({
+          id: 'ShippingService',
+          name: 'Shipping Service',
+          version: '0.0.1',
+          markdown: 'Shipping Service',
+          receives: [{ id: 'PaymentProcessed', version: '0.0.1', fields: ['orderId', 'amount'] }],
+        });
+
+        const navigationData = await getNestedSideBarData();
+        const messageNode = getNavigationConfigurationByKey('event:PaymentProcessed:0.0.1', navigationData);
+        expect(messageNode).toHaveNavigationLink({
+          type: 'item',
+          title: 'Field Usage',
+          href: '/docs/events/PaymentProcessed/0.0.1/field-lineage',
+        });
+      });
+
+      it('the field usage link is shown when the message declares schemas', async () => {
+        const { writeEvent, writeService } = utils(CATALOG_FOLDER);
+        await writeEvent({
+          id: 'PaymentProcessed',
+          name: 'Payment Processed',
+          version: '0.0.1',
+          markdown: 'Payment Processed',
+          schemas: [{ ref: 'git://contracts/events/PaymentProcessed.schema.json' }],
         });
         await writeService({
           id: 'ShippingService',

--- a/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/sidebar-builder.spec.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/sidebar-builder.spec.ts
@@ -11,6 +11,7 @@ const mockFlows: any[] = [];
 const mockResourceDocs: any[] = [];
 const mockResourceDocCategories: any[] = [];
 const mockAgents: any[] = [];
+const mockSchemas: any[] = [];
 
 declare global {
   interface Window {
@@ -96,6 +97,8 @@ vi.mock('astro:content', async (importOriginal) => {
         case 'diagrams':
           // NO SDK Support for diagrams yet, so we just mock it out for now
           return Promise.resolve([]);
+        case 'schemas':
+          return Promise.resolve(mockSchemas.map((schema) => toAstroCollection(schema, 'schemas')));
         case 'channels':
           const { getChannels } = utils(CATALOG_FOLDER);
           const channels = (await getChannels()) ?? [];
@@ -160,6 +163,7 @@ describe('getNestedSideBarData', () => {
     mockResourceDocs.length = 0;
     mockResourceDocCategories.length = 0;
     mockAgents.length = 0;
+    mockSchemas.length = 0;
     fs.rmSync(CATALOG_FOLDER, { recursive: true, force: true });
     fs.mkdirSync(CATALOG_FOLDER, { recursive: true });
     // Remove any navigation data from teh config
@@ -2186,7 +2190,7 @@ describe('getNestedSideBarData', () => {
     });
 
     describe('API & Contracts section', () => {
-      it('lists a schema link when the message declares schemas', async () => {
+      it('lists a schema link when the message has a resolved schema entry', async () => {
         const { writeEvent } = utils(CATALOG_FOLDER);
         await writeEvent({
           id: 'PaymentProcessed',
@@ -2194,6 +2198,13 @@ describe('getNestedSideBarData', () => {
           version: '0.0.1',
           markdown: 'Payment Processed',
           schemas: [{ ref: 'git://contracts/events/PaymentProcessed.schema.json' }],
+        });
+        mockSchemas.push({
+          id: 'git://contracts/events/PaymentProcessed.schema.json',
+          ref: 'git://contracts/events/PaymentProcessed.schema.json',
+          format: 'jsonschema',
+          source: { provider: 'git', path: 'events/PaymentProcessed.schema.json' },
+          message: { collection: 'events', id: 'PaymentProcessed', version: '0.0.1' },
         });
 
         const navigationData = await getNestedSideBarData();
@@ -2205,7 +2216,26 @@ describe('getNestedSideBarData', () => {
         });
       });
 
-      it('uses a generic schemas label when the message declares multiple schemas', async () => {
+      it('does not list a schema link when declared schemas are not resolved', async () => {
+        const { writeEvent } = utils(CATALOG_FOLDER);
+        await writeEvent({
+          id: 'PaymentProcessed',
+          name: 'Payment Processed',
+          version: '0.0.1',
+          markdown: 'Payment Processed',
+          schemas: [{ ref: 'git://contracts/events/Missing.schema.json' }],
+        });
+
+        const navigationData = await getNestedSideBarData();
+        const messageNode = getNavigationConfigurationByKey('event:PaymentProcessed:0.0.1', navigationData);
+        expect(messageNode).not.toHaveNavigationLink({
+          type: 'item',
+          title: 'Schema (JSON)',
+          href: '/schemas/events/PaymentProcessed/0.0.1',
+        });
+      });
+
+      it('uses a generic schemas label when the message has multiple resolved schemas', async () => {
         const { writeEvent } = utils(CATALOG_FOLDER);
         await writeEvent({
           id: 'PaymentProcessed',
@@ -2217,6 +2247,22 @@ describe('getNestedSideBarData', () => {
             { ref: 'git://contracts/events/PaymentProcessed.schema.avsc' },
           ],
         });
+        mockSchemas.push(
+          {
+            id: 'git://contracts/events/PaymentProcessed.schema.json',
+            ref: 'git://contracts/events/PaymentProcessed.schema.json',
+            format: 'jsonschema',
+            source: { provider: 'git', path: 'events/PaymentProcessed.schema.json' },
+            message: { collection: 'events', id: 'PaymentProcessed', version: '0.0.1' },
+          },
+          {
+            id: 'git://contracts/events/PaymentProcessed.schema.avsc',
+            ref: 'git://contracts/events/PaymentProcessed.schema.avsc',
+            format: 'avro',
+            source: { provider: 'git', path: 'events/PaymentProcessed.schema.avsc' },
+            message: { collection: 'events', id: 'PaymentProcessed', version: '0.0.1' },
+          }
+        );
 
         const navigationData = await getNestedSideBarData();
         const messageNode = getNavigationConfigurationByKey('event:PaymentProcessed:0.0.1', navigationData);
@@ -2282,6 +2328,13 @@ describe('getNestedSideBarData', () => {
           markdown: 'Payment Processed',
           schemaPath: 'schema.json',
         });
+        mockSchemas.push({
+          id: 'schema:events:PaymentProcessed:0.0.1:schema.json',
+          format: 'jsonschema',
+          file: 'schema.json',
+          source: { provider: 'file', path: 'schema.json' },
+          message: { collection: 'events', id: 'PaymentProcessed', version: '0.0.1' },
+        });
         await writeService({
           id: 'ShippingService',
           name: 'Shipping Service',
@@ -2307,6 +2360,13 @@ describe('getNestedSideBarData', () => {
           version: '0.0.1',
           markdown: 'Payment Processed',
           schemas: [{ ref: 'git://contracts/events/PaymentProcessed.schema.json' }],
+        });
+        mockSchemas.push({
+          id: 'git://contracts/events/PaymentProcessed.schema.json',
+          ref: 'git://contracts/events/PaymentProcessed.schema.json',
+          format: 'jsonschema',
+          source: { provider: 'git', path: 'events/PaymentProcessed.schema.json' },
+          message: { collection: 'events', id: 'PaymentProcessed', version: '0.0.1' },
         });
         await writeService({
           id: 'ShippingService',
@@ -2384,6 +2444,13 @@ describe('getNestedSideBarData', () => {
           version: '1.0.0',
           markdown: 'Inventory Adjusted',
           schemaPath: 'schema.json',
+        });
+        mockSchemas.push({
+          id: 'schema:events:InventoryAdjusted:1.0.0:schema.json',
+          format: 'jsonschema',
+          file: 'schema.json',
+          source: { provider: 'file', path: 'schema.json' },
+          message: { collection: 'events', id: 'InventoryAdjusted', version: '1.0.0' },
         });
         await writeService({
           id: 'InventoryService',

--- a/packages/core/eventcatalog/src/stores/sidebar-store/builders/message.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/builders/message.ts
@@ -20,6 +20,27 @@ const getProducerConsumerPageRef = (resource: any) => {
   return `${resourceType}:${resource.data.id}:${resource.data.version}`;
 };
 
+const getSchemaReferenceFormat = (schema: { id?: string; ref?: string; file?: string; path?: string; format?: string }) => {
+  if (schema.format) return schema.format;
+
+  const schemaLocation = schema.file ?? schema.path ?? schema.ref ?? schema.id;
+  if (!schemaLocation || !schemaLocation.includes('.')) return undefined;
+
+  return getSchemaFormatFromURL(schemaLocation);
+};
+
+const getSchemaNavTitle = (message: CollectionEntry<'events' | 'commands' | 'queries'>) => {
+  if (message.data.schemaPath) {
+    return `Schema (${getSchemaFormatFromURL(message.data.schemaPath).toUpperCase()})`;
+  }
+
+  const schemas = message.data.schemas ?? [];
+  if (schemas.length > 1) return 'Schemas';
+
+  const format = schemas[0] ? getSchemaReferenceFormat(schemas[0]) : undefined;
+  return format ? `Schema (${format.toUpperCase()})` : 'Schema';
+};
+
 export const buildMessageNode = (
   message: CollectionEntry<'events' | 'commands' | 'queries'>,
   owners: any[],
@@ -51,7 +72,7 @@ export const buildMessageNode = (
   };
   const defaultIcon = iconMap[collection] || 'Mail';
 
-  const hasSchema = message.data.schemaPath !== undefined;
+  const hasSchema = message.data.schemaPath !== undefined || (message.data.schemas ?? []).length > 0;
   const renderVisualiser = isVisualiserEnabled();
   const docsSection = buildResourceDocsSection(
     collection as 'events' | 'commands' | 'queries',
@@ -116,7 +137,7 @@ export const buildMessageNode = (
         pages: [
           {
             type: 'item',
-            title: `Schema (${getSchemaFormatFromURL(message.data.schemaPath!).toUpperCase()})`,
+            title: getSchemaNavTitle(message),
             href: buildUrl(`/schemas/${collection}/${message.data.id}/${message.data.version}`),
           },
           hasFieldUsage && {

--- a/packages/core/eventcatalog/src/stores/sidebar-store/builders/message.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/builders/message.ts
@@ -15,29 +15,30 @@ import { isVisualiserEnabled, isChangelogEnabled } from '@utils/feature';
 import { iconFieldsForResource } from '@utils/icon';
 import { collectionToResourceMap } from '@utils/collections/util';
 
+type MessageSchemaEntry = CollectionEntry<'schemas'>;
+
 const getProducerConsumerPageRef = (resource: any) => {
   const resourceType = collectionToResourceMap[resource.collection as keyof typeof collectionToResourceMap];
   return `${resourceType}:${resource.data.id}:${resource.data.version}`;
 };
 
-const getSchemaReferenceFormat = (schema: { id?: string; ref?: string; file?: string; path?: string; format?: string }) => {
-  if (schema.format) return schema.format;
-
-  const schemaLocation = schema.file ?? schema.path ?? schema.ref ?? schema.id;
-  if (!schemaLocation || !schemaLocation.includes('.')) return undefined;
-
-  return getSchemaFormatFromURL(schemaLocation);
+const getSchemasForMessage = (
+  message: CollectionEntry<'events' | 'commands' | 'queries'>,
+  schemas: MessageSchemaEntry[] = []
+) => {
+  return schemas.filter(
+    (schema) =>
+      schema.data.message.collection === message.collection &&
+      schema.data.message.id === message.data.id &&
+      schema.data.message.version === message.data.version
+  );
 };
 
-const getSchemaNavTitle = (message: CollectionEntry<'events' | 'commands' | 'queries'>) => {
-  if (message.data.schemaPath) {
-    return `Schema (${getSchemaFormatFromURL(message.data.schemaPath).toUpperCase()})`;
-  }
-
-  const schemas = message.data.schemas ?? [];
+const getSchemaNavTitle = (schemas: MessageSchemaEntry[]) => {
   if (schemas.length > 1) return 'Schemas';
 
-  const format = schemas[0] ? getSchemaReferenceFormat(schemas[0]) : undefined;
+  const schemaPath = schemas[0]?.data.file || schemas[0]?.data.source.path || schemas[0]?.data.ref || schemas[0]?.id;
+  const format = schemaPath ? getSchemaFormatFromURL(schemaPath) : schemas[0]?.data.format;
   return format ? `Schema (${format.toUpperCase()})` : 'Schema';
 };
 
@@ -72,7 +73,8 @@ export const buildMessageNode = (
   };
   const defaultIcon = iconMap[collection] || 'Mail';
 
-  const hasSchema = message.data.schemaPath !== undefined || (message.data.schemas ?? []).length > 0;
+  const resolvedSchemas = getSchemasForMessage(message, context.schemas);
+  const hasSchema = resolvedSchemas.length > 0;
   const renderVisualiser = isVisualiserEnabled();
   const docsSection = buildResourceDocsSection(
     collection as 'events' | 'commands' | 'queries',
@@ -137,7 +139,7 @@ export const buildMessageNode = (
         pages: [
           {
             type: 'item',
-            title: getSchemaNavTitle(message),
+            title: getSchemaNavTitle(resolvedSchemas),
             href: buildUrl(`/schemas/${collection}/${message.data.id}/${message.data.version}`),
           },
           hasFieldUsage && {

--- a/packages/core/eventcatalog/src/stores/sidebar-store/builders/shared.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/builders/shared.ts
@@ -67,6 +67,7 @@ export type ResourceGroupContext = {
   entities?: CollectionEntry<'entities'>[];
   dataProducts: CollectionEntry<'data-products'>[];
   diagrams: CollectionEntry<'diagrams'>[];
+  schemas?: CollectionEntry<'schemas'>[];
   adrs: Adr[];
   users?: CollectionEntry<'users'>[];
   teams?: CollectionEntry<'teams'>[];

--- a/packages/core/eventcatalog/src/stores/sidebar-store/state.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/state.ts
@@ -292,6 +292,7 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
     dataProducts,
     entities,
     adrs,
+    schemas,
     resourceDocs,
     resourceDocCategories,
   ] = await Promise.all([
@@ -309,6 +310,7 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
     getDataProducts({ getAllVersions: false }),
     getEntities({ getAllVersions: false }),
     getAdrs({ getAllVersions: false }),
+    getCollection('schemas'),
     getResourceDocs(),
     getResourceDocCategories(),
   ]);
@@ -330,6 +332,7 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
     containers,
     channels,
     diagrams,
+    schemas,
     dataProducts,
     entities,
     adrs,

--- a/packages/core/eventcatalog/src/utils/__tests__/schemas/schema-loader.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/schemas/schema-loader.spec.ts
@@ -1,10 +1,25 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { getMessageSchemasFromFrontmatter, loadMessageSchemas } from '@utils/collections/schema-loader';
 
+const originalScale = process.env.EVENTCATALOG_SCALE;
+
 describe('schema-loader', () => {
+  beforeEach(() => {
+    delete process.env.EVENTCATALOG_SCALE;
+  });
+
+  afterEach(() => {
+    if (originalScale === undefined) {
+      delete process.env.EVENTCATALOG_SCALE;
+      return;
+    }
+    process.env.EVENTCATALOG_SCALE = originalScale;
+  });
+
   it('normalizes legacy schemaPath into a generated message schema resource', () => {
     const schemas = getMessageSchemasFromFrontmatter({
       collection: 'commands',
@@ -121,18 +136,102 @@ describe('schema-loader', () => {
     ]);
   });
 
-  it('does not create local schema resources for external schema references', () => {
+  it('normalizes external schema references without local file metadata', () => {
     const schemas = getMessageSchemasFromFrontmatter({
       collection: 'events',
       messageFilePath: '/catalog/events/ShipmentCancelled/index.mdx',
       data: {
         id: 'ShipmentCancelled',
         version: '1.0.0',
-        schemas: [{ id: 'schema-from-confluent', environments: ['prod'] }],
+        schemas: [{ ref: 'git://contracts/events/ShipmentCancelled.schema.json', environments: ['prod'] }],
       },
     });
 
-    expect(schemas).toEqual([]);
+    expect(schemas).toEqual([
+      {
+        id: 'git://contracts/events/ShipmentCancelled.schema.json',
+        ref: 'git://contracts/events/ShipmentCancelled.schema.json',
+        name: undefined,
+        version: '1.0.0',
+        format: 'unknown',
+        file: undefined,
+        filePath: undefined,
+        environments: ['prod'],
+        default: undefined,
+        message: {
+          collection: 'events',
+          id: 'ShipmentCancelled',
+          name: undefined,
+          version: '1.0.0',
+          summary: undefined,
+          owners: undefined,
+        },
+        source: {
+          provider: 'git',
+          path: undefined,
+        },
+      },
+    ]);
+  });
+
+  it('normalizes legacy external schema references that use id', () => {
+    const schemas = getMessageSchemasFromFrontmatter({
+      collection: 'events',
+      messageFilePath: '/catalog/events/ShipmentCancelled/index.mdx',
+      data: {
+        id: 'ShipmentCancelled',
+        version: '1.0.0',
+        schemas: [{ id: 'git://contracts/events/ShipmentCancelled.schema.json' }],
+      },
+    });
+
+    expect(schemas).toMatchObject([
+      {
+        id: 'git://contracts/events/ShipmentCancelled.schema.json',
+        ref: 'git://contracts/events/ShipmentCancelled.schema.json',
+        source: {
+          provider: 'git',
+        },
+      },
+    ]);
+  });
+
+  it('normalizes file schema refs relative to the message file', () => {
+    const schemas = getMessageSchemasFromFrontmatter({
+      collection: 'events',
+      messageFilePath: '/catalog/events/OrderPlaced/index.mdx',
+      data: {
+        id: 'OrderPlaced',
+        version: '1.0.0',
+        schemas: [{ ref: 'file://./schemas/OrderPlaced.schema.json' }],
+      },
+    });
+
+    expect(schemas).toEqual([
+      {
+        id: 'file://./schemas/OrderPlaced.schema.json',
+        ref: 'file://./schemas/OrderPlaced.schema.json',
+        name: 'OrderPlaced.schema.json',
+        version: '1.0.0',
+        format: 'jsonschema',
+        file: undefined,
+        filePath: '/catalog/events/OrderPlaced/schemas/OrderPlaced.schema.json',
+        environments: undefined,
+        default: undefined,
+        message: {
+          collection: 'events',
+          id: 'OrderPlaced',
+          name: undefined,
+          version: '1.0.0',
+          summary: undefined,
+          owners: undefined,
+        },
+        source: {
+          provider: 'file',
+          path: './schemas/OrderPlaced.schema.json',
+        },
+      },
+    ]);
   });
 
   it('loads colocated schemas from message files using raw glob patterns', async () => {
@@ -194,6 +293,256 @@ schemaPath: missing-schema.json
     });
 
     expect(schemas).toEqual([]);
+  });
+
+  it('loads relative file schema refs without a configured schema source', async () => {
+    const catalogDir = await mkdtemp(path.join(tmpdir(), 'eventcatalog-schema-loader-'));
+    const messageDir = path.join(catalogDir, 'events', 'OrderPlaced');
+    const schemaDir = path.join(messageDir, 'schemas');
+
+    await mkdir(schemaDir, { recursive: true });
+    await writeFile(path.join(schemaDir, 'OrderPlaced.schema.json'), '{"type":"object"}');
+    await writeFile(
+      path.join(messageDir, 'index.mdx'),
+      `---
+id: OrderPlaced
+name: Order placed
+version: 1.0.0
+schemas:
+  - ref: file://./schemas/OrderPlaced.schema.json
+---
+`
+    );
+
+    const schemas = await loadMessageSchemas({
+      base: catalogDir,
+      pattern: ['**/events/*/index.{md,mdx}'],
+    });
+
+    expect(schemas).toHaveLength(1);
+    expect(schemas[0]).toMatchObject({
+      id: 'file://./schemas/OrderPlaced.schema.json',
+      ref: 'file://./schemas/OrderPlaced.schema.json',
+      name: 'OrderPlaced.schema.json',
+      format: 'jsonschema',
+      filePath: path.join(schemaDir, 'OrderPlaced.schema.json'),
+      latest: true,
+      source: {
+        provider: 'file',
+        path: './schemas/OrderPlaced.schema.json',
+      },
+    });
+  });
+
+  it('loads absolute file schema refs without a configured schema source', async () => {
+    const catalogDir = await mkdtemp(path.join(tmpdir(), 'eventcatalog-schema-loader-'));
+    const externalSchemaDir = await mkdtemp(path.join(tmpdir(), 'eventcatalog-schema-registry-'));
+    const messageDir = path.join(catalogDir, 'events', 'OrderPlaced');
+    const schemaPath = path.join(externalSchemaDir, 'OrderPlaced.avsc');
+    const schemaRef = pathToFileURL(schemaPath).toString();
+
+    await mkdir(messageDir, { recursive: true });
+    await writeFile(schemaPath, '{"type":"record"}');
+    await writeFile(
+      path.join(messageDir, 'index.mdx'),
+      `---
+id: OrderPlaced
+name: Order placed
+version: 1.0.0
+schemas:
+  - ref: ${schemaRef}
+---
+`
+    );
+
+    const schemas = await loadMessageSchemas({
+      base: catalogDir,
+      pattern: ['**/events/*/index.{md,mdx}'],
+    });
+
+    expect(schemas).toHaveLength(1);
+    expect(schemas[0]).toMatchObject({
+      id: schemaRef,
+      ref: schemaRef,
+      name: 'OrderPlaced.avsc',
+      format: 'avro',
+      filePath: schemaPath,
+      latest: true,
+      source: {
+        provider: 'file',
+        path: schemaPath,
+      },
+    });
+  });
+
+  it('requires EventCatalog Scale when schema sources are configured', async () => {
+    const catalogDir = await mkdtemp(path.join(tmpdir(), 'eventcatalog-schema-loader-'));
+    const messageDir = path.join(catalogDir, 'events', 'OrderPlaced');
+
+    await mkdir(messageDir, { recursive: true });
+    await writeFile(
+      path.join(messageDir, 'index.mdx'),
+      `---
+id: OrderPlaced
+name: Order placed
+version: 1.0.0
+schemas:
+  - ref: git://contracts/events/OrderPlaced.schema.json
+---
+`
+    );
+
+    await expect(
+      loadMessageSchemas(
+        {
+          base: catalogDir,
+          pattern: ['**/events/*/index.{md,mdx}'],
+        },
+        [
+          {
+            type: 'schemas',
+            name: 'contracts',
+            canResolve: (id) => id.startsWith('git://contracts/'),
+            resolve: async (id) => ({
+              id,
+              content: '{}',
+              source: {
+                provider: 'git',
+              },
+            }),
+          },
+        ]
+      )
+    ).rejects.toThrow('Schema sources require EventCatalog Scale.');
+  });
+
+  it('loads external schema entries from configured schema sources', async () => {
+    process.env.EVENTCATALOG_SCALE = 'true';
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const catalogDir = await mkdtemp(path.join(tmpdir(), 'eventcatalog-schema-loader-'));
+    const messageDir = path.join(catalogDir, 'events', 'OrderPlaced');
+
+    await mkdir(messageDir, { recursive: true });
+    await writeFile(
+      path.join(messageDir, 'index.mdx'),
+      `---
+id: OrderPlaced
+name: Order placed
+version: 1.0.0
+schemas:
+  - ref: git://contracts/events/OrderPlaced.schema.json
+    default: true
+---
+`
+    );
+
+    const schemas = await loadMessageSchemas(
+      {
+        base: catalogDir,
+        pattern: ['**/events/*/index.{md,mdx}'],
+      },
+      [
+        {
+          type: 'schemas',
+          name: 'contracts',
+          canResolve: (id) => id.startsWith('git://contracts/'),
+          resolve: async (id) => ({
+            id,
+            name: 'OrderPlaced.schema.json',
+            format: 'jsonschema',
+            content: '{"type":"object"}',
+            source: {
+              provider: 'git',
+              id: 'contracts:events/OrderPlaced.schema.json',
+              url: 'https://github.com/acme/schema-contracts.git',
+              ref: 'main',
+              path: 'schemas/events/OrderPlaced.schema.json',
+            },
+          }),
+        },
+      ]
+    );
+
+    expect(schemas).toHaveLength(1);
+    expect(schemas[0]).toMatchObject({
+      id: 'git://contracts/events/OrderPlaced.schema.json',
+      name: 'OrderPlaced.schema.json',
+      format: 'jsonschema',
+      content: '{"type":"object"}',
+      default: true,
+      latest: true,
+      readOnly: true,
+      message: {
+        collection: 'events',
+        id: 'OrderPlaced',
+        version: '1.0.0',
+      },
+      source: {
+        provider: 'git',
+        id: 'contracts:events/OrderPlaced.schema.json',
+        url: 'https://github.com/acme/schema-contracts.git',
+        ref: 'main',
+        path: 'schemas/events/OrderPlaced.schema.json',
+      },
+    });
+    expect(consoleLog).toHaveBeenCalledWith(expect.stringContaining('Loading 1 schema from schema source "contracts"'));
+    expect(consoleLog).toHaveBeenCalledWith(expect.stringContaining('Synced 1 schema from schema source "contracts"'));
+    consoleLog.mockRestore();
+  });
+
+  it('reports the message that referenced an external schema when the source cannot resolve it', async () => {
+    process.env.EVENTCATALOG_SCALE = 'true';
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const catalogDir = await mkdtemp(path.join(tmpdir(), 'eventcatalog-schema-loader-'));
+    const messageDir = path.join(catalogDir, 'events', 'DeliveryFailed');
+
+    await mkdir(messageDir, { recursive: true });
+    await writeFile(
+      path.join(messageDir, 'index.mdx'),
+      `---
+id: DeliveryFailed
+name: Delivery failed
+version: 1.0.0
+schemas:
+  - ref: git://contracts/events/Missing.schema.json
+---
+`
+    );
+
+    try {
+      await loadMessageSchemas(
+        {
+          base: catalogDir,
+          pattern: ['**/events/*/index.{md,mdx}'],
+        },
+        [
+          {
+            type: 'schemas',
+            name: 'contracts',
+            canResolve: (id) => id.startsWith('git://contracts/'),
+            resolve: async () => {
+              throw new Error(
+                'Git schema source "contracts" could not find schema file "schemas/events/Missing.schema.json" in "https://github.com/acme/schema-contracts.git" at ref "main".'
+              );
+            },
+          },
+        ]
+      );
+      throw new Error('Expected schema loading to fail.');
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      const message = (error as Error).message;
+      expect(message).toContain('[schemas] Failed to resolve schema');
+      expect(message).toContain('Message: event "DeliveryFailed" version "1.0.0"');
+      expect(message).toContain('Schema:  git://contracts/events/Missing.schema.json');
+      expect(message).toContain('Source:  contracts');
+      expect(message).toContain('Reason:');
+      expect(message).toContain(
+        'Git schema source "contracts" could not find schema file "schemas/events/Missing.schema.json" in "https://github.com/acme/schema-contracts.git" at ref "main".'
+      );
+    } finally {
+      consoleLog.mockRestore();
+    }
   });
 
   it('marks schemas for the latest message version using semver ordering', async () => {

--- a/packages/core/eventcatalog/src/utils/__tests__/schemas/schema-loader.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/schemas/schema-loader.spec.ts
@@ -455,7 +455,7 @@ schemas:
               provider: 'git',
               id: 'contracts:events/OrderPlaced.schema.json',
               url: 'https://github.com/acme/schema-contracts.git',
-              ref: 'main',
+              branch: 'main',
               path: 'schemas/events/OrderPlaced.schema.json',
             },
           }),
@@ -482,7 +482,7 @@ schemas:
         provider: 'git',
         id: 'contracts:events/OrderPlaced.schema.json',
         url: 'https://github.com/acme/schema-contracts.git',
-        ref: 'main',
+        branch: 'main',
         path: 'schemas/events/OrderPlaced.schema.json',
       },
     });
@@ -647,7 +647,7 @@ schemas:
             canResolve: (id) => id.startsWith('git://contracts/'),
             resolve: async () => {
               throw new Error(
-                'Git schema source "contracts" could not find schema file "schemas/events/Missing.schema.json" in "https://github.com/acme/schema-contracts.git" at ref "main".'
+                'Git schema source "contracts" could not find schema file "schemas/events/Missing.schema.json" in "https://github.com/acme/schema-contracts.git" on branch "main".'
               );
             },
           },
@@ -663,7 +663,7 @@ schemas:
       expect(message).toContain('Source:  contracts');
       expect(message).toContain('Reason:');
       expect(message).toContain(
-        'Git schema source "contracts" could not find schema file "schemas/events/Missing.schema.json" in "https://github.com/acme/schema-contracts.git" at ref "main".'
+        'Git schema source "contracts" could not find schema file "schemas/events/Missing.schema.json" in "https://github.com/acme/schema-contracts.git" on branch "main".'
       );
     } finally {
       consoleLog.mockRestore();

--- a/packages/core/eventcatalog/src/utils/__tests__/schemas/schema-loader.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/schemas/schema-loader.spec.ts
@@ -90,7 +90,8 @@ describe('schema-loader', () => {
 
     expect(schemas).toEqual([
       {
-        id: 'shipment-cancelled-prod',
+        id: 'schema:events:ShipmentCancelled:1.0.0:shipment-cancelled-prod',
+        schemaId: 'shipment-cancelled-prod',
         name: 'Production',
         version: '1.0.0',
         format: 'avro',
@@ -112,7 +113,8 @@ describe('schema-loader', () => {
         },
       },
       {
-        id: 'shipment-cancelled-uat',
+        id: 'schema:events:ShipmentCancelled:1.0.0:shipment-cancelled-uat',
+        schemaId: 'shipment-cancelled-uat',
         name: 'UAT',
         version: '1.0.0',
         format: 'avro',
@@ -151,7 +153,7 @@ describe('schema-loader', () => {
       {
         id: 'schema:events:ShipmentCancelled:1.0.0:git://contracts/events/ShipmentCancelled.schema.json',
         ref: 'git://contracts/events/ShipmentCancelled.schema.json',
-        name: undefined,
+        name: 'ShipmentCancelled.schema.json',
         version: '1.0.0',
         format: 'unknown',
         file: undefined,
@@ -334,6 +336,53 @@ schemas:
     });
   });
 
+  it('scopes explicit schema ids to the message version while preserving the user provided id', async () => {
+    const catalogDir = await mkdtemp(path.join(tmpdir(), 'eventcatalog-schema-loader-'));
+    const eventDir = path.join(catalogDir, 'events', 'OrderPlaced');
+    const versionedEventDir = path.join(eventDir, 'versioned', '2.0.0');
+
+    await mkdir(eventDir, { recursive: true });
+    await mkdir(versionedEventDir, { recursive: true });
+    await writeFile(path.join(eventDir, 'schema.json'), '{"type":"object","title":"v1"}');
+    await writeFile(path.join(versionedEventDir, 'schema.json'), '{"type":"object","title":"v2"}');
+    await writeFile(
+      path.join(eventDir, 'index.mdx'),
+      `---
+id: OrderPlaced
+name: Order placed
+version: 1.0.0
+schemas:
+  - id: prod
+    file: schema.json
+---
+`
+    );
+    await writeFile(
+      path.join(versionedEventDir, 'index.mdx'),
+      `---
+id: OrderPlaced
+name: Order placed
+version: 2.0.0
+schemas:
+  - id: prod
+    file: schema.json
+---
+`
+    );
+
+    const schemas = await loadMessageSchemas({
+      base: catalogDir,
+      pattern: ['**/events/*/index.{md,mdx}', '**/events/*/versioned/*/index.{md,mdx}'],
+    });
+
+    expect(schemas).toHaveLength(2);
+    expect(schemas.map((schema) => schema.id).sort()).toEqual([
+      'schema:events:OrderPlaced:1.0.0:prod',
+      'schema:events:OrderPlaced:2.0.0:prod',
+    ]);
+    expect(schemas.map((schema) => schema.schemaId)).toEqual(['prod', 'prod']);
+  });
+
   it('loads absolute file schema refs without a configured schema source', async () => {
     const catalogDir = await mkdtemp(path.join(tmpdir(), 'eventcatalog-schema-loader-'));
     const externalSchemaDir = await mkdtemp(path.join(tmpdir(), 'eventcatalog-schema-registry-'));
@@ -488,6 +537,57 @@ schemas:
     });
     expect(consoleLog).toHaveBeenCalledWith(expect.stringContaining('Loading 1 schema from schema source "contracts"'));
     expect(consoleLog).toHaveBeenCalledWith(expect.stringContaining('Synced 1 schema from schema source "contracts"'));
+    consoleLog.mockRestore();
+  });
+
+  it('uses the schema ref basename when an external schema source does not return a name', async () => {
+    process.env.EVENTCATALOG_SCALE = 'true';
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const catalogDir = await mkdtemp(path.join(tmpdir(), 'eventcatalog-schema-loader-'));
+    const messageDir = path.join(catalogDir, 'events', 'OrderPlaced');
+
+    await mkdir(messageDir, { recursive: true });
+    await writeFile(
+      path.join(messageDir, 'index.mdx'),
+      `---
+id: OrderPlaced
+name: Order placed
+version: 1.0.0
+schemas:
+  - ref: git://contracts/events/OrderPlaced.schema.json
+---
+`
+    );
+
+    const schemas = await loadMessageSchemas(
+      {
+        base: catalogDir,
+        pattern: ['**/events/*/index.{md,mdx}'],
+      },
+      [
+        {
+          type: 'schemas',
+          name: 'contracts',
+          canResolve: (id) => id.startsWith('git://contracts/'),
+          resolve: async (id) => ({
+            id,
+            format: 'jsonschema',
+            content: '{"type":"object"}',
+            source: {
+              provider: 'git',
+              id: 'contracts:events/OrderPlaced.schema.json',
+              path: 'schemas/events/OrderPlaced.schema.json',
+            },
+          }),
+        },
+      ]
+    );
+
+    expect(schemas[0]).toMatchObject({
+      name: 'OrderPlaced.schema.json',
+      content: '{"type":"object"}',
+      readOnly: true,
+    });
     consoleLog.mockRestore();
   });
 

--- a/packages/core/eventcatalog/src/utils/__tests__/schemas/schema-loader.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/schemas/schema-loader.spec.ts
@@ -490,6 +490,53 @@ schemas:
     consoleLog.mockRestore();
   });
 
+  it('passes the referencing message file path to configured schema sources', async () => {
+    process.env.EVENTCATALOG_SCALE = 'true';
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const catalogDir = await mkdtemp(path.join(tmpdir(), 'eventcatalog-schema-loader-'));
+    const messageDir = path.join(catalogDir, 'events', 'OrderPlaced');
+    const messageFilePath = path.join(messageDir, 'index.mdx');
+    const resolve = vi.fn(async (id: string) => ({
+      id,
+      content: '{}',
+      source: {
+        provider: 'git',
+      },
+    }));
+
+    await mkdir(messageDir, { recursive: true });
+    await writeFile(
+      messageFilePath,
+      `---
+id: OrderPlaced
+name: Order placed
+version: 1.0.0
+schemas:
+  - ref: git://contracts/events/OrderPlaced.schema.json
+---
+`
+    );
+
+    const schemas = await loadMessageSchemas(
+      {
+        base: catalogDir,
+        pattern: ['**/events/*/index.{md,mdx}'],
+      },
+      [
+        {
+          type: 'schemas',
+          name: 'contracts',
+          canResolve: (id) => id.startsWith('git://contracts/'),
+          resolve,
+        },
+      ]
+    );
+
+    expect(resolve).toHaveBeenCalledWith('git://contracts/events/OrderPlaced.schema.json', { messageFilePath });
+    expect(schemas[0]).not.toHaveProperty('_context');
+    consoleLog.mockRestore();
+  });
+
   it('reports the message that referenced an external schema when the source cannot resolve it', async () => {
     process.env.EVENTCATALOG_SCALE = 'true';
     const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});

--- a/packages/core/eventcatalog/src/utils/__tests__/schemas/schema-loader.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/schemas/schema-loader.spec.ts
@@ -149,7 +149,7 @@ describe('schema-loader', () => {
 
     expect(schemas).toEqual([
       {
-        id: 'git://contracts/events/ShipmentCancelled.schema.json',
+        id: 'schema:events:ShipmentCancelled:1.0.0:git://contracts/events/ShipmentCancelled.schema.json',
         ref: 'git://contracts/events/ShipmentCancelled.schema.json',
         name: undefined,
         version: '1.0.0',
@@ -187,7 +187,7 @@ describe('schema-loader', () => {
 
     expect(schemas).toMatchObject([
       {
-        id: 'git://contracts/events/ShipmentCancelled.schema.json',
+        id: 'schema:events:ShipmentCancelled:1.0.0:git://contracts/events/ShipmentCancelled.schema.json',
         ref: 'git://contracts/events/ShipmentCancelled.schema.json',
         source: {
           provider: 'git',
@@ -209,7 +209,7 @@ describe('schema-loader', () => {
 
     expect(schemas).toEqual([
       {
-        id: 'file://./schemas/OrderPlaced.schema.json',
+        id: 'schema:events:OrderPlaced:1.0.0:file://./schemas/OrderPlaced.schema.json',
         ref: 'file://./schemas/OrderPlaced.schema.json',
         name: 'OrderPlaced.schema.json',
         version: '1.0.0',
@@ -321,7 +321,7 @@ schemas:
 
     expect(schemas).toHaveLength(1);
     expect(schemas[0]).toMatchObject({
-      id: 'file://./schemas/OrderPlaced.schema.json',
+      id: 'schema:events:OrderPlaced:1.0.0:file://./schemas/OrderPlaced.schema.json',
       ref: 'file://./schemas/OrderPlaced.schema.json',
       name: 'OrderPlaced.schema.json',
       format: 'jsonschema',
@@ -362,7 +362,7 @@ schemas:
 
     expect(schemas).toHaveLength(1);
     expect(schemas[0]).toMatchObject({
-      id: schemaRef,
+      id: `schema:events:OrderPlaced:1.0.0:${schemaRef}`,
       ref: schemaRef,
       name: 'OrderPlaced.avsc',
       format: 'avro',
@@ -465,7 +465,8 @@ schemas:
 
     expect(schemas).toHaveLength(1);
     expect(schemas[0]).toMatchObject({
-      id: 'git://contracts/events/OrderPlaced.schema.json',
+      id: 'schema:events:OrderPlaced:1.0.0:git://contracts/events/OrderPlaced.schema.json',
+      ref: 'git://contracts/events/OrderPlaced.schema.json',
       name: 'OrderPlaced.schema.json',
       format: 'jsonschema',
       content: '{"type":"object"}',
@@ -487,6 +488,83 @@ schemas:
     });
     expect(consoleLog).toHaveBeenCalledWith(expect.stringContaining('Loading 1 schema from schema source "contracts"'));
     expect(consoleLog).toHaveBeenCalledWith(expect.stringContaining('Synced 1 schema from schema source "contracts"'));
+    consoleLog.mockRestore();
+  });
+
+  it('keeps distinct collection entries when multiple message versions reference the same external schema', async () => {
+    process.env.EVENTCATALOG_SCALE = 'true';
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const catalogDir = await mkdtemp(path.join(tmpdir(), 'eventcatalog-schema-loader-'));
+    const eventDir = path.join(catalogDir, 'events', 'UserCreated');
+    const versionedEventDir = path.join(eventDir, 'versioned', '2.0.0');
+
+    await mkdir(eventDir, { recursive: true });
+    await mkdir(versionedEventDir, { recursive: true });
+    await writeFile(
+      path.join(eventDir, 'index.mdx'),
+      `---
+id: UserCreated
+name: User created
+version: 1.0.0
+schemas:
+  - ref: git://contracts/common/User.schema.json
+---
+`
+    );
+    await writeFile(
+      path.join(versionedEventDir, 'index.mdx'),
+      `---
+id: UserCreated
+name: User created
+version: 2.0.0
+schemas:
+  - ref: git://contracts/common/User.schema.json
+---
+`
+    );
+
+    const resolve = vi.fn(async (id: string) => ({
+      id,
+      name: 'User.schema.json',
+      format: 'jsonschema',
+      content: '{"type":"object"}',
+      source: {
+        provider: 'git',
+        path: 'common/User.schema.json',
+      },
+    }));
+
+    const schemas = await loadMessageSchemas(
+      {
+        base: catalogDir,
+        pattern: ['**/events/*/index.{md,mdx}', '**/events/*/versioned/*/index.{md,mdx}'],
+      },
+      [
+        {
+          type: 'schemas',
+          name: 'contracts',
+          canResolve: (id) => id.startsWith('git://contracts/'),
+          resolve,
+        },
+      ]
+    );
+
+    expect(schemas).toHaveLength(2);
+    expect(schemas.map((schema) => schema.id).sort()).toEqual([
+      'schema:events:UserCreated:1.0.0:git://contracts/common/User.schema.json',
+      'schema:events:UserCreated:2.0.0:git://contracts/common/User.schema.json',
+    ]);
+    expect(schemas.map((schema) => schema.ref)).toEqual([
+      'git://contracts/common/User.schema.json',
+      'git://contracts/common/User.schema.json',
+    ]);
+    expect(schemas.map((schema) => schema.message.version).sort()).toEqual(['1.0.0', '2.0.0']);
+    expect(resolve).toHaveBeenCalledTimes(2);
+    expect(resolve).toHaveBeenNthCalledWith(
+      1,
+      'git://contracts/common/User.schema.json',
+      expect.objectContaining({ messageFilePath: expect.stringContaining('index.mdx') })
+    );
     consoleLog.mockRestore();
   });
 

--- a/packages/core/eventcatalog/src/utils/collections/schema-loader.ts
+++ b/packages/core/eventcatalog/src/utils/collections/schema-loader.ts
@@ -133,6 +133,22 @@ const getSchemaFormat = (schemaPath: string) => {
 const buildGeneratedSchemaId = (message: { collection: MessageCollection; id: string; version: string }, schemaPath: string) =>
   `schema:${message.collection}:${message.id}:${message.version}:${schemaPath}`;
 
+const getSchemaCollectionId = ({
+  message,
+  reference,
+  schemaRef,
+  schemaFile,
+}: {
+  message: { collection: MessageCollection; id: string; version: string };
+  reference: SchemaReference;
+  schemaRef?: string;
+  schemaFile?: string;
+}) => {
+  if (schemaRef) return buildGeneratedSchemaId(message, schemaRef);
+  if (reference.id) return reference.id;
+  return buildGeneratedSchemaId(message, schemaFile as string);
+};
+
 const getSchemaFile = (reference: SchemaReference) => reference.file ?? reference.path;
 
 const getSchemaRef = (reference: SchemaReference) => {
@@ -198,6 +214,8 @@ const getErrorMessage = (error: unknown) => {
   return error instanceof Error ? error.message : String(error);
 };
 
+const getSchemaResolveRef = (schema: MessageSchemaResource) => schema.ref ?? schema.id;
+
 const buildSchemaSourceErrorMessage = ({
   schema,
   source,
@@ -214,7 +232,7 @@ const buildSchemaSourceErrorMessage = ({
     colors.red(colors.bold('[schemas] Failed to resolve schema')),
     '',
     `  Message: ${messageType} "${schema.message.id}" version "${schema.message.version}"`,
-    `  Schema:  ${schema.id}`,
+    `  Schema:  ${getSchemaResolveRef(schema)}`,
     `  Source:  ${source.name}`,
     '',
     colors.bold('Reason:'),
@@ -288,7 +306,7 @@ export const getMessageSchemasFromFrontmatter = ({
     const schemaRef = getSchemaRef(reference);
     const fileSchemaRef = isFileSchemaRef(schemaRef) ? getFileSchemaRefPath(schemaRef as string, messageFilePath) : undefined;
     const schemaFilePath = schemaFile ? path.resolve(path.dirname(messageFilePath), schemaFile) : fileSchemaRef?.filePath;
-    const schemaId = schemaRef ?? reference.id ?? buildGeneratedSchemaId(message, schemaFile as string);
+    const schemaId = getSchemaCollectionId({ message, reference, schemaRef, schemaFile });
     const schemaPathForFormat = schemaFile ?? fileSchemaRef?.filePath;
 
     return {
@@ -303,7 +321,7 @@ export const getMessageSchemasFromFrontmatter = ({
       default: reference.default,
       message,
       source: {
-        provider: schemaFile || fileSchemaRef ? 'file' : getSchemaProvider(schemaId),
+        provider: schemaFile || fileSchemaRef ? 'file' : getSchemaProvider(schemaRef ?? schemaId),
         path: schemaFile ?? fileSchemaRef?.sourcePath,
       },
     };
@@ -318,9 +336,10 @@ const resolveSchemaSource = async (
   if (schema.filePath) return undefined;
 
   let resolvedSchema: Awaited<ReturnType<SchemaSource['resolve']>>;
+  const schemaResolveRef = getSchemaResolveRef(schema);
 
   try {
-    resolvedSchema = await source.resolve(schema.id, schema._context);
+    resolvedSchema = await source.resolve(schemaResolveRef, schema._context);
   } catch (error) {
     throw new Error(buildSchemaSourceErrorMessage({ schema, source, error }));
   }
@@ -352,7 +371,7 @@ const resolveSchemaSources = async (schemas: InternalMessageSchemaResource[], so
   const resolvedExternalSchemaIds = new Set<string>();
 
   for (const source of sources) {
-    const sourceSchemas = externalSchemas.filter((schema) => source.canResolve(schema.id));
+    const sourceSchemas = externalSchemas.filter((schema) => source.canResolve(getSchemaResolveRef(schema)));
     if (sourceSchemas.length === 0) continue;
 
     logSchemaInfo(

--- a/packages/core/eventcatalog/src/utils/collections/schema-loader.ts
+++ b/packages/core/eventcatalog/src/utils/collections/schema-loader.ts
@@ -4,18 +4,52 @@ import matter from 'gray-matter';
 import fs from 'node:fs/promises';
 import fsSync from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import pc from 'picocolors';
+import { isEventCatalogScaleEnabled } from '../feature';
 import { sortVersioned } from './util';
+
+const colors = pc.createColors(true);
 
 type MessageCollection = 'events' | 'commands' | 'queries';
 
 type SchemaReference = {
   id?: string;
+  ref?: string;
   file?: string;
   path?: string;
   name?: string;
   format?: string;
   environments?: string[];
   default?: boolean;
+};
+
+type SchemaSourceEntry = {
+  provider: string;
+  id?: string;
+  path?: string;
+  url?: string;
+  ref?: string;
+  [key: string]: unknown;
+};
+
+type SchemaSource = {
+  type: 'schemas';
+  name: string;
+  canResolve: (ref: string) => boolean;
+  resolve: (
+    ref: string,
+    context?: { messageFilePath?: string }
+  ) => Promise<
+    | {
+        id: string;
+        name?: string;
+        format?: string;
+        content: string;
+        source: SchemaSourceEntry;
+      }
+    | undefined
+  >;
 };
 
 type MessageFrontmatter = {
@@ -30,6 +64,7 @@ type MessageFrontmatter = {
 
 export type MessageSchemaResource = {
   id: string;
+  ref?: string;
   name?: string;
   version?: string;
   format: string;
@@ -48,9 +83,14 @@ export type MessageSchemaResource = {
     owners?: string[];
   };
   source: {
-    provider: 'file';
-    path: string;
+    provider: string;
+    id?: string;
+    path?: string;
+    url?: string;
+    ref?: string;
+    [key: string]: unknown;
   };
+  readOnly?: boolean;
 };
 
 type SchemaLoaderOptions = {
@@ -58,11 +98,13 @@ type SchemaLoaderOptions = {
     pattern: string[];
     base?: string;
   };
+  sources?: SchemaSource[];
 };
 
 type LoaderContext = Parameters<Loader['load']>[0];
 
 const MESSAGE_COLLECTIONS: MessageCollection[] = ['events', 'commands', 'queries'];
+const FILE_SCHEMA_REF_PREFIX = 'file://';
 
 const normalizePath = (value: string) => value.replace(/\\/g, '/');
 
@@ -87,8 +129,93 @@ const buildGeneratedSchemaId = (message: { collection: MessageCollection; id: st
 
 const getSchemaFile = (reference: SchemaReference) => reference.file ?? reference.path;
 
+const getSchemaRef = (reference: SchemaReference) => {
+  if (reference.ref) return reference.ref;
+  if (!getSchemaFile(reference)) return reference.id;
+  return undefined;
+};
+
 const schemaFileExists = (schema: MessageSchemaResource): schema is MessageSchemaResource & { filePath: string } =>
   Boolean(schema.filePath && fsSync.existsSync(schema.filePath));
+
+const getSchemaProvider = (id: string) => {
+  try {
+    const url = new URL(id);
+    return url.protocol.replace(':', '') || 'external';
+  } catch {
+    return 'external';
+  }
+};
+
+const isFileSchemaRef = (ref?: string) => ref?.startsWith(FILE_SCHEMA_REF_PREFIX);
+
+const getFileSchemaRefPath = (ref: string, messageFilePath: string) => {
+  if (ref.startsWith('file:///') || ref.startsWith('file://localhost/')) {
+    try {
+      const filePath = fileURLToPath(ref);
+      return {
+        filePath,
+        sourcePath: filePath,
+      };
+    } catch {
+      throw new Error(`Invalid file schema ref "${ref}". Expected file://<relative-path> or file:///absolute/path.`);
+    }
+  }
+
+  const sourcePath = decodeURIComponent(ref.slice(FILE_SCHEMA_REF_PREFIX.length));
+  if (!sourcePath) {
+    throw new Error(`Invalid file schema ref "${ref}". Expected file://<relative-path> or file:///absolute/path.`);
+  }
+
+  return {
+    filePath: path.resolve(path.dirname(messageFilePath), sourcePath),
+    sourcePath,
+  };
+};
+
+const getTimestamp = () => {
+  const now = new Date();
+  return now.toLocaleTimeString('en-US', { hour12: false });
+};
+
+const logSchemaInfo = (message: string) => {
+  console.log(`${colors.dim(getTimestamp())} ${colors.blue('[schemas]')} ${message}`);
+};
+
+const getMessageTypeLabel = (collection: MessageCollection) => {
+  if (collection === 'events') return 'event';
+  if (collection === 'commands') return 'command';
+  return 'query';
+};
+
+const getErrorMessage = (error: unknown) => {
+  return error instanceof Error ? error.message : String(error);
+};
+
+const buildSchemaSourceErrorMessage = ({
+  schema,
+  source,
+  error,
+}: {
+  schema: MessageSchemaResource;
+  source: SchemaSource;
+  error: unknown;
+}) => {
+  const messageType = getMessageTypeLabel(schema.message.collection);
+
+  return [
+    '',
+    colors.red(colors.bold('[schemas] Failed to resolve schema')),
+    '',
+    `  Message: ${messageType} "${schema.message.id}" version "${schema.message.version}"`,
+    `  Schema:  ${schema.id}`,
+    `  Source:  ${source.name}`,
+    '',
+    colors.bold('Reason:'),
+    `  ${getErrorMessage(error)}`,
+    '',
+  ].join('\n');
+};
 
 const addLatestMetadata = (schemas: MessageSchemaResource[]) => {
   const schemasByMessage = schemas.reduce(
@@ -138,7 +265,7 @@ export const getMessageSchemasFromFrontmatter = ({
   };
 
   const schemaReferences =
-    data.schemas?.filter((schema) => getSchemaFile(schema)) ??
+    data.schemas?.filter((schema) => getSchemaRef(schema) || getSchemaFile(schema)) ??
     (data.schemaPath
       ? [
           {
@@ -151,29 +278,108 @@ export const getMessageSchemasFromFrontmatter = ({
       : []);
 
   return schemaReferences.map((reference) => {
-    const schemaFile = getSchemaFile(reference) as string;
-    const schemaFilePath = path.resolve(path.dirname(messageFilePath), schemaFile);
-    const schemaId = reference.id ?? buildGeneratedSchemaId(message, schemaFile);
+    const schemaFile = getSchemaFile(reference);
+    const schemaRef = getSchemaRef(reference);
+    const fileSchemaRef = isFileSchemaRef(schemaRef) ? getFileSchemaRefPath(schemaRef as string, messageFilePath) : undefined;
+    const schemaFilePath = schemaFile ? path.resolve(path.dirname(messageFilePath), schemaFile) : fileSchemaRef?.filePath;
+    const schemaId = schemaRef ?? reference.id ?? buildGeneratedSchemaId(message, schemaFile as string);
+    const schemaPathForFormat = schemaFile ?? fileSchemaRef?.filePath;
 
     return {
       id: schemaId,
-      name: reference.name ?? schemaId,
+      ...(schemaRef ? { ref: schemaRef } : {}),
+      name: reference.name ?? (schemaFile ? schemaId : fileSchemaRef ? path.basename(fileSchemaRef.filePath) : undefined),
       version: data.version,
-      format: reference.format ?? getSchemaFormat(schemaFile),
+      format: reference.format ?? (schemaPathForFormat ? getSchemaFormat(schemaPathForFormat) : 'unknown'),
       file: schemaFile,
       filePath: schemaFilePath,
       environments: reference.environments,
       default: reference.default,
       message,
       source: {
-        provider: 'file',
-        path: schemaFile,
+        provider: schemaFile || fileSchemaRef ? 'file' : getSchemaProvider(schemaId),
+        path: schemaFile ?? fileSchemaRef?.sourcePath,
       },
     };
   });
 };
 
-export const loadMessageSchemas = async ({ pattern, base }: SchemaLoaderOptions['messages']) => {
+const resolveSchemaSource = async (
+  schema: MessageSchemaResource,
+  source: SchemaSource
+): Promise<MessageSchemaResource | undefined> => {
+  if (schemaFileExists(schema)) return schema;
+  if (schema.filePath) return undefined;
+
+  let resolvedSchema: Awaited<ReturnType<SchemaSource['resolve']>>;
+
+  try {
+    resolvedSchema = await source.resolve(schema.id);
+  } catch (error) {
+    throw new Error(buildSchemaSourceErrorMessage({ schema, source, error }));
+  }
+
+  if (!resolvedSchema) return undefined;
+
+  const resolvedMessageSchema: MessageSchemaResource = {
+    ...schema,
+    format: schema.format !== 'unknown' ? schema.format : (resolvedSchema.format ?? 'unknown'),
+    content: resolvedSchema.content,
+    source: resolvedSchema.source,
+    readOnly: true,
+  };
+
+  const name = schema.name ?? resolvedSchema.name;
+  if (name) resolvedMessageSchema.name = name;
+
+  return resolvedMessageSchema;
+};
+
+const resolveSchemaSources = async (schemas: MessageSchemaResource[], sources: SchemaSource[] = []) => {
+  if (sources.length > 0 && !isEventCatalogScaleEnabled()) {
+    throw new Error('Schema sources require EventCatalog Scale.');
+  }
+
+  const localSchemas = schemas.filter(schemaFileExists);
+  const externalSchemas = schemas.filter((schema) => !schema.filePath);
+  const resolvedExternalSchemas: MessageSchemaResource[] = [];
+  const resolvedExternalSchemaIds = new Set<string>();
+
+  for (const source of sources) {
+    const sourceSchemas = externalSchemas.filter((schema) => source.canResolve(schema.id));
+    if (sourceSchemas.length === 0) continue;
+
+    logSchemaInfo(
+      `Loading ${sourceSchemas.length} schema${sourceSchemas.length === 1 ? '' : 's'} from schema source "${source.name}"`
+    );
+
+    const resolvedSchemas = await Promise.all(sourceSchemas.map((schema) => resolveSchemaSource(schema, source)));
+    const syncedSchemas = resolvedSchemas.filter((schema): schema is MessageSchemaResource => schema !== undefined);
+
+    for (const schema of syncedSchemas) {
+      resolvedExternalSchemaIds.add(schema.id);
+      resolvedExternalSchemas.push(schema);
+    }
+
+    const skippedSchemas = sourceSchemas.length - syncedSchemas.length;
+    logSchemaInfo(
+      `Synced ${syncedSchemas.length} schema${syncedSchemas.length === 1 ? '' : 's'} from schema source "${source.name}"${
+        skippedSchemas > 0 ? ` (${skippedSchemas} skipped)` : ''
+      }`
+    );
+  }
+
+  return [
+    ...localSchemas,
+    ...resolvedExternalSchemas,
+    ...schemas.filter((schema) => schema.filePath && !schemaFileExists(schema)),
+  ].filter((schema) => {
+    if (schema.filePath) return schemaFileExists(schema);
+    return resolvedExternalSchemaIds.has(schema.id);
+  });
+};
+
+const loadMessageSchemaResources = async ({ pattern, base }: SchemaLoaderOptions['messages']) => {
   if (!base) return [];
 
   const files = await glob(pattern, {
@@ -193,10 +399,18 @@ export const loadMessageSchemas = async ({ pattern, base }: SchemaLoaderOptions[
     })
   );
 
-  return addLatestMetadata(schemas.flat().filter(schemaFileExists));
+  return schemas.flat();
+};
+
+export const loadMessageSchemas = async (messages: SchemaLoaderOptions['messages'], sources: SchemaSource[] = []) => {
+  const schemas = await loadMessageSchemaResources(messages);
+  const resolvedSchemas = await resolveSchemaSources(schemas, sources);
+
+  return addLatestMetadata(resolvedSchemas);
 };
 
 const getSchemaBody = async (schema: MessageSchemaResource) => {
+  if (schema.content !== undefined) return schema.content;
   if (!schemaFileExists(schema)) return undefined;
   return fs.readFile(schema.filePath, 'utf8');
 };
@@ -222,12 +436,12 @@ const setSchema = async (context: LoaderContext, schema: MessageSchemaResource) 
   });
 };
 
-export const schemaLoader = ({ messages }: SchemaLoaderOptions): Loader => {
+export const schemaLoader = ({ messages, sources = [] }: SchemaLoaderOptions): Loader => {
   return {
     name: 'eventcatalog-schema-loader',
     load: async (context) => {
       context.store.clear();
-      const schemas = await loadMessageSchemas(messages);
+      const schemas = await loadMessageSchemas(messages, sources);
 
       for (const schema of schemas) {
         await setSchema(context, schema);

--- a/packages/core/eventcatalog/src/utils/collections/schema-loader.ts
+++ b/packages/core/eventcatalog/src/utils/collections/schema-loader.ts
@@ -64,6 +64,7 @@ type MessageFrontmatter = {
 
 export type MessageSchemaResource = {
   id: string;
+  schemaId?: string;
   ref?: string;
   name?: string;
   version?: string;
@@ -145,7 +146,7 @@ const getSchemaCollectionId = ({
   schemaFile?: string;
 }) => {
   if (schemaRef) return buildGeneratedSchemaId(message, schemaRef);
-  if (reference.id) return reference.id;
+  if (reference.id) return buildGeneratedSchemaId(message, reference.id);
   return buildGeneratedSchemaId(message, schemaFile as string);
 };
 
@@ -155,6 +156,29 @@ const getSchemaRef = (reference: SchemaReference) => {
   if (reference.ref) return reference.ref;
   if (!getSchemaFile(reference)) return reference.id;
   return undefined;
+};
+
+const getSchemaDisplayName = ({
+  referenceName,
+  resolvedName,
+  schemaFile,
+  filePath,
+  schemaRef,
+  sourcePath,
+  schemaId,
+  messageName,
+}: {
+  referenceName?: string;
+  resolvedName?: string;
+  schemaFile?: string;
+  filePath?: string;
+  schemaRef?: string;
+  sourcePath?: string;
+  schemaId: string;
+  messageName?: string;
+}) => {
+  const pathLikeName = schemaFile ?? filePath ?? sourcePath ?? schemaRef ?? schemaId;
+  return referenceName ?? resolvedName ?? path.basename(pathLikeName) ?? messageName ?? 'Schema';
 };
 
 const schemaFileExists = (schema: MessageSchemaResource): schema is MessageSchemaResource & { filePath: string } =>
@@ -293,7 +317,6 @@ export const getMessageSchemasFromFrontmatter = ({
     (data.schemaPath
       ? [
           {
-            id: buildGeneratedSchemaId(message, data.schemaPath),
             file: data.schemaPath,
             name: 'Schema',
             default: true,
@@ -311,8 +334,16 @@ export const getMessageSchemasFromFrontmatter = ({
 
     return {
       id: schemaId,
+      ...(reference.id && !schemaRef ? { schemaId: reference.id } : {}),
       ...(schemaRef ? { ref: schemaRef } : {}),
-      name: reference.name ?? (schemaFile ? schemaId : fileSchemaRef ? path.basename(fileSchemaRef.filePath) : undefined),
+      name: getSchemaDisplayName({
+        referenceName: reference.name,
+        schemaFile,
+        filePath: fileSchemaRef?.filePath,
+        schemaRef,
+        schemaId,
+        messageName: data.name,
+      }),
       version: data.version,
       format: reference.format ?? (schemaPathForFormat ? getSchemaFormat(schemaPathForFormat) : 'unknown'),
       file: schemaFile,
@@ -354,8 +385,14 @@ const resolveSchemaSource = async (
     readOnly: true,
   };
 
-  const name = schema.name ?? resolvedSchema.name;
-  if (name) resolvedMessageSchema.name = name;
+  resolvedMessageSchema.name = getSchemaDisplayName({
+    referenceName: schema.name,
+    resolvedName: resolvedSchema.name,
+    schemaRef: schema.ref,
+    sourcePath: resolvedSchema.source.path,
+    schemaId: schema.id,
+    messageName: schema.message.name,
+  });
 
   return resolvedMessageSchema;
 };

--- a/packages/core/eventcatalog/src/utils/collections/schema-loader.ts
+++ b/packages/core/eventcatalog/src/utils/collections/schema-loader.ts
@@ -93,6 +93,12 @@ export type MessageSchemaResource = {
   readOnly?: boolean;
 };
 
+type InternalMessageSchemaResource = MessageSchemaResource & {
+  _context?: {
+    messageFilePath?: string;
+  };
+};
+
 type SchemaLoaderOptions = {
   messages: {
     pattern: string[];
@@ -305,23 +311,23 @@ export const getMessageSchemasFromFrontmatter = ({
 };
 
 const resolveSchemaSource = async (
-  schema: MessageSchemaResource,
+  schema: InternalMessageSchemaResource,
   source: SchemaSource
-): Promise<MessageSchemaResource | undefined> => {
+): Promise<InternalMessageSchemaResource | undefined> => {
   if (schemaFileExists(schema)) return schema;
   if (schema.filePath) return undefined;
 
   let resolvedSchema: Awaited<ReturnType<SchemaSource['resolve']>>;
 
   try {
-    resolvedSchema = await source.resolve(schema.id);
+    resolvedSchema = await source.resolve(schema.id, schema._context);
   } catch (error) {
     throw new Error(buildSchemaSourceErrorMessage({ schema, source, error }));
   }
 
   if (!resolvedSchema) return undefined;
 
-  const resolvedMessageSchema: MessageSchemaResource = {
+  const resolvedMessageSchema: InternalMessageSchemaResource = {
     ...schema,
     format: schema.format !== 'unknown' ? schema.format : (resolvedSchema.format ?? 'unknown'),
     content: resolvedSchema.content,
@@ -335,14 +341,14 @@ const resolveSchemaSource = async (
   return resolvedMessageSchema;
 };
 
-const resolveSchemaSources = async (schemas: MessageSchemaResource[], sources: SchemaSource[] = []) => {
+const resolveSchemaSources = async (schemas: InternalMessageSchemaResource[], sources: SchemaSource[] = []) => {
   if (sources.length > 0 && !isEventCatalogScaleEnabled()) {
     throw new Error('Schema sources require EventCatalog Scale.');
   }
 
   const localSchemas = schemas.filter(schemaFileExists);
   const externalSchemas = schemas.filter((schema) => !schema.filePath);
-  const resolvedExternalSchemas: MessageSchemaResource[] = [];
+  const resolvedExternalSchemas: InternalMessageSchemaResource[] = [];
   const resolvedExternalSchemaIds = new Set<string>();
 
   for (const source of sources) {
@@ -354,7 +360,7 @@ const resolveSchemaSources = async (schemas: MessageSchemaResource[], sources: S
     );
 
     const resolvedSchemas = await Promise.all(sourceSchemas.map((schema) => resolveSchemaSource(schema, source)));
-    const syncedSchemas = resolvedSchemas.filter((schema): schema is MessageSchemaResource => schema !== undefined);
+    const syncedSchemas = resolvedSchemas.filter((schema): schema is InternalMessageSchemaResource => schema !== undefined);
 
     for (const schema of syncedSchemas) {
       resolvedExternalSchemaIds.add(schema.id);
@@ -395,18 +401,28 @@ const loadMessageSchemaResources = async ({ pattern, base }: SchemaLoaderOptions
       if (!collection) return [];
 
       const { data } = matter.read(file) as { data: MessageFrontmatter };
-      return getMessageSchemasFromFrontmatter({ data, collection, messageFilePath: file });
+      return getMessageSchemasFromFrontmatter({ data, collection, messageFilePath: file }).map((schema) => ({
+        ...schema,
+        _context: {
+          messageFilePath: file,
+        },
+      }));
     })
   );
 
   return schemas.flat();
 };
 
+const stripSchemaLoaderContext = (schema: InternalMessageSchemaResource): MessageSchemaResource => {
+  const { _context, ...publicSchema } = schema;
+  return publicSchema;
+};
+
 export const loadMessageSchemas = async (messages: SchemaLoaderOptions['messages'], sources: SchemaSource[] = []) => {
   const schemas = await loadMessageSchemaResources(messages);
   const resolvedSchemas = await resolveSchemaSources(schemas, sources);
 
-  return addLatestMetadata(resolvedSchemas);
+  return addLatestMetadata(resolvedSchemas.map(stripSchemaLoaderContext));
 };
 
 const getSchemaBody = async (schema: MessageSchemaResource) => {

--- a/packages/core/eventcatalog/src/utils/files.ts
+++ b/packages/core/eventcatalog/src/utils/files.ts
@@ -1,4 +1,4 @@
-import path from 'node:path';
+import * as path from 'node:path';
 
 /**
  * Resolves a file path relative to PROJECT_DIR, handling ../ paths correctly

--- a/packages/core/src/eventcatalog.config.ts
+++ b/packages/core/src/eventcatalog.config.ts
@@ -69,6 +69,28 @@ type DirectorySource = {
   loadTeams?: () => Promise<DirectoryEntry[]>;
 };
 
+type SchemaEntry = {
+  id: string;
+  name?: string;
+  format?: string;
+  content: string;
+  source: {
+    provider: string;
+    id?: string;
+    url?: string;
+    ref?: string;
+    path?: string;
+    [key: string]: unknown;
+  };
+};
+
+type SchemaSource = {
+  type: 'schemas';
+  name: string;
+  canResolve: (id: string) => boolean;
+  resolve: (id: string, context?: { messageFilePath?: string }) => Promise<SchemaEntry | undefined>;
+};
+
 type DirectoryConfig = {
   /**
    * External sources that sync users and teams into EventCatalog.
@@ -81,6 +103,13 @@ type DirectoryConfig = {
    * @default 'local-wins'
    */
   conflictStrategy?: 'local-wins' | 'source-wins' | 'error';
+};
+
+type SchemaConfig = {
+  /**
+   * External sources that resolve message schema references into the generated schemas collection.
+   */
+  sources?: SchemaSource[];
 };
 
 type AuthConfig = {
@@ -245,6 +274,7 @@ export interface Config {
     domains?: ResourceDependency[];
   };
   directory?: DirectoryConfig;
+  schemas?: SchemaConfig;
   mermaid?: {
     maxTextSize?: number;
     iconPacks?: string[];

--- a/packages/core/vitest.config.js
+++ b/packages/core/vitest.config.js
@@ -29,6 +29,7 @@ export default defineConfig({
     alias: {
       'astro:content': path.resolve(__dirname, './src/__mocks__/astro-content.ts'),
       '@config': path.resolve(__dirname, 'eventcatalog/eventcatalog.config.js'),
+      '@eventcatalog/connectors': path.resolve(__dirname, 'node_modules/@eventcatalog/connectors/dist/index.mjs'),
       '@eventcatalog/sdk': path.resolve(__dirname, 'node_modules/@eventcatalog/sdk/dist/index.mjs'),
       '@eventcatalog': path.resolve(__dirname, 'eventcatalog/src/utils/eventcatalog-config/catalog.ts'),
       '@icons': path.resolve(__dirname, 'eventcatalog/src/icons'),

--- a/packages/sdk/src/types.d.ts
+++ b/packages/sdk/src/types.d.ts
@@ -10,6 +10,7 @@ export interface BaseSchema {
   };
   owners?: string[];
   schemaPath?: string;
+  schemas?: SchemaPointer[];
   markdown: string;
   repository?: {
     language?: string;
@@ -49,6 +50,17 @@ export type ResourcePointer = {
   id: string;
   version?: string;
   type?: string;
+};
+
+export type SchemaPointer = {
+  id?: string;
+  ref?: string;
+  file?: string;
+  path?: string;
+  name?: string;
+  format?: string;
+  environments?: string[];
+  default?: boolean;
 };
 
 export type SendsPointer = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,9 +148,6 @@ importers:
       '@auth/core':
         specifier: ^0.37.4
         version: 0.37.4
-      '@eventcatalog/connectors':
-        specifier: workspace:*
-        version: link:../connectors
       '@eventcatalog/license':
         specifier: ^0.0.7
         version: 0.0.7

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,10 @@ importers:
         version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.19)(jiti@2.6.1)(jsdom@27.0.0(postcss@8.5.9))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/connectors:
+    dependencies:
+      simple-git:
+        specifier: ^3.36.0
+        version: 3.36.0
     devDependencies:
       '@types/node':
         specifier: ^20.14.10
@@ -144,6 +148,9 @@ importers:
       '@auth/core':
         specifier: ^0.37.4
         version: 0.37.4
+      '@eventcatalog/connectors':
+        specifier: workspace:*
+        version: link:../connectors
       '@eventcatalog/license':
         specifier: ^0.0.7
         version: 0.0.7
@@ -2291,6 +2298,12 @@ packages:
   '@juggle/resize-observer@3.4.0':
     resolution: {integrity: sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==}
 
+  '@kwsites/file-exists@1.1.1':
+    resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
+
+  '@kwsites/promise-deferred@1.1.1':
+    resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
+
   '@lezer/common@1.2.3':
     resolution: {integrity: sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA==}
 
@@ -3274,6 +3287,12 @@ packages:
 
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
+  '@simple-git/args-pathspec@1.0.3':
+    resolution: {integrity: sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==}
+
+  '@simple-git/argv-parser@1.1.1':
+    resolution: {integrity: sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==}
 
   '@sindresorhus/merge-streams@2.3.0':
     resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
@@ -8008,6 +8027,9 @@ packages:
     resolution: {integrity: sha512-LH7FpTAkeD+y5xQC4fzS+tFtaNlvt3Ib1zKzvhjv/Y+cioV4zIuw4IZr2yhRLu67CWL7FR9/6KXKnjRoZTvGGQ==}
     engines: {node: '>=12'}
 
+  simple-git@3.36.0:
+    resolution: {integrity: sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==}
+
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
@@ -11041,6 +11063,14 @@ snapshots:
 
   '@juggle/resize-observer@3.4.0': {}
 
+  '@kwsites/file-exists@1.1.1':
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@kwsites/promise-deferred@1.1.1': {}
+
   '@lezer/common@1.2.3': {}
 
   '@lezer/css@1.3.0':
@@ -12376,6 +12406,12 @@ snapshots:
       '@types/hast': 3.0.4
 
   '@shikijs/vscode-textmate@10.0.2': {}
+
+  '@simple-git/args-pathspec@1.0.3': {}
+
+  '@simple-git/argv-parser@1.1.1':
+    dependencies:
+      '@simple-git/args-pathspec': 1.0.3
 
   '@sindresorhus/merge-streams@2.3.0': {}
 
@@ -18346,6 +18382,16 @@ snapshots:
   simple-eval@1.0.1:
     dependencies:
       jsep: 1.4.0
+
+  simple-git@3.36.0:
+    dependencies:
+      '@kwsites/file-exists': 1.1.1
+      '@kwsites/promise-deferred': 1.1.1
+      '@simple-git/args-pathspec': 1.0.3
+      '@simple-git/argv-parser': 1.1.1
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   sisteransi@1.0.5: {}
 


### PR DESCRIPTION
## What This PR Does

Adds support for resolving message schemas from external, configurable schema sources instead of only local files. Introduces a new `gitSchemaSource` connector that clones a git repository and resolves schemas referenced via `git://<source-name>/<path>`. Messages can now reference schemas by `ref`, resolved through schema sources defined in `eventcatalog.config`, and the sidebar reflects the resolved schema format.

## Changes Overview

### Key Changes

- **New `gitSchemaSource` connector** (`packages/connectors/src/git-schema-source.ts`): clones a repo (branch/ref, optional subdirectory, optional HTTPS token) and resolves `git://` schema refs, with path-traversal guards and clear not-found errors.
- **Schema source types** (`packages/connectors/src/types.ts`, `index.ts`): adds `SchemaSource`, `SchemaEntry`, `SchemaEntrySource`, `SchemaResolveContext`, and the `defineSchemaSource` helper.
- **Schema loader** (`packages/core/eventcatalog/src/utils/collections/schema-loader.ts`): resolves schema references through configured sources, supports `ref` references and `file://` refs, and carries richer `source` metadata (provider, id, url, ref, path) plus `readOnly`.
- **Content config & SDK types** (`content.config.ts`, `sdk/src/types.d.ts`): schema pointer/collection now accept `ref` and extended `source` fields; `schemas.sources` wired through from config.
- **Config** (`packages/core/src/eventcatalog.config.ts`): adds `schemas.sources` configuration.
- **Sidebar** (`builders/message.ts`): derives the schema nav title from resolved schema refs/formats and shows the Schema item when `schemas` are present (not just `schemaPath`).
- **Tests**: new connector tests and expanded schema-loader and sidebar-builder coverage.

## How It Works

Schema sources are registered in `eventcatalog.config` under `schemas.sources`. During schema loading, each schema reference (`ref` such as `git://contracts/events/OrderPlaced.schema.json`) is matched against the registered sources via `canResolve`, and the first matching source resolves it to schema content plus source metadata. The git source clones the repo once (shallow, single-branch) and reads files relative to the configured directory, rejecting any path that escapes it.

## Breaking Changes

None. Existing local-file schemas (`schemaPath`) continue to work unchanged.

## Additional Notes

- No editor change is required in `eventcatalog/eventcatalog-editor` for this change.