### PR TITLE
Add Protobuf support to SchemaViewer and Schema Explorer

### DIFF
--- a/.changeset/orange-protos-render.md
+++ b/.changeset/orange-protos-render.md
@@ -1,0 +1,11 @@
+---
+"@eventcatalog/core": minor
+---
+
+feat(core): add Protobuf support to SchemaViewer and Schema Explorer
+
+The `<SchemaViewer />` MDX component and the Schema Explorer now render
+structured views for Protocol Buffers (`.proto`) schemas, like JSON Schema
+and Avro. Includes a dependency-free proto2/proto3 parser that captures
+doc comments, nested messages, enums, maps, and oneofs. Also fixes the
+Schema Explorer filter panel not collapsing when filters are active.

--- a/examples/default/domains/E-Commerce/subdomains/Orders/services/InventoryService/events/WarehouseStockSnapshot/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Orders/services/InventoryService/events/WarehouseStockSnapshot/index.mdx
@@ -1,0 +1,33 @@
+---
+id: WarehouseStockSnapshot
+version: 0.0.1
+name: Warehouse Stock Snapshot
+summary: Periodic snapshot of stock positions across an entire warehouse
+tags:
+  - inventory
+  - warehouse
+  - snapshot
+badges:
+  - content: New
+    backgroundColor: neutral
+    textColor: neutral
+schemaPath: schema.proto
+---
+
+import Footer from '@catalog/components/footer.astro'
+
+## Overview
+
+The `WarehouseStockSnapshot` event is published every 15 minutes by the warehouse management system. It contains the stock position of every SKU in every zone of a warehouse, and is used to reconcile the central inventory ledger.
+
+## Schema
+
+<SchemaViewer title="WarehouseStockSnapshot Schema" file="schema.proto" />
+
+## Event Details
+
+- **Zones**: Each physical zone reports its own stock levels per SKU, including damaged and reserved units
+- **Count Confidence**: Indicates whether counts are system-calculated or verified by physical counts
+- **Sequence Number**: Monotonically increasing per warehouse so consumers can detect missed snapshots
+
+<Footer />

--- a/examples/default/domains/E-Commerce/subdomains/Orders/services/InventoryService/events/WarehouseStockSnapshot/schema.proto
+++ b/examples/default/domains/E-Commerce/subdomains/Orders/services/InventoryService/events/WarehouseStockSnapshot/schema.proto
@@ -1,0 +1,54 @@
+syntax = "proto3";
+
+package com.ecommerce.inventory.warehouse;
+
+// The stock position of a single SKU within one warehouse zone.
+message StockLevel {
+  // How confident the system is in this count.
+  enum CountConfidence {
+    COUNT_CONFIDENCE_UNSPECIFIED = 0;
+    SYSTEM_CALCULATED = 1; // Derived from movements since the last physical count
+    CYCLE_COUNTED = 2; // Verified by a recent cycle count
+    FULL_AUDIT = 3; // Verified by a full physical audit
+  }
+
+  int64 on_hand = 1; // Units physically present in the zone
+  int64 reserved = 2; // Units allocated to open orders
+  int64 damaged = 3; // Units present but not sellable
+  int64 in_transit_inbound = 4; // Units expected from inbound purchase orders
+  CountConfidence confidence = 5;
+  string last_counted_at = 6; // RFC 3339 timestamp of the last physical count
+}
+
+// A physical zone within the warehouse, e.g. a pick face or bulk storage area.
+message Zone {
+  string zone_id = 1; // e.g. "PICK-A-03"
+  string description = 2;
+  double utilisation_percent = 3; // How full the zone is, 0-100
+
+  // Stock levels for each SKU stored in this zone, keyed by SKU code.
+  map<string, StockLevel> stock_by_sku = 4;
+}
+
+/**
+ * A periodic snapshot of stock positions across an entire warehouse.
+ * Published every 15 minutes by the warehouse management system and used
+ * to reconcile the central inventory ledger.
+ */
+message WarehouseStockSnapshot {
+  string snapshot_id = 1;
+  string warehouse_id = 2; // e.g. "WH-BER-01"
+  string region = 3;
+
+  repeated Zone zones = 4; // All zones included in this snapshot
+
+  // Aggregate totals per SKU across all zones, keyed by SKU code.
+  map<string, int64> totals_by_sku = 5;
+
+  // Free-form labels attached by the warehouse management system,
+  // e.g. "wms_version" -> "4.2.1".
+  map<string, string> labels = 6;
+
+  uint32 sequence_number = 7; // Monotonically increasing per warehouse
+  string captured_at = 8; // When the snapshot was taken
+}

--- a/examples/default/domains/E-Commerce/subdomains/Orders/services/InventoryService/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Orders/services/InventoryService/index.mdx
@@ -35,6 +35,8 @@ receives:
       - warehouseId
   - id: DeleteInventory
 sends:
+  - id: WarehouseStockSnapshot
+    version: 0.0.1
   - id: InventoryAdjusted
     version: 1.0.0
     to:

--- a/examples/default/domains/E-Commerce/subdomains/Orders/services/NotificationService/events/CustomerEngagementRecorded/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Orders/services/NotificationService/events/CustomerEngagementRecorded/index.mdx
@@ -1,0 +1,33 @@
+---
+id: CustomerEngagementRecorded
+version: 0.0.1
+name: Customer Engagement Recorded
+summary: Emitted when a customer interacts with a notification across any channel
+tags:
+  - notifications
+  - engagement
+  - analytics
+badges:
+  - content: New
+    backgroundColor: neutral
+    textColor: neutral
+schemaPath: schema.proto
+---
+
+import Footer from '@catalog/components/footer.astro'
+
+## Overview
+
+The `CustomerEngagementRecorded` event is emitted when a customer interacts with a notification. Interactions form a **tree**: a customer can open an email, click a link inside it, and then dismiss the in-app banner that the link opened. Each node in the tree is an `Interaction` that may contain child interactions, and carries channel-specific details for email, push, or SMS.
+
+## Schema
+
+<SchemaViewer title="CustomerEngagementRecorded Schema" file="schema.proto" />
+
+## Event Details
+
+- **Interaction Tree**: `root_interaction` is the root node; `children` contain follow-up interactions triggered by it
+- **Channel Details**: Each interaction carries exactly one of email, push, or SMS specific details
+- **Deduplication**: Consumers should deduplicate using `engagement_id`
+
+<Footer />

--- a/examples/default/domains/E-Commerce/subdomains/Orders/services/NotificationService/events/CustomerEngagementRecorded/schema.proto
+++ b/examples/default/domains/E-Commerce/subdomains/Orders/services/NotificationService/events/CustomerEngagementRecorded/schema.proto
@@ -1,0 +1,86 @@
+syntax = "proto3";
+
+package com.ecommerce.notifications.engagement;
+
+// The channel a notification was delivered on.
+enum Channel {
+  CHANNEL_UNSPECIFIED = 0;
+  EMAIL = 1;
+  SMS = 2;
+  PUSH = 3;
+  IN_APP = 4;
+}
+
+/**
+ * Emitted when a customer interacts with a notification. Interactions form
+ * a tree: a customer can open an email, then click a link inside it, then
+ * dismiss the in-app banner that the link opened. Each node in the tree is
+ * an Interaction that may contain child interactions.
+ */
+message CustomerEngagementRecorded {
+  // Email-specific interaction details.
+  message EmailInteraction {
+    string subject_line_variant = 1; // A/B test variant of the subject line
+    string link_url = 2; // Populated for click interactions
+    bool opened_on_mobile = 3;
+  }
+
+  // Push notification interaction details.
+  message PushInteraction {
+    string device_platform = 1; // "ios" or "android"
+    string action_id = 2; // The action button pressed, if any
+  }
+
+  // SMS interaction details.
+  message SmsInteraction {
+    string short_link_token = 1; // Token from the shortened link the customer tapped
+  }
+
+  // A single interaction node. Children represent follow-up interactions
+  // triggered by this one, forming a tree of engagement.
+  message Interaction {
+    // What the customer did.
+    enum Kind {
+      KIND_UNSPECIFIED = 0;
+      DELIVERED = 1;
+      OPENED = 2;
+      CLICKED = 3;
+      DISMISSED = 4;
+      UNSUBSCRIBED = 5;
+    }
+
+    string interaction_id = 1;
+    Kind kind = 2;
+    Channel channel = 3;
+    string occurred_at = 4; // RFC 3339 timestamp of the interaction
+
+    // Channel-specific details for this interaction.
+    oneof details {
+      EmailInteraction email = 5;
+      PushInteraction push = 6;
+      SmsInteraction sms = 7;
+    }
+
+    repeated Interaction children = 8; // Follow-up interactions triggered by this one
+  }
+
+  string engagement_id = 1;
+  string customer_id = 2;
+  string notification_id = 3; // The notification that started this engagement
+  string campaign_id = 4; // Marketing campaign the notification belongs to, if any
+  Interaction root_interaction = 5; // The root of the interaction tree
+  uint32 total_interactions = 6; // Total nodes in the tree, for quick filtering
+  string recorded_at = 7;
+}
+
+// The engagement ingestion API exposed by the notification platform.
+// Service definitions are not rendered by the schema viewer but are kept
+// here to document the full contract.
+service EngagementIngestion {
+  rpc RecordEngagement (CustomerEngagementRecorded) returns (RecordEngagementResponse);
+}
+
+message RecordEngagementResponse {
+  bool accepted = 1;
+  string deduplication_key = 2; // Stable key consumers can use to deduplicate retries
+}

--- a/examples/default/domains/E-Commerce/subdomains/Orders/services/NotificationService/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Orders/services/NotificationService/index.mdx
@@ -9,6 +9,8 @@ styles:
 owners:
   - order-management
 sends: 
+  - id: CustomerEngagementRecorded
+    version: 0.0.1
   - id: NotificationSent
 receives:
   - id: InventoryAdjusted

--- a/examples/default/domains/E-Commerce/subdomains/Orders/services/OrdersService/events/LegacyOrderArchived/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Orders/services/OrdersService/events/LegacyOrderArchived/index.mdx
@@ -1,0 +1,33 @@
+---
+id: LegacyOrderArchived
+version: 0.0.1
+name: Legacy Order Archived
+summary: Emitted when an order older than seven years is moved to cold storage
+tags:
+  - orders
+  - archival
+  - compliance
+badges:
+  - content: New
+    backgroundColor: neutral
+    textColor: neutral
+schemaPath: schema.proto
+---
+
+import Footer from '@catalog/components/footer.astro'
+
+## Overview
+
+The `LegacyOrderArchived` event is emitted by the nightly archival job when an order older than seven years is moved from the live order store to cold storage. The schema still uses **proto2** because the downstream archival pipeline has not been migrated, which means fields carry explicit `required` and `optional` labels.
+
+## Schema
+
+<SchemaViewer title="LegacyOrderArchived Schema" file="schema.proto" showRequired="true" />
+
+## Event Details
+
+- **Archive Location**: The cold storage bucket and object key where the order document now lives
+- **GDPR Erasure**: Indicates whether PII was stripped before archival
+- **Line Items**: A summary of line items is retained for audit purposes
+
+<Footer />

--- a/examples/default/domains/E-Commerce/subdomains/Orders/services/OrdersService/events/LegacyOrderArchived/schema.proto
+++ b/examples/default/domains/E-Commerce/subdomains/Orders/services/OrdersService/events/LegacyOrderArchived/schema.proto
@@ -1,0 +1,32 @@
+syntax = "proto2";
+
+package com.ecommerce.orders.archive;
+
+// Emitted by the nightly archival job when an order older than seven years
+// is moved from the live order store to cold storage. This event still uses
+// proto2 because the downstream archival pipeline has not been migrated.
+message LegacyOrderArchived {
+  // Where the archived order document is stored.
+  message ArchiveLocation {
+    required string bucket = 1; // Cold storage bucket name
+    required string object_key = 2; // Path to the archived order document
+    optional string storage_class = 3 [default = "GLACIER"];
+  }
+
+  // A summary line item kept for audit purposes.
+  message ArchivedLineItem {
+    required string sku = 1;
+    required uint32 quantity = 2;
+    optional string product_name = 3; // Product name at the time of purchase
+  }
+
+  required string order_id = 1; // The order that was archived
+  required string customer_id = 2;
+  required ArchiveLocation location = 3;
+  repeated ArchivedLineItem line_items = 4;
+  optional string original_order_date = 5; // RFC 3339 date the order was originally placed
+  optional uint64 total_amount_minor_units = 6; // Order total in minor currency units
+  optional string currency_code = 7 [default = "GBP"];
+  required string archived_at = 8; // When the archival job processed this order
+  optional bool gdpr_erasure_applied = 9 [default = false]; // True when PII was stripped before archival
+}

