### PR TITLE
Add linter schemas and reference validation for new resource types

### DIFF
--- a/.changeset/swift-pandas-gather.md
+++ b/.changeset/swift-pandas-gather.md
@@ -1,0 +1,6 @@
+---
+"@eventcatalog/linter": minor
+"@eventcatalog/core": patch
+---
+
+Add linter support for agents, ADRs, containers, data products, and diagrams, expand reference validation across resource types, and update the LikeC4 install message to pin compatible versions.

--- a/packages/core/eventcatalog/src/plugins/likec4.ts
+++ b/packages/core/eventcatalog/src/plugins/likec4.ts
@@ -16,9 +16,9 @@ const likeC4InstallMessage = `LikeC4 diagrams were found, but LikeC4 is not inst
 
 Install LikeC4 in your EventCatalog project:
 
-  npm install --save-dev likec4@1.57.0 @likec4/icons@latest
-  pnpm add -D likec4@1.57.0 @likec4/icons@latest
-  yarn add -D likec4@1.57.0 @likec4/icons@latest`;
+  npm install --save-dev likec4@1.55.1 @likec4/icons@1.46.4
+  pnpm add -D likec4@1.55.1 @likec4/icons@1.46.4
+  yarn add -D likec4@1.55.1 @likec4/icons@1.46.4`;
 
 export const eventCatalogLikeC4 = async (workspaceDir: string): Promise<Plugin[]> => {
   const enabled = hasLikeC4Sources(workspaceDir);

--- a/packages/linter/README.md
+++ b/packages/linter/README.md
@@ -29,6 +29,11 @@ A comprehensive linter for EventCatalog that validates frontmatter schemas and r
 - 📡 **Channels**
 - 🔄 **Flows**
 - 📊 **Entities**
+- 🤖 **Agents**
+- 🧱 **Containers** (including the legacy data store alias)
+- 📈 **Data Products**
+- 🧭 **Diagrams**
+- 📝 **ADRs**
 - 👤 **Users**
 - 👥 **Teams**
 
@@ -301,21 +306,9 @@ npx @eventcatalog/linter
 npx @eventcatalog/linter --fail-on-warning
 ```
 
-### Using with CI/CD
-
-The configuration file allows you to have different validation rules for different environments:
-
-```bash
-# Development - warnings allowed
-npx @eventcatalog/linter
-
-# Production - fail on warnings
-npx @eventcatalog/linter --fail-on-warning
-```
-
 ### Default Behavior
 
-If no `.eventcatalogrc.js` file is found, the linter uses default rules where all validations are set to `'error'`. This ensures strict validation out of the box, making it easy to get started with quality documentation practices.
+If no `.eventcatalogrc.js` file is found, the linter uses the default rules listed above. Most validations are errors by default, while documentation quality checks such as orphan messages, missing descriptions, missing schemas, and deprecated references default to warnings.
 
 ## ✅ What It Validates
 
@@ -329,17 +322,24 @@ If no `.eventcatalogrc.js` file is found, the linter uses default rules where al
 - ✅ Email addresses are valid format
 - ✅ Enum values are from allowed lists
 - ✅ Nested object structures are correct
+- ✅ Common resource configuration is supported, including `attachments`, `editUrl`, `diagrams`, `detailsPanel`, sidebar colors, and GraphQL specifications
 
 ### Reference Validation
 
 - ✅ Services referenced in domains exist
+- ✅ Agents, data products, flows, entities, and subdomains referenced in domains exist
 - ✅ Events/Commands/Queries referenced in services exist
+- ✅ Events/Commands/Queries referenced in agents exist
+- ✅ Data product inputs and outputs reference existing resources
+- ✅ ADR relationships and typed `appliesTo` references exist
 - ✅ Entities referenced in domains/services exist
-- ✅ Channels referenced in sends/receives `to`/`from` exist
+- ✅ Channels referenced in sends/receives `to`/`from`, routes, messages, and message channels exist
 - ✅ Containers referenced in `writesTo`/`readsFrom` exist
+- ✅ Diagrams referenced from other resources exist
 - ✅ Users/Teams referenced as owners exist
-- ✅ Flow steps reference existing services/messages
+- ✅ Flow steps reference existing services/messages/agents/containers/data products
 - ✅ Entity properties reference existing entities
+- ✅ User/team owned resources and team members exist
 - ✅ Version-specific references are valid
 - ✅ Orphan messages (no producer and no consumer) are detected
 - ✅ References to deprecated resources are flagged
@@ -354,15 +354,41 @@ If no `.eventcatalogrc.js` file is found, the linter uses default rules where al
 
 ```
 my-eventcatalog/
+├── adrs/
+│   └── adr-001/
+│       └── index.mdx
 ├── domains/
 │   └── sales/
-│       └── index.mdx
+│       ├── index.mdx
+│       ├── agents/
+│       │   └── refund-agent/
+│       │       └── index.mdx
+│       ├── channels/
+│       │   └── refunds/
+│       │       └── index.mdx
+│       ├── data-products/
+│       │   └── refund-analytics/
+│       │       └── index.mdx
+│       ├── diagrams/
+│       │   └── refund-flow/
+│       │       └── index.mdx
+│       └── services/
+│           └── order-service/
+│               ├── index.mdx
+│               └── containers/
+│                   └── orders-db/
+│                       └── index.mdx
 ├── services/
 │   ├── user-service/
 │   │   └── index.mdx
 │   └── order-service/
 │       ├── index.mdx
-│       └── 2.0.0/
+│       └── versioned/
+│           └── 2.0.0/
+│               └── index.mdx
+├── channels/
+│   └── public-events/
+│       └── orders/
 │           └── index.mdx
 ├── events/
 │   ├── user-created/
@@ -461,10 +487,16 @@ services:
   - id: order-service
     version: 2.0.0
   - id: payment-service
+agents:
+  - id: refund-agent
 entities:
   - id: order
   - id: customer
     version: 1.2.0
+dataProducts:
+  - id: refund-analytics
+flows:
+  - id: refund-flow
 ---
 ```
 
@@ -491,6 +523,106 @@ entities:
 repository:
   language: TypeScript
   url: https://github.com/company/user-service
+---
+```
+
+#### Agent
+
+```yaml
+---
+id: refund-agent
+name: Refund Agent
+version: 1.0.0
+summary: Coordinates customer refund decisions
+owners:
+  - platform-team
+receives:
+  - id: refund-requested
+    from:
+      - id: refunds
+sends:
+  - id: refund-approved
+    to:
+      - id: public-events/orders
+readsFrom:
+  - id: orders-db
+model:
+  provider: OpenAI
+  name: gpt-4.1-mini
+tools:
+  - name: Payment lookup
+    type: mcp
+---
+```
+
+#### Container
+
+```yaml
+---
+id: orders-db
+name: Orders DB
+version: 1.0.0
+summary: Stores order records
+container_type: database
+technology: PostgreSQL
+classification: internal
+access_mode: readWrite
+authoritative: true
+---
+```
+
+#### Data Product
+
+```yaml
+---
+id: refund-analytics
+name: Refund Analytics
+version: 1.0.0
+summary: Curated refund metrics for finance teams
+inputs:
+  - id: refund-approved
+  - id: orders-db
+outputs:
+  - id: public-events/orders
+    contract:
+      path: contracts/refund-analytics.json
+      name: Refund Analytics Contract
+---
+```
+
+#### ADR
+
+```yaml
+---
+id: adr-001
+name: Use event-driven refunds
+version: 1.0.0
+summary: Records the decision to coordinate refunds through events
+status: accepted
+date: 2026-05-26
+decisionMakers:
+  - id: platform-team
+    collection: teams
+appliesTo:
+  - type: service
+    id: order-service
+  - type: data-product
+    id: refund-analytics
+related:
+  - id: adr-000
+---
+```
+
+#### Diagram
+
+```yaml
+---
+id: refund-flow
+name: Refund Flow Diagram
+version: 1.0.0
+summary: Shows the refund workflow across services and agents
+owners:
+  - platform-team
 ---
 ```
 
@@ -537,6 +669,10 @@ steps:
     message:
       id: user-created
       version: 1.0.0
+  - id: step4
+    title: Update analytics
+    dataProduct:
+      id: refund-analytics
 ---
 ```
 
@@ -660,8 +796,8 @@ The linter provides descriptive rule names in parentheses to help identify and f
 - `(refs/owner-exists)` - Referenced owner (user/team) doesn't exist
 - `(refs/valid-version-range)` - Referenced version doesn't exist or invalid pattern
 - `(refs/resource-exists)` - Referenced resource doesn't exist
-- `(refs/channel-exists)` - Referenced channel in sends/receives to/from doesn't exist
-- `(refs/container-exists)` - Referenced container in writesTo/readsFrom doesn't exist
+- `(refs/channel-exists)` - Referenced channel in sends/receives to/from, routes, messages, or message channels doesn't exist
+- `(refs/container-exists)` - Referenced container in writesTo/readsFrom or flow steps doesn't exist
 - `(refs/orphan-messages)` - Event/command/query has no producer and no consumer
 
 ### Best Practice Rules

