### PR TITLE
Make code blocks readable in dark mode

### DIFF
--- a/.changeset/dark-code-blocks-readable.md
+++ b/.changeset/dark-code-blocks-readable.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": minor
+---
+
+Fix unreadable code blocks in dark mode by making Expressive Code follow the EventCatalog theme toggle (`data-theme`) instead of the OS dark mode media query.

--- a/packages/core/eventcatalog/astro.config.mjs
+++ b/packages/core/eventcatalog/astro.config.mjs
@@ -19,6 +19,11 @@ import rehypeExpressiveCode from 'rehype-expressive-code';
 /** @type {import('bin/eventcatalog.config').Config} */
 import config from './eventcatalog.config';
 import expressiveCode from 'astro-expressive-code';
+// Expressive Code options (including the non-serializable `themeCssSelector`
+// function) live in ec.config.mjs. The `expressiveCode()` integration loads that
+// file automatically; the rehype plugin used by mdx() below needs it passed
+// explicitly, so we import it here to keep a single source of truth.
+import expressiveCodeConfig from './ec.config.mjs';
 import ecstudioWatcher from './integrations/ecstudio-watcher.mjs';
 import eventCatalogIntegration from './src/enterprise/integrations/eventcatalog-features.ts';
 
@@ -29,15 +34,6 @@ const compress = config.compress ?? false;
 const isDevMode = process.env.EVENTCATALOG_DEV_MODE === 'true';
 const effectiveOutput = isDevMode ? 'server' : config.output || 'static';
 const searchType = config.search?.type || 'resource';
-
-const expressiveCodeConfig = {
-  themes: ['github-light', 'github-dark'],
-  useDarkModeMediaQuery: false,
-  themeCssSelector: (theme) => `[data-theme='${theme.type}']`,
-  defaultProps: {
-    wrap: true,
-  },
-};
 
 const markdownRemarkPlugins = [remarkDirective, remarkDirectives, remarkComment, mermaid, plantuml];
 const mdxRemarkPlugins = [...markdownRemarkPlugins, remarkResourceRef];
@@ -80,9 +76,8 @@ export default defineConfig({
   devToolbar: { enabled: false },
   integrations: [
     react(),
-    expressiveCode({
-      ...expressiveCodeConfig,
-    }),
+    // Options are loaded automatically from ec.config.mjs.
+    expressiveCode(),
     mdx({
       // https://docs.astro.build/en/guides/integrations-guide/mdx/#optimize
       optimize: config.mdxOptimize || false,

--- a/packages/core/eventcatalog/astro.config.mjs
+++ b/packages/core/eventcatalog/astro.config.mjs
@@ -32,6 +32,8 @@ const searchType = config.search?.type || 'resource';
 
 const expressiveCodeConfig = {
   themes: ['github-light', 'github-dark'],
+  useDarkModeMediaQuery: false,
+  themeCssSelector: (theme) => `[data-theme='${theme.type}']`,
   defaultProps: {
     wrap: true,
   },

--- a/packages/core/eventcatalog/ec.config.mjs
+++ b/packages/core/eventcatalog/ec.config.mjs
@@ -1,0 +1,20 @@
+import { defineEcConfig } from 'astro-expressive-code';
+
+// Expressive Code configuration lives in this dedicated file (rather than inline
+// in astro.config.mjs) because it contains non-serializable options such as the
+// `themeCssSelector` function. Astro's `<Code>` component (used on the print
+// pages) requires Expressive Code options coming from the Astro config to be
+// JSON-serializable, so functions must be defined here instead.
+//
+// `useDarkModeMediaQuery: false` + `themeCssSelector` make code blocks follow
+// EventCatalog's own `data-theme` toggle instead of the OS `prefers-color-scheme`
+// media query, so they stay readable when the catalog theme and the OS
+// preference disagree (see issue #2607).
+export default defineEcConfig({
+  themes: ['github-light', 'github-dark'],
+  useDarkModeMediaQuery: false,
+  themeCssSelector: (theme) => `[data-theme='${theme.type}']`,
+  defaultProps: {
+    wrap: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -266,8 +266,8 @@ importers:
         specifier: ^4.0.3
         version: 4.0.3
       hono:
-        specifier: 4.12.18
-        version: 4.12.18
+        specifier: 4.12.21
+        version: 4.12.21
       html-to-image:
         specifier: ^1.11.11
         version: 1.11.13
@@ -5724,8 +5724,8 @@ packages:
   highlightjs-vue@1.0.0:
     resolution: {integrity: sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==}
 
-  hono@4.12.18:
-    resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
+  hono@4.12.21:
+    resolution: {integrity: sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==}
     engines: {node: '>=16.9.0'}
 
   hookable@6.1.0:
@@ -10787,9 +10787,9 @@ snapshots:
     dependencies:
       react: 18.3.1
 
-  '@hono/node-server@1.19.9(hono@4.12.18)':
+  '@hono/node-server@1.19.9(hono@4.12.21)':
     dependencies:
-      hono: 4.12.18
+      hono: 4.12.21
 
   '@iconify-json/logos@1.2.9':
     dependencies:
@@ -11174,7 +11174,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 1.19.9(hono@4.12.18)
+      '@hono/node-server': 1.19.9(hono@4.12.21)
       ajv: 8.17.1
       ajv-formats: 3.0.1(ajv@8.17.1)
       content-type: 1.0.5
@@ -11184,7 +11184,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.2.1(express@5.2.1)
-      hono: 4.12.18
+      hono: 4.12.21
       jose: 6.1.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -15589,7 +15589,7 @@ snapshots:
 
   highlightjs-vue@1.0.0: {}
 
-  hono@4.12.18: {}
+  hono@4.12.21: {}
 
   hookable@6.1.0: {}
 


### PR DESCRIPTION
Fixes #2607

## What This PR Does

Code blocks (and other Expressive Code rendered content like the Avro schema viewer) were unreadable in dark mode because Expressive Code was keying its theme off the OS-level dark mode media query rather than EventCatalog's own theme toggle. When the catalog theme and the OS preference disagreed, you'd get dark text on a dark background. This PR makes Expressive Code follow the `data-theme` attribute so code blocks always match the active EventCatalog theme.

## Changes Overview

### Key Changes

- Configure Expressive Code in `astro.config.mjs` with `useDarkModeMediaQuery: false` so it no longer relies on the OS `prefers-color-scheme` media query.
- Add `themeCssSelector` pointing at `[data-theme='light']` / `[data-theme='dark']` so the light/dark code themes are scoped to EventCatalog's `data-theme` attribute (the same mechanism the rest of the app uses for theming).

## How It Works

EventCatalog toggles light/dark via a `data-theme` attribute on the document. Expressive Code ships two themes (`github-light`, `github-dark`) and by default switches between them using a media query. By disabling the media query and pointing the theme CSS selector at `[data-theme='light']` / `[data-theme='dark']`, the correct code theme is applied based on the active EventCatalog theme rather than the OS setting.

## Breaking Changes

None.

## Additional Notes

- No editor (`eventcatalog/eventcatalog-editor`) change is needed for this fix.