### PR TITLE
Hide Ubiquitous Language link and pages when no terms are defined

### DIFF
--- a/.changeset/quiet-otters-jump.md
+++ b/.changeset/quiet-otters-jump.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Hide the Ubiquitous Language sidebar link and language pages for domains (and their subdomains) that have no ubiquitous language terms defined

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/language.mdx.ts
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/language.mdx.ts
@@ -1,4 +1,4 @@
-import { getDomains, getUbiquitousLanguage } from '@utils/collections/domains';
+import { getDomains, getUbiquitousLanguage, hasUbiquitousLanguageTerms } from '@utils/collections/domains';
 import type { CollectionEntry } from 'astro:content';
 import type { APIRoute } from 'astro';
 import config from '@config';
@@ -9,8 +9,19 @@ import { filterMarkdownForAgents } from '@utils/llms';
 export async function getStaticPaths() {
   const domains = await getDomains({ getAllVersions: false });
 
-  const buildPages = (collection: CollectionEntry<'domains'>[]) => {
-    return collection.map((item) => ({
+  const buildPages = async (collection: CollectionEntry<'domains'>[]) => {
+    const collectionWithUbiquitousLanguage = await collection.reduce<Promise<CollectionEntry<'domains'>[]>>(async (acc, item) => {
+      const accumulator = await acc;
+      const ubiquitousLanguages = await getUbiquitousLanguage(item);
+
+      if (ubiquitousLanguages.some(hasUbiquitousLanguageTerms)) {
+        return [...accumulator, item];
+      }
+
+      return accumulator;
+    }, Promise.resolve([]));
+
+    return collectionWithUbiquitousLanguage.map((item) => ({
       params: {
         type: item.collection,
         id: item.data.id,
@@ -22,7 +33,7 @@ export async function getStaticPaths() {
     }));
   };
 
-  return [...buildPages(domains)];
+  return [...(await buildPages(domains))];
 }
 
 export const GET: APIRoute = async ({ params, props }) => {
@@ -40,7 +51,7 @@ export const GET: APIRoute = async ({ params, props }) => {
   const ubiquitousLanguages = await getUbiquitousLanguage(domain as CollectionEntry<'domains'>);
   const ubiquitousLanguage = ubiquitousLanguages[0];
 
-  if (ubiquitousLanguage?.filePath) {
+  if (ubiquitousLanguage?.filePath && hasUbiquitousLanguageTerms(ubiquitousLanguage)) {
     let file = filterMarkdownForAgents(fs.readFileSync(ubiquitousLanguage.filePath, 'utf8'));
 
     return new Response(file, { status: 200 });

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/language/_index.data.ts
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/language/_index.data.ts
@@ -10,10 +10,19 @@ export class Page extends HybridPage {
       return [];
     }
 
-    const { getDomains } = await import('@utils/collections/domains');
+    const { getDomains, hasUbiquitousLanguageTermsWithSubdomains } = await import('@utils/collections/domains');
     const domains = await getDomains({ getAllVersions: false });
+    const domainsWithUbiquitousLanguage = await domains.reduce<Promise<typeof domains>>(async (acc, domain) => {
+      const accumulator = await acc;
 
-    return domains.map((item) => ({
+      if (await hasUbiquitousLanguageTermsWithSubdomains(domain)) {
+        return [...accumulator, domain];
+      }
+
+      return accumulator;
+    }, Promise.resolve([]));
+
+    return domainsWithUbiquitousLanguage.map((item) => ({
       params: {
         type: item.collection,
         id: item.data.id,
@@ -23,9 +32,15 @@ export class Page extends HybridPage {
   }
 
   protected static async fetchData(params: any) {
-    const { getDomains } = await import('@utils/collections/domains');
+    const { getDomains, hasUbiquitousLanguageTermsWithSubdomains } = await import('@utils/collections/domains');
     const domains = await getDomains({ getAllVersions: false });
-    return domains.find((d) => d.data.id === params.id && d.collection === params.type) || null;
+    const domain = domains.find((d) => d.data.id === params.id && d.collection === params.type);
+
+    if (!domain || !(await hasUbiquitousLanguageTermsWithSubdomains(domain))) {
+      return null;
+    }
+
+    return domain;
   }
 
   protected static createNotFoundResponse(): Response {

--- a/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/sidebar-builder.spec.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/sidebar-builder.spec.ts
@@ -12,6 +12,7 @@ const mockResourceDocs: any[] = [];
 const mockResourceDocCategories: any[] = [];
 const mockAgents: any[] = [];
 const mockSchemas: any[] = [];
+const mockUbiquitousLanguages: any[] = [];
 
 declare global {
   interface Window {
@@ -107,6 +108,10 @@ vi.mock('astro:content', async (importOriginal) => {
           const { getDataProducts } = utils(CATALOG_FOLDER);
           const dataProducts = (await getDataProducts()) ?? [];
           return Promise.resolve(dataProducts.map((dataProduct) => toAstroCollection(dataProduct, 'data-products')));
+        case 'ubiquitousLanguages':
+          return Promise.resolve(
+            mockUbiquitousLanguages.map((ubiquitousLanguage) => toAstroCollection(ubiquitousLanguage, 'ubiquitousLanguages'))
+          );
         case 'resourceDocs':
           return Promise.resolve(mockResourceDocs);
         case 'resourceDocCategories':
@@ -118,7 +123,7 @@ vi.mock('astro:content', async (importOriginal) => {
   };
 });
 
-const buildDomainQuickReferenceSection = (resource: any) => {
+const buildDomainQuickReferenceSection = (resource: any, includeUbiquitousLanguage = false) => {
   return {
     type: 'group',
     title: 'Quick Reference',
@@ -129,12 +134,12 @@ const buildDomainQuickReferenceSection = (resource: any) => {
         title: 'Overview',
         href: `/docs/${resource.collection}/${resource.data.id}/${resource.data.version}`,
       },
-      {
+      includeUbiquitousLanguage && {
         type: 'item',
         title: 'Ubiquitous Language',
         href: `/docs/domains/${resource.data.id}/language`,
       },
-    ],
+    ].filter(Boolean),
   };
 };
 
@@ -164,6 +169,7 @@ describe('getNestedSideBarData', () => {
     mockResourceDocCategories.length = 0;
     mockAgents.length = 0;
     mockSchemas.length = 0;
+    mockUbiquitousLanguages.length = 0;
     fs.rmSync(CATALOG_FOLDER, { recursive: true, force: true });
     fs.mkdirSync(CATALOG_FOLDER, { recursive: true });
     // Remove any navigation data from teh config
@@ -419,7 +425,7 @@ describe('getNestedSideBarData', () => {
     });
 
     describe('quick reference section', () => {
-      it('the overview link ubiquitous language link are always listed in the navigation item', async () => {
+      it('the overview link is always listed in the navigation item', async () => {
         const { writeDomain } = utils(CATALOG_FOLDER);
 
         await writeDomain({
@@ -433,7 +439,51 @@ describe('getNestedSideBarData', () => {
         const domainNode = getNavigationConfigurationByKey('domain:Shipping:0.0.1', navigationData);
 
         expect(domainNode).toHaveNavigationLink({ type: 'item', title: 'Overview', href: '/docs/domains/Shipping/0.0.1' });
+      });
+
+      it('the ubiquitous language link is listed when terms are defined', async () => {
+        const { writeDomain } = utils(CATALOG_FOLDER);
+
+        await writeDomain({
+          id: 'Shipping',
+          name: 'Shipping',
+          version: '0.0.1',
+          markdown: 'Shipping',
+        });
+        mockUbiquitousLanguages.push({
+          dictionary: [
+            {
+              id: 'Shipment',
+              name: 'Shipment',
+              summary: 'Goods prepared for delivery',
+            },
+          ],
+        });
+
+        const navigationData = await getNestedSideBarData();
+        const domainNode = getNavigationConfigurationByKey('domain:Shipping:0.0.1', navigationData);
+
         expect(domainNode).toHaveNavigationLink({
+          type: 'item',
+          title: 'Ubiquitous Language',
+          href: '/docs/domains/Shipping/language',
+        });
+      });
+
+      it('the ubiquitous language link is not listed when no terms are defined', async () => {
+        const { writeDomain } = utils(CATALOG_FOLDER);
+
+        await writeDomain({
+          id: 'Shipping',
+          name: 'Shipping',
+          version: '0.0.1',
+          markdown: 'Shipping',
+        });
+
+        const navigationData = await getNestedSideBarData();
+        const domainNode = getNavigationConfigurationByKey('domain:Shipping:0.0.1', navigationData);
+
+        expect(domainNode).not.toHaveNavigationLink({
           type: 'item',
           title: 'Ubiquitous Language',
           href: '/docs/domains/Shipping/language',
@@ -452,6 +502,15 @@ describe('getNestedSideBarData', () => {
               visible: false,
             },
           },
+        });
+        mockUbiquitousLanguages.push({
+          dictionary: [
+            {
+              id: 'Shipment',
+              name: 'Shipment',
+              summary: 'Goods prepared for delivery',
+            },
+          ],
         });
         const navigationData = await getNestedSideBarData();
         const domainNode = getNavigationConfigurationByKey('domain:Shipping:0.0.1', navigationData);

--- a/packages/core/eventcatalog/src/stores/sidebar-store/builders/domain.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/builders/domain.ts
@@ -13,7 +13,7 @@ import {
 } from './shared';
 import { isVisualiserEnabled, isChangelogEnabled } from '@utils/feature';
 import { pluralizeMessageType } from '@utils/collections/messages';
-import { getSpecificationsForDomain } from '@utils/collections/domains';
+import { getSpecificationsForDomain, hasUbiquitousLanguageTermsWithSubdomainsInCollection } from '@utils/collections/domains';
 import { iconFieldsForResource } from '@utils/icon';
 
 export const buildDomainNode = (domain: CollectionEntry<'domains'>, owners: any[], context: ResourceGroupContext): NavNode => {
@@ -41,7 +41,9 @@ export const buildDomainNode = (domain: CollectionEntry<'domains'>, owners: any[
   const resourceGroups = domain.data.resourceGroups || [];
   const hasResourceGroups = resourceGroups.length > 0;
 
-  const renderUbiquitousLanguage = shouldRenderSideBarSection(domain, 'ubiquitousLanguage');
+  const renderUbiquitousLanguage =
+    hasUbiquitousLanguageTermsWithSubdomainsInCollection(domain, context.ubiquitousLanguages || []) &&
+    shouldRenderSideBarSection(domain, 'ubiquitousLanguage');
   const renderOwners = owners.length > 0 && shouldRenderSideBarSection(domain, 'owners');
 
   const renderVisualiser = isVisualiserEnabled();

--- a/packages/core/eventcatalog/src/stores/sidebar-store/builders/shared.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/builders/shared.ts
@@ -66,6 +66,7 @@ export type ResourceGroupContext = {
   containers: CollectionEntry<'containers'>[];
   entities?: CollectionEntry<'entities'>[];
   dataProducts: CollectionEntry<'data-products'>[];
+  ubiquitousLanguages?: CollectionEntry<'ubiquitousLanguages'>[];
   diagrams: CollectionEntry<'diagrams'>[];
   schemas?: CollectionEntry<'schemas'>[];
   adrs: Adr[];

--- a/packages/core/eventcatalog/src/stores/sidebar-store/state.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/state.ts
@@ -294,6 +294,7 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
     entities,
     adrs,
     schemas,
+    ubiquitousLanguages,
     resourceDocs,
     resourceDocCategories,
   ] = await Promise.all([
@@ -312,6 +313,7 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
     getEntities({ getAllVersions: false }),
     getAdrs({ getAllVersions: false }),
     getCollection('schemas'),
+    getCollection('ubiquitousLanguages'),
     getResourceDocs(),
     getResourceDocCategories(),
   ]);
@@ -334,6 +336,7 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
     channels,
     diagrams,
     schemas,
+    ubiquitousLanguages,
     dataProducts,
     entities,
     adrs,

--- a/packages/core/eventcatalog/src/utils/__tests__/domains/domains.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/domains/domains.spec.ts
@@ -6,6 +6,7 @@ import {
   getDomains,
   getDomainsForService,
   getParentDomains,
+  hasUbiquitousLanguageTermsWithSubdomains,
   getUbiquitousLanguage,
   getUbiquitousLanguageWithSubdomains,
 } from '../../collections/domains';
@@ -238,6 +239,52 @@ describe('Domains', () => {
       expect(result.domain).toBeNull();
       expect(result.subdomains).toHaveLength(0);
       expect(result.duplicateTerms.size).toBe(0);
+    });
+
+    it('should return true when a domain has ubiquitous language terms', async () => {
+      const domains = await getDomains();
+      const shippingDomain = domains.find((d) => d.data.id === 'Shipping');
+
+      const result = await hasUbiquitousLanguageTermsWithSubdomains(shippingDomain as Domain);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return true when a subdomain has ubiquitous language terms', async () => {
+      const checkoutDomain = mockDomains.find((d) => d.data.id === 'Checkout') as unknown as Domain;
+      const mockDomainWithSubdomainLanguage = {
+        id: 'domains/Parent/index.mdx',
+        collection: 'domains',
+        filePath: 'domains/Parent/index.mdx',
+        data: {
+          id: 'Parent',
+          name: 'Parent',
+          version: '0.0.1',
+          domains: [checkoutDomain],
+        },
+      };
+
+      const result = await hasUbiquitousLanguageTermsWithSubdomains(mockDomainWithSubdomainLanguage as unknown as Domain);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false when a domain and its subdomains have no ubiquitous language terms', async () => {
+      const mockDomainWithoutLanguage = {
+        id: 'domains/Empty/index.mdx',
+        collection: 'domains',
+        filePath: 'domains/Empty/index.mdx',
+        data: {
+          id: 'Empty',
+          name: 'Empty',
+          version: '0.0.1',
+          domains: [],
+        },
+      };
+
+      const result = await hasUbiquitousLanguageTermsWithSubdomains(mockDomainWithoutLanguage as unknown as Domain);
+
+      expect(result).toBe(false);
     });
   });
 

--- a/packages/core/eventcatalog/src/utils/collections/domains.ts
+++ b/packages/core/eventcatalog/src/utils/collections/domains.ts
@@ -367,6 +367,36 @@ export const getUbiquitousLanguage = async (domain: Domain): Promise<UbiquitousL
   return ubiquitousLanguages;
 };
 
+export const hasUbiquitousLanguageTerms = (ubiquitousLanguage: UbiquitousLanguage | null | undefined): boolean =>
+  (ubiquitousLanguage?.data?.dictionary?.length || 0) > 0;
+
+export const getUbiquitousLanguageFromCollection = (
+  domain: Domain,
+  ubiquitousLanguages: UbiquitousLanguage[]
+): UbiquitousLanguage[] => {
+  const domainFolder = path.dirname(domain.filePath || '');
+
+  return ubiquitousLanguages.filter((ubiquitousLanguage) => {
+    const ubiquitousLanguageFolder = path.dirname(ubiquitousLanguage.filePath || '');
+    return domainFolder === ubiquitousLanguageFolder;
+  });
+};
+
+export const hasUbiquitousLanguageTermsInCollection = (domain: Domain, ubiquitousLanguages: UbiquitousLanguage[]): boolean =>
+  getUbiquitousLanguageFromCollection(domain, ubiquitousLanguages).some(hasUbiquitousLanguageTerms);
+
+export const hasUbiquitousLanguageTermsWithSubdomainsInCollection = (
+  domain: Domain,
+  ubiquitousLanguages: UbiquitousLanguage[]
+): boolean => {
+  const subdomains = (domain.data.domains as unknown as Domain[]) || [];
+
+  return (
+    hasUbiquitousLanguageTermsInCollection(domain, ubiquitousLanguages) ||
+    subdomains.some((subdomain) => hasUbiquitousLanguageTermsInCollection(subdomain, ubiquitousLanguages))
+  );
+};
+
 export const getUbiquitousLanguageWithSubdomains = async (
   domain: Domain
 ): Promise<{
@@ -426,6 +456,15 @@ export const getUbiquitousLanguageWithSubdomains = async (
     subdomains: subdomainULs,
     duplicateTerms,
   };
+};
+
+export const hasUbiquitousLanguageTermsWithSubdomains = async (domain: Domain): Promise<boolean> => {
+  const { domain: domainUbiquitousLanguage, subdomains } = await getUbiquitousLanguageWithSubdomains(domain);
+
+  return (
+    hasUbiquitousLanguageTerms(domainUbiquitousLanguage) ||
+    subdomains.some(({ ubiquitousLanguage }) => hasUbiquitousLanguageTerms(ubiquitousLanguage))
+  );
 };
 
 export const getParentDomains = async (domain: Domain): Promise<Domain[]> => {


### PR DESCRIPTION
Closes #2515

## What This PR Does

The "Ubiquitous Language" link was always shown in a domain's Quick Reference sidebar section, and the corresponding language pages (`/docs/domains/{id}/language` and the agent-facing `language.mdx`) were always generated — even when a domain (and its subdomains) had no ubiquitous language terms defined. This PR makes those links and pages appear only when there are actually terms to display.

## Changes Overview

### Key Changes

- Sidebar: the Ubiquitous Language link now only renders when the domain or one of its subdomains has ubiquitous language terms.
- Language pages: `getStaticPaths` for both the HTML page and the agent `language.mdx` route now skip domains that have no terms, so empty language pages are no longer built. `fetchData` returns `null` (404) for empty domains.
- New helpers in `@utils/collections/domains`:
  - `hasUbiquitousLanguageTerms` — checks a single ubiquitous language entry for terms.
  - `getUbiquitousLanguageFromCollection` / `hasUbiquitousLanguageTermsInCollection` — synchronous, collection-driven checks used by the sidebar builder.
  - `hasUbiquitousLanguageTermsWithSubdomainsInCollection` — collection-driven check across a domain and its subdomains.
  - `hasUbiquitousLanguageTermsWithSubdomains` — async check across a domain and its subdomains, used by page routes.
- Sidebar store now loads the `ubiquitousLanguages` collection and threads it through `ResourceGroupContext` so the domain builder can check term presence without extra async lookups.

## How It Works

The sidebar builder receives the full `ubiquitousLanguages` collection via `ResourceGroupContext` and matches entries to a domain by comparing their folder paths. The page routes use the existing async `getUbiquitousLanguageWithSubdomains` helper to determine whether any terms exist before building the page. A term is considered present when the ubiquitous language `dictionary` is non-empty.

## Breaking Changes

None.

## Additional Notes

- Tests added/updated in `sidebar-builder.spec.ts` (link shown/hidden cases) and `domains.spec.ts` (domain, subdomain, and empty cases).
- No corresponding change needed in the `eventcatalog-editor` repository.