--- a/examples/default/domains/E-Commerce/subdomains/Orders/services/OrdersService/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Orders/services/OrdersService/index.mdx
@@ -26,6 +26,8 @@ readsFrom:
   - id: inventory-readmodel
   - id: order-metadata-store
 sends:
+  - id: LegacyOrderArchived
+    version: 0.0.1
   - id: OrderAmended
     to:
       - id: orders-domain-eventbus

--- a/examples/default/domains/E-Commerce/subdomains/Orders/services/ShippingService/events/ShipmentRouteUpdated/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Orders/services/ShippingService/events/ShipmentRouteUpdated/index.mdx
@@ -1,0 +1,35 @@
+---
+id: ShipmentRouteUpdated
+version: 0.0.1
+name: Shipment Route Updated
+summary: Emitted when the routing engine recalculates the route for an in-flight shipment
+tags:
+  - shipping
+  - logistics
+  - routing
+badges:
+  - content: New
+    backgroundColor: neutral
+    textColor: neutral
+schemaPath: schema.proto
+---
+
+import Footer from '@catalog/components/footer.astro'
+
+## Overview
+
+The `ShipmentRouteUpdated` event is emitted whenever the routing engine recalculates the route for a shipment that is already in transit. This can happen due to traffic congestion, weather events, vehicle breakdowns, hub capacity issues, or a customer address change.
+
+Consumers use this event to update customer-facing tracking pages and recalculate estimated delivery dates.
+
+## Schema
+
+<SchemaViewer title="ShipmentRouteUpdated Schema" file="schema.proto" />
+
+## Event Details
+
+- **Route Version**: Increments every time the route is recalculated, allowing consumers to discard stale updates
+- **Segments**: The ordered legs of the journey, each with origin/destination waypoints, transport mode, and assigned vehicle
+- **Customer Notification**: Set when the ETA moved by more than 24 hours
+
+<Footer />

--- a/examples/default/domains/E-Commerce/subdomains/Orders/services/ShippingService/events/ShipmentRouteUpdated/schema.proto
+++ b/examples/default/domains/E-Commerce/subdomains/Orders/services/ShippingService/events/ShipmentRouteUpdated/schema.proto
@@ -1,0 +1,85 @@
+syntax = "proto3";
+
+package com.ecommerce.shipping.routing;
+
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/duration.proto";
+
+// The transport mode used for a route segment.
+enum TransportMode {
+  TRANSPORT_MODE_UNSPECIFIED = 0;
+  ROAD = 1;
+  RAIL = 2;
+  AIR = 3; // Air freight, used for express international shipments
+  SEA = 4;
+  LAST_MILE_COURIER = 5;
+}
+
+// Why the route was recalculated.
+enum RouteChangeReason {
+  ROUTE_CHANGE_REASON_UNSPECIFIED = 0;
+  TRAFFIC_CONGESTION = 1;
+  WEATHER_EVENT = 2;
+  VEHICLE_BREAKDOWN = 3;
+  HUB_CAPACITY_EXCEEDED = 4;
+  CUSTOMER_ADDRESS_CHANGED = 5;
+}
+
+/**
+ * Emitted whenever the routing engine recalculates the route for an
+ * in-flight shipment. Consumers use this to update tracking pages and
+ * recalculate estimated delivery dates.
+ */
+message ShipmentRouteUpdated {
+  // A WGS84 coordinate pair.
+  message GeoPoint {
+    double latitude = 1; // Degrees north of the equator, negative for south
+    double longitude = 2; // Degrees east of the prime meridian, negative for west
+  }
+
+  // A stop along the route, such as a sorting hub or delivery depot.
+  message Waypoint {
+    string facility_id = 1; // Internal facility identifier, e.g. "HUB-FRA-04"
+    string name = 2;
+    GeoPoint location = 3;
+    google.protobuf.Timestamp estimated_arrival = 4;
+    google.protobuf.Timestamp estimated_departure = 5;
+    bool customs_clearance_required = 6; // True when the waypoint crosses a customs border
+  }
+
+  // A leg of the journey between two waypoints.
+  message RouteSegment {
+    // The vehicle assigned to carry the shipment on this segment.
+    message Vehicle {
+      // The operational status of the assigned vehicle.
+      enum Status {
+        STATUS_UNSPECIFIED = 0;
+        AVAILABLE = 1;
+        IN_TRANSIT = 2;
+        MAINTENANCE = 3;
+      }
+
+      string vehicle_id = 1;
+      string carrier_code = 2; // SCAC code of the operating carrier
+      Status status = 3;
+      uint32 capacity_kg = 4;
+    }
+
+    Waypoint origin = 1;
+    Waypoint destination = 2;
+    TransportMode mode = 3;
+    Vehicle assigned_vehicle = 4;
+    google.protobuf.Duration estimated_duration = 5;
+    double distance_km = 6;
+  }
+
+  string shipment_id = 1; // The shipment whose route changed
+  string order_id = 2;
+  uint32 route_version = 3; // Increments every time the route is recalculated
+  RouteChangeReason reason = 4;
+  repeated RouteSegment segments = 5; // Ordered legs from origin to final destination
+  google.protobuf.Timestamp previous_eta = 6;
+  google.protobuf.Timestamp updated_eta = 7;
+  bool customer_notification_required = 8; // True when the ETA moved by more than 24 hours
+  google.protobuf.Timestamp occurred_at = 9;
+}

--- a/examples/default/domains/E-Commerce/subdomains/Orders/services/ShippingService/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Orders/services/ShippingService/index.mdx
@@ -26,6 +26,8 @@ receives:
     from:
       - id: orders-domain-eventbus
 sends:
+  - id: ShipmentRouteUpdated
+    version: 0.0.1
   - id: ShipmentCreated
     fields:
       - shipmentId

--- a/examples/default/domains/E-Commerce/subdomains/Payment/services/FraudDetectionService/events/FraudCheckCompleted/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Payment/services/FraudDetectionService/events/FraudCheckCompleted/index.mdx
@@ -22,7 +22,7 @@ The `FraudCheckCompleted` event is emitted when the fraud detection service has 
 
 ## Schema
 
-<SchemaViewer title="FraudCheckCompleted Schema" file="schema.json" />
+<SchemaViewer title="FraudCheckCompleted Schema" file="schema.proto" />
 
 ## Event Details
 

--- a/examples/default/domains/E-Commerce/subdomains/Payment/services/FraudDetectionService/events/FraudCheckCompleted/schema.proto
+++ b/examples/default/domains/E-Commerce/subdomains/Payment/services/FraudDetectionService/events/FraudCheckCompleted/schema.proto
@@ -2,14 +2,30 @@ syntax = "proto3";
 
 package com.example.frauddetection;
 
