### PR TITLE
Add getC4Diagram MCP tool and ADR collection support

### DIFF
--- a/.changeset/c4-diagram-mcp-tool.md
+++ b/.changeset/c4-diagram-mcp-tool.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": minor
+---
+
+Add `getC4Diagram` MCP tool to expose LikeC4 source files and view metadata, and add support for the `adrs` collection in MCP resources and tools

--- a/packages/core/eventcatalog/src/enterprise/mcp/__tests__/mcp-server.spec.ts
+++ b/packages/core/eventcatalog/src/enterprise/mcp/__tests__/mcp-server.spec.ts
@@ -31,6 +31,7 @@ vi.mock('hono', () => {
               'eventcatalog://agents',
               'eventcatalog://services',
               'eventcatalog://domains',
+              'eventcatalog://entities',
               'eventcatalog://flows',
               'eventcatalog://teams',
               'eventcatalog://users',
@@ -163,6 +164,7 @@ describe('MCP Health Check Endpoint (GET /docs/mcp/)', () => {
       'findResourcesByOwner',
       'getProducersOfMessage',
       'getConsumersOfMessage',
+      'getC4Diagram',
       'analyzeChangeImpact',
       'explainBusinessFlow',
       'getTeams',
@@ -179,7 +181,7 @@ describe('MCP Health Check Endpoint (GET /docs/mcp/)', () => {
     for (const tool of expectedTools) {
       expect(toolDescriptions[tool as keyof typeof toolDescriptions]).toBeDefined();
     }
-    expect(Object.keys(toolDescriptions).length).toBe(18);
+    expect(Object.keys(toolDescriptions).length).toBe(19);
   });
 });
 
@@ -308,6 +310,7 @@ describe('MCP Resources', () => {
       'eventcatalog://agents',
       'eventcatalog://services',
       'eventcatalog://domains',
+      'eventcatalog://entities',
       'eventcatalog://flows',
       'eventcatalog://teams',
       'eventcatalog://users',
@@ -324,7 +327,7 @@ describe('MCP Resources', () => {
     const body = await response.json();
 
     expect(body.resources).toBeDefined();
-    expect(body.resources.length).toBe(10);
+    expect(body.resources.length).toBe(11);
 
     for (const uri of expectedResources) {
       expect(body.resources).toContain(uri);

--- a/packages/core/eventcatalog/src/enterprise/mcp/__tests__/mcp-server.spec.ts
+++ b/packages/core/eventcatalog/src/enterprise/mcp/__tests__/mcp-server.spec.ts
@@ -155,7 +155,7 @@ describe('MCP Health Check Endpoint (GET /docs/mcp/)', () => {
   it('should verify toolDescriptions contains all expected tools', async () => {
     const { toolDescriptions } = await import('@enterprise/tools/catalog-tools');
 
-    // 15 built-in tools from toolDescriptions
+    // 19 built-in tools from toolDescriptions
     const expectedTools = [
       'getResources',
       'getResource',

--- a/packages/core/eventcatalog/src/enterprise/mcp/mcp-server.ts
+++ b/packages/core/eventcatalog/src/enterprise/mcp/mcp-server.ts
@@ -30,6 +30,7 @@ import {
   resourceCollectionSchema,
   messageCollectionSchema,
   toolDescriptions,
+  getC4Diagram,
 } from '@enterprise/tools/catalog-tools';
 import { getCollection } from 'astro:content';
 import { createMcpAuthErrorResponse, validateMcpRequest } from './mcp-auth';
@@ -182,6 +183,17 @@ function createMcpServer() {
   );
 
   server.registerTool(
+    'getC4Diagram',
+    {
+      description: toolDescriptions.getC4Diagram,
+      inputSchema: z.object({
+        viewId: z.string().describe('The id of the LikeC4 view to return source files for').optional(),
+      }),
+    },
+    createToolHandler(getC4Diagram, 'Failed to get c4 diagram')
+  );
+
+  server.registerTool(
     'analyzeChangeImpact',
     {
       description: toolDescriptions.analyzeChangeImpact,
@@ -328,7 +340,18 @@ function createMcpServer() {
       name: 'All Resources in EventCatalog',
       uri: 'eventcatalog://all',
       description: 'All messages, agents, domains and services in EventCatalog',
-      collections: ['events', 'commands', 'queries', 'agents', 'services', 'domains', 'flows', 'channels', 'entities'] as const,
+      collections: [
+        'events',
+        'commands',
+        'queries',
+        'agents',
+        'services',
+        'domains',
+        'flows',
+        'channels',
+        'entities',
+        'adrs',
+      ] as const,
     },
     {
       name: 'All Events in EventCatalog',
@@ -359,6 +382,12 @@ function createMcpServer() {
       uri: 'eventcatalog://agents',
       description: 'All agents in EventCatalog',
       collections: ['agents'] as const,
+    },
+    {
+      name: 'All Architecture Decision Records (adrs) in EventCatalog',
+      uri: 'eventcatalog://adrs',
+      description: 'All architecture decision records in EventCatalog',
+      collections: ['adrs'] as const,
     },
     {
       name: 'All Domains in EventCatalog',
@@ -461,6 +490,7 @@ const mcpResources = [
   'eventcatalog://commands',
   'eventcatalog://queries',
   'eventcatalog://agents',
+  'eventcatalog://adrs',
   'eventcatalog://services',
   'eventcatalog://domains',
   'eventcatalog://flows',
@@ -478,7 +508,7 @@ app.get('/', async (c: Context) => {
 
   return c.json({
     name: 'EventCatalog MCP Server',
-    version: '1.0.0',
+    version: '1.1.0',
     status: 'running',
     tools: [...builtInTools, ...extendedToolNames],
     extendedTools: extendedToolNames.length > 0 ? extendedToolNames : undefined,

--- a/packages/core/eventcatalog/src/enterprise/mcp/mcp-server.ts
+++ b/packages/core/eventcatalog/src/enterprise/mcp/mcp-server.ts
@@ -408,6 +408,12 @@ function createMcpServer() {
       collections: ['channels'] as const,
     },
     {
+      name: 'All Entities in EventCatalog',
+      uri: 'eventcatalog://entities',
+      description: 'All entities in EventCatalog',
+      collections: ['entities'] as const,
+    },
+    {
       name: 'All Containers  in EventCatalog',
       uri: 'eventcatalog://containers',
       description: 'All containers in EventCatalog',
@@ -493,6 +499,7 @@ const mcpResources = [
   'eventcatalog://adrs',
   'eventcatalog://services',
   'eventcatalog://domains',
+  'eventcatalog://entities',
   'eventcatalog://flows',
   'eventcatalog://teams',
   'eventcatalog://users',

--- a/packages/core/eventcatalog/src/enterprise/tools/__tests__/catalog-tools.mocks.ts
+++ b/packages/core/eventcatalog/src/enterprise/tools/__tests__/catalog-tools.mocks.ts
@@ -497,6 +497,7 @@ export const mockContainers = [
       name: 'Order Database',
       version: '1.0.0',
       summary: 'Order data storage',
+      owners: ['order-team'],
     },
   },
 ];
@@ -515,6 +516,28 @@ export const mockDiagrams = [
       name: 'System Overview',
       version: '1.0.0',
       summary: 'High-level system diagram',
+      owners: ['order-team'],
+    },
+  },
+];
+
+// ============================================
+// Mock ADRs
+// ============================================
+export const mockAdrs = [
+  {
+    id: 'adr-001-1.0.0',
+    slug: 'adrs/adr-001',
+    collection: 'adrs',
+    body: 'ADR description',
+    data: {
+      id: 'adr-001',
+      name: 'Choose event-driven orders',
+      version: '1.0.0',
+      summary: 'Decision to use events for order workflows',
+      owners: ['order-team'],
+      status: 'accepted',
+      date: new Date('2025-01-01'),
     },
   },
 ];
@@ -563,6 +586,7 @@ export const mockCollections: Record<string, any[]> = {
   domains: mockDomains,
   channels: mockChannels,
   entities: mockEntities,
+  adrs: mockAdrs,
   containers: mockContainers,
   diagrams: mockDiagrams,
   schemas: mockSchemas,

--- a/packages/core/eventcatalog/src/enterprise/tools/__tests__/catalog-tools.spec.ts
+++ b/packages/core/eventcatalog/src/enterprise/tools/__tests__/catalog-tools.spec.ts
@@ -5,6 +5,8 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { CollectionKey } from 'astro:content';
+import fs from 'node:fs';
+import { glob } from 'glob';
 
 // Type definitions for test results
 type ProducerConsumer = { id: string; version: string; name: string };
@@ -102,6 +104,10 @@ vi.mock('node:fs', () => ({
   },
 }));
 
+vi.mock('glob', () => ({
+  glob: vi.fn(async () => []),
+}));
+
 import {
   encodeCursor,
   decodeCursor,
@@ -122,8 +128,15 @@ import {
   getUser,
   findMessageBySchemaId,
   explainUbiquitousLanguageTerms,
+  getC4Diagram,
 } from '../catalog-tools';
 import { getSchemasFromResource } from '@utils/collections/schemas';
+
+beforeEach(() => {
+  vi.mocked(glob).mockResolvedValue([]);
+  vi.mocked(fs.readFileSync).mockReturnValue('{"schema": "content"}');
+  delete process.env.PROJECT_DIR;
+});
 
 // ============================================
 // Pagination Utilities Tests
@@ -539,6 +552,123 @@ describe('getConsumersOfMessage', () => {
       messageCollection: 'events',
     });
     expect('error' in result).toBe(true);
+  });
+});
+
+describe('getC4Diagram', () => {
+  const projectRoot = '/catalog';
+  const sourceFiles = ['architecture/model.c4', 'architecture/views.c4', 'payments/model.c4', 'payments/views.c4'];
+  const fileContents: Record<string, string> = {
+    '/catalog/architecture/model.c4': `specification {
+  element actor
+  element system
+}
+
+model {
+  customer = actor 'Customer'
+  ordering = system 'Ordering service'
+}`,
+    '/catalog/architecture/views.c4': `views {
+  view OrderFlow {
+    include *
+  }
+
+  dynamic view Checkout {
+    customer -> ordering 'places order'
+  }
+}`,
+    '/catalog/payments/model.c4': `model {
+  payment = system 'Payment service'
+}`,
+    '/catalog/payments/views.c4': `views {
+  deployment view PaymentsOverview {
+    include *
+  }
+}`,
+  };
+
+  beforeEach(() => {
+    process.env.PROJECT_DIR = projectRoot;
+    vi.mocked(glob).mockImplementation(async (pattern) => {
+      if (pattern === '**/*.{c4,likec4}') {
+        return sourceFiles;
+      }
+
+      return [];
+    });
+    vi.mocked(fs.readFileSync).mockImplementation((filePath) => fileContents[String(filePath)] ?? '');
+  });
+
+  it('returns all LikeC4 source files when no viewId is provided', async () => {
+    const result = await getC4Diagram({});
+
+    expect('error' in result).toBe(false);
+    if (!('error' in result)) {
+      expect(result.totalSourceFiles).toBe(4);
+      expect(result.totalViews).toBe(3);
+      expect(result.sources.map((source: any) => source.path)).toEqual([
+        'architecture/model.c4',
+        'architecture/views.c4',
+        'payments/model.c4',
+        'payments/views.c4',
+      ]);
+      expect(result.sources[0].content).toContain("customer = actor 'Customer'");
+      expect(result.sources[1].views.map((view: any) => view.id)).toEqual(['OrderFlow', 'Checkout']);
+    }
+  });
+
+  it('returns all source files and the matching view when viewId is provided', async () => {
+    const result = await getC4Diagram({ viewId: 'OrderFlow' });
+
+    expect('error' in result).toBe(false);
+    if (!('error' in result)) {
+      expect((result as any).matchingViews[0]).toMatchObject({
+        id: 'OrderFlow',
+        kind: 'element',
+        filePath: 'architecture/views.c4',
+      });
+      expect(result.sources.map((source: any) => source.path)).toEqual([
+        'architecture/model.c4',
+        'architecture/views.c4',
+        'payments/model.c4',
+        'payments/views.c4',
+      ]);
+      expect(result.sources[0].content).toContain("customer = actor 'Customer'");
+    }
+  });
+
+  it('returns sources for another matching view', async () => {
+    const result = await getC4Diagram({ viewId: 'PaymentsOverview' });
+
+    expect('error' in result).toBe(false);
+    if (!('error' in result)) {
+      expect((result as any).matchingViews[0]).toMatchObject({
+        id: 'PaymentsOverview',
+        kind: 'deployment',
+      });
+    }
+  });
+
+  it('returns available views when the requested view cannot be found', async () => {
+    const result = await getC4Diagram({ viewId: 'MissingView' });
+
+    expect('error' in result).toBe(true);
+    if ('error' in result) {
+      expect(result.error).toContain('MissingView');
+      expect((result as any).availableViews.map((view: any) => view.id)).toContain('OrderFlow');
+    }
+  });
+
+  it('returns an empty result when no LikeC4 source files are found', async () => {
+    vi.mocked(glob).mockResolvedValue([]);
+
+    const result = await getC4Diagram({});
+
+    expect('error' in result).toBe(false);
+    if (!('error' in result)) {
+      expect(result.totalSourceFiles).toBe(0);
+      expect(result.sources).toEqual([]);
+    }
   });
 });
 

--- a/packages/core/eventcatalog/src/enterprise/tools/__tests__/catalog-tools.spec.ts
+++ b/packages/core/eventcatalog/src/enterprise/tools/__tests__/catalog-tools.spec.ts
@@ -779,6 +779,9 @@ describe('findResourcesByOwner', () => {
       expect(result.totalCount).toBeGreaterThan(0);
       expect(result.resources.some((r: ResourceResult) => r.collection === 'events')).toBe(true);
       expect(result.resources.some((r: ResourceResult) => r.collection === 'services')).toBe(true);
+      expect(result.resources.some((r: ResourceResult) => r.collection === 'adrs')).toBe(true);
+      expect(result.resources.some((r: ResourceResult) => r.collection === 'containers')).toBe(true);
+      expect(result.resources.some((r: ResourceResult) => r.collection === 'diagrams')).toBe(true);
     }
   });
 

--- a/packages/core/eventcatalog/src/enterprise/tools/catalog-tools.ts
+++ b/packages/core/eventcatalog/src/enterprise/tools/catalog-tools.ts
@@ -345,6 +345,9 @@ export async function findResourcesByOwner(params: { ownerId: string }) {
     'flows',
     'channels',
     'entities',
+    'adrs',
+    'containers',
+    'diagrams',
     'data-products',
   ] as const;
 

--- a/packages/core/eventcatalog/src/enterprise/tools/catalog-tools.ts
+++ b/packages/core/eventcatalog/src/enterprise/tools/catalog-tools.ts
@@ -27,8 +27,75 @@ import { getNodesAndEdges as getNodesAndEdgesForDataProduct } from '@utils/node-
 import { getNodesAndEdges as getNodesAndEdgesForContainer } from '@utils/node-graphs/container-node-graph';
 import { convertToMermaid } from '@utils/node-graphs/export-mermaid';
 import config from '@config';
+import { glob } from 'glob';
+import path from 'node:path';
 
 const MESSAGE_COLLECTIONS = new Set(['events', 'commands', 'queries']);
+const LIKEC4_SOURCE_PATTERN = '**/*.{c4,likec4}';
+
+type LikeC4View = {
+  id: string;
+  kind: 'element' | 'dynamic' | 'deployment';
+  filePath: string;
+  line: number;
+};
+
+type LikeC4SourceFile = {
+  path: string;
+  content: string;
+  views: LikeC4View[];
+};
+
+const toPosixPath = (filePath: string) => filePath.split(path.sep).join(path.posix.sep);
+
+const lineNumberAtIndex = (content: string, index: number) => content.slice(0, index).split(/\r\n|\r|\n/).length;
+
+const stripLikeC4Comments = (content: string) => content.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+
+const parseLikeC4Views = (content: string, filePath: string): LikeC4View[] => {
+  const contentWithoutComments = stripLikeC4Comments(content);
+  const viewDeclarationPattern =
+    /\b(?:(dynamic|deployment)\s+)?view(?:\s+([A-Za-z_][\w.-]*))?(?:\s+of\s+[A-Za-z_][\w.-]*(?:\.[A-Za-z_][\w.-]*)*)?\s*\{/g;
+  const views: LikeC4View[] = [];
+  let match: RegExpExecArray | null;
+
+  while ((match = viewDeclarationPattern.exec(contentWithoutComments)) !== null) {
+    const [, kind, id] = match;
+
+    if (!id) {
+      continue;
+    }
+
+    views.push({
+      id,
+      kind: kind === 'dynamic' || kind === 'deployment' ? kind : 'element',
+      filePath,
+      line: lineNumberAtIndex(contentWithoutComments, match.index),
+    });
+  }
+
+  return views;
+};
+
+const discoverLikeC4Sources = async (projectRoot: string): Promise<LikeC4SourceFile[]> => {
+  const sourceFiles = await glob(LIKEC4_SOURCE_PATTERN, {
+    cwd: projectRoot,
+    ignore: ['**/node_modules/**'],
+    nodir: true,
+  });
+
+  return sourceFiles
+    .map(toPosixPath)
+    .sort()
+    .map((sourceFile) => {
+      const content = fs.readFileSync(path.join(projectRoot, sourceFile), 'utf-8');
+      return {
+        path: sourceFile,
+        content,
+        views: parseLikeC4Views(content, sourceFile),
+      };
+    });
+};
 
 // ============================================
 // Pagination utilities
@@ -105,6 +172,7 @@ export function paginate<T>(
 export const collectionSchema = z.enum([
   'events',
   'agents',
+  'adrs',
   'services',
   'commands',
   'queries',
@@ -122,6 +190,7 @@ export const messageCollectionSchema = z.enum(['events', 'commands', 'queries'])
 export const resourceCollectionSchema = z.enum([
   'agents',
   'services',
+  'adrs',
   'events',
   'commands',
   'queries',
@@ -342,6 +411,46 @@ export async function getProducersOfMessage(params: { messageId: string; message
       collection: s.collection,
     })),
     count: producers.length,
+  };
+}
+
+export async function getC4Diagram(params: { viewId?: string }) {
+  const projectRoot = process.env.PROJECT_DIR || process.cwd();
+  const sources = await discoverLikeC4Sources(projectRoot);
+  const availableViews = sources.flatMap((source) => source.views);
+
+  if (sources.length === 0) {
+    return {
+      message: 'No LikeC4 source files found in this EventCatalog project',
+      sources: [],
+      totalSourceFiles: 0,
+      totalViews: 0,
+    };
+  }
+
+  if (!params.viewId) {
+    return {
+      message: 'LikeC4 source files found',
+      sources,
+      totalSourceFiles: sources.length,
+      totalViews: availableViews.length,
+    };
+  }
+
+  const matchingViews = availableViews.filter((view) => view.id === params.viewId);
+
+  if (matchingViews.length === 0) {
+    return {
+      error: `LikeC4 view not found: ${params.viewId}`,
+      availableViews,
+    };
+  }
+
+  return {
+    viewId: params.viewId,
+    matchingViews,
+    sources,
+    totalSourceFiles: sources.length,
   };
 }
 
@@ -992,6 +1101,8 @@ export const toolDescriptions = {
     'Use this tool to find which agents or services produce (send) a specific message (event, command, or query)',
   getConsumersOfMessage:
     'Use this tool to find which agents or services consume (receive) a specific message (event, command, or query)',
+  getC4Diagram:
+    'Use this tool to get the C4 diagram (or likeC4) in EventCatalog. These files usually have a .c4 extension on them',
   analyzeChangeImpact:
     'Use this tool to analyze the impact of changing a message. Returns all affected agents and services (producers and consumers), the teams that own them, and the blast radius of the change',
   explainBusinessFlow:


### PR DESCRIPTION
## What This PR Does

Adds a new `getC4Diagram` tool to the EventCatalog MCP server, allowing AI clients to discover and read LikeC4 architecture diagram source files (`.c4` / `.likec4`) and their view metadata directly from a catalog. It also adds support for the `adrs` (Architecture Decision Records) collection across MCP resources and catalog tool schemas.

## Changes Overview

### Key Changes

- **New `getC4Diagram` tool** (`catalog-tools.ts`): discovers LikeC4 source files in the project, parses out view declarations (element, dynamic, and deployment views) with their file paths and line numbers, and returns either all sources or the source(s) matching a requested `viewId`.
- **MCP server registration** (`mcp-server.ts`): registers the `getC4Diagram` tool with an optional `viewId` input, bumps the server version to `1.1.0`.
- **ADR collection support**: adds `adrs` to the `collectionSchema` and `resourceCollectionSchema`, exposes a new `eventcatalog://adrs` resource, and includes `adrs` in the "All Resources" aggregate resource.
- **Tests** (`catalog-tools.spec.ts`): full coverage for `getC4Diagram` — listing all sources, resolving a view by id, handling missing views, and the empty-project case. Mocks `glob` and `node:fs`.

## How It Works

`discoverLikeC4Sources` globs the project root (using `PROJECT_DIR` or `process.cwd()`) for `**/*.{c4,likec4}` files, excluding `node_modules`. Each file's contents are read and scanned by `parseLikeC4Views`, which strips comments and uses a regex to extract `view` / `dynamic view` / `deployment view` declarations along with their line numbers. The tool returns all source files when no `viewId` is given, the matching view plus all sources when a `viewId` resolves, or an error listing available views when it does not.

## Breaking Changes

None.

## Additional Notes

The view parser is regex-based rather than a full LikeC4 grammar parse; it intentionally returns all source files alongside any matched view so the consuming client has full context. No editor (`eventcatalog-editor`) change is required for this server-side MCP addition.