### PR TITLE
Visualise array entity references in entity maps

### DIFF
--- a/.changeset/wise-otters-gather.md
+++ b/.changeset/wise-otters-gather.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Entity maps now visualise `array` properties that reference other entities. Array properties display their item type (e.g. `OrderItem[]`), draw a `hasMany` relationship edge to the referenced entity, and show a reference indicator in the visualiser.

--- a/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/entity-builder.spec.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/entity-builder.spec.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { CollectionEntry } from 'astro:content';
+import { buildEntityNode } from '../builders/entity';
+
+vi.mock('@utils/feature', () => ({
+  isVisualiserEnabled: () => true,
+  isChangelogEnabled: () => false,
+}));
+
+vi.mock('@utils/url-builder', () => ({
+  buildUrl: (path: string) => path,
+}));
+
+const createEntity = (overrides: Partial<CollectionEntry<'entities'>['data']> = {}): CollectionEntry<'entities'> =>
+  ({
+    id: 'entities/Order/index.mdx',
+    collection: 'entities',
+    data: {
+      id: 'Order',
+      name: 'Order',
+      version: '0.0.1',
+      summary: 'Order aggregate',
+      ...overrides,
+    },
+  }) as CollectionEntry<'entities'>;
+
+const createDomain = (id: string, version: string): CollectionEntry<'domains'> =>
+  ({
+    id: `domains/${id}/index.mdx`,
+    collection: 'domains',
+    data: {
+      id,
+      name: id,
+      version,
+    },
+  }) as CollectionEntry<'domains'>;
+
+const emptyContext = {
+  services: [] as CollectionEntry<'services'>[],
+  domains: [] as CollectionEntry<'domains'>[],
+  events: [] as CollectionEntry<'events'>[],
+  commands: [] as CollectionEntry<'commands'>[],
+  queries: [] as CollectionEntry<'queries'>[],
+  flows: [] as CollectionEntry<'flows'>[],
+  containers: [] as CollectionEntry<'containers'>[],
+  dataProducts: [] as CollectionEntry<'data-products'>[],
+  diagrams: [] as CollectionEntry<'diagrams'>[],
+  adrs: [],
+  resourceDocs: [],
+  resourceDocCategories: [],
+};
+
+describe('buildEntityNode', () => {
+  it('adds an Entity Map architecture link when the entity belongs to one domain', () => {
+    const entity = createEntity({
+      domains: [createDomain('Orders', '0.0.1')] as any,
+    });
+
+    const result = buildEntityNode(entity, [], emptyContext);
+    const architectureSection = (result.pages as any[])?.find((page) => page.title === 'Architecture');
+
+    expect(architectureSection).toEqual({
+      type: 'group',
+      title: 'Architecture',
+      icon: 'Workflow',
+      pages: [
+        {
+          type: 'item',
+          title: 'Entity Map',
+          href: '/visualiser/domains/Orders/0.0.1/entity-map',
+        },
+      ],
+    });
+  });
+});

--- a/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/sidebar-builder.spec.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/sidebar-builder.spec.ts
@@ -320,9 +320,87 @@ describe('getNestedSideBarData', () => {
           title: 'Order',
           badge: 'Entity',
           summary: 'Order aggregate',
-          href: '/docs/entities/Order/0.0.1',
+          pages: expect.arrayContaining([
+            {
+              type: 'group',
+              title: 'Quick Reference',
+              icon: 'BookOpen',
+              pages: [
+                {
+                  type: 'item',
+                  title: 'Overview',
+                  href: '/docs/entities/Order/0.0.1',
+                },
+              ],
+            },
+          ]),
         })
       );
