### PR TITLE
Improve type safety in SchemaViewer

### DIFF
--- a/.changeset/quiet-otters-listen.md
+++ b/.changeset/quiet-otters-listen.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Improve type safety in SchemaViewer by typing the resolved schemas array and documenting supported SchemaViewer props

--- a/packages/core/eventcatalog/src/components/MDX/SchemaViewer/SchemaViewerRoot.astro
+++ b/packages/core/eventcatalog/src/components/MDX/SchemaViewer/SchemaViewerRoot.astro
@@ -10,7 +10,9 @@ import { getMDXComponentsByName } from '@utils/markdown';
 import { resolveProjectPath } from '@utils/files';
 import { resolveSchemaViewer } from './schema-viewer-utils';
 
-let schemas = [];
+type ResolvedSchemaViewer = Awaited<ReturnType<typeof resolveSchemaViewer>>;
+
+let schemas: ResolvedSchemaViewer[] = [];
 
 try {
   const absoluteFilePath = resolveProjectPath(filePath);

--- a/packages/core/eventcatalog/src/components/MDX/SchemaViewer/schema-viewer-utils.ts
+++ b/packages/core/eventcatalog/src/components/MDX/SchemaViewer/schema-viewer-utils.ts
@@ -7,6 +7,11 @@ import { parseProtobufSchema } from '../../../utils/protobuf-schema';
 type SchemaViewerProps = {
   id?: string;
   file?: string;
+  title?: string;
+  maxHeight?: string;
+  expand?: boolean;
+  search?: boolean;
+  showRequired?: boolean;
   [key: string]: any;
 };
 


### PR DESCRIPTION
## What This PR Does

Small type-safety cleanup for the SchemaViewer MDX component. The `schemas` array in `SchemaViewerRoot.astro` was untyped (`let schemas = []`), and the `SchemaViewerProps` type only declared `id` and `file` while the component actually supports several more props. This PR makes both explicit.

## Changes Overview

### Key Changes
- `SchemaViewerRoot.astro`: type the `schemas` array as `ResolvedSchemaViewer[]`, derived from the return type of `resolveSchemaViewer` via `Awaited<ReturnType<...>>`
- `schema-viewer-utils.ts`: add explicit optional props to `SchemaViewerProps` — `title`, `maxHeight`, `expand`, `search`, `showRequired`

## How It Works

Instead of duplicating the resolved schema shape, the Astro component derives the type directly from `resolveSchemaViewer`, so it stays in sync if the resolver changes. The new props in `SchemaViewerProps` document the supported options that were previously only reachable through the `[key: string]: any` index signature.

## Breaking Changes

None — types only, no runtime behavior changes.

## Additional Notes

No editor repository (`eventcatalog/eventcatalog-editor`) changes are needed; this is internal typing only.