--- a/packages/linter/src/config/index.ts
+++ b/packages/linter/src/config/index.ts
@@ -56,12 +56,17 @@ const PLURAL_TO_SINGULAR: Record<string, string> = {
   commands: 'command',
   queries: 'query',
   services: 'service',
+  agents: 'agent',
+  adrs: 'adr',
   domains: 'domain',
   entities: 'entity',
   channels: 'channel',
   flows: 'flow',
   users: 'user',
   teams: 'team',
+  containers: 'container',
+  'data-products': 'dataProduct',
+  diagrams: 'diagram',
 };
 
 export const loadEventCatalogConfig = (rootDir: string): CatalogDependencies => {

--- a/packages/linter/src/scanner/index.ts
+++ b/packages/linter/src/scanner/index.ts
@@ -10,7 +10,14 @@ export interface CatalogFile {
   version?: string;
 }
 
-const RESOURCE_PATTERNS: Record<ResourceType, string[]> = {
+const RESOURCE_DIRECTORY_NAMES: Partial<Record<ResourceType, string>> = {
+  dataProduct: 'data-products',
+  dataStore: 'containers',
+  container: 'containers',
+  adr: 'adrs',
+};
+
+const RESOURCE_PATTERNS: Partial<Record<ResourceType, string[]>> = {
   domain: [
     'domains/*/index.{md,mdx}',
     'domains/*/versioned/*/index.{md,mdx}',
@@ -25,15 +32,19 @@ const RESOURCE_PATTERNS: Record<ResourceType, string[]> = {
     'services/*/index.{md,mdx}',
     'services/*/versioned/*/index.{md,mdx}',
   ],
+  agent: ['**/agents/*/index.{md,mdx}', '**/agents/*/versioned/*/index.{md,mdx}'],
+  adr: ['**/adrs/*/index.{md,mdx}', '**/adrs/*/versioned/*/index.{md,mdx}'],
   event: ['**/events/*/index.{md,mdx}', '**/events/*/versioned/*/index.{md,mdx}'],
   command: ['**/commands/*/index.{md,mdx}', '**/commands/*/versioned/*/index.{md,mdx}'],
   query: ['**/queries/*/index.{md,mdx}', '**/queries/*/versioned/*/index.{md,mdx}'],
-  channel: ['**/channels/*/index.{md,mdx}', '**/channels/*/versioned/*/index.{md,mdx}'],
-  flow: ['**/flows/*/index.{md,mdx}', '**/flows/*/versioned/*/index.{md,mdx}'],
+  channel: ['**/channels/**/index.{md,mdx}', '**/channels/**/versioned/*/index.{md,mdx}'],
+  flow: ['**/flows/**/index.{md,mdx}', '**/flows/**/versioned/*/index.{md,mdx}'],
   entity: ['**/entities/*/index.{md,mdx}', '**/entities/*/versioned/*/index.{md,mdx}'],
+  container: ['**/containers/**/index.{md,mdx}', '**/containers/**/versioned/*/index.{md,mdx}'],
+  dataProduct: ['**/data-products/*/index.{md,mdx}', '**/data-products/*/versioned/*/index.{md,mdx}'],
+  diagram: ['**/diagrams/**/index.{md,mdx}', '**/diagrams/**/versioned/*/index.{md,mdx}'],
   user: ['users/*.{md,mdx}'],
   team: ['teams/*.{md,mdx}'],
-  dataStore: ['**/containers/*/index.{md,mdx}', '**/containers/*/versioned/*/index.{md,mdx}'],
 };
 
 export const extractResourceInfo = (filePath: string, resourceType: ResourceType): { id: string; version?: string } => {
@@ -47,7 +58,7 @@ export const extractResourceInfo = (filePath: string, resourceType: ResourceType
   }
 
   // Find the resource type directory in the path
-  const resourceTypePattern = `${resourceType}s`;
+  const resourceTypePattern = RESOURCE_DIRECTORY_NAMES[resourceType] || `${resourceType}s`;
   const resourceTypeIndex = relativePath.findIndex((part) => part === resourceTypePattern);
 
   if (resourceTypeIndex === -1) {

--- a/packages/linter/src/schemas/adr.ts
+++ b/packages/linter/src/schemas/adr.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+import { baseSchema, detailPanelPropertySchema, pointerSchema, resourcePointerSchema } from './common';
+
+export const adrSchema = z
+  .object({
+    status: z.enum(['proposed', 'accepted', 'rejected', 'deprecated', 'superseded']),
+    date: z.coerce.date(),
+    decisionMakers: z.array(z.any()).optional(),
+    appliesTo: z.array(resourcePointerSchema).optional(),
+    supersedes: z.array(pointerSchema).optional(),
+    supersededBy: z.array(pointerSchema).optional(),
+    amends: z.array(pointerSchema).optional(),
+    amendedBy: z.array(pointerSchema).optional(),
+    related: z.array(pointerSchema).optional(),
+    detailsPanel: z
+      .object({
+        status: detailPanelPropertySchema,
+        date: detailPanelPropertySchema,
+        decisionMakers: detailPanelPropertySchema,
+        appliesTo: detailPanelPropertySchema,
+        relationships: detailPanelPropertySchema,
+        owners: detailPanelPropertySchema,
+        repository: detailPanelPropertySchema,
+        changelog: detailPanelPropertySchema,
+      })
+      .optional(),
+  })
+  .merge(baseSchema);

--- a/packages/linter/src/schemas/agent.ts
+++ b/packages/linter/src/schemas/agent.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod';
+import { baseSchema, detailPanelPropertySchema, pointerSchema, receivesPointerSchema, sendsPointerSchema } from './common';
+
+const agentToolSchema = z.object({
+  name: z.string(),
+  type: z.string(),
+  icon: z.string().optional(),
+  url: z.string().optional(),
+  description: z.string().optional(),
+});
+
+const agentModelSchema = z.object({
+  provider: z.string().optional(),
+  name: z.string().optional(),
+  version: z.string().optional(),
+});
+
+export const agentSchema = z
+  .object({
+    sends: z.array(sendsPointerSchema).optional(),
+    receives: z.array(receivesPointerSchema).optional(),
+    writesTo: z.array(pointerSchema).optional(),
+    readsFrom: z.array(pointerSchema).optional(),
+    flows: z.array(pointerSchema).optional(),
+    model: agentModelSchema.optional(),
+    tools: z.array(agentToolSchema).optional(),
+    specifications: z.undefined().optional(),
+    detailsPanel: z
+      .object({
+        domains: detailPanelPropertySchema,
+        messages: detailPanelPropertySchema,
+        versions: detailPanelPropertySchema,
+        repository: detailPanelPropertySchema,
+        owners: detailPanelPropertySchema,
+        changelog: detailPanelPropertySchema,
+        containers: detailPanelPropertySchema,
+        tools: detailPanelPropertySchema,
+        model: detailPanelPropertySchema,
+      })
+      .optional(),
+  })
+  .merge(baseSchema.omit({ specifications: true }));

--- a/packages/linter/src/schemas/channel.ts
+++ b/packages/linter/src/schemas/channel.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { baseSchema, pointerSchema } from './common';
+import { baseSchema, detailPanelPropertySchema, pointerSchema, channelPointerSchema } from './common';
 
 const parameterSchema = z.object({
   enum: z.array(z.string()).optional(),
@@ -10,9 +10,26 @@ const parameterSchema = z.object({
 
 export const channelSchema = z
   .object({
+    channels: z.array(channelPointerSchema).optional(),
     address: z.string().optional(),
     protocols: z.array(z.string()).optional(),
+    deliveryGuarantee: z.enum(['at-most-once', 'at-least-once', 'exactly-once']).optional(),
+    routes: z.array(channelPointerSchema).optional(),
     parameters: z.record(parameterSchema).optional(),
     messages: z.array(z.object({ collection: z.string(), name: z.string(), ...pointerSchema.shape })).optional(),
+    detailsPanel: z
+      .object({
+        producers: detailPanelPropertySchema,
+        consumers: detailPanelPropertySchema,
+        messages: detailPanelPropertySchema,
+        protocols: detailPanelPropertySchema,
+        parameters: detailPanelPropertySchema,
+        versions: detailPanelPropertySchema,
+        repository: detailPanelPropertySchema,
+        owners: detailPanelPropertySchema,
+        changelog: detailPanelPropertySchema,
+        attachments: detailPanelPropertySchema,
+      })
+      .optional(),
   })
   .merge(baseSchema);

--- a/packages/linter/src/schemas/common.ts
+++ b/packages/linter/src/schemas/common.ts
@@ -28,12 +28,14 @@ export const specificationSchema = z.union([
   z.object({
     openapiPath: z.string().optional(),
     asyncapiPath: z.string().optional(),
+    graphqlPath: z.string().optional(),
   }),
   z.array(
     z.object({
-      type: z.enum(['openapi', 'asyncapi']),
+      type: z.enum(['openapi', 'asyncapi', 'graphql']),
       path: z.string(),
       name: z.string().optional(),
+      headers: z.record(z.string()).optional(),
     })
   ),
 ]);
@@ -67,7 +69,23 @@ export const pointerSchema = z.object({
 export const resourcePointerSchema = z.object({
   id: z.string(),
   version: z.string().optional().default('latest'),
-  type: z.enum(['service', 'event', 'command', 'query', 'flow', 'channel', 'domain', 'user', 'team']),
+  type: z.enum([
+    'agent',
+    'service',
+    'event',
+    'command',
+    'query',
+    'flow',
+    'channel',
+    'domain',
+    'user',
+    'team',
+    'container',
+    'entity',
+    'diagram',
+    'data-product',
+    'adr',
+  ]),
 });
 
 export const channelPointerSchema = z
@@ -75,6 +93,40 @@ export const channelPointerSchema = z
     parameters: z.record(z.string()).optional(),
   })
   .merge(pointerSchema);
+
+export const detailPanelPropertySchema = z
+  .object({
+    visible: z.boolean().optional(),
+  })
+  .optional();
+
+export const sendsPointerSchema = z.object({
+  id: z.string(),
+  version: z.string().optional().default('latest'),
+  fields: z.array(z.string()).optional(),
+  group: z.string().optional(),
+  to: z
+    .array(
+      channelPointerSchema.extend({
+        delivery_mode: z.enum(['push', 'pull', 'push-pull']).optional().default('push'),
+      })
+    )
+    .optional(),
+});
+
+export const receivesPointerSchema = z.object({
+  id: z.string(),
+  version: z.string().optional().default('latest'),
+  fields: z.array(z.string()).optional(),
+  group: z.string().optional(),
+  from: z
+    .array(
+      channelPointerSchema.extend({
+        delivery_mode: z.enum(['push', 'pull', 'push-pull']).optional().default('push'),
+      })
+    )
+    .optional(),
+});
 
 export const resourceReferenceSchema = pointerSchema;
 
@@ -104,6 +156,8 @@ export const sidebarSchema = z
   .object({
     label: z.string().optional(),
     badge: z.string().optional(),
+    color: z.string().optional(),
+    backgroundColor: z.string().optional(),
   })
   .optional();
 
@@ -154,10 +208,26 @@ export const baseSchema = z.object({
   repository: repositorySchema.optional(),
   specifications: specificationSchema.optional(),
   hidden: z.boolean().optional(),
+  editUrl: z.string().optional(),
   resourceGroups: resourceGroupSchema,
   styles: stylesSchema,
   deprecated: deprecatedSchema.optional(),
   visualiser: z.boolean().optional(),
+  attachments: z
+    .array(
+      z.union([
+        z.string().url(),
+        z.object({
+          url: z.string().url(),
+          title: z.string().optional(),
+          type: z.string().optional(),
+          description: z.string().optional(),
+          icon: z.string().optional(),
+        }),
+      ])
+    )
+    .optional(),
+  diagrams: z.array(pointerSchema).optional(),
   versions: z.array(z.string()).optional(),
   latestVersion: z.string().optional(),
   catalog: catalogMetadataSchema,

--- a/packages/linter/src/schemas/container.ts
+++ b/packages/linter/src/schemas/container.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod';
+import { baseSchema, detailPanelPropertySchema } from './common';
+
+export const containerSchema = z
+  .object({
+    container_type: z.enum([
+      'database',
+      'cache',
+      'objectStore',
+      'searchIndex',
+      'dataWarehouse',
+      'dataLake',
+      'externalSaaS',
+      'other',
+    ]),
+    technology: z.string().optional(),
+    authoritative: z.boolean().optional().default(false),
+    access_mode: z.enum(['read', 'write', 'readWrite', 'appendOnly']).optional(),
+    classification: z.enum(['public', 'internal', 'confidential', 'regulated']).optional(),
+    residency: z.string().optional(),
+    retention: z.string().optional(),
+    detailsPanel: z
+      .object({
+        versions: detailPanelPropertySchema,
+        repository: detailPanelPropertySchema,
+        owners: detailPanelPropertySchema,
+        changelog: detailPanelPropertySchema,
+        attachments: detailPanelPropertySchema,
+        services: detailPanelPropertySchema,
+        flows: detailPanelPropertySchema,
+      })
+      .optional(),
+    services: z.array(z.any()).optional(),
+    servicesThatWriteToContainer: z.array(z.any()).optional(),
+    servicesThatReadFromContainer: z.array(z.any()).optional(),
+    dataProductsThatWriteToContainer: z.array(z.any()).optional(),
+    dataProductsThatReadFromContainer: z.array(z.any()).optional(),
+  })
+  .merge(baseSchema);

--- a/packages/linter/src/schemas/data-product.ts
+++ b/packages/linter/src/schemas/data-product.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+import { baseSchema, detailPanelPropertySchema, pointerSchema } from './common';
+
+const dataProductOutputPointerSchema = z.object({
+  id: z.string(),
+  version: z.string().optional().default('latest'),
+  contract: z
+    .object({
+      path: z.string(),
+      name: z.string(),
+      type: z.string().optional(),
+    })
+    .optional(),
+});
+
+export const dataProductSchema = z
+  .object({
+    inputs: z.array(pointerSchema).optional(),
+    outputs: z.array(dataProductOutputPointerSchema).optional(),
+    detailsPanel: z
+      .object({
+        domains: detailPanelPropertySchema,
+        inputs: detailPanelPropertySchema,
+        outputs: detailPanelPropertySchema,
+        versions: detailPanelPropertySchema,
+        repository: detailPanelPropertySchema,
+        owners: detailPanelPropertySchema,
+        changelog: detailPanelPropertySchema,
+        flows: detailPanelPropertySchema,
+      })
+      .optional(),
+  })
+  .merge(baseSchema);

--- a/packages/linter/src/schemas/data-store.ts
+++ b/packages/linter/src/schemas/data-store.ts
@@ -1,14 +1,1 @@
-import { z } from 'zod';
-import { baseSchema } from './common';
-
-export const dataStoreSchema = z
-  .object({
-    container_type: z.enum(['database', 'cache', 'objectStore', 'searchIndex', 'dataWarehouse', 'dataLake', 'externalSaaS']),
-    technology: z.string().optional(),
-    authoritative: z.boolean().optional(),
-    access_mode: z.enum(['read', 'write', 'readWrite', 'appendOnly']),
-    classification: z.enum(['public', 'internal', 'confidential', 'regulated']),
-    residency: z.string().optional(),
-    retention: z.string().optional(),
-  })
-  .merge(baseSchema);
+export { containerSchema as dataStoreSchema } from './container';

--- a/packages/linter/src/schemas/diagram.ts
+++ b/packages/linter/src/schemas/diagram.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+import { baseSchema, detailPanelPropertySchema } from './common';
+
+export const diagramSchema = z
+  .object({
+    detailsPanel: z
+      .object({
+        versions: detailPanelPropertySchema,
+        owners: detailPanelPropertySchema,
+        changelog: detailPanelPropertySchema,
+        attachments: detailPanelPropertySchema,
+      })
+      .optional(),
+  })
+  .merge(baseSchema);

--- a/packages/linter/src/schemas/domain.ts
+++ b/packages/linter/src/schemas/domain.ts
@@ -1,10 +1,32 @@
 import { z } from 'zod';
-import { baseSchema, pointerSchema } from './common';
+import { baseSchema, pointerSchema, receivesPointerSchema, sendsPointerSchema, detailPanelPropertySchema } from './common';
 
 export const domainSchema = z
   .object({
     services: z.array(pointerSchema).optional(),
+    agents: z.array(pointerSchema).optional(),
     domains: z.array(pointerSchema).optional(),
     entities: z.array(pointerSchema).optional(),
+    'data-products': z.array(pointerSchema).optional(),
+    dataProducts: z.array(pointerSchema).optional(),
+    flows: z.array(pointerSchema).optional(),
+    sends: z.array(sendsPointerSchema).optional(),
+    receives: z.array(receivesPointerSchema).optional(),
+    detailsPanel: z
+      .object({
+        parentDomains: detailPanelPropertySchema,
+        subdomains: detailPanelPropertySchema,
+        services: detailPanelPropertySchema,
+        agents: detailPanelPropertySchema,
+        entities: detailPanelPropertySchema,
+        messages: detailPanelPropertySchema,
+        ubiquitousLanguage: detailPanelPropertySchema,
+        repository: detailPanelPropertySchema,
+        versions: detailPanelPropertySchema,
+        owners: detailPanelPropertySchema,
+        changelog: detailPanelPropertySchema,
+        attachments: detailPanelPropertySchema,
+      })
+      .optional(),
   })
   .merge(baseSchema);

--- a/packages/linter/src/schemas/entity.ts
+++ b/packages/linter/src/schemas/entity.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { baseSchema } from './common';
+import { baseSchema, detailPanelPropertySchema } from './common';
 
 const propertySchema = z.object({
   name: z.string(),
@@ -9,6 +9,12 @@ const propertySchema = z.object({
   references: z.string().optional(),
   referencesIdentifier: z.string().optional(),
   relationType: z.string().optional(),
+  enum: z.array(z.string()).optional(),
+  items: z
+    .object({
+      type: z.string(),
+    })
+    .optional(),
 });
 
 export const entitySchema = z
@@ -18,5 +24,16 @@ export const entitySchema = z
     properties: z.array(propertySchema).optional(),
     services: z.array(z.any()).optional(), // reference('services')
     domains: z.array(z.any()).optional(), // reference('domains')
+    detailsPanel: z
+      .object({
+        domains: detailPanelPropertySchema,
+        services: detailPanelPropertySchema,
+        messages: detailPanelPropertySchema,
+        versions: detailPanelPropertySchema,
+        owners: detailPanelPropertySchema,
+        changelog: detailPanelPropertySchema,
+        attachments: detailPanelPropertySchema,
+      })
+      .optional(),
   })
   .merge(baseSchema);

--- a/packages/linter/src/schemas/flow.ts
+++ b/packages/linter/src/schemas/flow.ts
@@ -16,15 +16,19 @@ const flowStep = z
 const flowStepSchema = z
   .object({
     id: z.union([z.string(), z.number()]),
-    type: z.enum(['node', 'message', 'user', 'actor']).optional(),
+    type: z.enum(['node', 'message', 'agent', 'user', 'actor']).optional(),
     title: z.string(),
     summary: z.string().optional(),
     message: pointerSchema.optional(),
+    agent: pointerSchema.optional(),
     service: pointerSchema.optional(),
     flow: pointerSchema.optional(),
+    container: pointerSchema.optional(),
+    dataProduct: pointerSchema.optional(),
     actor: z
       .object({
         name: z.string(),
+        summary: z.string().optional(),
       })
       .optional(),
     custom: z
@@ -59,7 +63,16 @@ const flowStepSchema = z
   })
   .refine((data) => {
     if (data.next_step && data.next_steps) return false;
-    const typesUsed = [data.message, data.service, data.flow, data.actor, data.custom].filter((v) => v).length;
+    const typesUsed = [
+      data.message,
+      data.agent,
+      data.service,
+      data.flow,
+      data.container,
+      data.dataProduct,
+      data.actor,
+      data.custom,
+    ].filter((v) => v).length;
     return typesUsed === 0 || typesUsed === 1;
   });
 

--- a/packages/linter/src/schemas/index.ts
+++ b/packages/linter/src/schemas/index.ts
@@ -7,6 +7,11 @@ export * from './flow';
 export * from './entity';
 export * from './user';
 export * from './team';
+export * from './agent';
+export * from './adr';
+export * from './container';
+export * from './data-product';
+export * from './diagram';
 export * from './data-store';
 
 import { domainSchema } from './domain';
@@ -17,19 +22,30 @@ import { flowSchema } from './flow';
 import { entitySchema } from './entity';
 import { userSchema } from './user';
 import { teamSchema } from './team';
+import { agentSchema } from './agent';
+import { adrSchema } from './adr';
+import { containerSchema } from './container';
+import { dataProductSchema } from './data-product';
+import { diagramSchema } from './diagram';
 import { dataStoreSchema } from './data-store';
 
 export const schemas = {
   domain: domainSchema,
   service: serviceSchema,
+  agent: agentSchema,
+  adr: adrSchema,
   event: eventSchema,
   command: commandSchema,
   query: querySchema,
   channel: channelSchema,
   flow: flowSchema,
   entity: entitySchema,
+  container: containerSchema,
+  dataProduct: dataProductSchema,
+  diagram: diagramSchema,
   user: userSchema,
   team: teamSchema,
+  // Backwards-compatible alias for older linter integrations.
   dataStore: dataStoreSchema,
 } as const;
 

--- a/packages/linter/src/schemas/message.ts
+++ b/packages/linter/src/schemas/message.ts
@@ -1,12 +1,49 @@
 import { z } from 'zod';
-import { baseSchema, channelPointerSchema } from './common';
+import { baseSchema, channelPointerSchema, detailPanelPropertySchema } from './common';
+
+const operationSchema = z
+  .object({
+    method: z.enum(['GET', 'POST', 'PUT', 'DELETE', 'PATCH']).optional(),
+    path: z.string().optional(),
+    statusCodes: z.array(z.string()).optional(),
+  })
+  .optional();
+
+const messageDetailsPanelSchema = z
+  .object({
+    producers: detailPanelPropertySchema,
+    consumers: detailPanelPropertySchema,
+    channels: detailPanelPropertySchema,
+    versions: detailPanelPropertySchema,
+    repository: detailPanelPropertySchema,
+    owners: detailPanelPropertySchema,
+    changelog: detailPanelPropertySchema,
+    attachments: detailPanelPropertySchema,
+  })
+  .optional();
 
 const baseMessageSchema = z
   .object({
+    operation: operationSchema,
     producers: z.array(z.any()).optional(), // reference('services')
     consumers: z.array(z.any()).optional(), // reference('services')
     channels: z.array(channelPointerSchema).optional(),
+    schemas: z
+      .array(
+        z.object({
+          id: z.string().optional(),
+          ref: z.string().optional(),
+          file: z.string().optional(),
+          path: z.string().optional(),
+          name: z.string().optional(),
+          format: z.string().optional(),
+          environments: z.array(z.string()).optional(),
+          default: z.boolean().optional(),
+        })
+      )
+      .optional(),
     messageChannels: z.array(z.any()).optional(), // reference('channels')
+    detailsPanel: messageDetailsPanelSchema,
   })
   .merge(baseSchema);
 

--- a/packages/linter/src/schemas/service.ts
+++ b/packages/linter/src/schemas/service.ts
@@ -1,12 +1,27 @@
 import { z } from 'zod';
-import { baseSchema, pointerSchema } from './common';
+import { baseSchema, pointerSchema, receivesPointerSchema, sendsPointerSchema, detailPanelPropertySchema } from './common';
 
 export const serviceSchema = z
   .object({
-    sends: z.array(pointerSchema).optional(),
-    receives: z.array(pointerSchema).optional(),
+    sends: z.array(sendsPointerSchema).optional(),
+    receives: z.array(receivesPointerSchema).optional(),
     entities: z.array(pointerSchema).optional(),
     writesTo: z.array(pointerSchema).optional(),
     readsFrom: z.array(pointerSchema).optional(),
+    flows: z.array(pointerSchema).optional(),
+    externalSystem: z.boolean().optional(),
+    detailsPanel: z
+      .object({
+        domains: detailPanelPropertySchema,
+        messages: detailPanelPropertySchema,
+        versions: detailPanelPropertySchema,
+        specifications: detailPanelPropertySchema,
+        entities: detailPanelPropertySchema,
+        repository: detailPanelPropertySchema,
+        owners: detailPanelPropertySchema,
+        changelog: detailPanelPropertySchema,
+        containers: detailPanelPropertySchema,
+      })
+      .optional(),
   })
   .merge(baseSchema);

--- a/packages/linter/src/schemas/team.ts
+++ b/packages/linter/src/schemas/team.ts
@@ -6,9 +6,18 @@ export const teamSchema = z.object({
   summary: z.string().optional(),
   email: z.string().email().optional(),
   hidden: z.boolean().optional(),
+  source: z
+    .object({
+      provider: z.string(),
+      id: z.string().optional(),
+      url: z.string().optional(),
+    })
+    .optional(),
+  readOnly: z.boolean().optional(),
   slackDirectMessageUrl: z.string().optional(),
   msTeamsDirectMessageUrl: z.string().optional(),
   members: z.array(z.any()).optional(), // reference('users')
+  ownedAgents: z.array(z.any()).optional(), // reference('agents')
   ownedCommands: z.array(z.any()).optional(), // reference('commands')
   ownedQueries: z.array(z.any()).optional(), // reference('queries')
   ownedDomains: z.array(z.any()).optional(), // reference('domains')

--- a/packages/linter/src/schemas/user.ts
+++ b/packages/linter/src/schemas/user.ts
@@ -6,9 +6,18 @@ export const userSchema = z.object({
   avatarUrl: z.string().optional(),
   role: z.string().optional(),
   hidden: z.boolean().optional(),
+  source: z
+    .object({
+      provider: z.string(),
+      id: z.string().optional(),
+      url: z.string().optional(),
+    })
+    .optional(),
+  readOnly: z.boolean().optional(),
   email: z.string().email().optional(),
   slackDirectMessageUrl: z.string().optional(),
   msTeamsDirectMessageUrl: z.string().optional(),
+  ownedAgents: z.array(z.any()).optional(), // reference('agents')
   ownedDomains: z.array(z.any()).optional(), // reference('domains')
   ownedServices: z.array(z.any()).optional(), // reference('services')
   ownedEvents: z.array(z.any()).optional(), // reference('events')

--- a/packages/linter/src/validators/reference-validator.ts
+++ b/packages/linter/src/validators/reference-validator.ts
@@ -10,6 +10,97 @@ interface ResourceIndex {
   };
 }
 
+const MESSAGE_TYPES: ResourceType[] = ['event', 'command', 'query'];
+
+const RESOURCE_TYPE_ALIASES: Partial<Record<ResourceType, ResourceType[]>> = {
+  container: ['container', 'dataStore'],
+  dataStore: ['container', 'dataStore'],
+};
+
+const normalizeResourceType = (type: unknown): ResourceType | undefined => {
+  if (typeof type !== 'string') return undefined;
+
+  const normalizedTypes: Record<string, ResourceType> = {
+    agent: 'agent',
+    agents: 'agent',
+    adr: 'adr',
+    adrs: 'adr',
+    service: 'service',
+    services: 'service',
+    event: 'event',
+    events: 'event',
+    command: 'command',
+    commands: 'command',
+    query: 'query',
+    queries: 'query',
+    flow: 'flow',
+    flows: 'flow',
+    channel: 'channel',
+    channels: 'channel',
+    domain: 'domain',
+    domains: 'domain',
+    user: 'user',
+    users: 'user',
+    team: 'team',
+    teams: 'team',
+    container: 'container',
+    containers: 'container',
+    dataStore: 'container',
+    dataStores: 'container',
+    'data-product': 'dataProduct',
+    'data-products': 'dataProduct',
+    dataProduct: 'dataProduct',
+    dataProducts: 'dataProduct',
+    entity: 'entity',
+    entities: 'entity',
+    diagram: 'diagram',
+    diagrams: 'diagram',
+  };
+
+  return normalizedTypes[type];
+};
+
+const getReference = (value: unknown): ResourceReference | undefined => {
+  if (typeof value === 'string') {
+    return { id: value };
+  }
+
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+
+  const ref = value as Record<string, unknown>;
+  if (typeof ref.id !== 'string') {
+    return undefined;
+  }
+
+  return {
+    id: ref.id,
+    version: typeof ref.version === 'string' ? ref.version : undefined,
+  };
+};
+
+const addReference = (references: ReferenceInfo[], value: unknown, possibleTypes: ResourceType[], field: string): void => {
+  const ref = getReference(value);
+  if (ref) {
+    references.push({ ref, possibleTypes, field });
+  }
+};
+
+const addReferences = (references: ReferenceInfo[], values: unknown, possibleTypes: ResourceType[], field: string): void => {
+  if (!Array.isArray(values)) return;
+  values.forEach((value) => {
+    addReference(references, value, possibleTypes, field);
+  });
+};
+
+const addTypedReference = (references: ReferenceInfo[], value: unknown, field: string): void => {
+  if (!value || typeof value !== 'object') return;
+  const resourceType = normalizeResourceType((value as Record<string, unknown>).type);
+  if (!resourceType) return;
+  addReference(references, value, [resourceType], field);
+};
+
 export const buildResourceIndex = (parsedFiles: ParsedFile[], dependencies?: CatalogDependencies): ResourceIndex => {
   const index: ResourceIndex = {};
 
@@ -61,7 +152,15 @@ export const buildResourceIndex = (parsedFiles: ParsedFile[], dependencies?: Cat
 };
 
 const checkResourceExists = (ref: ResourceReference, resourceType: ResourceType, index: ResourceIndex): boolean => {
-  const resourceVersions = index[resourceType]?.[ref.id];
+  const resourceTypes = RESOURCE_TYPE_ALIASES[resourceType] || [resourceType];
+  const resourceVersions = new Set<string>();
+
+  for (const type of resourceTypes) {
+    const versions = index[type]?.[ref.id];
+    if (versions) {
+      versions.forEach((version) => resourceVersions.add(version));
+    }
+  }
 
   if (!resourceVersions || resourceVersions.size === 0) {
     return false;
@@ -123,63 +222,79 @@ const extractReferences = (parsedFile: ParsedFile): ReferenceInfo[] => {
   const { file, frontmatter } = parsedFile;
   const references: ReferenceInfo[] = [];
 
+  if (frontmatter.owners && Array.isArray(frontmatter.owners)) {
+    frontmatter.owners.forEach((owner: unknown, index: number) => {
+      if (owner && typeof owner === 'object' && 'collection' in owner) {
+        const ownerType = normalizeResourceType((owner as Record<string, unknown>).collection);
+        if (ownerType) {
+          addReference(references, owner, [ownerType], `owners[${index}]`);
+          return;
+        }
+      }
+      addReference(references, owner, ['user', 'team'], `owners[${index}]`);
+    });
+  }
+
+  addReferences(references, frontmatter.diagrams, ['diagram'], 'diagrams');
+
+  if (frontmatter.resourceGroups && Array.isArray(frontmatter.resourceGroups)) {
+    frontmatter.resourceGroups.forEach((group: unknown, groupIndex: number) => {
+      if (!group || typeof group !== 'object') return;
+      const items = (group as Record<string, unknown>).items;
+      if (!Array.isArray(items)) return;
+      items.forEach((item, itemIndex) =>
+        addTypedReference(references, item, `resourceGroups[${groupIndex}].items[${itemIndex}]`)
+      );
+    });
+  }
+
   if (file.resourceType === 'domain') {
-    if (frontmatter.services && Array.isArray(frontmatter.services)) {
-      frontmatter.services.forEach((ref: ResourceReference) => {
-        references.push({ ref, possibleTypes: ['service'], field: 'services' });
-      });
+    addReferences(references, frontmatter.services, ['service'], 'services');
+    addReferences(references, frontmatter.agents, ['agent'], 'agents');
+    addReferences(references, frontmatter.domains, ['domain'], 'domains');
+    addReferences(references, frontmatter.entities, ['entity'], 'entities');
+    addReferences(references, frontmatter['data-products'], ['dataProduct'], 'data-products');
+    addReferences(references, frontmatter.dataProducts, ['dataProduct'], 'dataProducts');
+    addReferences(references, frontmatter.flows, ['flow'], 'flows');
+    addReferences(references, frontmatter.sends, MESSAGE_TYPES, 'sends');
+    addReferences(references, frontmatter.receives, MESSAGE_TYPES, 'receives');
+  }
+
+  if (file.resourceType === 'service' || file.resourceType === 'agent') {
+    addReferences(references, frontmatter.sends, MESSAGE_TYPES, 'sends');
+    addReferences(references, frontmatter.receives, MESSAGE_TYPES, 'receives');
+    if (frontmatter.writesTo && Array.isArray(frontmatter.writesTo)) {
+      frontmatter.writesTo.forEach((ref: unknown) => addReference(references, ref, ['container'], 'writesTo'));
     }
-    if (frontmatter.domains && Array.isArray(frontmatter.domains)) {
-      frontmatter.domains.forEach((ref: ResourceReference) => {
-        references.push({ ref, possibleTypes: ['domain'], field: 'domains' });
-      });
+    if (frontmatter.readsFrom && Array.isArray(frontmatter.readsFrom)) {
+      frontmatter.readsFrom.forEach((ref: unknown) => addReference(references, ref, ['container'], 'readsFrom'));
     }
-    if (frontmatter.entities && Array.isArray(frontmatter.entities)) {
-      frontmatter.entities.forEach((ref: ResourceReference) => {
-        references.push({ ref, possibleTypes: ['entity'], field: 'entities' });
-      });
-    }
+    addReferences(references, frontmatter.flows, ['flow'], 'flows');
   }
 
   if (file.resourceType === 'service') {
-    if (frontmatter.sends && Array.isArray(frontmatter.sends)) {
-      frontmatter.sends.forEach((ref: ResourceReference) => {
-        references.push({ ref, possibleTypes: ['event', 'command', 'query'], field: 'sends' });
-      });
-    }
-    if (frontmatter.receives && Array.isArray(frontmatter.receives)) {
-      frontmatter.receives.forEach((ref: ResourceReference) => {
-        references.push({ ref, possibleTypes: ['event', 'command', 'query'], field: 'receives' });
-      });
-    }
-    if (frontmatter.entities && Array.isArray(frontmatter.entities)) {
-      frontmatter.entities.forEach((ref: ResourceReference) => {
-        references.push({ ref, possibleTypes: ['entity'], field: 'entities' });
-      });
-    }
-    if (frontmatter.writesTo && Array.isArray(frontmatter.writesTo)) {
-      frontmatter.writesTo.forEach((ref: ResourceReference) => {
-        references.push({ ref, possibleTypes: ['dataStore'], field: 'writesTo' });
-      });
-    }
-    if (frontmatter.readsFrom && Array.isArray(frontmatter.readsFrom)) {
-      frontmatter.readsFrom.forEach((ref: ResourceReference) => {
-        references.push({ ref, possibleTypes: ['dataStore'], field: 'readsFrom' });
-      });
-    }
+    addReferences(references, frontmatter.entities, ['entity'], 'entities');
   }
 
   if (file.resourceType === 'flow' && frontmatter.steps && Array.isArray(frontmatter.steps)) {
     frontmatter.steps.forEach((step: Record<string, unknown>, index: number) => {
       if (step.message) {
-        references.push({
-          ref: step.message as ResourceReference,
-          possibleTypes: ['event', 'command', 'query'],
-          field: `steps[${index}].message`,
-        });
+        addReference(references, step.message, MESSAGE_TYPES, `steps[${index}].message`);
       }
       if (step.service) {
-        references.push({ ref: step.service as ResourceReference, possibleTypes: ['service'], field: `steps[${index}].service` });
+        addReference(references, step.service, ['service'], `steps[${index}].service`);
+      }
+      if (step.agent) {
+        addReference(references, step.agent, ['agent'], `steps[${index}].agent`);
+      }
+      if (step.flow) {
+        addReference(references, step.flow, ['flow'], `steps[${index}].flow`);
+      }
+      if (step.container) {
+        addReference(references, step.container, ['container'], `steps[${index}].container`);
+      }
+      if (step.dataProduct) {
+        addReference(references, step.dataProduct, ['dataProduct'], `steps[${index}].dataProduct`);
       }
     });
   }
@@ -194,18 +309,94 @@ const extractReferences = (parsedFile: ParsedFile): ReferenceInfo[] => {
         });
       }
     });
+    addReferences(references, frontmatter.services, ['service'], 'services');
+    addReferences(references, frontmatter.domains, ['domain'], 'domains');
   }
 
-  if (frontmatter.owners && Array.isArray(frontmatter.owners)) {
-    frontmatter.owners.forEach((owner: string) => {
-      references.push({ ref: { id: owner }, possibleTypes: ['user', 'team'], field: 'owners' });
-    });
+  if (MESSAGE_TYPES.includes(file.resourceType)) {
+    addReferences(references, frontmatter.producers, ['service'], 'producers');
+    addReferences(references, frontmatter.consumers, ['service'], 'consumers');
+    addReferences(references, frontmatter.channels, ['channel'], 'channels');
+    addReferences(references, frontmatter.messageChannels, ['channel'], 'messageChannels');
+  }
+
+  if (file.resourceType === 'channel') {
+    addReferences(references, frontmatter.channels, ['channel'], 'channels');
+    addReferences(references, frontmatter.routes, ['channel'], 'routes');
+    if (frontmatter.messages && Array.isArray(frontmatter.messages)) {
+      frontmatter.messages.forEach((message: unknown, index: number) => {
+        if (!message || typeof message !== 'object') return;
+        const messageType = normalizeResourceType((message as Record<string, unknown>).collection);
+        if (messageType && MESSAGE_TYPES.includes(messageType)) {
+          addReference(references, message, [messageType], `messages[${index}]`);
+        }
+      });
+    }
+  }
+
+  if (file.resourceType === 'container' || file.resourceType === 'dataStore') {
+    addReferences(references, frontmatter.services, ['service'], 'services');
+    addReferences(references, frontmatter.servicesThatWriteToContainer, ['service'], 'servicesThatWriteToContainer');
+    addReferences(references, frontmatter.servicesThatReadFromContainer, ['service'], 'servicesThatReadFromContainer');
+    addReferences(references, frontmatter.dataProductsThatWriteToContainer, ['dataProduct'], 'dataProductsThatWriteToContainer');
+    addReferences(
+      references,
+      frontmatter.dataProductsThatReadFromContainer,
+      ['dataProduct'],
+      'dataProductsThatReadFromContainer'
+    );
+  }
+
+  if (file.resourceType === 'dataProduct') {
+    const dataProductLinkTypes: ResourceType[] = [
+      'event',
+      'command',
+      'query',
+      'service',
+      'agent',
+      'container',
+      'channel',
+      'dataProduct',
+    ];
+    addReferences(references, frontmatter.inputs, dataProductLinkTypes, 'inputs');
+    addReferences(references, frontmatter.outputs, dataProductLinkTypes, 'outputs');
+  }
+
+  if (file.resourceType === 'adr') {
+    if (frontmatter.decisionMakers && Array.isArray(frontmatter.decisionMakers)) {
+      frontmatter.decisionMakers.forEach((owner: unknown, index: number) => {
+        addReference(references, owner, ['user', 'team'], `decisionMakers[${index}]`);
+      });
+    }
+    if (frontmatter.appliesTo && Array.isArray(frontmatter.appliesTo)) {
+      frontmatter.appliesTo.forEach((target: unknown, index: number) => {
+        addTypedReference(references, target, `appliesTo[${index}]`);
+      });
+    }
+    addReferences(references, frontmatter.supersedes, ['adr'], 'supersedes');
+    addReferences(references, frontmatter.supersededBy, ['adr'], 'supersededBy');
+    addReferences(references, frontmatter.amends, ['adr'], 'amends');
+    addReferences(references, frontmatter.amendedBy, ['adr'], 'amendedBy');
+    addReferences(references, frontmatter.related, ['adr'], 'related');
   }
 
   if (file.resourceType === 'team' && frontmatter.members && Array.isArray(frontmatter.members)) {
-    frontmatter.members.forEach((member: string) => {
-      references.push({ ref: { id: member }, possibleTypes: ['user'], field: 'members' });
+    frontmatter.members.forEach((member: unknown, index: number) => {
+      addReference(references, member, ['user'], `members[${index}]`);
     });
+  }
+
+  if (file.resourceType === 'user' || file.resourceType === 'team') {
+    addReferences(references, frontmatter.ownedAgents, ['agent'], 'ownedAgents');
+    addReferences(references, frontmatter.ownedDomains, ['domain'], 'ownedDomains');
+    addReferences(references, frontmatter.ownedServices, ['service'], 'ownedServices');
+    addReferences(references, frontmatter.ownedEvents, ['event'], 'ownedEvents');
+    addReferences(references, frontmatter.ownedCommands, ['command'], 'ownedCommands');
+    addReferences(references, frontmatter.ownedQueries, ['query'], 'ownedQueries');
+  }
+
+  if (file.resourceType === 'user') {
+    addReferences(references, frontmatter.associatedTeams, ['team'], 'associatedTeams');
   }
 
   return references;
@@ -216,7 +407,7 @@ const extractChannelReferences = (parsedFile: ParsedFile): ReferenceInfo[] => {
   const { file, frontmatter } = parsedFile;
   const references: ReferenceInfo[] = [];
 
-  if (file.resourceType !== 'service' && file.resourceType !== 'domain') {
+  if (file.resourceType !== 'service' && file.resourceType !== 'domain' && file.resourceType !== 'agent') {
     return references;
   }
 
@@ -273,10 +464,19 @@ export const validateReferences = (parsedFiles: ParsedFile[], dependencies?: Cat
         const typeStr = possibleTypes.length === 1 ? possibleTypes[0] : possibleTypes.join('/');
 
         let rule = 'refs/resource-exists';
-        if (field === 'owners') {
+        if (field === 'owners' || field.startsWith('owners[') || field.startsWith('decisionMakers[')) {
           rule = 'refs/owner-exists';
-        } else if (field === 'writesTo' || field === 'readsFrom') {
+        } else if (field === 'writesTo' || field === 'readsFrom' || field.includes('container') || field.includes('Container')) {
           rule = 'refs/container-exists';
+        } else if (
+          field.includes('channel') ||
+          field.includes('Channel') ||
+          field.includes('.to[') ||
+          field.includes('.from[') ||
+          field === 'routes' ||
+          field.startsWith('routes[')
+        ) {
+          rule = 'refs/channel-exists';
         } else if (ref.version) {
           rule = 'refs/valid-version-range';
         }
@@ -331,7 +531,7 @@ export const validateOrphanMessages = (parsedFiles: ParsedFile[], dependencies?:
   for (const parsedFile of parsedFiles) {
     const { file, frontmatter } = parsedFile;
 
-    if (file.resourceType === 'service' || file.resourceType === 'domain') {
+    if (file.resourceType === 'service' || file.resourceType === 'domain' || file.resourceType === 'agent') {
       if (frontmatter.sends && Array.isArray(frontmatter.sends)) {
         frontmatter.sends.forEach((ref: any) => {
           if (ref && ref.id) producedMessages.add(ref.id);
@@ -431,7 +631,7 @@ export const validateDeprecatedReferences = (parsedFiles: ParsedFile[]): Validat
 
     for (const { ref, possibleTypes, field } of references) {
       // Skip owner references for this check
-      if (field === 'owners' || field === 'members') continue;
+      if (field === 'owners' || field.startsWith('owners[') || field === 'members' || field.startsWith('members[')) continue;
 
       for (const type of possibleTypes) {
         if (isDeprecated(type, ref.id, ref.version)) {

--- a/packages/linter/tests/reference-validator.test.ts
+++ b/packages/linter/tests/reference-validator.test.ts
@@ -131,6 +131,24 @@ describe('buildResourceIndex', () => {
     // Should NOT have entries for the path-based IDs
     expect(index.flow['OrderFlow']).toBeUndefined();
   });
+
+  it('should build index for newer resource types', () => {
+    const parsedFiles: ParsedFile[] = [
+      createParsedFile('agent', 'RefundAgent', { id: 'refund-agent', version: '1.0.0' }),
+      createParsedFile('container', 'PaymentsDb', { id: 'payments-db', version: '1.0.0' }),
+      createParsedFile('dataProduct', 'PaymentAnalytics', { id: 'payment-analytics', version: '1.0.0' }),
+      createParsedFile('diagram', 'OrderFlow', { id: 'order-flow', version: '1.0.0' }),
+      createParsedFile('adr', 'ADR001', { id: 'adr-001', version: '1.0.0' }),
+    ];
+
+    const index = buildResourceIndex(parsedFiles);
+
+    expect(index.agent['refund-agent']).toBeDefined();
+    expect(index.container['payments-db']).toBeDefined();
+    expect(index.dataProduct['payment-analytics']).toBeDefined();
+    expect(index.diagram['order-flow']).toBeDefined();
+    expect(index.adr['adr-001']).toBeDefined();
+  });
 });
 
 describe('validateReferences', () => {
@@ -243,6 +261,57 @@ describe('validateReferences', () => {
     expect(errors).toHaveLength(0);
   });
 
+  it('should validate domain references to agents, data products, and flows', () => {
+    const parsedFiles: ParsedFile[] = [
+      createParsedFile('domain', 'sales', {
+        version: '1.0.0',
+        agents: [{ id: 'refund-agent' }],
+        'data-products': [{ id: 'payment-analytics' }],
+        flows: [{ id: 'refund-flow' }],
+      }),
+      createParsedFile('agent', 'refund-agent', { id: 'refund-agent', version: '1.0.0' }),
+      createParsedFile('dataProduct', 'payment-analytics', { id: 'payment-analytics', version: '1.0.0' }),
+      createParsedFile('flow', 'refund-flow', { id: 'refund-flow', version: '1.0.0' }),
+    ];
+
+    const errors = validateReferences(parsedFiles);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should report missing domain references to agents and data products', () => {
+    const parsedFiles: ParsedFile[] = [
+      createParsedFile('domain', 'sales', {
+        version: '1.0.0',
+        agents: [{ id: 'missing-agent' }],
+        'data-products': [{ id: 'missing-product' }],
+      }),
+    ];
+
+    const errors = validateReferences(parsedFiles);
+    expect(errors).toHaveLength(2);
+    expect(errors.map((error) => error.message)).toEqual(
+      expect.arrayContaining([expect.stringContaining('missing-agent'), expect.stringContaining('missing-product')])
+    );
+  });
+
+  it('should validate data product input and output references across resource types', () => {
+    const parsedFiles: ParsedFile[] = [
+      createParsedFile('dataProduct', 'order-metrics', {
+        id: 'order-metrics',
+        version: '1.0.0',
+        inputs: [{ id: 'OrderConfirmed' }, { id: 'order-service' }, { id: 'orders-db' }],
+        outputs: [{ id: 'metrics-channel' }],
+      }),
+      createParsedFile('event', 'OrderConfirmed', { id: 'OrderConfirmed', version: '1.0.0' }),
+      createParsedFile('service', 'order-service', { id: 'order-service', version: '1.0.0' }),
+      createParsedFile('container', 'orders-db', { id: 'orders-db', version: '1.0.0' }),
+      createParsedFile('channel', 'metrics-channel', { id: 'metrics-channel', version: '1.0.0' }),
+    ];
+
+    const errors = validateReferences(parsedFiles);
+    expect(errors).toHaveLength(0);
+  });
+
   it('should use frontmatter.id for command references when different from file path', () => {
     const parsedFiles: ParsedFile[] = [
       createParsedFile('service', 'user-service', {
@@ -322,6 +391,46 @@ describe('validateReferences', () => {
     expect(errors).toHaveLength(0);
   });
 
+  it('should validate flow step references to agents, containers, and data products', () => {
+    const parsedFiles: ParsedFile[] = [
+      createParsedFile('flow', 'refund-flow', {
+        id: 'refund-flow',
+        version: '1.0.0',
+        steps: [
+          { id: 'agent', title: 'Refund Agent', agent: { id: 'refund-agent' } },
+          { id: 'container', title: 'Payments DB', container: { id: 'payments-db' } },
+          { id: 'data-product', title: 'Payment Analytics', dataProduct: { id: 'payment-analytics' } },
+        ],
+      }),
+      createParsedFile('agent', 'refund-agent', { id: 'refund-agent', version: '1.0.0' }),
+      createParsedFile('container', 'payments-db', { id: 'payments-db', version: '1.0.0' }),
+      createParsedFile('dataProduct', 'payment-analytics', { id: 'payment-analytics', version: '1.0.0' }),
+    ];
+
+    const errors = validateReferences(parsedFiles);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should report missing flow step references to agents, containers, and data products', () => {
+    const parsedFiles: ParsedFile[] = [
+      createParsedFile('flow', 'refund-flow', {
+        id: 'refund-flow',
+        version: '1.0.0',
+        steps: [
+          { id: 'agent', title: 'Refund Agent', agent: { id: 'missing-agent' } },
+          { id: 'container', title: 'Payments DB', container: { id: 'missing-db' } },
+          { id: 'data-product', title: 'Payment Analytics', dataProduct: { id: 'missing-product' } },
+        ],
+      }),
+    ];
+
+    const errors = validateReferences(parsedFiles);
+    expect(errors).toHaveLength(3);
+    expect(errors.map((error) => error.field)).toEqual(
+      expect.arrayContaining(['steps[0].agent', 'steps[1].container', 'steps[2].dataProduct'])
+    );
+  });
+
   it('should use frontmatter.id for flow step service references when different from file path', () => {
     const parsedFiles: ParsedFile[] = [
       createParsedFile('flow', 'order-flow', {
@@ -353,6 +462,20 @@ describe('validateReferences', () => {
       }),
       createParsedFile('user', 'john-doe', {}),
       createParsedFile('team', 'platform-team', {}),
+    ];
+
+    const errors = validateReferences(parsedFiles);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should validate owner object references', () => {
+    const parsedFiles: ParsedFile[] = [
+      createParsedFile('service', 'order-service', {
+        id: 'order-service',
+        version: '1.0.0',
+        owners: [{ id: 'platform-team', collection: 'teams' }],
+      }),
+      createParsedFile('team', 'platform-team', { id: 'platform-team' }),
     ];
 
     const errors = validateReferences(parsedFiles);
@@ -414,6 +537,51 @@ describe('validateReferences', () => {
         }),
         createParsedFile('event', 'OutOfStock', { id: 'OutOfStock', version: '2.0.0' }),
         createParsedFile('event', 'OutOfStock', { id: 'OutOfStock', version: '1.5.0' }),
+      ];
+
+      const errors = validateReferences(parsedFiles);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should validate channel routes', () => {
+      const parsedFiles: ParsedFile[] = [
+        createParsedFile('channel', 'domain-bus', {
+          id: 'domain-bus',
+          version: '1.0.0',
+          routes: [{ id: 'orders-channel' }],
+        }),
+        createParsedFile('channel', 'orders-channel', { id: 'orders-channel', version: '1.0.0' }),
+      ];
+
+      const errors = validateReferences(parsedFiles);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should validate ADR typed resource references and relationships', () => {
+      const parsedFiles: ParsedFile[] = [
+        createParsedFile('adr', 'adr-002', {
+          id: 'adr-002',
+          version: '1.0.0',
+          appliesTo: [
+            { type: 'service', id: 'order-service' },
+            { type: 'data-product', id: 'order-metrics' },
+          ],
+          supersedes: [{ id: 'adr-001' }],
+        }),
+        createParsedFile('adr', 'adr-001', { id: 'adr-001', version: '1.0.0' }),
+        createParsedFile('service', 'order-service', { id: 'order-service', version: '1.0.0' }),
+        createParsedFile('dataProduct', 'order-metrics', { id: 'order-metrics', version: '1.0.0' }),
+      ];
+
+      const errors = validateReferences(parsedFiles);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should validate user and team owned agent references', () => {
+      const parsedFiles: ParsedFile[] = [
+        createParsedFile('user', 'dboyne', { id: 'dboyne', ownedAgents: [{ id: 'support-agent' }] }),
+        createParsedFile('team', 'platform', { id: 'platform', ownedAgents: [{ id: 'support-agent' }] }),
+        createParsedFile('agent', 'support-agent', { id: 'support-agent', version: '1.0.0' }),
       ];
 
       const errors = validateReferences(parsedFiles);

--- a/packages/linter/tests/scanner.test.ts
+++ b/packages/linter/tests/scanner.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { extractResourceInfo } from '../src/scanner';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { extractResourceInfo, scanCatalogFiles } from '../src/scanner';
 
 describe('extractResourceInfo', () => {
   it('should extract simple resource id', () => {
@@ -43,5 +46,47 @@ describe('extractResourceInfo', () => {
   it('should extract team id from filename', () => {
     const result = extractResourceInfo('teams/platform-team.mdx', 'team');
     expect(result).toEqual({ id: 'platform-team' });
+  });
+
+  it('should extract nested container id', () => {
+    const result = extractResourceInfo('domains/sales/services/order-service/containers/orders-db/index.mdx', 'container');
+    expect(result).toEqual({ id: 'orders-db' });
+  });
+
+  it('should extract data product id from data-products folders', () => {
+    const result = extractResourceInfo('domains/sales/data-products/order-metrics/versioned/1.0.0/index.mdx', 'dataProduct');
+    expect(result).toEqual({ id: 'order-metrics', version: '1.0.0' });
+  });
+
+  it('should extract nested diagram id', () => {
+    const result = extractResourceInfo('domains/sales/diagrams/order-flow/versioned/1.0.0/index.mdx', 'diagram');
+    expect(result).toEqual({ id: 'order-flow', version: '1.0.0' });
+  });
+
+  it('should extract adr id', () => {
+    const result = extractResourceInfo('adrs/adr-001/index.md', 'adr');
+    expect(result).toEqual({ id: 'adr-001' });
+  });
+
+  it('should scan newer resource types', async () => {
+    const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), 'eventcatalog-linter-scanner-'));
+    const files = [
+      'domains/sales/agents/refund-agent/index.mdx',
+      'domains/sales/data-products/order-metrics/index.mdx',
+      'domains/sales/services/order-service/containers/orders-db/index.mdx',
+      'domains/sales/diagrams/order-flow/index.mdx',
+      'adrs/adr-001/index.md',
+    ];
+
+    await Promise.all(
+      files.map(async (file) => {
+        const filePath = path.join(rootDir, file);
+        await fs.mkdir(path.dirname(filePath), { recursive: true });
+        await fs.writeFile(filePath, '---\nid: test\nname: Test\nversion: 1.0.0\n---\n');
+      })
+    );
+
+    const catalogFiles = await scanCatalogFiles(rootDir);
+    expect(catalogFiles.map((file) => file.resourceType).sort()).toEqual(['adr', 'agent', 'container', 'dataProduct', 'diagram']);
   });
 });

--- a/packages/linter/tests/schema-validator.test.ts
+++ b/packages/linter/tests/schema-validator.test.ts
@@ -138,6 +138,37 @@ describe('validateSchema', () => {
       const errors = validateSchema(parsedFile);
       expect(errors).toHaveLength(0);
     });
+
+    it('should pass with agent, container, and data product flow steps', () => {
+      const parsedFile = createParsedFile('flow', {
+        id: 'refund-flow',
+        name: 'Refund Flow',
+        version: '1.0.0',
+        steps: [
+          {
+            id: 'agent',
+            type: 'agent',
+            title: 'Refund Agent',
+            agent: { id: 'refund-agent' },
+            next_step: 'container',
+          },
+          {
+            id: 'container',
+            title: 'Payments DB',
+            container: { id: 'payments-db' },
+            next_step: 'data-product',
+          },
+          {
+            id: 'data-product',
+            title: 'Payment Analytics',
+            dataProduct: { id: 'payment-analytics' },
+          },
+        ],
+      });
+
+      const errors = validateSchema(parsedFile);
+      expect(errors).toHaveLength(0);
+    });
   });
 
   describe('entity validation', () => {
@@ -285,6 +316,73 @@ describe('validateSchema', () => {
       });
       const errors = validateSchema(parsedFile);
       expect(errors.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('newer resource validation', () => {
+    it('should pass with valid agent frontmatter', () => {
+      const parsedFile = createParsedFile('agent', {
+        id: 'refund-agent',
+        name: 'Refund Agent',
+        version: '1.0.0',
+        receives: [{ id: 'RefundRequested' }],
+        readsFrom: [{ id: 'payments-db' }],
+        tools: [{ name: 'Payment lookup', type: 'mcp' }],
+        model: { provider: 'OpenAI', name: 'gpt-4.1-mini' },
+      });
+
+      const errors = validateSchema(parsedFile);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should pass with valid container frontmatter', () => {
+      const parsedFile = createParsedFile('container', {
+        id: 'payments-db',
+        name: 'Payments DB',
+        version: '1.0.0',
+        container_type: 'other',
+      });
+
+      const errors = validateSchema(parsedFile);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should pass with valid data product frontmatter', () => {
+      const parsedFile = createParsedFile('dataProduct', {
+        id: 'payment-analytics',
+        name: 'Payment Analytics',
+        version: '1.0.0',
+        inputs: [{ id: 'PaymentProcessed' }],
+        outputs: [{ id: 'payments-db', contract: { path: 'contract.json', name: 'Payments Contract' } }],
+      });
+
+      const errors = validateSchema(parsedFile);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should pass with valid adr frontmatter', () => {
+      const parsedFile = createParsedFile('adr', {
+        id: 'adr-001',
+        name: 'Use events',
+        version: '1.0.0',
+        status: 'accepted',
+        date: '2026-05-26',
+        appliesTo: [{ type: 'service', id: 'OrderService' }],
+      });
+
+      const errors = validateSchema(parsedFile);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should pass with valid diagram frontmatter', () => {
+      const parsedFile = createParsedFile('diagram', {
+        id: 'order-flow',
+        name: 'Order Flow',
+        version: '1.0.0',
+      });
+
+      const errors = validateSchema(parsedFile);
+      expect(errors).toHaveLength(0);
     });
   });
 });


### PR DESCRIPTION
## What This PR Does

Expands the `@eventcatalog/linter` package to understand the full range of EventCatalog resource types. It adds schemas for agents, ADRs, containers, data products, and diagrams, teaches the scanner how to discover them on disk, and significantly extends the reference validator so cross-resource references are checked consistently across every resource type. A small `@eventcatalog/core` change pins the LikeC4 install message to compatible versions.

## Changes Overview

### Key Changes

- **New schemas** — `adr`, `agent`, `container`, `data-product`, and `diagram` schemas added under `packages/linter/src/schemas/`, exported from the schema index and registered in the `schemas` map.
- **Scanner discovery** — `RESOURCE_PATTERNS` now covers the new resource types and supports nested directories (`**`) for channels, flows, containers, and diagrams. A new `RESOURCE_DIRECTORY_NAMES` map handles types whose directory name differs from `${type}s` (e.g. `data-products`, `containers`, `adrs`).
- **Reference validation** — the reference validator gains resource-type normalization (singular/plural aliases), typed reference extraction, container/dataStore aliasing, and helper functions (`getReference`, `addReference`, `addReferences`, `addTypedReference`) for consistent reference collection across schemas.
- **Config** — `PLURAL_TO_SINGULAR` extended with `agents`, `adrs`, `containers`, `data-products`, and `diagrams`.
- **Backwards compatibility** — `dataStore` is kept as an alias for `container` so existing linter integrations keep working.
- **LikeC4 install message** — `@eventcatalog/core` install hint now pins `likec4@1.55.1` and `@likec4/icons@1.46.4`.
- **Tests** — new coverage in `reference-validator.test.ts`, `scanner.test.ts`, and `schema-validator.test.ts`, plus an updated linter README.

## How It Works

The scanner resolves each resource type to a set of glob patterns and a directory name, so new types like data products (`data-products/`) and ADRs (`adrs/`) are found even though their folder name isn't a simple pluralization of the type. The reference validator normalizes any incoming type string (singular or plural) to a canonical `ResourceType`, then resolves references through a shared set of helpers. Container and dataStore are treated as aliases of one another during existence checks, so a reference resolves whether the target is indexed as a container or a data store.

## Breaking Changes

None. `dataStore` remains a supported alias for `container`.

## Additional Notes

- The `@eventcatalog/linter` package gets a `minor` bump (new resource-type support); `@eventcatalog/core` gets a `patch` (LikeC4 install message).
- No editor repo change is required for this PR — the work is contained to the linter and a core-only message string.