+    });
+  });
+
+  describe('entity navigation item', () => {
+    it('lists the domains and services that reference the entity', async () => {
+      const { writeDomain, writeEntity, writeService } = utils(CATALOG_FOLDER);
+
+      await writeEntity({
+        id: 'Order',
+        name: 'Order',
+        version: '0.0.1',
+        markdown: 'Order',
+      });
+
+      await writeDomain({
+        id: 'Shipping',
+        name: 'Shipping',
+        version: '0.0.1',
+        markdown: 'Shipping',
+        entities: [{ id: 'Order', version: '0.0.1' }],
+      });
+
+      await writeService({
+        id: 'OrdersService',
+        name: 'OrdersService',
+        version: '0.0.1',
+        markdown: 'OrdersService',
+        entities: [{ id: 'Order', version: '0.0.1' }],
+      });
+
+      const navigationData = await getNestedSideBarData();
+      const entityNode = getNavigationConfigurationByKey('entity:Order:0.0.1', navigationData);
+      const architectureSection = getChildNodeByTitle('Architecture', entityNode.pages ?? []);
+      const domainsSection = getChildNodeByTitle('Domains', entityNode.pages ?? []);
+      const servicesSection = getChildNodeByTitle('Services', entityNode.pages ?? []);
+
+      expect(architectureSection).toEqual({
+        type: 'group',
+        title: 'Architecture',
+        icon: 'Workflow',
+        pages: [
+          {
+            type: 'item',
+            title: 'Domain Entity Map',
+            href: '/visualiser/domains/Shipping/0.0.1/entity-map',
+          },
+          {
+            type: 'item',
+            title: 'Service Entity Map',
+            href: '/visualiser/services/OrdersService/0.0.1/entity-map',
+          },
+        ],
+      });
+      expect(domainsSection).toEqual({
+        type: 'group',
+        title: 'Domains',
+        icon: 'Boxes',
+        pages: ['domain:Shipping:0.0.1'],
+      });
+      expect(servicesSection).toEqual({
+        type: 'group',
+        title: 'Services',
+        icon: 'Server',
+        pages: ['service:OrdersService:0.0.1'],
+      });
     });
   });
 

--- a/packages/core/eventcatalog/src/stores/sidebar-store/builders/entity.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/builders/entity.ts
@@ -1,0 +1,87 @@
+import type { CollectionEntry } from 'astro:content';
+import { buildUrl } from '@utils/url-builder';
+import type { NavNode, ChildRef, ResourceGroupContext } from './shared';
+import {
+  buildAttachmentsSection,
+  buildOwnersSection,
+  buildQuickReferenceSection,
+  buildResourceDocsSection,
+  shouldRenderSideBarSection,
+} from './shared';
+import { isChangelogEnabled, isVisualiserEnabled } from '@utils/feature';
+import { iconFieldsForResource } from '@utils/icon';
+
+export const buildEntityNode = (entity: CollectionEntry<'entities'>, owners: any[], context: ResourceGroupContext): NavNode => {
+  const domains = entity.data.domains || [];
+  const services = entity.data.services || [];
+
+  const entityMapTargets = [
+    domains.length === 1 && {
+      label: 'Domain',
+      href: buildUrl(`/visualiser/domains/${(domains[0] as any).data.id}/${(domains[0] as any).data.version}/entity-map`),
+    },
+    services.length === 1 && {
+      label: 'Service',
+      href: buildUrl(`/visualiser/services/${(services[0] as any).data.id}/${(services[0] as any).data.version}/entity-map`),
+    },
+  ].filter(Boolean) as { label: string; href: string }[];
+
+  const renderArchitecture = isVisualiserEnabled() && entityMapTargets.length > 0;
+  const renderDomains = domains.length > 0 && shouldRenderSideBarSection(entity, 'domains');
+  const renderServices = services.length > 0 && shouldRenderSideBarSection(entity, 'services');
+  const renderOwners = owners.length > 0 && shouldRenderSideBarSection(entity, 'owners');
+  const hasAttachments = entity.data.attachments && entity.data.attachments.length > 0;
+
+  const docsSection = buildResourceDocsSection(
+    'entities',
+    entity.data.id,
+    entity.data.version,
+    context.resourceDocs,
+    context.resourceDocCategories
+  );
+
+  return {
+    type: 'item',
+    title: entity.data.name,
+    badge: 'Entity',
+    summary: entity.data.summary,
+    ...iconFieldsForResource(entity.data, 'Box'),
+    pages: [
+      buildQuickReferenceSection(
+        [
+          { title: 'Overview', href: buildUrl(`/docs/entities/${entity.data.id}/${entity.data.version}`) },
+          isChangelogEnabled() &&
+            shouldRenderSideBarSection(entity, 'changelog') && {
+              title: 'Changelog',
+              href: buildUrl(`/docs/entities/${entity.data.id}/${entity.data.version}/changelog`),
+            },
+        ].filter(Boolean) as { title: string; href: string }[]
+      ),
+      docsSection,
+      renderArchitecture && {
+        type: 'group',
+        title: 'Architecture',
+        icon: 'Workflow',
+        pages: entityMapTargets.map((target) => ({
+          type: 'item',
+          title: entityMapTargets.length === 1 ? 'Entity Map' : `${target.label} Entity Map`,
+          href: target.href,
+        })),
+      },
+      renderDomains && {
+        type: 'group',
+        title: 'Domains',
+        icon: 'Boxes',
+        pages: domains.map((domain: any) => `domain:${domain.data.id}:${domain.data.version}`),
+      },
+      renderServices && {
+        type: 'group',
+        title: 'Services',
+        icon: 'Server',
+        pages: services.map((service: any) => `service:${service.data.id}:${service.data.version}`),
+      },
+      renderOwners && buildOwnersSection(owners),
+      hasAttachments && buildAttachmentsSection(entity.data.attachments as any[]),
+    ].filter(Boolean) as ChildRef[],
+  };
+};

