### PR TITLE
Exclude LikeC4 source files from generated public assets

### DIFF
--- a/.changeset/fix-likec4-generated-sources.md
+++ b/.changeset/fix-likec4-generated-sources.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Prevent LikeC4 source files from being copied into generated public assets.

--- a/packages/core/eventcatalog/src/plugins/likec4.ts
+++ b/packages/core/eventcatalog/src/plugins/likec4.ts
@@ -16,9 +16,9 @@ const likeC4InstallMessage = `LikeC4 diagrams were found, but LikeC4 is not inst
 
 Install LikeC4 in your EventCatalog project:
 
-  npm install --save-dev likec4@latest @likec4/icons@latest
-  pnpm add -D likec4@latest @likec4/icons@latest
-  yarn add -D likec4@latest @likec4/icons@latest`;
+  npm install --save-dev likec4@1.57.0 @likec4/icons@latest
+  pnpm add -D likec4@1.57.0 @likec4/icons@latest
+  yarn add -D likec4@1.57.0 @likec4/icons@latest`;
 
 export const eventCatalogLikeC4 = async (workspaceDir: string): Promise<Plugin[]> => {
   const enabled = hasLikeC4Sources(workspaceDir);

--- a/packages/core/src/__tests__/catalog-to-astro-content-directory.spec.ts
+++ b/packages/core/src/__tests__/catalog-to-astro-content-directory.spec.ts
@@ -19,6 +19,12 @@ describe('catalog-to-astro-content-directory', () => {
     // create src/content inside astro directory
     await fs.mkdir(ASTRO_CONTENT_DIRECTORY, { recursive: true });
     await fs.writeFile(path.join(ASTRO_CONTENT_DIRECTORY, 'config.ts'), 'export const config = {};');
+    await fs.writeFile(
+      path.join(CATALOG_DIR, 'events', 'OrderAmended', 'order-flow.c4'),
+      'views { view OrderFlow { include * } }'
+    );
+    await fs.mkdir(path.join(ASTRO_OUTPUT, 'public', 'generated', 'events', 'OrderAmended'), { recursive: true });
+    await fs.writeFile(path.join(ASTRO_OUTPUT, 'public', 'generated', 'events', 'OrderAmended', 'stale.c4'), 'stale');
 
     // Convert the catalog
     await catalogToAstro(CATALOG_DIR, ASTRO_OUTPUT);
@@ -26,6 +32,7 @@ describe('catalog-to-astro-content-directory', () => {
 
   afterAll(async () => {
     await fs.rm(TMP_DIRECTORY, { recursive: true });
+    await fs.rm(path.join(CATALOG_DIR, 'events', 'OrderAmended', 'order-flow.c4'), { force: true });
     // await fs.rm(path.join(__dirname, 'public'), { recursive: true });
     const defaultFile = await fs.readFile(path.join(CATALOG_DIR, 'eventcatalog.config.defaults.js'), 'utf8');
     await fs.writeFile(path.join(CATALOG_DIR, 'eventcatalog.config.js'), defaultFile);
@@ -45,6 +52,11 @@ describe('catalog-to-astro-content-directory', () => {
 
     it('copies custom files from the public directory into the astro directory', async () => {
       expect(existsSync(path.join(ASTRO_OUTPUT, 'public', 'custom-file.txt'))).toBe(true);
+    });
+
+    it('does not copy LikeC4 source files into the public directory', async () => {
+      expect(existsSync(path.join(ASTRO_OUTPUT, 'public', 'generated', 'events', 'OrderAmended', 'order-flow.c4'))).toBe(false);
+      expect(existsSync(path.join(ASTRO_OUTPUT, 'public', 'generated', 'events', 'OrderAmended', 'stale.c4'))).toBe(false);
     });
   });
 

--- a/packages/core/src/catalog-to-astro-content-directory.js
+++ b/packages/core/src/catalog-to-astro-content-directory.js
@@ -43,6 +43,18 @@ const copyFiles = async (source, target) => {
   }
 };
 
+const removeGeneratedLikeC4Sources = async (target) => {
+  const generatedDir = path.join(target, 'public', 'generated');
+  const files = await glob(path.join(generatedDir, '**/*.{c4,likec4}'), {
+    nodir: true,
+    windowsPathsNoEscape: os.platform() == 'win32',
+  });
+
+  for (const file of files) {
+    fs.rmSync(file);
+  }
+};
+
 export const catalogToAstro = async (source, astroDir) => {
   const astroContentDir = path.join(astroDir, 'src/content/');
 
@@ -60,5 +72,6 @@ export const catalogToAstro = async (source, astroDir) => {
     fs.writeFileSync(path.join(source, 'eventcatalog.styles.css'), '');
   }
 
+  await removeGeneratedLikeC4Sources(astroDir);
   await copyFiles(source, astroDir);
 };

--- a/packages/core/src/map-catalog-to-astro.js
+++ b/packages/core/src/map-catalog-to-astro.js
@@ -30,6 +30,10 @@ const COLLECTION_KEYS = [
 export function mapCatalogToAstro({ filePath, astroDir, projectDir }) {
   const relativeFilePath = removeBasePath(filePath, projectDir);
 
+  if (isLikeC4Source(relativeFilePath)) {
+    return [];
+  }
+
   if (!isCatalogRelated(relativeFilePath)) {
     return [];
   }
@@ -58,6 +62,10 @@ function removeBasePath(fullPath, basePath) {
  */
 function isCollectionKey(key) {
   return COLLECTION_KEYS.includes(key);
+}
+
+function isLikeC4Source(filePath) {
+  return filePath.endsWith('.c4') || filePath.endsWith('.likec4');
 }
 
 /**


### PR DESCRIPTION
## What This PR Does

LikeC4 source files (`.c4` / `.likec4`) were being copied into the generated public assets directory during the catalog-to-Astro build. This PR prevents those source files from being written into `public/generated`, and cleans up any stale source files left over from previous builds. It also pins the LikeC4 install instructions to a known-good version.

## Changes Overview

### Key Changes

- Skip LikeC4 source files (`.c4`, `.likec4`) when mapping catalog files into the Astro content directory (`map-catalog-to-astro.js`).
- Remove any previously generated LikeC4 source files from `public/generated` before copying files (`catalog-to-astro-content-directory.js`).
- Pin the LikeC4 install message to `likec4@1.57.0` instead of `@latest`.
- Add tests verifying LikeC4 source files are not copied into the public directory and stale files are removed.

## How It Works

`mapCatalogToAstro` now short-circuits with an empty result when the file path ends in `.c4` or `.likec4`, so these sources are never treated as catalog content. During the build, `removeGeneratedLikeC4Sources` globs `public/generated/**/*.{c4,likec4}` and deletes any matches before the copy step runs, ensuring stale sources from earlier builds are cleared.

## Breaking Changes

None.

## Additional Notes

No corresponding change needed in the editor repository.