### PR TITLE
feat(linter): validate ADRs (Architecture Decision Records)

### DIFF
--- a/.changeset/linter-validate-adrs.md
+++ b/.changeset/linter-validate-adrs.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/linter": minor
+---
+
+Validate ADRs (Architecture Decision Records). The linter now scans `**/adrs/*/index.{md,mdx}` and validates their frontmatter against a schema mirroring the EventCatalog content collection — including the `status` enum (`proposed`, `accepted`, `rejected`, `deprecated`, `superseded`). Previously invalid ADR frontmatter (e.g. an unknown `status`) passed the linter but failed `eventcatalog build` with `InvalidContentEntryDataError`. ADRs are exempt from the `owner-required` best practice since they declare ownership via `decisionMakers`.

--- a/packages/linter/README.md
+++ b/packages/linter/README.md
@@ -31,6 +31,7 @@ A comprehensive linter for EventCatalog that validates frontmatter schemas and r
 - 📊 **Entities**
 - 👤 **Users**
 - 👥 **Teams**
+- 📝 **ADRs** (Architecture Decision Records)
 
 ## 📦 Installation
 

--- a/packages/linter/src/scanner/index.ts
+++ b/packages/linter/src/scanner/index.ts
@@ -34,6 +34,7 @@ const RESOURCE_PATTERNS: Record<ResourceType, string[]> = {
   user: ['users/*.{md,mdx}'],
   team: ['teams/*.{md,mdx}'],
   dataStore: ['**/containers/*/index.{md,mdx}', '**/containers/*/versioned/*/index.{md,mdx}'],
+  adr: ['**/adrs/*/index.{md,mdx}', '**/adrs/*/versioned/*/index.{md,mdx}'],
 };
 
 export const extractResourceInfo = (filePath: string, resourceType: ResourceType): { id: string; version?: string } => {

--- a/packages/linter/src/schemas/adr.ts
+++ b/packages/linter/src/schemas/adr.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod';
+import { baseSchema, ownerReferenceSchema, pointerSchema } from './common';
+
+// Mirrors `ADR_STATUS_VALUES` in @eventcatalog/core
+// (packages/core/eventcatalog/src/utils/collections/adr-constants.ts). Keep in
+// sync — a value outside this set is rejected by the content collection schema
+// at build time, so the linter must reject it too.
+export const ADR_STATUS_VALUES = ['proposed', 'accepted', 'rejected', 'deprecated', 'superseded'] as const;
+
+// Mirrors `adrResourcePointer` in core's content.config.ts — a typed pointer to
+// any catalog resource an ADR applies to.
+const adrResourcePointerSchema = pointerSchema.extend({
+  type: z.enum([
+    'agent',
+    'service',
+    'event',
+    'command',
+    'query',
+    'flow',
+    'channel',
+    'domain',
+    'user',
+    'team',
+    'container',
+    'entity',
+    'diagram',
+    'data-product',
+  ]),
+});
+
+export const adrSchema = z
+  .object({
+    status: z.enum(ADR_STATUS_VALUES),
+    date: z.coerce.date(),
+    decisionMakers: z.array(ownerReferenceSchema).optional(),
+    appliesTo: z.array(adrResourcePointerSchema).optional(),
+    supersedes: z.array(pointerSchema).optional(),
+    supersededBy: z.array(pointerSchema).optional(),
+    amends: z.array(pointerSchema).optional(),
+    amendedBy: z.array(pointerSchema).optional(),
+    related: z.array(pointerSchema).optional(),
+  })
+  .merge(baseSchema);

--- a/packages/linter/src/schemas/index.ts
+++ b/packages/linter/src/schemas/index.ts
@@ -8,6 +8,7 @@ export * from './entity';
 export * from './user';
 export * from './team';
 export * from './data-store';
+export * from './adr';
 
 import { domainSchema } from './domain';
 import { serviceSchema } from './service';
@@ -18,6 +19,7 @@ import { entitySchema } from './entity';
 import { userSchema } from './user';
 import { teamSchema } from './team';
 import { dataStoreSchema } from './data-store';
+import { adrSchema } from './adr';
 
 export const schemas = {
   domain: domainSchema,
@@ -31,6 +33,7 @@ export const schemas = {
   user: userSchema,
   team: teamSchema,
   dataStore: dataStoreSchema,
+  adr: adrSchema,
 } as const;
 
 export type ResourceType = keyof typeof schemas;

--- a/packages/linter/src/validators/best-practices-validator.ts
+++ b/packages/linter/src/validators/best-practices-validator.ts
@@ -20,10 +20,12 @@ export const validateBestPractices = (parsedFiles: ParsedFile[]): ValidationErro
       });
     }
 