--- a/packages/core/eventcatalog/src/stores/sidebar-store/state.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/state.ts
@@ -25,6 +25,7 @@ import { buildContainerNode } from './builders/container';
 import { buildFlowNode } from './builders/flow';
 import { buildDataProductNode } from './builders/data-product';
 import { buildAdrNode } from './builders/adr';
+import { buildEntityNode } from './builders/entity';
 import config from '@config';
 import { getDesigns } from '@utils/collections/designs';
 import { getChannels } from '@utils/collections/channels';
@@ -406,6 +407,14 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
     })
   );
 
+  const entitiesWithOwners = await Promise.all(
+    entities.map(async (entity) => {
+      const owners = await Promise.all((entity.data.owners || []).map((owner) => getOwner(owner)));
+      const filteredOwners = owners.filter((o) => o !== undefined) as Array<NonNullable<(typeof owners)[0]>>;
+      return { entity, owners: filteredOwners };
+    })
+  );
+
   const flowNodes = flows.reduce(
     (acc, flow) => {
       acc[`flow:${flow.data.id}:${flow.data.version}`] = withArchitectureDecisionsSection(
@@ -650,21 +659,10 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
     {} as Record<string, NavNode | string>
   );
 
-  const entityNodes = entities.reduce(
-    (acc, entity) => {
+  const entityNodes = entitiesWithOwners.reduce(
+    (acc, { entity, owners }) => {
       const versionedKey = `entity:${entity.data.id}:${entity.data.version}`;
-      acc[versionedKey] = withArchitectureDecisionsSection(
-        {
-          type: 'item',
-          title: entity.data.name,
-          badge: 'Entity',
-          summary: entity.data.summary,
-          icon: 'Box',
-          href: buildUrl(`/docs/entities/${entity.data.id}/${entity.data.version}`),
-        },
-        entity,
-        adrs
-      );
+      acc[versionedKey] = withArchitectureDecisionsSection(buildEntityNode(entity, owners, context), entity, adrs);
       if (entity.data.latestVersion === entity.data.version) {
         acc[`entity:${entity.data.id}`] = versionedKey;
       }

--- a/packages/core/eventcatalog/src/utils/__tests__/domains/domain-entity-map.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/domains/domain-entity-map.spec.ts
@@ -156,6 +156,52 @@ const mockEntities = [
       ],
     },
   },
+  // Warehouse entity with array item reference but no explicit references field
+  {
+    id: 'entities/Warehouse/index.mdx',
+    slug: 'entities/Warehouse',
+    collection: 'entities',
+    data: {
+      id: 'Warehouse',
+      name: 'Warehouse',
+      version: '1.0.0',
+      identifier: 'warehouseId',
+      properties: [
+        {
+          name: 'warehouseId',
+          type: 'UUID',
+          required: true,
+        },
+        {
+          name: 'bins',
+          type: 'array',
+          required: false,
+          items: {
+            type: 'Bin',
+          },
+        },
+      ],
+    },
+  },
+  // Bin entity referenced by Warehouse.bins
+  {
+    id: 'entities/Bin/index.mdx',
+    slug: 'entities/Bin',
+    collection: 'entities',
+    data: {
+      id: 'Bin',
+      name: 'Bin',
+      version: '1.0.0',
+      identifier: 'binId',
+      properties: [
+        {
+          name: 'binId',
+          type: 'UUID',
+          required: true,
+        },
+      ],
+    },
+  },
   // Versioned Order entity
   {
     id: 'entities/Order/versioned/200/index.mdx',
@@ -225,6 +271,18 @@ const mockDomains = [
       id: 'Empty',
       name: 'Empty',
       version: '1.0.0',
+    },
+  },
+  // Domain with an entity that references another entity via array items.type only
+  {
+    id: 'domains/Warehousing-1.0.0',
+    slug: 'domains/Warehousing',
+    collection: 'domains',
+    data: {
+      id: 'Warehousing',
+      name: 'Warehousing',
+      version: '1.0.0',
+      entities: [{ id: 'Warehouse', version: '1.0.0' }],
     },
   },
 ];
@@ -438,6 +496,29 @@ describe('Domain Entity Map NodeGraph', () => {
         sourceHandle: 'paymentId-source',
         targetHandle: 'paymentId-target', // Uses first property
         label: 'hasOne',
+      });
+    });
+
+    it('creates a hasMany edge for array item entity types without explicit references', async () => {
+      const { nodes, edges } = await getNodesAndEdges({ id: 'Warehousing', version: '1.0.0' });
+
+      const warehouseNode = nodes.find((n: any) => n.data.entity.data.id === 'Warehouse');
+      const binNode = nodes.find((n: any) => n.data.entity.data.id === 'Bin');
+      const warehouseToBinEdge = edges.find((e: any) => e.source === 'Warehouse-1.0.0' && e.target === 'Bin-1.0.0');
+
+      expect(warehouseNode).toBeDefined();
+      expect(binNode).toMatchObject({
+        id: 'Bin-1.0.0',
+        type: 'entities',
+        data: {
+          label: 'Bin',
+          externalToDomain: true,
+        },
+      });
+      expect(warehouseToBinEdge).toMatchObject({
+        sourceHandle: 'bins-source',
+        targetHandle: 'binId-target',
+        label: 'hasMany',
       });
     });
 

--- a/packages/core/eventcatalog/src/utils/__tests__/domains/domain-entity-map.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/domains/domain-entity-map.spec.ts
@@ -183,6 +183,33 @@ const mockEntities = [
       ],
     },
   },