+// The decision made by the fraud engine.
+enum Decision {
+  APPROVED = 0;
+  DECLINED = 1; // Transaction was declined and should not be processed
+  MANUAL_REVIEW = 2;
+}
+
+// Emitted when a fraud check has been completed for a transaction.
 message FraudCheckCompleted {
-  string transactionId = 1;
+  // Details about an individual fraud signal that contributed to the score.
+  message FraudSignal {
+    string name = 1; // Name of the signal, e.g. "velocity_check"
+    double weight = 2; // How much this signal contributed to the risk score
+  }
+
+  string transactionId = 1; // The unique transaction identifier
   string paymentId = 2;
-  int32 riskScore = 3;
-  string decision = 4;
-  repeated string reasons = 5;
-  double confidence = 6;
-  string timestamp = 7;
+  int32 riskScore = 3; // A numerical score from 0-100 indicating fraud risk
+  Decision decision = 4;
+  repeated string reasons = 5; // Human readable reasons for the decision
+  repeated FraudSignal signals = 6;
+  double confidence = 7;
+  map<string, string> metadata = 8; // Additional context from the fraud engine
+  string timestamp = 9;
 }
 
 message FraudCheckCompletedEvent {

--- a/examples/default/domains/E-Commerce/subdomains/Payment/services/PaymentService/events/PaymentSettled/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Payment/services/PaymentService/events/PaymentSettled/index.mdx
@@ -1,0 +1,33 @@
+---
+id: PaymentSettled
+version: 0.0.1
+name: Payment Settled
+summary: Emitted when funds for a captured payment have been settled with the acquiring bank
+tags:
+  - payment
+  - settlement
+  - finance
+badges:
+  - content: New
+    backgroundColor: neutral
+    textColor: neutral
+schemaPath: schema.proto
+---
+
+import Footer from '@catalog/components/footer.astro'
+
+## Overview
+
+The `PaymentSettled` event is emitted when funds for a captured payment have been settled with the acquiring bank and are confirmed in the merchant account. It carries the gross, fee, and net amounts, plus details of the settlement instrument used (card network, bank transfer, or digital wallet).
+
+## Schema
+
+<SchemaViewer title="PaymentSettled Schema" file="schema.proto" />
+
+## Event Details
+
+- **Amounts**: Gross (captured from the customer), fees (deducted by acquirer/networks), and net (credited to the merchant)
+- **Instrument**: Exactly one of card, bank transfer, or wallet settlement details is present
+- **Batch Settlement**: When settled as part of a netted daily batch, `batch_id` identifies the batch
+
+<Footer />

--- a/examples/default/domains/E-Commerce/subdomains/Payment/services/PaymentService/events/PaymentSettled/schema.proto
+++ b/examples/default/domains/E-Commerce/subdomains/Payment/services/PaymentService/events/PaymentSettled/schema.proto
@@ -1,0 +1,71 @@
+syntax = "proto3";
+
+package com.ecommerce.payments.settlement;
+
+option java_package = "com.ecommerce.payments.settlement.v1";
+option java_multiple_files = true;
+
+// An amount of money in a specific currency.
+message Money {
+  string currency_code = 1; // ISO 4217 currency code, e.g. "EUR"
+  int64 units = 2; // Whole units of the currency
+  int32 nanos = 3; // Fractional units, in nano units (10^-9)
+}
+
+// How the funds were settled with the acquiring bank.
+enum SettlementType {
+  SETTLEMENT_TYPE_UNSPECIFIED = 0;
+  GROSS = 1; // Each transaction settled individually
+  NET_BATCH = 2; // Settled as part of a netted daily batch
+}
+
+/**
+ * Emitted when funds for a captured payment have been settled with the
+ * acquiring bank and are confirmed in the merchant account.
+ */
+message PaymentSettled {
+  reserved 6, 7;
+  reserved "legacy_batch_ref";
+
+  // Settlement via a card network.
+  message CardSettlement {
+    string network = 1; // Card network, e.g. "VISA" or "MASTERCARD"
+    string acquirer_reference_number = 2; // ARN used to trace the settlement with the acquirer
+    string masked_pan = 3; // e.g. "411111******1111"
+  }
+
+  // Settlement via direct bank transfer (SEPA, ACH, etc).
+  message BankTransferSettlement {
+    string scheme = 1; // Transfer scheme, e.g. "SEPA_CREDIT" or "ACH"
+    string bank_reference = 2;
+    string iban_last_four = 3;
+  }
+
+  // Settlement via a digital wallet provider.
+  message WalletSettlement {
+    string provider = 1; // Wallet provider, e.g. "PAYPAL" or "APPLE_PAY"
+    string provider_transaction_id = 2;
+  }
+
+  string settlement_id = 1; // Unique identifier for this settlement
+  string payment_id = 2;
+  string merchant_account_id = 3;
+
+  Money gross_amount = 4; // Amount captured from the customer
+  Money fee_amount = 5; // Fees deducted by the acquirer and card networks
+  Money net_amount = 8; // Amount credited to the merchant account
+
+  SettlementType settlement_type = 9;
+  string batch_id = 10; // Present when settlement_type is NET_BATCH
+
+  // Exactly one settlement instrument is present, depending on how the
+  // customer originally paid.
+  oneof instrument {
+    CardSettlement card = 11;
+    BankTransferSettlement bank_transfer = 12;
+    WalletSettlement wallet = 13;
+  }
+
+  string statement_descriptor = 14 [deprecated = true]; // Use merchant_account_id instead
+  string settled_at = 15; // RFC 3339 timestamp of the settlement confirmation
+}

--- a/examples/default/domains/E-Commerce/subdomains/Payment/services/PaymentService/index.mdx
+++ b/examples/default/domains/E-Commerce/subdomains/Payment/services/PaymentService/index.mdx
@@ -16,6 +16,8 @@ receives:
         parameters:
           env: staging
 sends:
+  - id: PaymentSettled
+    version: 0.0.1
   - id: PaymentProcessed
 writesTo:
   - id: payments-db

--- a/packages/core/eventcatalog/src/components/MDX/SchemaViewer/SchemaViewerRoot.astro
+++ b/packages/core/eventcatalog/src/components/MDX/SchemaViewer/SchemaViewerRoot.astro
@@ -4,6 +4,7 @@ import fs from 'node:fs/promises';
 import { getCollection } from 'astro:content';
 import JSONSchemaViewer from '@components/SchemaExplorer/JSONSchemaViewer';
 import AvroSchemaViewer from '@components/SchemaExplorer/AvroSchemaViewer';
+import ProtobufSchemaViewer from '@components/SchemaExplorer/ProtobufSchemaViewer';
 import Admonition from '../Admonition';
 import { getMDXComponentsByName } from '@utils/markdown';
 import { resolveProjectPath } from '@utils/files';
@@ -46,9 +47,18 @@ try {
               >
                 {schema.title && <h2 class="text-2xl font-bold mb-2 mt-0!">{schema.title}</h2>}
 
-                {/* Render AvroSchemaViewer for Avro schemas */}
+                {/* Render the viewer matching the schema format */}
                 {schema.isAvroSchema ? (
                   <AvroSchemaViewer
+                    client:load
+                    schema={schema.schema}
+                    maxHeight={schema.maxHeight}
+                    expand={schema.expand}
+                    search={schema.search}
+                    showRequired={schema.showRequired}
+                  />
+                ) : schema.isProtobufSchema ? (
+                  <ProtobufSchemaViewer
                     client:load
                     schema={schema.schema}
                     maxHeight={schema.maxHeight}

--- a/packages/core/eventcatalog/src/components/MDX/SchemaViewer/schema-viewer-utils.spec.ts
+++ b/packages/core/eventcatalog/src/components/MDX/SchemaViewer/schema-viewer-utils.spec.ts
@@ -33,6 +33,69 @@ describe('resolveSchemaViewer', () => {
     expect(schema.schemaPath).toBe('git://contracts/events/OrderPlaced.schema.json');
   });
 
+  it('parses protobuf schemas from the schema collection', async () => {
+    const protoSchema = {
+      id: 'schema:events:FraudCheckCompleted:1.0.0:git://contracts/events/FraudCheckCompleted.proto',
+      data: {
+        ref: 'git://contracts/events/FraudCheckCompleted.proto',
+        format: 'protobuf',
+        content: 'syntax = "proto3";\nmessage FraudCheckCompleted {\n  string transaction_id = 1;\n}',
+        default: true,
+        message: {
+          collection: 'events',
+          id: 'FraudCheckCompleted',
+          version: '1.0.0',
+        },
+      },
+    };
+
+    const schema = await resolveSchemaViewer({
+      id: 'FraudCheckCompleted',
+      version: '1.0.0',
+      collection: 'events',
+      filePath: 'events/FraudCheckCompleted/index.mdx',
+      schemaViewerProps: {},
+      collectionSchemas: [protoSchema],
+      index: 0,
+    });
+
+    expect(schema.exists).toBe(true);
+    expect(schema.isProtobufSchema).toBe(true);
+    expect(schema.schema.syntax).toBe('proto3');
+    expect(schema.schema.messages[0].name).toBe('FraudCheckCompleted');
+    expect(schema.schema.messages[0].fields[0].name).toBe('transaction_id');
+  });
+
+  it('captures parse errors for invalid protobuf schemas', async () => {
+    const protoSchema = {
+      id: 'schema:events:FraudCheckCompleted:1.0.0:git://contracts/events/FraudCheckCompleted.proto',
+      data: {
+        ref: 'git://contracts/events/FraudCheckCompleted.proto',
+        format: 'protobuf',
+        content: '{"this": "is not protobuf"}',
+        default: true,
+        message: {
+          collection: 'events',
+          id: 'FraudCheckCompleted',
+          version: '1.0.0',
+        },
+      },
+    };
+
+    const schema = await resolveSchemaViewer({
+      id: 'FraudCheckCompleted',
+      version: '1.0.0',
+      collection: 'events',
+      filePath: 'events/FraudCheckCompleted/index.mdx',
+      schemaViewerProps: {},
+      collectionSchemas: [protoSchema],
+      index: 0,
+    });
+
+    expect(schema.exists).toBe(false);
+    expect(schema.parseError).toBeDefined();
+  });
+
   it('does not use the schema collection when a file is set and missing', async () => {
     const schema = await resolveSchemaViewer({
       id: 'OrderPlaced',

--- a/packages/core/eventcatalog/src/components/MDX/SchemaViewer/schema-viewer-utils.ts
+++ b/packages/core/eventcatalog/src/components/MDX/SchemaViewer/schema-viewer-utils.ts
@@ -1,7 +1,8 @@
 import { readFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { load as loadYaml } from 'js-yaml';
-import { getAbsoluteFilePathForAstroFile, isAvroSchema } from '../../../utils/files';
+import { getAbsoluteFilePathForAstroFile, isAvroSchema, isProtobufSchema } from '../../../utils/files';
+import { parseProtobufSchema } from '../../../utils/protobuf-schema';
 
 type SchemaViewerProps = {
   id?: string;
@@ -48,13 +49,17 @@ const isYamlSchema = (schemaPath?: string, format?: string) =>
 const isAvroSchemaReference = (schemaPath?: string, format?: string) =>
   format === 'avro' || (schemaPath ? isAvroSchema(schemaPath) : false);
 
+const isProtobufSchemaReference = (schemaPath?: string, format?: string) =>
+  format === 'protobuf' || format === 'proto' || (schemaPath ? isProtobufSchema(schemaPath) : false);
+
 const parseSchemaContent = (content: string, schemaPath?: string, format?: string) => {
+  if (isProtobufSchemaReference(schemaPath, format)) return parseProtobufSchema(content);
   if (isYamlSchema(schemaPath, format)) return loadYaml(content);
   return JSON.parse(content);
 };
 
-const shouldRenderSchema = (schema: any, isAvro: boolean) => {
-  if (isAvro) return true;
+const shouldRenderSchema = (schema: any, alwaysRender: boolean) => {
+  if (alwaysRender) return true;
   return schema?.['x-eventcatalog-render-schema-viewer'] !== undefined ? schema['x-eventcatalog-render-schema-viewer'] : true;
 };
 
@@ -94,14 +99,20 @@ export const resolveSchemaViewer = async ({
   let schema;
   let render = true;
   let isAvro = false;
+  let isProtobuf = false;
   let schemaPath = localSchemaPath;
   let parseError;
 
   if (localSchemaExists && localSchemaPath) {
     isAvro = isAvroSchema(localSchemaPath);
+    isProtobuf = isProtobufSchema(localSchemaPath);
     const content = await readFile(localSchemaPath, 'utf-8');
-    schema = parseSchemaContent(content, localSchemaPath);
-    render = shouldRenderSchema(schema, isAvro);
+    try {
+      schema = parseSchemaContent(content, localSchemaPath);
+      render = shouldRenderSchema(schema, isAvro || isProtobuf);
+    } catch (error) {
+      parseError = error instanceof Error ? error.message : 'Unknown parsing error';
+    }
   } else if (!schemaViewerProps.file) {
     const collectionSchema = getCollectionSchemaForViewer({ collectionSchemas, collection, id, version });
     const content = collectionSchema?.data.content;
@@ -110,8 +121,9 @@ export const resolveSchemaViewer = async ({
     if (content) {
       try {
         isAvro = isAvroSchemaReference(schemaPath, collectionSchema?.data.format);
+        isProtobuf = isProtobufSchemaReference(schemaPath, collectionSchema?.data.format);
         schema = parseSchemaContent(content, schemaPath, collectionSchema?.data.format);
-        render = shouldRenderSchema(schema, isAvro);
+        render = shouldRenderSchema(schema, isAvro || isProtobuf);
       } catch (error) {
         parseError = error instanceof Error ? error.message : 'Unknown parsing error';
       }
@@ -120,11 +132,12 @@ export const resolveSchemaViewer = async ({
 
   return {
     id: schemaViewerProps.id || id,
-    exists: localSchemaExists || schema !== undefined,
+    exists: schema !== undefined,
     schema,
     schemaPath,
     schemaKey,
     isAvroSchema: isAvro,
+    isProtobufSchema: isProtobuf,
     parseError,
     ...schemaViewerProps,
     render,

--- a/packages/core/eventcatalog/src/components/SchemaExplorer/ProtobufSchemaViewer.tsx
+++ b/packages/core/eventcatalog/src/components/SchemaExplorer/ProtobufSchemaViewer.tsx
@@ -42,14 +42,16 @@ function buildTypeRegistry(schema: ProtobufSchema): TypeRegistry {
 }
 
 // Resolve a field type name against the registry, trying the name as written,
-// without the package prefix, and by its last segment (e.g. "com.example.Order" -> "Order")
+// without the package prefix, and by its last segment (e.g. "com.example.Order" -> "Order").
+// Leading dots (fully-qualified references like ".com.example.Order") are stripped first.
 function resolveTypeName(typeName: string, packageName: string | undefined): string[] {
-  const candidates = [typeName];
-  if (packageName && typeName.startsWith(`${packageName}.`)) {
-    candidates.push(typeName.slice(packageName.length + 1));
+  const normalized = typeName.startsWith('.') ? typeName.slice(1) : typeName;
+  const candidates = [normalized];
+  if (packageName && normalized.startsWith(`${packageName}.`)) {
+    candidates.push(normalized.slice(packageName.length + 1));
   }
-  const lastSegment = typeName.split('.').pop();
-  if (lastSegment && lastSegment !== typeName) candidates.push(lastSegment);
+  const lastSegment = normalized.split('.').pop();
+  if (lastSegment && lastSegment !== normalized) candidates.push(lastSegment);
   return candidates;
 }
 

--- a/packages/core/eventcatalog/src/components/SchemaExplorer/ProtobufSchemaViewer.tsx
+++ b/packages/core/eventcatalog/src/components/SchemaExplorer/ProtobufSchemaViewer.tsx
@@ -1,0 +1,530 @@
+import { useState, useEffect, useRef, useMemo } from 'react';
+import type { ProtobufSchema, ProtobufMessage, ProtobufEnum, ProtobufField } from '@utils/protobuf-schema';
+
+interface ProtobufSchemaViewerProps {
+  schema: ProtobufSchema;
+  title?: string;
+  maxHeight?: string;
+  expand?: boolean | string;
+  search?: boolean | string;
+  showRequired?: boolean | string;
+  onOpenFullscreen?: () => void;
+}
+
+// Proto types are referenced by name (not nested inline like Avro), so we build
+// a registry of every message/enum in the file to resolve field types against.
+interface TypeRegistry {
+  messages: Map<string, ProtobufMessage>;
+  enums: Map<string, ProtobufEnum>;
+}
+
+function buildTypeRegistry(schema: ProtobufSchema): TypeRegistry {
+  const registry: TypeRegistry = { messages: new Map(), enums: new Map() };
+
+  const register = <T,>(map: Map<string, T>, qualifiedName: string, simpleName: string, value: T) => {
+    map.set(qualifiedName, value);
+    if (!map.has(simpleName)) map.set(simpleName, value);
+  };
+
+  const walk = (messages: ProtobufMessage[], enums: ProtobufEnum[], prefix: string) => {
+    for (const protoEnum of enums) {
+      register(registry.enums, prefix ? `${prefix}.${protoEnum.name}` : protoEnum.name, protoEnum.name, protoEnum);
+    }
+    for (const message of messages) {
+      const qualifiedName = prefix ? `${prefix}.${message.name}` : message.name;
+      register(registry.messages, qualifiedName, message.name, message);
+      walk(message.messages, message.enums, qualifiedName);
+    }
+  };
+
+  walk(schema.messages, schema.enums, '');
+  return registry;
+}
+
+// Resolve a field type name against the registry, trying the name as written,
+// without the package prefix, and by its last segment (e.g. "com.example.Order" -> "Order")
+function resolveTypeName(typeName: string, packageName: string | undefined): string[] {
+  const candidates = [typeName];
+  if (packageName && typeName.startsWith(`${packageName}.`)) {
+    candidates.push(typeName.slice(packageName.length + 1));
+  }
+  const lastSegment = typeName.split('.').pop();
+  if (lastSegment && lastSegment !== typeName) candidates.push(lastSegment);
+  return candidates;
+}
+
+function lookupType<T>(map: Map<string, T>, typeName: string, packageName?: string): T | undefined {
+  for (const candidate of resolveTypeName(typeName, packageName)) {
+    const match = map.get(candidate);
+    if (match) return match;
+  }
+  return undefined;
+}
+
+function formatProtobufType(field: ProtobufField): string {
+  if (field.map) return field.type;
+  return field.label ? `${field.label} ${field.type}` : field.type;
+}
+
+function countFields(messages: ProtobufMessage[]): number {
+  return messages.reduce((total, message) => total + message.fields.length + countFields(message.messages), 0);
+}
+
+interface ProtobufFieldRowProps {
+  field: ProtobufField;
+  level: number;
+  expand: boolean;
+  showRequired?: boolean;
+  registry: TypeRegistry;
+  packageName?: string;
+  ancestors: string[];
+}
+
+const ProtobufFieldRow = ({ field, level, expand, showRequired, registry, packageName, ancestors }: ProtobufFieldRowProps) => {
+  const [isExpanded, setIsExpanded] = useState(expand);
+  const indentationClass = `pl-${level * 3}`;
+
+  // The type to drill into: map values and plain types can both reference messages
+  const targetTypeName = field.map ? field.map.valueType : field.type;
+  const nestedMessage = lookupType(registry.messages, targetTypeName, packageName);
+  const nestedEnum = nestedMessage ? undefined : lookupType(registry.enums, targetTypeName, packageName);
+  const isCyclic = nestedMessage ? ancestors.includes(nestedMessage.name) : false;
+  const hasNested = !!nestedMessage && nestedMessage.fields.length > 0 && !isCyclic;
+  const isRequired = field.label === 'required';
+
+  useEffect(() => {
+    setIsExpanded(expand);
+  }, [expand]);
+
+  return (
+    <div className={`proto-field-container mb-1.5 border-l border-[rgb(var(--ec-page-border))] relative ${indentationClass}`}>
+      <div className="flex items-start space-x-1.5">
+        {hasNested ? (
+          <button
+            type="button"
+            aria-expanded={isExpanded}
+            onClick={() => setIsExpanded(!isExpanded)}
+            className="proto-field-toggle text-[rgb(var(--ec-page-text-muted))] hover:text-[rgb(var(--ec-page-text))] pt-0.5 focus:outline-hidden w-3 text-center flex-shrink-0"
+          >
+            <span className={`icon-collapsed font-mono text-xs ${isExpanded ? 'hidden' : ''}`}>&gt;</span>
+            <span className={`icon-expanded font-mono text-xs ${!isExpanded ? 'hidden' : ''}`}>v</span>
+          </button>
+        ) : (
+          <div className="w-3 h-4 flex-shrink-0" />
+        )}
+
+        <div className="flex-grow">
+          <div className="flex justify-between items-baseline">
+            <div>
+              <span className="proto-field-name font-semibold text-[rgb(var(--ec-page-text))] text-sm">{field.name}</span>
+              <span className="ml-1.5 text-[rgb(var(--ec-accent))] font-mono text-xs">{formatProtobufType(field)}</span>
+              {field.number !== undefined && (
+                <span className="ml-1.5 text-[rgb(var(--ec-page-text-muted))] font-mono text-xs">= {field.number}</span>
+              )}
+              {field.oneof && (
+                <span className="ml-1.5 text-[rgb(var(--ec-page-text-muted))] text-xs bg-[rgb(var(--ec-content-hover))] px-1 rounded">
+                  oneof {field.oneof}
+                </span>
+              )}
+            </div>
+            {showRequired && isRequired && (
+              <span className="text-red-600 dark:text-red-400 text-xs ml-3 flex-shrink-0">required</span>
+            )}
+          </div>
+
+          {field.doc && <p className="text-[rgb(var(--ec-page-text-muted))] text-xs mt-0.5">{field.doc}</p>}
+
+          {/* Show enum values if the field type resolves to an enum */}
+          {nestedEnum && nestedEnum.values.length > 0 && (
+            <div className="text-xs text-[rgb(var(--ec-page-text-muted))] mt-0.5">
+              <span className="text-xs inline-block">Allowed values:</span>
+              {nestedEnum.values.map((value) => (
+                <span key={value.name} className="text-xs">
+                  {' '}
+                  <code className="bg-[rgb(var(--ec-content-hover))] px-1 rounded text-[rgb(var(--ec-page-text))] font-thin py-0.5">
+                    {value.name}
+                  </code>
+                </span>
+              ))}
+            </div>
+          )}
+
+          {/* Nested fields for message types */}
+          {hasNested && nestedMessage && (
+            <div className={`proto-nested-content mt-1 ${!isExpanded ? 'hidden' : ''}`}>
+              {nestedMessage.fields.map((nestedField) => (
+                <ProtobufFieldRow
+                  key={nestedField.name}
+                  field={nestedField}
+                  level={level + 1}
+                  expand={expand}
+                  showRequired={showRequired}
+                  registry={registry}
+                  packageName={packageName}
+                  ancestors={[...ancestors, nestedMessage.name]}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// Main ProtobufSchemaViewer component
+export default function ProtobufSchemaViewer({
+  schema,
+  title,
+  maxHeight,
+  expand = false,
+  search = true,
+  showRequired = false,
+  onOpenFullscreen,
+}: ProtobufSchemaViewerProps) {
+  const expandBool = expand === true || expand === 'true';
+  const searchBool = search !== false && search !== 'false';
+  const showRequiredBool = showRequired === true || showRequired === 'true';
+
+  const [searchQuery, setSearchQuery] = useState('');
+  const [expandAll, setExpandAll] = useState(expandBool);
+  const [currentMatches, setCurrentMatches] = useState<HTMLElement[]>([]);
+  const [currentMatchIndex, setCurrentMatchIndex] = useState(-1);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const fieldsContainerRef = useRef<HTMLDivElement>(null);
+
+  const registry = useMemo(() => (schema ? buildTypeRegistry(schema) : { messages: new Map(), enums: new Map() }), [schema]);
+  const totalFields = useMemo(() => (schema ? countFields(schema.messages) : 0), [schema]);
+
+  // Search functionality with highlighting
+  useEffect(() => {
+    if (!fieldsContainerRef.current) return;
+
+    const fieldContainers = fieldsContainerRef.current.querySelectorAll('.proto-field-container');
+    const matches: HTMLElement[] = [];
+
+    if (searchQuery === '') {
+      // Reset search
+      fieldContainers.forEach((container) => {
+        container.classList.remove('search-match', 'search-no-match', 'search-current-match', 'search-dimmed');
+        const nameEl = container.querySelector('.proto-field-name');
+        if (nameEl) {
+          nameEl.innerHTML = nameEl.textContent || '';
+        }
+      });
+      setCurrentMatches([]);
+      setCurrentMatchIndex(-1);
+      return;
+    }
+
+    const query = searchQuery.toLowerCase().trim();
+
+    fieldContainers.forEach((container) => {
+      const nameEl = container.querySelector('.proto-field-name');
+      if (!nameEl) return;
+
+      const fieldName = (nameEl.textContent || '').toLowerCase();
+
+      if (fieldName.includes(query)) {
+        container.classList.add('search-match');
+        container.classList.remove('search-dimmed');
+        matches.push(container as HTMLElement);
+
+        // Highlight the search term
+        const regex = new RegExp(`(${query})`, 'gi');
+        nameEl.innerHTML = (nameEl.textContent || '').replace(regex, '<mark class="bg-yellow-200 rounded px-0.5">$1</mark>');
+
+        // Expand parent containers
+        let parent = container.parentElement;
+        while (parent && parent !== fieldsContainerRef.current) {
+          if (parent.classList.contains('proto-nested-content') && parent.classList.contains('hidden')) {
+            const parentFieldContainer = parent.closest('.proto-field-container');
+            if (parentFieldContainer) {
+              const toggleBtn = parentFieldContainer.querySelector('.proto-field-toggle');
+              if (toggleBtn && toggleBtn.getAttribute('aria-expanded') === 'false') {
+                (toggleBtn as HTMLButtonElement).click();
+              }
+            }
+          }
+          // Remove dimming from parent containers
+          if (parent.classList.contains('proto-field-container')) {
+            parent.classList.remove('search-dimmed');
+          }
+          parent = parent.parentElement;
+        }
+      } else {
+        container.classList.remove('search-match', 'search-current-match');
+        container.classList.add('search-dimmed');
+        nameEl.innerHTML = nameEl.textContent || '';
+      }
+    });
+
+    setCurrentMatches(matches);
+    if (matches.length > 0) {
+      setCurrentMatchIndex(0);
+      matches[0].scrollIntoView({ behavior: 'smooth', block: 'center' });
+    } else {
+      setCurrentMatchIndex(-1);
+    }
+  }, [searchQuery]);
+
+  // Update match highlighting
+  useEffect(() => {
+    currentMatches.forEach((match, index) => {
+      if (index === currentMatchIndex) {
+        match.classList.add('search-current-match');
+      } else {
+        match.classList.remove('search-current-match');
+      }
+    });
+
+    if (currentMatchIndex >= 0 && currentMatches[currentMatchIndex]) {
+      currentMatches[currentMatchIndex].scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  }, [currentMatchIndex, currentMatches]);
+
+  const handleExpandAll = () => {
+    setExpandAll(true);
+  };
+
+  const handleCollapseAll = () => {
+    setExpandAll(false);
+  };
+
+  const handlePrevMatch = () => {
+    if (currentMatchIndex > 0) {
+      setCurrentMatchIndex(currentMatchIndex - 1);
+    }
+  };
+
+  const handleNextMatch = () => {
+    if (currentMatchIndex < currentMatches.length - 1) {
+      setCurrentMatchIndex(currentMatchIndex + 1);
+    }
+  };
+
+  if (!schema || !Array.isArray(schema.messages)) {
+    return (
+      <div className="flex items-center justify-center p-8 text-[rgb(var(--ec-page-text-muted))]">
+        <p className="text-sm">Invalid Protobuf schema format</p>
+      </div>
+    );
+  }
+
+  const containerStyle = maxHeight
+    ? { maxHeight: maxHeight.includes('px') ? maxHeight : `${maxHeight}px`, minHeight: '15em' }
+    : {};
+
+  const heightClass = maxHeight ? '' : 'h-full';
+  const overflowClass = maxHeight ? 'overflow-hidden' : '';
+
+  return (
+    <div
+      className={`${heightClass} ${overflowClass} flex flex-col bg-[rgb(var(--ec-card-bg,var(--ec-page-bg)))] border border-[rgb(var(--ec-page-border))] rounded-md shadow-xs`}
+      style={containerStyle}
+    >
+      {/* Toolbar */}
+      {searchBool && (
+        <div className="flex-shrink-0 bg-[rgb(var(--ec-card-bg,var(--ec-page-bg)))] pt-4 px-4 mb-4 pb-3 border-b border-[rgb(var(--ec-page-border))] shadow-xs">
+          <div className="flex flex-col sm:flex-row gap-3">
+            <div className="flex-1 relative">
+              <input
+                ref={searchInputRef}
+                type="text"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                placeholder="Search fields..."
+                className="w-full px-3 py-1.5 pr-20 text-sm border border-[rgb(var(--ec-input-border))] bg-[rgb(var(--ec-input-bg))] text-[rgb(var(--ec-input-text))] placeholder:text-[rgb(var(--ec-input-placeholder))] rounded-md focus:outline-hidden focus:ring-2 focus:ring-[rgb(var(--ec-accent))] focus:border-transparent"
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    if (e.shiftKey) {
+                      handlePrevMatch();
+                    } else {
+                      handleNextMatch();
+                    }
+                  }
+                }}
+              />
+              <div className="absolute right-2 top-1/2 transform -translate-y-1/2 flex items-center gap-1">
+                <button
+                  onClick={handlePrevMatch}
+                  disabled={currentMatches.length === 0 || currentMatchIndex <= 0}
+                  className="p-1 text-[rgb(var(--ec-icon-color))] hover:text-[rgb(var(--ec-page-text))] disabled:opacity-30 disabled:cursor-not-allowed"
+                  title="Previous match"
+                >
+                  <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15 19l-7-7 7-7" />
+                  </svg>
+                </button>
+                <button
+                  onClick={handleNextMatch}
+                  disabled={currentMatches.length === 0 || currentMatchIndex >= currentMatches.length - 1}
+                  className="p-1 text-[rgb(var(--ec-icon-color))] hover:text-[rgb(var(--ec-page-text))] disabled:opacity-30 disabled:cursor-not-allowed"
+                  title="Next match"
+                >
+                  <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7" />
+                  </svg>
+                </button>
+              </div>
+            </div>
+            <div className="flex items-center gap-2">
+              {onOpenFullscreen && (
+                <button
+                  onClick={onOpenFullscreen}
+                  className="px-3 py-1.5 text-xs font-medium text-[rgb(var(--ec-page-text))] bg-[rgb(var(--ec-content-hover))] rounded-md hover:bg-[rgb(var(--ec-content-active))] focus:outline-hidden focus:ring-2 focus:ring-[rgb(var(--ec-accent))]"
+                  title="Open in fullscreen"
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    className="h-3.5 w-3.5 inline-block"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4"
+                    />
+                  </svg>
+                </button>
+              )}
+              <button
+                onClick={handleExpandAll}
+                className="px-3 py-1.5 text-xs font-medium text-[rgb(var(--ec-page-text))] bg-[rgb(var(--ec-content-hover))] rounded-md hover:bg-[rgb(var(--ec-content-active))] focus:outline-hidden focus:ring-2 focus:ring-[rgb(var(--ec-accent))]"
+              >
+                Expand All
+              </button>
+              <button
+                onClick={handleCollapseAll}
+                className="px-3 py-1.5 text-xs font-medium text-[rgb(var(--ec-page-text))] bg-[rgb(var(--ec-content-hover))] rounded-md hover:bg-[rgb(var(--ec-content-active))] focus:outline-hidden focus:ring-2 focus:ring-[rgb(var(--ec-accent))]"
+              >
+                Collapse All
+              </button>
+              <div className="text-xs text-[rgb(var(--ec-page-text-muted))]">
+                {totalFields} {totalFields === 1 ? 'field' : 'fields'}
+              </div>
+            </div>
+          </div>
+          {searchQuery && (
+            <div className="mt-2 text-xs text-[rgb(var(--ec-page-text-muted))]">
+              {currentMatches.length > 0
+                ? `${currentMatchIndex + 1} of ${currentMatches.length} ${currentMatches.length === 1 ? 'match' : 'matches'}`
+                : 'No fields found'}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Messages and enums */}
+      <div ref={fieldsContainerRef} className="flex-1 px-4 pb-4 overflow-auto">
+        {(schema.package || schema.syntax) && (
+          <div className="flex items-baseline gap-2 mb-4">
+            {schema.package && (
+              <>
+                <span className="text-sm font-medium text-[rgb(var(--ec-page-text-muted))]">Package:</span>
+                <span className="font-mono text-sm text-blue-600 dark:text-blue-400">{schema.package}</span>
+              </>
+            )}
+            {schema.syntax && <span className="font-mono text-xs text-[rgb(var(--ec-page-text-muted))]">({schema.syntax})</span>}
+          </div>
+        )}
+
+        {schema.messages.length > 0 || schema.enums.length > 0 ? (
+          <>
+            {schema.messages.map((message) => (
+              <div key={message.name} className="mt-4 first:mt-0">
+                <div className="flex items-baseline gap-2 mb-2">
+                  <span className="text-sm font-medium text-[rgb(var(--ec-page-text-muted))]">Message:</span>
+                  <span className="font-mono text-sm text-blue-600 dark:text-blue-400">{message.name}</span>
+                </div>
+                {message.doc && <p className="text-[rgb(var(--ec-page-text-muted))] text-xs mb-3">{message.doc}</p>}
+                {message.fields.length > 0 ? (
+                  message.fields.map((field) => (
+                    <ProtobufFieldRow
+                      key={field.name}
+                      field={field}
+                      level={0}
+                      expand={expandAll}
+                      showRequired={showRequiredBool}
+                      registry={registry}
+                      packageName={schema.package}
+                      ancestors={[message.name]}
+                    />
+                  ))
+                ) : (
+                  <p className="text-xs text-[rgb(var(--ec-page-text-muted))] mb-2">No fields defined</p>
+                )}
+              </div>
+            ))}
+
+            {schema.enums.map((protoEnum) => (
+              <div key={protoEnum.name} className="mt-4">
+                <div className="flex items-baseline gap-2 mb-2">
+                  <span className="text-sm font-medium text-[rgb(var(--ec-page-text-muted))]">Enum:</span>
+                  <span className="font-mono text-sm text-blue-600 dark:text-blue-400">{protoEnum.name}</span>
+                </div>
+                {protoEnum.doc && <p className="text-[rgb(var(--ec-page-text-muted))] text-xs mb-2">{protoEnum.doc}</p>}
+                <div className="text-xs text-[rgb(var(--ec-page-text-muted))]">
+                  <span className="text-xs inline-block">Allowed values:</span>
+                  {protoEnum.values.map((value) => (
+                    <span key={value.name} className="text-xs">
+                      {' '}
+                      <code className="bg-[rgb(var(--ec-content-hover))] px-1 rounded text-[rgb(var(--ec-page-text))] font-thin py-0.5">
+                        {value.name}
+                      </code>
+                    </span>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </>
+        ) : (
+          <div className="text-center py-8 text-[rgb(var(--ec-icon-color))]">
+            <p className="text-sm">No messages defined</p>
+          </div>
+        )}
+
+        {searchQuery && currentMatches.length === 0 && (
+          <div className="text-center py-8">
+            <div className="text-[rgb(var(--ec-icon-color))] text-sm">
+              <svg className="mx-auto h-12 w-12 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+                />
+              </svg>
+              <p>No fields match your search</p>
+              <p className="text-xs mt-1">Try a different search term or clear the search to see all fields</p>
+            </div>
+          </div>
+        )}
+      </div>
+
+      <style>{`
+        .search-dimmed {
+          opacity: 0.4;
+          transition: opacity 0.2s ease;
+        }
+
+        .search-match {
+          opacity: 1;
+          transition: opacity 0.2s ease;
+        }
+
+        .search-current-match {
+          background-color: rgba(59, 130, 246, 0.1);
+          border-left: 3px solid #3b82f6;
+          padding-left: 8px;
+          margin-left: -11px;
+          transition: all 0.2s ease;
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/packages/core/eventcatalog/src/components/SchemaExplorer/SchemaContentViewer.tsx
+++ b/packages/core/eventcatalog/src/components/SchemaExplorer/SchemaContentViewer.tsx
@@ -5,6 +5,7 @@ import { oneLight } from 'react-syntax-highlighter/dist/cjs/styles/prism';
 import { buildUrl } from '@utils/url-builder';
 import JSONSchemaViewer from './JSONSchemaViewer';
 import AvroSchemaViewer from './AvroSchemaViewer';
+import ProtobufSchemaViewer from './ProtobufSchemaViewer';
 import { getLanguageForHighlight } from './utils';
 import type { SchemaItem } from './types';
 import { useDarkMode } from './useDarkMode';
@@ -16,6 +17,7 @@ interface SchemaContentViewerProps {
   viewMode: 'code' | 'schema' | 'diff';
   parsedSchema: any;
   parsedAvroSchema?: any;
+  parsedProtoSchema?: any;
   onOpenFullscreen?: () => void;
   showRequired?: boolean;
 }
@@ -27,6 +29,7 @@ export default function SchemaContentViewer({
   viewMode,
   parsedSchema,
   parsedAvroSchema,
+  parsedProtoSchema,
   showRequired = false,
   onOpenFullscreen,
 }: SchemaContentViewerProps) {
@@ -44,6 +47,9 @@ export default function SchemaContentViewer({
   if (viewMode === 'schema') {
     if (parsedAvroSchema) {
       return <AvroSchemaViewer schema={parsedAvroSchema} onOpenFullscreen={onOpenFullscreen} showRequired={showRequired} />;
+    }
+    if (parsedProtoSchema) {
+      return <ProtobufSchemaViewer schema={parsedProtoSchema} onOpenFullscreen={onOpenFullscreen} showRequired={showRequired} />;
     }
     if (parsedSchema) {
       return <JSONSchemaViewer schema={parsedSchema} onOpenFullscreen={onOpenFullscreen} />;

--- a/packages/core/eventcatalog/src/components/SchemaExplorer/SchemaDetailsPanel.tsx
+++ b/packages/core/eventcatalog/src/components/SchemaExplorer/SchemaDetailsPanel.tsx
@@ -137,10 +137,12 @@ export default function SchemaDetailsPanel({
     }
   }, [message.schemaContent, message.schemaExtension]);
 
-  // Check if this is a Protobuf schema
+  // Check if this is a Protobuf schema. The extension falls back to the schema
+  // format when the schema has no file path, so accept both 'proto' and 'protobuf'.
   const parsedProtoSchema = useMemo(() => {
+    const extLower = message.schemaExtension?.toLowerCase();
     const isProtoSchema =
-      message.schemaExtension?.toLowerCase() === 'proto' && message.schemaContent && message.schemaContent.trim() !== '';
+      (extLower === 'proto' || extLower === 'protobuf') && message.schemaContent && message.schemaContent.trim() !== '';
     if (!isProtoSchema) return null;
 
     try {

--- a/packages/core/eventcatalog/src/components/SchemaExplorer/SchemaDetailsPanel.tsx
+++ b/packages/core/eventcatalog/src/components/SchemaExplorer/SchemaDetailsPanel.tsx
@@ -25,6 +25,7 @@ import VersionHistoryModal from './VersionHistoryModal';
 import SchemaCodeModal from './SchemaCodeModal';
 import SchemaViewerModal from './SchemaViewerModal';
 import { copyToClipboard, downloadSchema, getSchemaTypeLabel, ICON_SPECS, extractServiceName } from './utils';
+import { parseProtobufSchema } from '@utils/protobuf-schema';
 import type { SchemaItem, VersionDiff, Owner, Producer, Consumer } from './types';
 
 interface SchemaDetailsPanelProps {
@@ -136,6 +137,19 @@ export default function SchemaDetailsPanel({
     }
   }, [message.schemaContent, message.schemaExtension]);
 
+  // Check if this is a Protobuf schema
+  const parsedProtoSchema = useMemo(() => {
+    const isProtoSchema =
+      message.schemaExtension?.toLowerCase() === 'proto' && message.schemaContent && message.schemaContent.trim() !== '';
+    if (!isProtoSchema) return null;
+
+    try {
+      return parseProtobufSchema(message.schemaContent ?? '');
+    } catch {
+      return null;
+    }
+  }, [message.schemaContent, message.schemaExtension]);
+
   const handleCopy = async () => {
     if (!message.schemaContent) return;
     const success = await copyToClipboard(message.schemaContent);
@@ -184,7 +198,7 @@ export default function SchemaDetailsPanel({
     };
   }, []);
 
-  const hasParsedSchema = !!parsedSchema || !!parsedAvroSchema;
+  const hasParsedSchema = !!parsedSchema || !!parsedAvroSchema || !!parsedProtoSchema;
   // Build tabs
   const tabs: { id: string; label: string; icon: React.ReactNode }[] = [
     { id: 'code', label: 'Schema', icon: <CodeBracketIcon className="h-3.5 w-3.5" /> },
@@ -335,11 +349,12 @@ export default function SchemaDetailsPanel({
               viewMode={activeTab === 'schema' ? 'schema' : 'code'}
               parsedSchema={parsedSchema}
               parsedAvroSchema={parsedAvroSchema}
+              parsedProtoSchema={parsedProtoSchema}
               showRequired={true}
               onOpenFullscreen={
                 activeTab === 'code'
                   ? () => setIsCodeModalOpen(true)
-                  : activeTab === 'schema' && (parsedSchema || parsedAvroSchema)
+                  : activeTab === 'schema' && (parsedSchema || parsedAvroSchema || parsedProtoSchema)
                     ? () => setIsSchemaViewerModalOpen(true)
                     : undefined
               }
@@ -507,6 +522,7 @@ export default function SchemaDetailsPanel({
         message={message}
         parsedSchema={parsedSchema}
         parsedAvroSchema={parsedAvroSchema}
+        parsedProtoSchema={parsedProtoSchema}
       />
     </div>
   );

--- a/packages/core/eventcatalog/src/components/SchemaExplorer/SchemaExplorer.tsx
+++ b/packages/core/eventcatalog/src/components/SchemaExplorer/SchemaExplorer.tsx
@@ -18,6 +18,7 @@ const SCHEMA_TYPE_LABELS: Record<string, string> = {
   avro: 'Avro',
   avsc: 'Avro',
   proto: 'Protobuf',
+  protobuf: 'Protobuf',
   yaml: 'YAML',
   yml: 'YAML',
   xml: 'XML',

--- a/packages/core/eventcatalog/src/components/SchemaExplorer/SchemaExplorer.tsx
+++ b/packages/core/eventcatalog/src/components/SchemaExplorer/SchemaExplorer.tsx
@@ -80,8 +80,16 @@ export default function SchemaExplorer({ schemas, apiAccessEnabled = false }: Sc
 
   const [showFormatFilters, setShowFormatFilters] = useState(() => {
     if (typeof window !== 'undefined') {
-      const stored = localStorage.getItem('schemaRegistrySelectedSchemaType');
-      return stored !== null && stored !== 'all';
+      const storedSchemaType = localStorage.getItem('schemaRegistrySelectedSchemaType');
+      if (storedSchemaType !== null && storedSchemaType !== 'all') return true;
+      const storedTypes = localStorage.getItem('schemaRegistrySelectedTypes');
+      if (storedTypes) {
+        try {
+          return JSON.parse(storedTypes).length > 0;
+        } catch {
+          return false;
+        }
+      }
     }
     return false;
   });
@@ -396,9 +404,9 @@ export default function SchemaExplorer({ schemas, apiAccessEnabled = false }: Sc
             {schemaTypes.length > 0 && (
               <button
                 onClick={() => setShowFormatFilters((prev) => !prev)}
-                aria-pressed={showFormatFilters || selectedSchemaType !== 'all'}
+                aria-pressed={showFormatFilters}
                 className={`relative inline-flex h-9 w-9 items-center justify-center rounded-lg border transition-all ${
-                  showFormatFilters || selectedSchemaType !== 'all'
+                  showFormatFilters || activeFilterCount > 0
                     ? 'border-[rgb(var(--ec-accent)/0.5)] bg-[rgb(var(--ec-accent))] text-white shadow-[0_10px_28px_rgb(var(--ec-accent)/0.3)]'
                     : 'border-[rgb(var(--ec-page-border))] bg-[rgb(var(--ec-dropdown-bg))] text-[rgb(var(--ec-page-text-muted))] hover:border-[rgb(var(--ec-page-text-muted)/0.45)] hover:text-[rgb(var(--ec-page-text))]'
                 }`}
@@ -413,7 +421,7 @@ export default function SchemaExplorer({ schemas, apiAccessEnabled = false }: Sc
             )}
           </div>
 
-          {(showFormatFilters || selectedSchemaType !== 'all' || selectedTypes.size > 0) && (
+          {showFormatFilters && (
             <div className="flex-shrink-0 border-b border-[rgb(var(--ec-page-border))] px-4 py-3">
               <div className="rounded-xl border border-[rgb(var(--ec-page-border))] bg-[rgb(var(--ec-content-hover)/0.45)] p-3">
                 <div className="mb-3 flex items-center justify-between gap-3">

--- a/packages/core/eventcatalog/src/components/SchemaExplorer/SchemaViewerModal.tsx
+++ b/packages/core/eventcatalog/src/components/SchemaExplorer/SchemaViewerModal.tsx
@@ -2,6 +2,7 @@ import * as Dialog from '@radix-ui/react-dialog';
 import { XMarkIcon, ArrowsPointingOutIcon } from '@heroicons/react/24/outline';
 import JSONSchemaViewer from './JSONSchemaViewer';
 import AvroSchemaViewer from './AvroSchemaViewer';
+import ProtobufSchemaViewer from './ProtobufSchemaViewer';
 import type { SchemaItem } from './types';
 
 interface SchemaViewerModalProps {
@@ -10,6 +11,7 @@ interface SchemaViewerModalProps {
   message: SchemaItem;
   parsedSchema: any;
   parsedAvroSchema?: any;
+  parsedProtoSchema?: any;
 }
 
 export default function SchemaViewerModal({
@@ -18,10 +20,12 @@ export default function SchemaViewerModal({
   message,
   parsedSchema,
   parsedAvroSchema,
+  parsedProtoSchema,
 }: SchemaViewerModalProps) {
-  if (!parsedSchema && !parsedAvroSchema) return null;
+  if (!parsedSchema && !parsedAvroSchema && !parsedProtoSchema) return null;
 
   const isAvro = !!parsedAvroSchema;
+  const isProto = !!parsedProtoSchema;
 
   return (
     <Dialog.Root open={isOpen} onOpenChange={onOpenChange}>
@@ -35,7 +39,7 @@ export default function SchemaViewerModal({
               <div>
                 <Dialog.Title className="text-xl font-semibold text-[rgb(var(--ec-page-text))]">{message.data.name}</Dialog.Title>
                 <Dialog.Description className="text-sm text-[rgb(var(--ec-page-text-muted))] mt-1">
-                  v{message.data.version} · {isAvro ? 'Avro' : 'JSON'} Schema
+                  v{message.data.version} · {isAvro ? 'Avro' : isProto ? 'Protobuf' : 'JSON'} Schema
                 </Dialog.Description>
               </div>
             </div>
@@ -54,6 +58,8 @@ export default function SchemaViewerModal({
           <div className="flex-1 overflow-hidden p-6">
             {isAvro ? (
               <AvroSchemaViewer schema={parsedAvroSchema} expand={true} search={true} />
+            ) : isProto ? (
+              <ProtobufSchemaViewer schema={parsedProtoSchema} expand={true} search={true} />
             ) : (
               <JSONSchemaViewer schema={parsedSchema} expand={true} search={true} />
             )}

--- a/packages/core/eventcatalog/src/components/SchemaExplorer/utils.ts
+++ b/packages/core/eventcatalog/src/components/SchemaExplorer/utils.ts
@@ -7,6 +7,7 @@ export const ICON_SPECS: Record<string, string> = {
   avro: 'avro',
   avsc: 'avro',
   proto: 'proto',
+  protobuf: 'proto',
   json: 'json-schema',
 };
 
@@ -20,6 +21,7 @@ export function getFormatBadge(ext?: string): { label: string; color: string } {
     case 'avsc':
       return { label: 'avro', color: 'text-blue-400' };
     case 'proto':
+    case 'protobuf':
       return { label: 'proto', color: 'text-orange-400' };
     case 'yaml':
     case 'yml':
@@ -48,6 +50,7 @@ export const getLanguageForHighlight = (extension?: string): string => {
     case 'json':
       return 'json';
     case 'proto':
+    case 'protobuf':
       return 'protobuf';
     case 'xsd':
     case 'xml':
@@ -79,6 +82,7 @@ export const getSchemaTypeLabel = (extension?: string): string => {
     case 'avsc':
       return 'Avro';
     case 'proto':
+    case 'protobuf':
       return 'Protobuf';
     case 'xsd':
       return 'XML Schema';

--- a/packages/core/eventcatalog/src/utils/__tests__/protobuf-schema.test.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/protobuf-schema.test.ts
@@ -197,6 +197,27 @@ describe('parseProtobufSchema', () => {
     expect(order.fields[1].type).toBe('google.protobuf.Timestamp');
   });
 
+  it('parses fully-qualified type names with a leading dot', () => {
+    const schema = parseProtobufSchema(`
+      syntax = "proto3";
+
+      package com.example;
+
+      message Order {
+        .google.protobuf.Timestamp created_at = 1;
+        .com.example.LineItem item = 2;
+      }
+
+      message LineItem {
+        string sku = 1;
+      }
+    `);
+
+    const order = schema.messages[0];
+    expect(order.fields[0].type).toBe('.google.protobuf.Timestamp');
+    expect(order.fields[1].type).toBe('.com.example.LineItem');
+  });
+
   it('throws on empty content', () => {
     expect(() => parseProtobufSchema('')).toThrow('Protobuf schema is empty');
   });

--- a/packages/core/eventcatalog/src/utils/__tests__/protobuf-schema.test.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/protobuf-schema.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from 'vitest';
+import { parseProtobufSchema } from '../protobuf-schema';
+
+describe('parseProtobufSchema', () => {
+  it('parses a simple proto3 message', () => {
+    const schema = parseProtobufSchema(`
+      syntax = "proto3";
+
+      package com.example.frauddetection;
+
+      message FraudCheckCompleted {
+        string transactionId = 1;
+        int32 riskScore = 2;
+        repeated string reasons = 3;
+        double confidence = 4;
+      }
+    `);
+
+    expect(schema.syntax).toBe('proto3');
+    expect(schema.package).toBe('com.example.frauddetection');
+    expect(schema.messages).toHaveLength(1);
+
+    const message = schema.messages[0];
+    expect(message.name).toBe('FraudCheckCompleted');
+    expect(message.fields).toEqual([
+      { name: 'transactionId', type: 'string', number: 1, label: undefined, oneof: undefined, doc: undefined },
+      { name: 'riskScore', type: 'int32', number: 2, label: undefined, oneof: undefined, doc: undefined },
+      { name: 'reasons', type: 'string', number: 3, label: 'repeated', oneof: undefined, doc: undefined },
+      { name: 'confidence', type: 'double', number: 4, label: undefined, oneof: undefined, doc: undefined },
+    ]);
+  });
+
+  it('parses multiple top-level messages', () => {
+    const schema = parseProtobufSchema(`
+      syntax = "proto3";
+
+      message OrderPlaced {
+        string order_id = 1;
+      }
+
+      message OrderCancelled {
+        string order_id = 1;
+        string reason = 2;
+      }
+    `);
+
+    expect(schema.messages.map((m) => m.name)).toEqual(['OrderPlaced', 'OrderCancelled']);
+  });
+
+  it('parses nested messages and enums', () => {
+    const schema = parseProtobufSchema(`
+      syntax = "proto3";
+
+      message Order {
+        message LineItem {
+          string sku = 1;
+          int32 quantity = 2;
+        }
+
+        enum Status {
+          PENDING = 0;
+          CONFIRMED = 1;
+        }
+
+        string order_id = 1;
+        repeated LineItem items = 2;
+        Status status = 3;
+      }
+    `);
+
+    const order = schema.messages[0];
+    expect(order.messages).toHaveLength(1);
+    expect(order.messages[0].name).toBe('LineItem');
+    expect(order.messages[0].fields.map((f) => f.name)).toEqual(['sku', 'quantity']);
+    expect(order.enums).toHaveLength(1);
+    expect(order.enums[0].name).toBe('Status');
+    expect(order.enums[0].values).toEqual([
+      { name: 'PENDING', value: 0, doc: undefined },
+      { name: 'CONFIRMED', value: 1, doc: undefined },
+    ]);
+    expect(order.fields.map((f) => f.type)).toEqual(['string', 'LineItem', 'Status']);
+  });
+
+  it('captures leading and trailing comments as field docs', () => {
+    const schema = parseProtobufSchema(`
+      syntax = "proto3";
+
+      // Emitted when a fraud check completes.
+      message FraudCheckCompleted {
+        // The unique transaction identifier.
+        string transaction_id = 1;
+        int32 risk_score = 2; // Score between 0 and 100
+        /**
+         * The decision made by the fraud engine.
+         */
+        string decision = 3;
+      }
+    `);
+
+    const message = schema.messages[0];
+    expect(message.doc).toBe('Emitted when a fraud check completes.');
+    expect(message.fields[0].doc).toBe('The unique transaction identifier.');
+    expect(message.fields[1].doc).toBe('Score between 0 and 100');
+    expect(message.fields[2].doc).toBe('The decision made by the fraud engine.');
+  });
+
+  it('parses map fields', () => {
+    const schema = parseProtobufSchema(`
+      syntax = "proto3";
+
+      message Order {
+        map<string, int32> quantities = 1;
+      }
+    `);
+
+    const field = schema.messages[0].fields[0];
+    expect(field.name).toBe('quantities');
+    expect(field.type).toBe('map<string, int32>');
+    expect(field.map).toEqual({ keyType: 'string', valueType: 'int32' });
+  });
+
+  it('parses oneof fields', () => {
+    const schema = parseProtobufSchema(`
+      syntax = "proto3";
+
+      message Payment {
+        oneof payment_method {
+          string card_token = 1;
+          string paypal_id = 2;
+        }
+        string currency = 3;
+      }
+    `);
+
+    const fields = schema.messages[0].fields;
+    expect(fields[0]).toMatchObject({ name: 'card_token', oneof: 'payment_method' });
+    expect(fields[1]).toMatchObject({ name: 'paypal_id', oneof: 'payment_method' });
+    expect(fields[2].oneof).toBeUndefined();
+  });
+
+  it('parses proto2 required and optional labels', () => {
+    const schema = parseProtobufSchema(`
+      syntax = "proto2";
+
+      message User {
+        required string id = 1;
+        optional string nickname = 2;
+      }
+    `);
+
+    const fields = schema.messages[0].fields;
+    expect(fields[0].label).toBe('required');
+    expect(fields[1].label).toBe('optional');
+  });
+
+  it('parses top-level enums', () => {
+    const schema = parseProtobufSchema(`
+      syntax = "proto3";
+
+      // The decision outcome.
+      enum Decision {
+        APPROVED = 0;
+        DECLINED = 1; // Transaction was declined
+        MANUAL_REVIEW = 2;
+      }
+    `);
+
+    expect(schema.enums).toHaveLength(1);
+    expect(schema.enums[0].doc).toBe('The decision outcome.');
+    expect(schema.enums[0].values[1]).toEqual({ name: 'DECLINED', value: 1, doc: 'Transaction was declined' });
+  });
+
+  it('ignores imports, options, reserved fields, field options and services', () => {
+    const schema = parseProtobufSchema(`
+      syntax = "proto3";
+
+      import "google/protobuf/timestamp.proto";
+
+      option java_package = "com.example";
+      option (custom.aggregate) = { foo: 1 };
+
+      message Order {
+        option deprecated = true;
+        reserved 4, 5;
+        reserved "old_field";
+        string order_id = 1 [deprecated = true];
+        google.protobuf.Timestamp created_at = 2;
+      }
+
+      service OrderService {
+        rpc GetOrder (GetOrderRequest) returns (Order);
+      }
+    `);
+
+    const order = schema.messages[0];
+    expect(order.fields.map((f) => f.name)).toEqual(['order_id', 'created_at']);
+    expect(order.fields[1].type).toBe('google.protobuf.Timestamp');
+  });
+
+  it('throws on empty content', () => {
+    expect(() => parseProtobufSchema('')).toThrow('Protobuf schema is empty');
+  });
+
+  it('throws on non-protobuf content', () => {
+    expect(() => parseProtobufSchema('{"type": "object", "properties": {}}')).toThrow();
+  });
+
+  it('throws on an unclosed message', () => {
+    expect(() =>
+      parseProtobufSchema(`
+        syntax = "proto3";
+        message Order {
+          string order_id = 1;
+      `)
+    ).toThrow('Unexpected end of message "Order"');
+  });
+});

--- a/packages/core/eventcatalog/src/utils/files.ts
+++ b/packages/core/eventcatalog/src/utils/files.ts
@@ -59,3 +59,12 @@ export const getAbsoluteFilePathForAstroFile = (filePath: string, fileName?: str
 export const isAvroSchema = (filePath: string): boolean => {
   return filePath.endsWith('.avro') || filePath.endsWith('.avsc');
 };
+
+/**
+ * Checks if a file path is a Protocol Buffers schema based on its extension
+ * @param filePath - The file path to check
+ * @returns True if the file is a Protocol Buffers schema (.proto)
+ */
+export const isProtobufSchema = (filePath: string): boolean => {
+  return filePath.endsWith('.proto');
+};

--- a/packages/core/eventcatalog/src/utils/protobuf-schema.ts
+++ b/packages/core/eventcatalog/src/utils/protobuf-schema.ts
@@ -1,0 +1,473 @@
+/**
+ * Lightweight Protocol Buffers (.proto) parser.
+ *
+ * Parses proto2/proto3 files into a plain JSON tree used by the
+ * ProtobufSchemaViewer component. Runs in both Node (Astro build) and the
+ * browser (Schema Explorer), so it must stay dependency free.
+ *
+ * Captures doc comments (leading `//`, `/* ... *\/` and trailing same-line
+ * comments) so they can be displayed alongside fields, like Avro `doc`.
+ */
+
+export interface ProtobufField {
+  name: string;
+  type: string;
+  number?: number;
+  label?: 'repeated' | 'optional' | 'required';
+  map?: { keyType: string; valueType: string };
+  oneof?: string;
+  doc?: string;
+}
+
+export interface ProtobufEnumValue {
+  name: string;
+  value?: number;
+  doc?: string;
+}
+
+export interface ProtobufEnum {
+  name: string;
+  doc?: string;
+  values: ProtobufEnumValue[];
+}
+
+export interface ProtobufMessage {
+  name: string;
+  doc?: string;
+  fields: ProtobufField[];
+  messages: ProtobufMessage[];
+  enums: ProtobufEnum[];
+}
+
+export interface ProtobufSchema {
+  syntax?: string;
+  package?: string;
+  messages: ProtobufMessage[];
+  enums: ProtobufEnum[];
+}
+
+interface Token {
+  value: string;
+  line: number;
+  doc?: string;
+  isString?: boolean;
+}
+
+const SYMBOLS = new Set(['{', '}', ';', '=', '<', '>', ',', '[', ']', '(', ')', ':']);
+
+const isIdentifierStart = (char: string) => /[A-Za-z_]/.test(char);
+const isIdentifierChar = (char: string) => /[A-Za-z0-9_.]/.test(char);
+const isNumberStart = (char: string) => /[0-9-]/.test(char);
+const isNumberChar = (char: string) => /[0-9a-fA-FxX.+-]/.test(char);
+
+function tokenize(content: string): { tokens: Token[]; trailingComments: Map<number, string> } {
+  const tokens: Token[] = [];
+  const trailingComments = new Map<number, string>();
+  let pendingDoc: string[] = [];
+  let line = 1;
+  let lineHasTokens = false;
+  let i = 0;
+
+  const pushToken = (token: Omit<Token, 'doc'>) => {
+    tokens.push(pendingDoc.length > 0 ? { ...token, doc: pendingDoc.join('\n') } : token);
+    pendingDoc = [];
+    lineHasTokens = true;
+  };
+
+  while (i < content.length) {
+    const char = content[i];
+
+    if (char === '\n') {
+      line++;
+      lineHasTokens = false;
+      i++;
+      continue;
+    }
+
+    if (/\s/.test(char)) {
+      i++;
+      continue;
+    }
+
+    // Line comment
+    if (char === '/' && content[i + 1] === '/') {
+      let comment = '';
+      i += 2;
+      while (i < content.length && content[i] !== '\n') {
+        comment += content[i];
+        i++;
+      }
+      comment = comment.replace(/^\/*\s?/, '').trim();
+      if (lineHasTokens) {
+        trailingComments.set(line, trailingComments.has(line) ? `${trailingComments.get(line)}\n${comment}` : comment);
+      } else if (comment) {
+        pendingDoc.push(comment);
+      }
+      continue;
+    }
+
+    // Block comment
+    if (char === '/' && content[i + 1] === '*') {
+      let comment = '';
+      i += 2;
+      while (i < content.length && !(content[i] === '*' && content[i + 1] === '/')) {
+        if (content[i] === '\n') line++;
+        comment += content[i];
+        i++;
+      }
+      i += 2;
+      const cleaned = comment
+        .split('\n')
+        .map((commentLine) => commentLine.replace(/^\s*\*?\s?/, '').trim())
+        .filter(Boolean)
+        .join('\n');
+      if (cleaned) pendingDoc.push(cleaned);
+      continue;
+    }
+
+    // String literal
+    if (char === '"' || char === "'") {
+      const quote = char;
+      let value = '';
+      i++;
+      while (i < content.length && content[i] !== quote) {
+        if (content[i] === '\\') {
+          value += content[i + 1];
+          i += 2;
+          continue;
+        }
+        if (content[i] === '\n') line++;
+        value += content[i];
+        i++;
+      }
+      i++;
+      pushToken({ value, line, isString: true });
+      continue;
+    }
+
+    if (SYMBOLS.has(char)) {
+      pushToken({ value: char, line });
+      i++;
+      continue;
+    }
+
+    if (isIdentifierStart(char)) {
+      let value = '';
+      while (i < content.length && isIdentifierChar(content[i])) {
+        value += content[i];
+        i++;
+      }
+      pushToken({ value, line });
+      continue;
+    }
+
+    if (isNumberStart(char)) {
+      let value = content[i];
+      i++;
+      while (i < content.length && isNumberChar(content[i])) {
+        value += content[i];
+        i++;
+      }
+      pushToken({ value, line });
+      continue;
+    }
+
+    throw new Error(`Unexpected character "${char}" at line ${line}`);
+  }
+
+  return { tokens, trailingComments };
+}
+
+class ProtobufParser {
+  private tokens: Token[];
+  private trailingComments: Map<number, string>;
+  private pos = 0;
+
+  constructor(content: string) {
+    const { tokens, trailingComments } = tokenize(content);
+    this.tokens = tokens;
+    this.trailingComments = trailingComments;
+  }
+
+  private peek(): Token | undefined {
+    return this.tokens[this.pos];
+  }
+
+  private next(): Token {
+    const token = this.tokens[this.pos];
+    if (!token) throw new Error('Unexpected end of protobuf schema');
+    this.pos++;
+    return token;
+  }
+
+  private expect(value: string): Token {
+    const token = this.next();
+    if (token.value !== value) {
+      throw new Error(`Expected "${value}" but found "${token.value}" at line ${token.line}`);
+    }
+    return token;
+  }
+
+  // Consume tokens until a top-level ";" (skips over nested braces, e.g. aggregate options)
+  private skipStatement() {
+    let depth = 0;
+    while (this.pos < this.tokens.length) {
+      const token = this.next();
+      if (token.value === '{') depth++;
+      if (token.value === '}') depth--;
+      if (token.value === ';' && depth <= 0) return;
+    }
+  }
+
+  private skipBlock() {
+    this.expect('{');
+    let depth = 1;
+    while (this.pos < this.tokens.length && depth > 0) {
+      const token = this.next();
+      if (token.value === '{') depth++;
+      if (token.value === '}') depth--;
+    }
+  }
+
+  // Skip field options like [deprecated = true, (custom) = "value"]
+  private skipFieldOptions() {
+    if (this.peek()?.value !== '[') return;
+    let depth = 0;
+    while (this.pos < this.tokens.length) {
+      const token = this.next();
+      if (token.value === '[') depth++;
+      if (token.value === ']') depth--;
+      if (depth === 0) return;
+    }
+  }
+
+  private getTrailingDoc(line: number): string | undefined {
+    return this.trailingComments.get(line);
+  }
+
+  parse(): ProtobufSchema {
+    const schema: ProtobufSchema = { messages: [], enums: [] };
+
+    while (this.pos < this.tokens.length) {
+      const token = this.peek()!;
+
+      switch (token.value) {
+        case 'syntax':
+        case 'edition': {
+          this.next();
+          this.expect('=');
+          schema.syntax = this.next().value;
+          this.expect(';');
+          break;
+        }
+        case 'package': {
+          this.next();
+          schema.package = this.next().value;
+          this.expect(';');
+          break;
+        }
+        case 'import':
+        case 'option': {
+          this.next();
+          this.skipStatement();
+          break;
+        }
+        case 'message': {
+          schema.messages.push(this.parseMessage());
+          break;
+        }
+        case 'enum': {
+          schema.enums.push(this.parseEnum());
+          break;
+        }
+        case 'service':
+        case 'extend': {
+          this.next();
+          this.next(); // name
+          this.skipBlock();
+          break;
+        }
+        case ';': {
+          this.next();
+          break;
+        }
+        default:
+          throw new Error(`Unexpected token "${token.value}" at line ${token.line}`);
+      }
+    }
+
+    return schema;
+  }
+
+  private parseMessage(): ProtobufMessage {
+    const keyword = this.expect('message');
+    const name = this.next().value;
+    const message: ProtobufMessage = { name, doc: keyword.doc, fields: [], messages: [], enums: [] };
+
+    this.expect('{');
+
+    while (this.pos < this.tokens.length) {
+      const token = this.peek()!;
+
+      if (token.value === '}') {
+        this.next();
+        return message;
+      }
+
+      switch (token.value) {
+        case 'message':
+          message.messages.push(this.parseMessage());
+          break;
+        case 'enum':
+          message.enums.push(this.parseEnum());
+          break;
+        case 'oneof': {
+          this.next();
+          const oneofName = this.next().value;
+          this.expect('{');
+          while (this.peek() && this.peek()!.value !== '}') {
+            if (this.peek()!.value === 'option') {
+              this.next();
+              this.skipStatement();
+              continue;
+            }
+            message.fields.push(this.parseField(oneofName));
+          }
+          this.expect('}');
+          break;
+        }
+        case 'map':
+          message.fields.push(this.parseMapField());
+          break;
+        case 'option':
+        case 'reserved':
+        case 'extensions': {
+          this.next();
+          this.skipStatement();
+          break;
+        }
+        case 'extend': {
+          this.next();
+          this.next(); // type name
+          this.skipBlock();
+          break;
+        }
+        case ';':
+          this.next();
+          break;
+        default:
+          message.fields.push(this.parseField());
+      }
+    }
+
+    throw new Error(`Unexpected end of message "${name}"`);
+  }
+
+  private parseField(oneof?: string): ProtobufField {
+    let firstToken = this.peek()!;
+    let label: ProtobufField['label'];
+
+    if (firstToken.value === 'repeated' || firstToken.value === 'optional' || firstToken.value === 'required') {
+      label = firstToken.value;
+      this.next();
+    }
+
+    if (this.peek()?.value === 'map') {
+      const mapField = this.parseMapField();
+      return { ...mapField, doc: mapField.doc || firstToken.doc, oneof };
+    }
+
+    const typeToken = this.next();
+    const name = this.next().value;
+    this.expect('=');
+    const numberToken = this.next();
+    this.skipFieldOptions();
+    const terminator = this.expect(';');
+
+    const parsedNumber = Number.parseInt(numberToken.value, 10);
+
+    return {
+      name,
+      type: typeToken.value,
+      number: Number.isNaN(parsedNumber) ? undefined : parsedNumber,
+      label,
+      oneof,
+      doc: firstToken.doc || typeToken.doc || this.getTrailingDoc(terminator.line),
+    };
+  }
+
+  private parseMapField(): ProtobufField {
+    const keyword = this.expect('map');
+    this.expect('<');
+    const keyType = this.next().value;
+    this.expect(',');
+    const valueType = this.next().value;
+    this.expect('>');
+    const name = this.next().value;
+    this.expect('=');
+    const numberToken = this.next();
+    this.skipFieldOptions();
+    const terminator = this.expect(';');
+
+    const parsedNumber = Number.parseInt(numberToken.value, 10);
+
+    return {
+      name,
+      type: `map<${keyType}, ${valueType}>`,
+      map: { keyType, valueType },
+      number: Number.isNaN(parsedNumber) ? undefined : parsedNumber,
+      doc: keyword.doc || this.getTrailingDoc(terminator.line),
+    };
+  }
+
+  private parseEnum(): ProtobufEnum {
+    const keyword = this.expect('enum');
+    const name = this.next().value;
+    const protoEnum: ProtobufEnum = { name, doc: keyword.doc, values: [] };
+
+    this.expect('{');
+
+    while (this.pos < this.tokens.length) {
+      const token = this.peek()!;
+
+      if (token.value === '}') {
+        this.next();
+        return protoEnum;
+      }
+
+      if (token.value === 'option' || token.value === 'reserved') {
+        this.next();
+        this.skipStatement();
+        continue;
+      }
+
+      if (token.value === ';') {
+        this.next();
+        continue;
+      }
+
+      const valueToken = this.next();
+      this.expect('=');
+      const numberToken = this.next();
+      this.skipFieldOptions();
+      const terminator = this.expect(';');
+
+      const parsedNumber = Number.parseInt(numberToken.value, 10);
+
+      protoEnum.values.push({
+        name: valueToken.value,
+        value: Number.isNaN(parsedNumber) ? undefined : parsedNumber,
+        doc: valueToken.doc || this.getTrailingDoc(terminator.line),
+      });
+    }
+
+    throw new Error(`Unexpected end of enum "${name}"`);
+  }
+}
+
+export function parseProtobufSchema(content: string): ProtobufSchema {
+  if (!content || content.trim() === '') {
+    throw new Error('Protobuf schema is empty');
+  }
+  return new ProtobufParser(content).parse();
+}

--- a/packages/core/eventcatalog/src/utils/protobuf-schema.ts
+++ b/packages/core/eventcatalog/src/utils/protobuf-schema.ts
@@ -151,8 +151,11 @@ function tokenize(content: string): { tokens: Token[]; trailingComments: Map<num
       continue;
     }
 
-    if (isIdentifierStart(char)) {
-      let value = '';
+    // Identifiers, including fully-qualified type names with a leading dot
+    // (e.g. ".google.protobuf.Timestamp")
+    if (isIdentifierStart(char) || (char === '.' && isIdentifierStart(content[i + 1] || ''))) {
+      let value = char === '.' ? '.' : '';
+      if (char === '.') i++;
       while (i < content.length && isIdentifierChar(content[i])) {
         value += content[i];
         i++;


### PR DESCRIPTION

Closes https://github.com/event-catalog/eventcatalog/issues/1182

## What This PR Does

Adds first-class Protocol Buffers (`.proto`) support to EventCatalog's schema rendering. The `<SchemaViewer />` MDX component and the Schema Explorer now render structured, searchable views for proto schemas — the same experience JSON Schema and Avro already have — instead of falling back to raw code display (or failing to parse).

## Changes Overview

### Key Changes

- **New dependency-free proto parser** (`utils/protobuf-schema.ts`): a small tokenizer + recursive-descent parser for proto2/proto3 that runs in both Node (Astro build) and the browser (Schema Explorer). It captures doc comments (leading `//`, `/* */`, and trailing same-line comments) so field documentation renders like Avro's `doc`, and handles nested messages, enums, maps, oneofs, reserved fields, field options, aggregate options, imports, and service blocks (skipped).
- **New `ProtobufSchemaViewer` component**: search with match navigation, expand/collapse all, fullscreen, package/syntax header, per-message sections, field numbers, `oneof` badges, enum value chips, and `required` badges for proto2. Styled to match `JSONSchemaViewer` row-for-row (same toggle glyphs, gutter alignment, and spacing). Proto types reference messages/enums by name, so the viewer builds a type registry to resolve and expand them inline, with a cycle guard for self-referencing messages.
- **MDX `<SchemaViewer />` wiring**: `.proto` files (via `file` prop or the schemas collection with `format: protobuf`) are detected and rendered with the new viewer. Parse errors now surface as a warning admonition instead of silently breaking every viewer on the page (previously, a malformed local schema file threw during render with no try/catch).
- **Schema Explorer wiring**: proto schemas get the "Properties" tab, the structured viewer, and the fullscreen modal (labelled "Protobuf Schema").
- **Schema Explorer filter panel fix**: the filter panel could not be collapsed while a filter was active, because the render condition forced it open. The toggle button now always controls the panel; active filters remain visible via the accent styling and count badge.
- **Example catalog**: fixed `FraudCheckCompleted` pointing at a non-existent `schema.json`, enriched its proto with comments/enums/nested messages, and added five new proto-backed events that stress different parser/renderer features:
  - `ShipmentRouteUpdated` (ShippingService) — deep nesting, imports, well-known types
  - `PaymentSettled` (PaymentService) — oneofs, reserved fields, deprecated field options
  - `WarehouseStockSnapshot` (InventoryService) — maps with message values, multiple top-level messages
  - `LegacyOrderArchived` (OrdersService) — proto2 with `required`/`optional` labels
  - `CustomerEngagementRecorded` (NotificationService) — self-referencing message tree, oneofs, service block

## How It Works

`resolveSchemaViewer` detects proto schemas by file extension (`.proto`) or schema collection format (`protobuf`/`proto`) and parses the content with `parseProtobufSchema` into a plain JSON tree (`{ syntax, package, messages, enums }`). `SchemaViewerRoot.astro` branches on `isProtobufSchema` to render the new viewer. In the Schema Explorer, `SchemaDetailsPanel` parses proto content client-side (memoized) and threads `parsedProtoSchema` through `SchemaContentViewer` and `SchemaViewerModal`, mirroring the existing Avro flow.

Since proto fields reference types by name (unlike Avro's inline nesting), the viewer registers every message/enum under both its qualified and simple name, then resolves field types by trying the name as written, without the package prefix, and by last segment. Self-referencing types stop expanding via an ancestor check.

## Breaking Changes

None.

## Additional Notes

- The repo now has three proto field extractors: the new parser, the regex one in `schema-utils.ts` (print/field-lineage), and the regex one in `enterprise/fields/field-extractor.ts` (AI field indexing). Consolidating the two regex extractors onto the new parser is a recommended follow-up — it would give nested field paths in lineage.
- The viewer toolbar/search shell is now duplicated three times (JSON, Avro, Protobuf); extracting a shared shell is a separate refactor candidate.
- Type resolution is name-based, not full proto scope resolution; two nested messages sharing a simple name in different scopes resolve first-wins.
- Docs in `website-2` and a compatible follow-up in `eventcatalog-editor` (proto syntax highlighting / schema preview, if applicable) should follow this release.