-    // Check for required owners (skip users and teams - they are owners, not owned)
+    // Check for required owners (skip users and teams - they are owners, not owned;
+    // skip ADRs - they declare ownership via `decisionMakers`, `owners` is optional)
     if (
       file.resourceType !== 'user' &&
       file.resourceType !== 'team' &&
+      file.resourceType !== 'adr' &&
       (!frontmatter.owners || !Array.isArray(frontmatter.owners) || frontmatter.owners.length === 0)
     ) {
       errors.push({

--- a/packages/linter/tests/new-rules.test.ts
+++ b/packages/linter/tests/new-rules.test.ts
@@ -513,6 +513,50 @@ describe('best-practices/schema-required', () => {
   });
 });
 
+describe('best-practices/owner-required', () => {
+  it('should not report for ADRs without owners (they use decisionMakers)', () => {
+    const parsedFiles: ParsedFile[] = [
+      createParsedFile(
+        'adr',
+        'adr-0001',
+        {
+          id: 'adr-0001',
+          name: 'A decision',
+          version: '1.0.0',
+          summary: 'A decision record',
+          status: 'accepted',
+          date: '2026-06-18',
+          decisionMakers: ['jane-doe'],
+        },
+        'Some content'
+      ),
+    ];
+
+    const errors = validateBestPractices(parsedFiles);
+    const ownerErrors = errors.filter((e) => e.rule === 'best-practices/owner-required');
+    expect(ownerErrors).toHaveLength(0);
+  });
+
+  it('should still report for a service without owners', () => {
+    const parsedFiles: ParsedFile[] = [
+      createParsedFile(
+        'service',
+        'order-service',
+        {
+          id: 'order-service',
+          version: '1.0.0',
+          summary: 'A service',
+        },
+        'Some content'
+      ),
+    ];
+
+    const errors = validateBestPractices(parsedFiles);
+    const ownerErrors = errors.filter((e) => e.rule === 'best-practices/owner-required');
+    expect(ownerErrors).toHaveLength(1);
+  });
+});
+
 describe('versions/no-deprecated-references', () => {
   it('should warn when referencing a deprecated resource', () => {
     const parsedFiles: ParsedFile[] = [

--- a/packages/linter/tests/scanner.test.ts
+++ b/packages/linter/tests/scanner.test.ts
@@ -44,4 +44,19 @@ describe('extractResourceInfo', () => {
     const result = extractResourceInfo('teams/platform-team.mdx', 'team');
     expect(result).toEqual({ id: 'platform-team' });
   });
+
+  it('should extract adr id at the domain level', () => {
+    const result = extractResourceInfo('domains/sales/adrs/adr-0001/index.mdx', 'adr');
+    expect(result).toEqual({ id: 'adr-0001' });
+  });
+
+  it('should extract adr id at the service level', () => {
+    const result = extractResourceInfo('domains/sales/services/orders-service/adrs/adr-0001/index.mdx', 'adr');
+    expect(result).toEqual({ id: 'adr-0001' });
+  });
+
+  it('should extract adr id with versioned structure', () => {
+    const result = extractResourceInfo('domains/sales/adrs/adr-0001/versioned/2.0.0/index.mdx', 'adr');
+    expect(result).toEqual({ id: 'adr-0001', version: '2.0.0' });
+  });
 });

--- a/packages/linter/tests/schema-validator.test.ts
+++ b/packages/linter/tests/schema-validator.test.ts
@@ -287,4 +287,92 @@ describe('validateSchema', () => {
       expect(errors.length).toBeGreaterThan(0);
     });
   });
+
+  describe('adr validation', () => {
+    it('should pass with valid adr frontmatter', () => {
+      const parsedFile = createParsedFile('adr', {
+        id: 'adr-0001-use-event-sourcing',
+        name: 'Use event sourcing',
+        version: '1.0.0',
+        status: 'accepted',
+        date: '2026-06-18',
+      });
+
+      const errors = validateSchema(parsedFile);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should pass for every valid status value', () => {
+      for (const status of ['proposed', 'accepted', 'rejected', 'deprecated', 'superseded']) {
+        const parsedFile = createParsedFile('adr', {
+          id: 'adr-0001',
+          name: 'A decision',
+          version: '1.0.0',
+          status,
+          date: '2026-06-18',
+        });
+        expect(validateSchema(parsedFile)).toHaveLength(0);
+      }
+    });
+
+    it('should fail with a status outside the schema enum', () => {
+      const parsedFile = createParsedFile('adr', {
+        id: 'adr-0001',
+        name: 'A decision',
+        version: '1.0.0',
+        status: 'draft',
+        date: '2026-06-18',
+      });
+
+      const errors = validateSchema(parsedFile);
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors[0].field).toBe('status');
+    });
+
+    it('should fail with missing required fields (status, date)', () => {
+      const parsedFile = createParsedFile('adr', {
+        id: 'adr-0001',
+        name: 'A decision',
+        version: '1.0.0',
+      });
+
+      const errors = validateSchema(parsedFile);
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    it('should pass with typed appliesTo, decisionMakers and relationships', () => {
+      const parsedFile = createParsedFile('adr', {
+        id: 'adr-0001',
+        name: 'A decision',
+        version: '1.0.0',
+        status: 'accepted',
+        date: '2026-06-18',
+        decisionMakers: ['jane-doe', { id: 'platform-team', collection: 'teams' }],
+        appliesTo: [
+          { type: 'service', id: 'orders-service' },
+          { type: 'domain', id: 'sales', version: '2.0.0' },
+          { type: 'container', id: 'orders-db' },
+        ],
+        supersedes: [{ id: 'adr-0000' }],
+        related: [{ id: 'adr-0002', version: '1.0.0' }],
+      });
+
+      const errors = validateSchema(parsedFile);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should fail when an appliesTo entry has an unknown type', () => {
+      const parsedFile = createParsedFile('adr', {
+        id: 'adr-0001',
+        name: 'A decision',
+        version: '1.0.0',
+        status: 'accepted',
+        date: '2026-06-18',
+        appliesTo: [{ type: 'not-a-resource', id: 'orders-service' }],
+      });
+
+      const errors = validateSchema(parsedFile);
+      expect(errors.length).toBeGreaterThan(0);
+    });
+  });
 });


### PR DESCRIPTION
## Motivation

The linter advertises *“comprehensive coverage … supports all EventCatalog resource types”*, but ADRs were silently ignored — there was no schema, no scanner glob, and no entry in the `schemas` registry for them.

The practical consequence: invalid ADR frontmatter passes the linter but breaks the build. For example an ADR with `status: draft`:

```
✔ No problems found!   # npx @eventcatalog/linter
```

```
[InvalidContentEntryDataError] adrs → … data does not match collection schema.
  status: Invalid option: expected one of "proposed"|"accepted"|"rejected"|"deprecated"|"superseded"
# eventcatalog build  → exit 1
```

So the lint gate is green and the break only surfaces post-merge, during `eventcatalog build`. This makes the linter unsuitable as a pre-merge guard for any catalog that uses ADRs.

## What this does

Adds `adr` as a first-class resource type, mirroring the `adrs` content collection in `packages/core/eventcatalog/src/content.config.ts`:

- **Schema** (`src/schemas/adr.ts`): `status` enum (`proposed`/`accepted`/`rejected`/`deprecated`/`superseded`), `date`, optional `decisionMakers`, typed `appliesTo` pointers, and `supersedes`/`supersededBy`/`amends`/`amendedBy`/`related`. The status enum values are kept in sync with core's `ADR_STATUS_VALUES`.
- **Scanner**: discovers `**/adrs/*/index.{md,mdx}` and the versioned variant.
- **Registry**: registered in `schemas` so it's picked up by schema validation; owners references are validated by the existing generic owners handling.
- **Best practices**: ADRs are exempt from `owner-required` because they declare ownership via `decisionMakers` (`owners` is optional in the schema) — otherwise the linter would reject valid ADRs the build accepts.

After this change, the `status: draft` example above is reported as a `schema/required-fields` error (exit 1), matching the build.

## Tests

- `schema-validator.test.ts`: valid ADR, every valid status value, the invalid-status regression, missing required fields, typed `appliesTo`/`decisionMakers`/relationships, and an unknown `appliesTo` type.
- `scanner.test.ts`: ADR id extraction at domain/service level and versioned.
- `new-rules.test.ts`: ADRs without `owners` are not flagged for `owner-required` (and a service still is).

All 155 linter tests pass.

> Note: this touches only `@eventcatalog/linter`; no change is needed in `eventcatalog/eventcatalog-editor`.