### PR TITLE
Enable AI assistant on paid plans

### DIFF
--- a/.changeset/curious-otters-listen.md
+++ b/.changeset/curious-otters-listen.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Enable the AI assistant on paid (Starter) plans, not just Scale, and update billing copy to reflect that MCP server and other advanced features remain Scale-only

--- a/packages/core/eventcatalog/src/components/Settings/BillingSettingsForm.tsx
+++ b/packages/core/eventcatalog/src/components/Settings/BillingSettingsForm.tsx
@@ -129,7 +129,7 @@ export const BillingSettingsForm = ({ currentPlan }: Props) => {
     <div className="divide-y divide-[rgb(var(--ec-page-border))]">
       <Row
         title="Billing plan"
-        description="View and manage your billing plan. Upgrade unlocks the AI assistant, MCP server, and other Scale-only features."
+        description="View and manage your billing plan. Paid plans unlock the AI assistant, with MCP server and other advanced features available on Scale."
         canEdit={false}
         dirty={false}
       >

--- a/packages/core/eventcatalog/src/enterprise/ai/chat-api.ts
+++ b/packages/core/eventcatalog/src/enterprise/ai/chat-api.ts
@@ -6,7 +6,7 @@
 import type { APIContext } from 'astro';
 import { convertToModelMessages, stepCountIs, streamText, tool, type LanguageModel, type ModelMessage, type UIMessage } from 'ai';
 import { join } from 'node:path';
-import { isEventCatalogScaleEnabled } from '@utils/feature';
+import { isEventCatalogScaleEnabled, isEventCatalogStarterEnabled } from '@utils/feature';
 import { getCollection, getEntry } from 'astro:content';
 import { z } from 'astro/zod';
 import { getConsumersOfMessage, getProducersOfMessage } from '@utils/collections/services';
@@ -40,6 +40,8 @@ let hasChatConfiguration = false;
 let model: LanguageModel;
 let modelConfiguration: any;
 let extendedTools: any;
+
+const hasAssistantPlan = () => isEventCatalogStarterEnabled() || isEventCatalogScaleEnabled();
 
 try {
   const providerConfiguration = await import(/* @vite-ignore */ join(catalogDirectory, 'eventcatalog.chat.js'));
@@ -158,7 +160,7 @@ interface Message {
 }
 
 export const GET = async ({ request }: APIContext<{ question: string; messages: Message[]; additionalContext?: string }>) => {
-  if (!isEventCatalogScaleEnabled()) {
+  if (!hasAssistantPlan()) {
     return new Response(JSON.stringify({ error: 'Chat is not enabled' }), {
       status: 403,
       headers: { 'Content-Type': 'application/json' },
@@ -183,8 +185,8 @@ export const GET = async ({ request }: APIContext<{ question: string; messages: 
 export const POST = async ({ request }: APIContext<{ question: string; messages: Message[]; additionalContext?: string }>) => {
   const { messages }: { messages: UIMessage[] } = await request.json();
 
-  if (!isEventCatalogScaleEnabled()) {
-    return new Response(JSON.stringify({ error: 'Chat is not enabled, please upgrade to the scale plan to use this feature' }), {
+  if (!hasAssistantPlan()) {
+    return new Response(JSON.stringify({ error: 'Chat is not enabled, please upgrade to a paid plan to use this feature' }), {
       status: 403,
       headers: { 'Content-Type': 'application/json' },
     });


### PR DESCRIPTION
## What This PR Does

Makes the AI chat assistant available on paid (Starter) plans, not just the Scale plan. Previously the chat API gated access behind `isEventCatalogScaleEnabled()` alone; it now also accepts the Starter plan. Billing copy is updated to clarify that paid plans unlock the AI assistant while the MCP server and other advanced features remain Scale-only.

## Changes Overview

### Key Changes

- Add a `hasAssistantPlan()` helper in `chat-api.ts` that returns true for either Starter or Scale plans.
- Use `hasAssistantPlan()` in both the `GET` and `POST` chat handlers instead of `isEventCatalogScaleEnabled()`.
- Update the `POST` error message to refer to "a paid plan" rather than "the scale plan".
- Update the billing plan description in `BillingSettingsForm.tsx` to reflect the new plan tiers.

## How It Works

The chat API now imports `isEventCatalogStarterEnabled` alongside `isEventCatalogScaleEnabled` from `@utils/feature`. The new `hasAssistantPlan()` helper combines them so the assistant is available whenever the catalog is on any paid plan. Both chat entry points (GET and POST) call this helper for their access checks.

## Breaking Changes

None.

## Additional Notes

No corresponding change is needed in the editor repository (`eventcatalog/eventcatalog-editor`) — these changes are scoped to the core chat API and billing settings UI.