### PR TITLE
Sort ADRs in the sidebar by resource name

### DIFF
--- a/.changeset/calm-otters-cheer.md
+++ b/.changeset/calm-otters-cheer.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Sort ADRs in the sidebar by resource name instead of date

--- a/packages/core/eventcatalog/src/stores/sidebar-store/builders/__tests__/shared.spec.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/builders/__tests__/shared.spec.ts
@@ -77,4 +77,47 @@ describe('withArchitectureDecisionsSection', () => {
       },
     ]);
   });
+
+  it('sorts Decision Records by name then id', () => {
+    const node: NavNode = {
+      type: 'item',
+      title: 'Orders Service',
+      href: '/docs/services/OrdersService/1.0.0',
+    };
+
+    const resource = {
+      collection: 'services',
+      data: { id: 'OrdersService', version: '1.0.0' },
+    };
+
+    const createAdr = (id: string, name?: string) => ({
+      collection: 'adrs',
+      data: {
+        id,
+        name,
+        version: '1.0.0',
+        appliesTo: [{ type: 'service', id: 'OrdersService', version: '1.0.0' }],
+      },
+    });
+
+    const result = withArchitectureDecisionsSection(
+      node,
+      resource as any,
+      [
+        createAdr('adr-003', 'Store payment authorization'),
+        createAdr('adr-002', 'Choose event format'),
+        createAdr('adr-001', 'Choose event format'),
+        createAdr('adr-004'),
+      ] as any
+    );
+
+    const decisionRecords = result.pages?.find((page) => typeof page !== 'string' && page.title === 'Decision Records');
+
+    expect(decisionRecords && typeof decisionRecords !== 'string' ? decisionRecords.pages : undefined).toEqual([
+      'adr:adr-004:1.0.0',
+      'adr:adr-001:1.0.0',
+      'adr:adr-002:1.0.0',
+      'adr:adr-003:1.0.0',
+    ]);
+  });
 });

--- a/packages/core/eventcatalog/src/stores/sidebar-store/builders/shared.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/builders/shared.ts
@@ -102,6 +102,12 @@ export const buildOwnersSection = (owners: any[]): NavNode | null => {
   };
 };
 
+const byAdrName = (a: Adr, b: Adr) => {
+  const name = (a.data.name || a.data.id).localeCompare(b.data.name || b.data.id);
+  if (name !== 0) return name;
+  return a.data.id.localeCompare(b.data.id);
+};
+
 export const buildArchitectureDecisionsSection = (resource: AdrResource, adrs: Adr[]): NavNode | null => {
   const relatedAdrs = getAdrsForResource(resource, adrs);
   if (relatedAdrs.length === 0) return null;
@@ -110,7 +116,7 @@ export const buildArchitectureDecisionsSection = (resource: AdrResource, adrs: A
     type: 'group',
     title: 'Decision Records',
     icon: 'BookText',
-    pages: relatedAdrs.map(getAdrNodeKey),
+    pages: [...relatedAdrs].sort(byAdrName).map(getAdrNodeKey),
   };
 };
 

--- a/packages/core/eventcatalog/src/stores/sidebar-store/state.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/state.ts
@@ -58,12 +58,6 @@ const byResourceName = <T extends { data: { name?: string; id: string } }>(a: T,
 
 const sortByResourceName = <T extends { data: { name?: string; id: string } }>(items: T[]) => [...items].sort(byResourceName);
 
-const byAdrDateDesc = (a: Adr, b: Adr) => {
-  const date = new Date(b.data.date).getTime() - new Date(a.data.date).getTime();
-  if (date !== 0) return date;
-  return byResourceName(a, b);
-};
-
 const groupAdrsByStatus = (adrs: Adr[]): NavNode[] =>
   ADR_STATUS_VALUES.reduce<NavNode[]>((groups, status) => {
     const adrsForStatus = adrs.filter((adr) => adr.data.status === status);
@@ -73,7 +67,7 @@ const groupAdrsByStatus = (adrs: Adr[]): NavNode[] =>
       type: 'group',
       title: `${formatAdrStatus(status)} (${adrsForStatus.length})`,
       subtle: true,
-      pages: [...adrsForStatus].sort(byAdrDateDesc).map(getAdrNodeKey),
+      pages: [...adrsForStatus].sort(byResourceName).map(getAdrNodeKey),
     });
 
     return groups;


### PR DESCRIPTION
## What This PR Does

Changes how Architecture Decision Records (ADRs) are ordered within each status group in the sidebar. Previously ADRs were sorted by their `date` field (most recent first), with name as a tie-breaker. They are now sorted alphabetically by resource name, consistent with how other resources appear in the sidebar.

## Changes Overview

### Key Changes

- Remove the `byAdrDateDesc` comparator from the sidebar store state
- Sort ADRs within each status group using `byResourceName` instead

## How It Works

The `groupAdrsByStatus` helper builds a navigation group per ADR status. The sorting applied to each group's `pages` array now uses the shared `byResourceName` comparator, removing the date-based ordering that was specific to ADRs.

## Breaking Changes

None.

## Additional Notes

No editor repository change is needed for this update.