### PR TITLE
Add LikeC4View MDX component for rendering LikeC4 diagrams

### DIFF
--- a/.changeset/curly-otters-grin.md
+++ b/.changeset/curly-otters-grin.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Add LikeC4 diagram support via the `<LikeC4View />` MDX component. EventCatalog now auto-detects `.c4` sources, loads the LikeC4 Vite plugin when present, and renders views from discovered LikeC4 projects.

--- a/packages/core/eventcatalog/astro.config.mjs
+++ b/packages/core/eventcatalog/astro.config.mjs
@@ -13,6 +13,7 @@ import node from '@astrojs/node';
 import remarkComment from 'remark-comment';
 import rehypeSlug from 'rehype-slug';
 import rehypeAutolinkHeadings from 'rehype-autolink-headings';
+import { eventCatalogLikeC4 } from './src/plugins/likec4';
 
 import rehypeExpressiveCode from 'rehype-expressive-code';
 
@@ -41,7 +42,7 @@ const mdxRemarkPlugins = [...markdownRemarkPlugins, remarkResourceRef];
 // https://astro.build/config
 export default defineConfig({
   base,
-  server: { 
+  server: {
     port: config.port || 3000,
     host: host,
     // Add allowed hosts if its set
@@ -110,7 +111,7 @@ export default defineConfig({
     eventCatalogIntegration(),
   ].filter(Boolean),
   vite: {
-    plugins: [tailwindcss()],
+    plugins: [tailwindcss(), ...(await eventCatalogLikeC4(projectDirectory))],
     define: {
       /**
        * Trailing slash is exposed as global variable here principally for `@utils/url-builder`.
@@ -124,7 +125,7 @@ export default defineConfig({
     },
     server: {
       fs: {
-        allow: ['..', './node_modules/@fontsource', searchForWorkspaceRoot(process.cwd())],
+        allow: ['..', './node_modules/@fontsource', projectDirectory, searchForWorkspaceRoot(process.cwd())],
       },
       // Prevent stale FSEvents from triggering a config-dependency restart on first run.
       // During startup, catalogToAstro copies eventcatalog.config.js into .eventcatalog-core

--- a/packages/core/eventcatalog/src/components/MDX/LikeC4View/LikeC4View.astro
+++ b/packages/core/eventcatalog/src/components/MDX/LikeC4View/LikeC4View.astro
@@ -1,0 +1,13 @@
+---
+import LikeC4ViewWrapper from './LikeC4ViewWrapper';
+
+interface Props {
+  viewId: string;
+  project?: string;
+  height?: string;
+}
+
+const { viewId, project, height } = Astro.props;
+---
+
+<LikeC4ViewWrapper viewId={viewId} project={project} height={height} client:only="react" />

--- a/packages/core/eventcatalog/src/components/MDX/LikeC4View/LikeC4ViewWrapper.tsx
+++ b/packages/core/eventcatalog/src/components/MDX/LikeC4View/LikeC4ViewWrapper.tsx
@@ -1,0 +1,52 @@
+import { lazy, Suspense, useMemo, type ComponentType } from 'react';
+import { getProjectLoader } from 'virtual:likec4-projects';
+
+interface LikeC4ViewWrapperProps {
+  viewId: string;
+  project?: string;
+  height?: string;
+}
+
+interface LikeC4ViewProps {
+  viewId: string;
+  controls?: boolean;
+  browser?: {
+    enableFocusMode?: boolean;
+    enableSearch?: boolean;
+  };
+}
+
+const lazyComponentCache = new Map<string, ComponentType<LikeC4ViewProps>>();
+
+const getLazyComponent = (project: string): ComponentType<LikeC4ViewProps> => {
+  const key = project || 'default';
+
+  if (!lazyComponentCache.has(key)) {
+    const loader = getProjectLoader(key);
+    const LazyComponent = lazy(() => loader().then((mod) => ({ default: mod.LikeC4View })));
+    lazyComponentCache.set(key, LazyComponent);
+  }
+
+  return lazyComponentCache.get(key)!;
+};
+
+export default function LikeC4ViewWrapper({ viewId, project, height = '600px' }: LikeC4ViewWrapperProps) {
+  const LikeC4ViewComponent = useMemo(() => getLazyComponent(project || 'default'), [project]);
+
+  return (
+    <div style={{ height, maxHeight: height }} className="w-full overflow-hidden rounded-lg border border-gray-200">
+      <Suspense
+        fallback={<div className="flex h-full items-center justify-center rounded-lg bg-gray-100">Loading diagram...</div>}
+      >
+        <LikeC4ViewComponent
+          viewId={viewId}
+          controls={false}
+          browser={{
+            enableFocusMode: false,
+            enableSearch: false,
+          }}
+        />
+      </Suspense>
+    </div>
+  );
+}

--- a/packages/core/eventcatalog/src/components/MDX/components.tsx
+++ b/packages/core/eventcatalog/src/components/MDX/components.tsx
@@ -31,6 +31,7 @@ import FigJam from '@components/MDX/FigJam/FigJam.astro';
 import IcePanel from '@components/MDX/IcePanel/IcePanel.astro';
 import Design from '@components/MDX/Design/Design.astro';
 import MermaidFileLoader from '@components/MDX/MermaidFileLoader/MermaidFileLoader.astro';
+import LikeC4View from '@components/MDX/LikeC4View/LikeC4View.astro';
 //  Portals: required for server/client components
 import NodeGraphPortal from '@components/MDX/NodeGraph/NodeGraphPortal';
 import SchemaViewerPortal from '@components/MDX/SchemaViewer/SchemaViewerPortal';
@@ -76,6 +77,7 @@ const components = (props: any) => {
     FigJam: (mdxProp: any) => jsx(FigJam, { ...props, ...mdxProp }),
     IcePanel: (mdxProp: any) => jsx(IcePanel, { ...props, ...mdxProp }),
     MermaidFileLoader: (mdxProp: any) => jsx(MermaidFileLoader, { ...props, ...mdxProp }),
+    LikeC4View: (mdxProp: any) => jsx(LikeC4View, { ...props, ...mdxProp }),
   };
 };
 

--- a/packages/core/eventcatalog/src/env.d.ts
+++ b/packages/core/eventcatalog/src/env.d.ts
@@ -5,6 +5,12 @@ declare const __EC_TRAILING_SLASH__: boolean;
 declare const __EC_BASE__: string;
 declare const __EC_SEARCH_TYPE__: 'resource' | 'indexed';
 
+declare module 'virtual:likec4-projects' {
+  export const projectRegistry: Record<string, () => Promise<{ LikeC4View: import('react').ComponentType<any> }>>;
+  export const discoveredProjects: string[];
+  export function getProjectLoader(projectName: string): () => Promise<{ LikeC4View: import('react').ComponentType<any> }>;
+}
+
 interface EventCatalogConfig {
   mermaid?: {
     iconPacks?: string[];

--- a/packages/core/eventcatalog/src/plugins/likec4.ts
+++ b/packages/core/eventcatalog/src/plugins/likec4.ts
@@ -1,0 +1,169 @@
+import type { Plugin } from 'vite';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { glob, globSync } from 'glob';
+
+interface LikeC4Config {
+  name?: string;
+}
+
+const virtualModuleId = 'virtual:likec4-projects';
+const resolvedVirtualModuleId = `\0${virtualModuleId}`;
+
+const likeC4InstallMessage = `LikeC4 diagrams were found, but LikeC4 is not installed.
+
+Install LikeC4 in your EventCatalog project:
+
+  npm install --save-dev likec4@latest @likec4/icons@latest
+  pnpm add -D likec4@latest @likec4/icons@latest
+  yarn add -D likec4@latest @likec4/icons@latest`;
+
+export const eventCatalogLikeC4 = async (workspaceDir: string): Promise<Plugin[]> => {
+  const enabled = hasLikeC4Sources(workspaceDir);
+  const registry = likeC4ProjectRegistry(workspaceDir, enabled);
+
+  if (!enabled) {
+    return [registry];
+  }
+
+  const LikeC4VitePlugin = await loadLikeC4VitePlugin(workspaceDir);
+
+  return [
+    LikeC4VitePlugin({
+      workspace: workspaceDir,
+    }),
+    registry,
+  ];
+};
+
+const hasLikeC4Sources = (workspaceDir: string) => {
+  return (
+    globSync('**/*.c4', {
+      cwd: workspaceDir,
+      ignore: ['**/node_modules/**'],
+    }).length > 0
+  );
+};
+
+const loadLikeC4VitePlugin = async (workspaceDir: string) => {
+  try {
+    const requireFromCatalog = createRequire(join(workspaceDir, 'package.json'));
+    const likeC4VitePluginPath = requireFromCatalog.resolve('likec4/vite-plugin');
+    const likeC4 = await import(/* @vite-ignore */ pathToFileURL(likeC4VitePluginPath).href);
+
+    if (!likeC4.LikeC4VitePlugin) {
+      throw new Error('The installed likec4 package does not export LikeC4VitePlugin from likec4/vite-plugin.');
+    }
+
+    return likeC4.LikeC4VitePlugin;
+  } catch (error) {
+    throw new Error(`${likeC4InstallMessage}\n\n${error instanceof Error ? error.message : String(error)}`);
+  }
+};
+
+const likeC4ProjectRegistry = (workspaceDir: string, enabled: boolean): Plugin => {
+  let discoveredProjects: string[] = [];
+
+  const discoverProjects = async () => {
+    const configFiles = await glob('**/likec4.config.json', {
+      cwd: workspaceDir,
+      ignore: ['**/node_modules/**'],
+      absolute: true,
+    });
+
+    const projectNames = new Set<string>();
+
+    for (const configPath of configFiles) {
+      try {
+        const config = JSON.parse(readFileSync(configPath, 'utf-8')) as LikeC4Config;
+        if (config.name) {
+          projectNames.add(config.name);
+        }
+      } catch (error) {
+        console.warn(`[likec4-registry] Failed to parse ${configPath}:`, error);
+      }
+    }
+
+    discoveredProjects = Array.from(projectNames).sort();
+
+    if (discoveredProjects.length > 0) {
+      console.log(`[likec4-registry] Discovered projects: ${discoveredProjects.join(', ')}`);
+    }
+  };
+
+  return {
+    name: 'eventcatalog-likec4',
+
+    async buildStart() {
+      if (enabled) {
+        await discoverProjects();
+      }
+    },
+
+    resolveId(id) {
+      if (id === virtualModuleId) {
+        return resolvedVirtualModuleId;
+      }
+    },
+
+    load(id) {
+      if (id !== resolvedVirtualModuleId) {
+        return;
+      }
+
+      if (!enabled) {
+        return `
+export const projectRegistry = {
+  default: () => Promise.resolve({
+    LikeC4View: () => null,
+  }),
+};
+
+export const discoveredProjects = [];
+
+export function getProjectLoader() {
+  return projectRegistry.default;
+}
+`;
+      }
+
+      const imports = discoveredProjects
+        .map((name, index) => `import * as project_${index} from ${JSON.stringify(`likec4:react/${name}`)};`)
+        .join('\n');
+      const registryEntries = discoveredProjects
+        .map((name, index) => `  ${JSON.stringify(name)}: () => Promise.resolve(project_${index}),`)
+        .join('\n');
+
+      return `
+import * as defaultProject from 'likec4:react';
+${imports}
+
+export const projectRegistry = {
+  default: () => Promise.resolve(defaultProject),
+${registryEntries}
+};
+
+export const discoveredProjects = ${JSON.stringify(discoveredProjects)};
+
+export function getProjectLoader(projectName) {
+  return projectRegistry[projectName] || projectRegistry.default;
+}
+`;
+    },
+
+    configureServer(server) {
+      server.watcher.add(join(workspaceDir, '**/likec4.config.json'));
+      server.watcher.on('change', async (path) => {
+        if (path.endsWith('likec4.config.json')) {
+          await discoverProjects();
+          const module = server.moduleGraph.getModuleById(resolvedVirtualModuleId);
+          if (module) {
+            server.moduleGraph.invalidateModule(module);
+          }
+        }
+      });
+    },
+  };
+};

--- a/packages/core/eventcatalog/src/plugins/likec4.ts
+++ b/packages/core/eventcatalog/src/plugins/likec4.ts
@@ -40,7 +40,7 @@ export const eventCatalogLikeC4 = async (workspaceDir: string): Promise<Plugin[]
 
 const hasLikeC4Sources = (workspaceDir: string) => {
   return (
-    globSync('**/*.c4', {
+    globSync('**/*.{c4,likec4}', {
       cwd: workspaceDir,
       ignore: ['**/node_modules/**'],
     }).length > 0
@@ -67,7 +67,7 @@ const likeC4ProjectRegistry = (workspaceDir: string, enabled: boolean): Plugin =
   let discoveredProjects: string[] = [];
 
   const discoverProjects = async () => {
-    const configFiles = await glob('**/likec4.config.json', {
+    const configFiles = await glob('**/{likec4.config.json,.likec4rc}', {
       cwd: workspaceDir,
       ignore: ['**/node_modules/**'],
       absolute: true,


### PR DESCRIPTION
## What This PR Does

Adds first-class support for embedding [LikeC4](https://likec4.dev) diagrams directly in EventCatalog documentation. Authors can drop a `<LikeC4View />` component into any MDX page to render a view from their LikeC4 model. EventCatalog auto-detects `.c4` sources in the project, loads the LikeC4 Vite plugin only when LikeC4 is installed, and discovers multiple LikeC4 projects so views can be referenced by project name.

## Changes Overview

### Key Changes

- **New `<LikeC4View />` MDX component** (`LikeC4View.astro` + `LikeC4ViewWrapper.tsx`) — renders a LikeC4 view by `viewId`, with optional `project` and `height` props. The React view is lazy-loaded per project and cached, with a loading fallback.
- **New Vite plugin** (`src/plugins/likec4.ts`) — detects `.c4` files, conditionally loads `likec4/vite-plugin`, and exposes a `virtual:likec4-projects` module that maps discovered LikeC4 projects to their React loaders. Watches `likec4.config.json` files for changes in dev.
- **Astro config wiring** (`astro.config.mjs`) — registers the plugin and allows the project directory in the Vite dev server `fs.allow` list.
- **Component registration** (`components.tsx`) — exposes `LikeC4View` to MDX.
- **Type declarations** (`env.d.ts`) — declares the `virtual:likec4-projects` virtual module.

## How It Works

On startup the plugin globs for `.c4` files. If none exist, it registers a no-op virtual module so the component renders nothing and LikeC4 stays an optional dependency. If `.c4` sources are found, it resolves `likec4/vite-plugin` from the catalog's `node_modules` (surfacing an install message if missing) and scans `likec4.config.json` files to build a registry of named projects. The virtual module emits per-project `likec4:react/<name>` imports, and the wrapper lazy-loads the matching `LikeC4View` React component on demand, caching loaders by project key.

## Breaking Changes

None. LikeC4 support is opt-in and only activates when `.c4` sources are present and LikeC4 is installed.

## Additional Notes

LikeC4 (`likec4` and `@likec4/icons`) is an optional peer dependency — the plugin guides users to install it when `.c4` files are detected but the package is missing. No changes are needed in the editor repository (`eventcatalog/eventcatalog-editor`) for this MDX rendering feature.