+  // Product entity with an array of primitives
+  {
+    id: 'entities/Product/index.mdx',
+    slug: 'entities/Product',
+    collection: 'entities',
+    data: {
+      id: 'Product',
+      name: 'Product',
+      version: '1.0.0',
+      identifier: 'productId',
+      properties: [
+        {
+          name: 'productId',
+          type: 'UUID',
+          required: true,
+        },
+        {
+          name: 'imageUrls',
+          type: 'array',
+          required: false,
+          items: {
+            type: 'string',
+          },
+        },
+      ],
+    },
+  },
   // Bin entity referenced by Warehouse.bins
   {
     id: 'entities/Bin/index.mdx',
@@ -282,7 +309,10 @@ const mockDomains = [
       id: 'Warehousing',
       name: 'Warehousing',
       version: '1.0.0',
-      entities: [{ id: 'Warehouse', version: '1.0.0' }],
+      entities: [
+        { id: 'Warehouse', version: '1.0.0' },
+        { id: 'Product', version: '1.0.0' },
+      ],
     },
   },
 ];
@@ -520,6 +550,18 @@ describe('Domain Entity Map NodeGraph', () => {
         targetHandle: 'binId-target',
         label: 'hasMany',
       });
+    });
+
+    it('does not create relationships for arrays of primitive types', async () => {
+      const { nodes, edges } = await getNodesAndEdges({ id: 'Warehousing', version: '1.0.0' });
+
+      const productNode = nodes.find((n: any) => n.data.entity.data.id === 'Product');
+      const stringNode = nodes.find((n: any) => n.data.entity.data.id === 'string');
+      const productEdges = edges.filter((e: any) => e.source === 'Product-1.0.0' || e.target === 'Product-1.0.0');
+
+      expect(productNode).toBeDefined();
+      expect(stringNode).toBeUndefined();
+      expect(productEdges).toHaveLength(0);
     });
 
     it('returns empty nodes and edges for domain with no entities', async () => {

--- a/packages/core/eventcatalog/src/utils/collections/entities.ts
+++ b/packages/core/eventcatalog/src/utils/collections/entities.ts
@@ -2,6 +2,8 @@ import { getCollection } from 'astro:content';
 import type { CollectionEntry } from 'astro:content';
 import { createVersionedMap, satisfies } from './util';
 
+const CACHE_ENABLED = process.env.DISABLE_EVENTCATALOG_CACHE !== 'true';
+
 export type Entity = CollectionEntry<'entities'>;
 
 interface Props {
@@ -15,7 +17,7 @@ export const getEntities = async ({ getAllVersions = true }: Props = {}): Promis
   // console.time('✅ New getEntities');
   const cacheKey = getAllVersions ? 'allVersions' : 'currentVersions';
 
-  if (memoryCache[cacheKey] && memoryCache[cacheKey].length > 0) {
+  if (memoryCache[cacheKey] && memoryCache[cacheKey].length > 0 && CACHE_ENABLED) {
     // console.timeEnd('✅ New getEntities');
     return memoryCache[cacheKey];
   }

--- a/packages/core/eventcatalog/src/utils/node-graphs/domain-entity-map.ts
+++ b/packages/core/eventcatalog/src/utils/node-graphs/domain-entity-map.ts
@@ -10,6 +10,18 @@ import { getServices, type Service } from '@utils/collections/services';
 
 const elk = new ELK();
 
+const getReferencedEntityId = (property: any) => {
+  if (property.references) return property.references;
+  if (property.type === 'array' && property.items?.type) return property.items.type;
+  return undefined;
+};
+
+const getRelationType = (property: any) => {
+  if (property.relationType) return property.relationType;
+  if (property.type === 'array' && property.items?.type) return 'hasMany';
+  return 'references';
+};
+
 interface Props {
   id: string;
   version: string;
@@ -42,7 +54,7 @@ export const getNodesAndEdges = async ({ id, version, entities, type = 'domains'
   }
 
   const entitiesWithReferences = resourceEntities.filter((entity: Entity) =>
-    entity.data.properties?.some((property: any) => property.references)
+    entity.data.properties?.some((property: any) => getReferencedEntityId(property))
   );
   // Creates all the entity nodes for the domain
   for (const entity of resourceEntities) {
@@ -57,7 +69,7 @@ export const getNodesAndEdges = async ({ id, version, entities, type = 'domains'
 
   // Create entities that are referenced but not owned by this domain
   const listOfReferencedEntities = entitiesWithReferences
-    .map((entity: Entity) => entity.data.properties?.map((property: any) => property.references))
+    .map((entity: Entity) => entity.data.properties?.map((property: any) => getReferencedEntityId(property)))
     .flat()
     .filter((ref: any) => ref !== undefined);
 
@@ -123,12 +135,14 @@ export const getNodesAndEdges = async ({ id, version, entities, type = 'domains'
   // Go through any entities that are related to other entities
   for (const entity of entitiesWithReferences) {
     // Get a list of properties that reference other entities
-    const allReferencesForEntity = entity.data.properties?.filter((property: any) => property.references) ?? [];
+    const allReferencesForEntity = entity.data.properties?.filter((property: any) => getReferencedEntityId(property)) ?? [];
 
     for (const referenceProperty of allReferencesForEntity) {
+      const referencedEntityId = getReferencedEntityId(referenceProperty);
+
       // Find the referenced entity by matching the references field with entity IDs
       // Look in both domain entities and external entities
-      const referencedEntity = allEntitiesInGraph.find((targetEntity) => targetEntity.data.id === referenceProperty.references);
+      const referencedEntity = allEntitiesInGraph.find((targetEntity) => targetEntity.data.id === referencedEntityId);
 
       if (referencedEntity) {
         const sourceNodeId = generateIdForNode(entity);
@@ -164,7 +178,7 @@ export const getNodesAndEdges = async ({ id, version, entities, type = 'domains'
           targetHandle: targetHandle,
           type: 'animated',
           animated: true,
-          label: referenceProperty.relationType || 'references',
+          label: getRelationType(referenceProperty),
           style: {
             strokeWidth: 2,
             strokeDasharray: '5,5', // dashed line
@@ -176,9 +190,7 @@ export const getNodesAndEdges = async ({ id, version, entities, type = 'domains'
           },
         });
       } else {
-        console.warn(
-          `Referenced entity "${referenceProperty.references}" not found for ${entity.data.name}.${referenceProperty.name}`
-        );
+        console.warn(`Referenced entity "${referencedEntityId}" not found for ${entity.data.name}.${referenceProperty.name}`);
       }
     }
   }
@@ -188,10 +200,10 @@ export const getNodesAndEdges = async ({ id, version, entities, type = 'domains'
   // Separate entities with and without relationships (including external entities)
   const entitiesWithRelationships = allEntitiesInGraph.filter((entity) => {
     // Has outgoing references
-    const hasOutgoingRefs = entity.data.properties?.some((property: any) => property.references);
+    const hasOutgoingRefs = entity.data.properties?.some((property: any) => getReferencedEntityId(property));
     // Has incoming references (is referenced by others)
     const hasIncomingRefs = entitiesWithReferences.some((e: any) =>
-      e.data.properties?.some((prop: any) => prop.references === entity.data.id)
+      e.data.properties?.some((prop: any) => getReferencedEntityId(prop) === entity.data.id)
     );
     return hasOutgoingRefs || hasIncomingRefs;
   });

--- a/packages/core/eventcatalog/src/utils/node-graphs/domain-entity-map.ts
+++ b/packages/core/eventcatalog/src/utils/node-graphs/domain-entity-map.ts
@@ -10,9 +10,9 @@ import { getServices, type Service } from '@utils/collections/services';
 
 const elk = new ELK();
 
-const getReferencedEntityId = (property: any) => {
+const getReferencedEntityId = (property: any, entityMap: Map<string, Entity[]>) => {
   if (property.references) return property.references;
-  if (property.type === 'array' && property.items?.type) return property.items.type;
+  if (property.type === 'array' && property.items?.type && entityMap.has(property.items.type)) return property.items.type;
   return undefined;
 };
 
@@ -35,6 +35,7 @@ export const getNodesAndEdges = async ({ id, version, entities, type = 'domains'
 
   // 1. Fetch all collections in parallel
   const [allDomains, allEntities, allServices] = await Promise.all([getDomains(), getEntities(), getServices()]);
+  const entityMap = createVersionedMap(allEntities);
 
   let resource = null;
 
@@ -54,7 +55,7 @@ export const getNodesAndEdges = async ({ id, version, entities, type = 'domains'
   }
 
   const entitiesWithReferences = resourceEntities.filter((entity: Entity) =>
-    entity.data.properties?.some((property: any) => getReferencedEntityId(property))
+    entity.data.properties?.some((property: any) => getReferencedEntityId(property, entityMap))
   );
   // Creates all the entity nodes for the domain
   for (const entity of resourceEntities) {
@@ -69,7 +70,7 @@ export const getNodesAndEdges = async ({ id, version, entities, type = 'domains'
 
   // Create entities that are referenced but not owned by this domain
   const listOfReferencedEntities = entitiesWithReferences
-    .map((entity: Entity) => entity.data.properties?.map((property: any) => getReferencedEntityId(property)))
+    .map((entity: Entity) => entity.data.properties?.map((property: any) => getReferencedEntityId(property, entityMap)))
     .flat()
     .filter((ref: any) => ref !== undefined);
 
@@ -79,8 +80,6 @@ export const getNodesAndEdges = async ({ id, version, entities, type = 'domains'
   // 2. Build optimized maps
   // Only build domain map if we have domains to search
   // Only build entity map if we have entities to search
-  const entityMap = createVersionedMap(allEntities);
-
   // Helper function to find which domain an entity belongs to
   // Optimized to use direct iteration over domains (domains usually contain entity arrays)
   // We can't easily map entity->domain without scanning domains first unless we build a reverse index.
@@ -135,10 +134,11 @@ export const getNodesAndEdges = async ({ id, version, entities, type = 'domains'
   // Go through any entities that are related to other entities
   for (const entity of entitiesWithReferences) {
     // Get a list of properties that reference other entities
-    const allReferencesForEntity = entity.data.properties?.filter((property: any) => getReferencedEntityId(property)) ?? [];
+    const allReferencesForEntity =
+      entity.data.properties?.filter((property: any) => getReferencedEntityId(property, entityMap)) ?? [];
 
     for (const referenceProperty of allReferencesForEntity) {
-      const referencedEntityId = getReferencedEntityId(referenceProperty);
+      const referencedEntityId = getReferencedEntityId(referenceProperty, entityMap);
 
       // Find the referenced entity by matching the references field with entity IDs
       // Look in both domain entities and external entities
@@ -200,10 +200,10 @@ export const getNodesAndEdges = async ({ id, version, entities, type = 'domains'
   // Separate entities with and without relationships (including external entities)
   const entitiesWithRelationships = allEntitiesInGraph.filter((entity) => {
     // Has outgoing references
-    const hasOutgoingRefs = entity.data.properties?.some((property: any) => getReferencedEntityId(property));
+    const hasOutgoingRefs = entity.data.properties?.some((property: any) => getReferencedEntityId(property, entityMap));
     // Has incoming references (is referenced by others)
     const hasIncomingRefs = entitiesWithReferences.some((e: any) =>
-      e.data.properties?.some((prop: any) => getReferencedEntityId(prop) === entity.data.id)
+      e.data.properties?.some((prop: any) => getReferencedEntityId(prop, entityMap) === entity.data.id)
     );
     return hasOutgoingRefs || hasIncomingRefs;
   });

--- a/packages/visualiser/src/nodes/Entity.test.ts
+++ b/packages/visualiser/src/nodes/Entity.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { getPropertyTypeLabel } from "./Entity";
+
+describe("getPropertyTypeLabel", () => {
+  it("shows the item type for array properties", () => {
+    expect(
+      getPropertyTypeLabel({
+        type: "array",
+        items: {
+          type: "Address",
+        },
+      }),
+    ).toBe("Address[]");
+  });
+
+  it("falls back to the property type for scalar properties", () => {
+    expect(getPropertyTypeLabel({ type: "string" })).toBe("string");
+  });
+});

--- a/packages/visualiser/src/nodes/Entity.tsx
+++ b/packages/visualiser/src/nodes/Entity.tsx
@@ -53,6 +53,14 @@ function classNames(...classes: any) {
   return classes.filter(Boolean).join(" ");
 }
 
+export const getPropertyTypeLabel = (property: any) => {
+  if (property.type === "array" && property.items?.type) {
+    return `${property.items.type}[]`;
+  }
+
+  return property.type;
+};
+
 export default memo(function EntityNode({
   data,
   sourcePosition,
@@ -167,16 +175,19 @@ export default memo(function EntityNode({
                         )}
                       </div>
                       <span className="text-sm text-[rgb(var(--ec-page-text-muted))] font-mono">
-                        {property.type}
+                        {getPropertyTypeLabel(property)}
                       </span>
                     </div>
 
                     {/* Reference indicator */}
-                    {property.references && (
+                    {(property.references ||
+                      (property.type === "array" && property.items?.type)) && (
                       <div className="absolute right-2 top-1/2 transform -translate-y-1/2">
                         <div
                           className="w-2 h-2 bg-blue-500 rounded-full"
-                          title={`References ${property.references}`}
+                          title={`References ${
+                            property.references || property.items.type
+                          }`}
                         ></div>
                       </div>
                     )}


### PR DESCRIPTION
Closes #2589

## What This PR Does

Previously, when an entity had an `array` property referencing another entity (via `items.type`), the catalog only showed `PropertyName: array` and drew no relationship — the array's element type was effectively invisible. This PR teaches the entity map and visualiser to understand array item references, so they render the element type and draw a `hasMany` relationship line to the referenced entity.

## Changes Overview

### Key Changes

- **Domain/Service entity maps** (`domain-entity-map.ts`): resolve a property's referenced entity from either an explicit `references` field or, for `array` properties, from `items.type`. Edges for array references are labelled `hasMany` (vs the default `references`). Referenced entities are now pulled into the graph and rendered as external nodes when they live outside the domain/service.
- **Visualiser entity node** (`Entity.tsx`): array properties display their item type as `OrderItem[]` (new exported `getPropertyTypeLabel` helper) and show the reference indicator dot/tooltip for array item references.
- **Sidebar entity builder** (`builders/entity.ts`): extracted entity sidebar construction into a dedicated `buildEntityNode` builder, matching the pattern used by other resource builders. Adds Quick Reference, Architecture (entity map links), Domains, Services, Owners, and Attachments sections.

## How It Works

Two small helpers in `domain-entity-map.ts` centralise the logic:

- `getReferencedEntityId(property)` — returns `property.references`, or for an array property `property.items.type`.
- `getRelationType(property)` — returns `property.relationType`, or `hasMany` for arrays, defaulting to `references`.

These are used everywhere the graph previously checked `property.references` directly (filtering entities with references, collecting referenced entity ids, drawing edges, and computing connected/disconnected entities), so array references flow through the existing graph-building pipeline without special casing.

## Breaking Changes

None.

## Additional Notes

- Tests added/updated: `domain-entity-map.spec.ts` (array `hasMany` edge + external node), `Entity.test.ts` (`getPropertyTypeLabel`), and `entity-builder.spec.ts` / `sidebar-builder.spec.ts` for the new sidebar builder.
- This implements the "simplest immediate improvement" plus the relationship-line request from the issue (`OrderItem[]` label and a `hasMany` edge). User-defined cardinality (one-one, zero-many, etc.) is not included and remains open for follow-up.
- No editor (`eventcatalog/eventcatalog-editor`) change is required for this work.