### PR TITLE
Remove backticks from inline code in MDX docs

### DIFF
--- a/.changeset/quiet-pandas-shine.md
+++ b/.changeset/quiet-pandas-shine.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Remove decorative backticks from inline code in MDX docs and improve inline code styling

--- a/packages/core/eventcatalog/src/styles/tailwind.css
+++ b/packages/core/eventcatalog/src/styles/tailwind.css
@@ -2,6 +2,24 @@
 
 @plugin "@tailwindcss/typography";
 
+/*
+ * EventCatalog renders MDX inside Tailwind Typography's `.prose` wrapper.
+ * Typography adds decorative backticks around inline code via pseudo-elements;
+ * docs should show only the code content itself.
+ */
+.prose code::before,
+.prose code::after {
+  content: '';
+}
+
+.prose :not(pre) > code {
+  background-color: oklab(0.97 0 0.0013 / 0.5);
+  border-radius: 0.25rem;
+  font-family: var(--font-mono);
+  padding: 0.125rem 0.375rem;
+  font-weight: 400;
+}
+
 /* Dark mode uses data-theme attribute, not prefers-color-scheme */
 @custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *));
 


### PR DESCRIPTION
Closes #2602
References #2602

## What This PR Does

Inline code in MDX docs was rendering with decorative backticks around it, because Tailwind Typography's `.prose` styles add backtick characters via `code::before` / `code::after` pseudo-elements. This PR overrides those pseudo-elements to show only the code content, and adds explicit inline-code styling (subtle background, padding, rounded corners, mono font) so inline code remains visually distinct without the stray backticks.

## Changes Overview

### Key Changes
- Override `.prose code::before` and `.prose code::after` to render empty content, removing the decorative backticks.
- Add styling for `.prose :not(pre) > code` (background, border-radius, padding, mono font, normal weight) so inline code stays readable.

## How It Works

EventCatalog renders MDX inside Tailwind Typography's `.prose` wrapper. Typography injects backtick characters around inline `<code>` elements through `::before` and `::after` pseudo-elements. Setting their `content` to an empty string suppresses the backticks. The `:not(pre) > code` selector targets only inline code (not fenced code blocks inside `<pre>`), applying lightweight styling that keeps inline code distinguishable from surrounding text.

## Breaking Changes

None.

## Additional Notes

No editor repository change is needed — this is a styling-only change scoped to the core catalog's Tailwind theme.