### PR TITLE
Defer dagre layout for composed sub-graphs and use map-based de-duplication

### DIFF
--- a/.changeset/quiet-otters-jump.md
+++ b/.changeset/quiet-otters-jump.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Improve node graph performance by deferring dagre layout when composing sub-graphs and using Map-based de-duplication for nodes and edges

--- a/packages/core/eventcatalog/src/utils/node-graphs/data-products-node-graph.ts
+++ b/packages/core/eventcatalog/src/utils/node-graphs/data-products-node-graph.ts
@@ -26,6 +26,7 @@ interface Props {
   version: string;
   defaultFlow?: DagreGraph;
   mode?: 'simple' | 'full';
+  layout?: boolean;
 }
 
 const getNodePropertyFromCollectionType = (type: string) => {
@@ -34,7 +35,7 @@ const getNodePropertyFromCollectionType = (type: string) => {
   return collectionToResourceMap[type as keyof typeof collectionToResourceMap];
 };
 
-export const getNodesAndEdges = async ({ id, defaultFlow, version, mode = 'simple' }: Props) => {
+export const getNodesAndEdges = async ({ id, defaultFlow, version, mode = 'simple', layout = true }: Props) => {
   const flow = defaultFlow || createDagreGraph({ ranksep: 300, nodesep: 50 });
   let nodes = [] as any,
     edges = [] as any;
@@ -217,17 +218,19 @@ export const getNodesAndEdges = async ({ id, defaultFlow, version, mode = 'simpl
     flow.setEdge(edge.source, edge.target);
   });
 
-  // Render the diagram in memory getting the X and Y
-  dagre.layout(flow);
+  if (layout) {
+    // Render the diagram in memory getting the X and Y
+    dagre.layout(flow);
+  }
 
   // Find any duplicated edges, and merge them into one edge
-  const uniqueEdges = edges.reduce((acc: any[], edge: any) => {
-    const existingEdge = acc.find((e: any) => e.id === edge.id);
-    if (!existingEdge) {
-      acc.push(edge);
+  const uniqueEdgesById = new Map<string, any>();
+  edges.forEach((edge: any) => {
+    if (!uniqueEdgesById.has(edge.id)) {
+      uniqueEdgesById.set(edge.id, edge);
     }
-    return acc;
-  }, []);
+  });
+  const uniqueEdges = Array.from(uniqueEdgesById.values());
 
   return {
     nodes: calculatedNodes(flow, nodes),

--- a/packages/core/eventcatalog/src/utils/node-graphs/domains-node-graph.ts
+++ b/packages/core/eventcatalog/src/utils/node-graphs/domains-node-graph.ts
@@ -1,4 +1,5 @@
 import { getCollection } from 'astro:content';
+import dagre from 'dagre';
 import {
   createDagreGraph,
   calculatedNodes,
@@ -194,6 +195,7 @@ interface NodesAndEdgesProps {
   mode: 'simple' | 'full';
   group?: boolean;
   channelRenderMode?: 'single' | 'flat';
+  layout?: boolean;
 }
 
 export const getNodesAndEdges = async ({
@@ -203,6 +205,7 @@ export const getNodesAndEdges = async ({
   mode = 'simple',
   group = false,
   channelRenderMode = 'flat',
+  layout = true,
 }: NodesAndEdgesProps) => {
   const flow = defaultFlow || createDagreGraph({ ranksep: 360, nodesep: 50, edgesep: 50 });
   let nodes = new Map(),
@@ -268,6 +271,7 @@ export const getNodesAndEdges = async ({
       mode,
       renderAllEdges: true,
       channelRenderMode,
+      layout: false,
     });
     serviceNodes.forEach((n) => {
       /**
@@ -292,6 +296,7 @@ export const getNodesAndEdges = async ({
       mode,
       renderAllEdges: true,
       channelRenderMode,
+      layout: false,
     });
     agentNodes.forEach((n) => {
       nodes.set(n.id, nodes.has(n.id) ? merge(nodes.get(n.id), n) : n);
@@ -306,6 +311,7 @@ export const getNodesAndEdges = async ({
       version: dataProduct.version,
       defaultFlow: flow,
       mode,
+      layout: false,
     });
     dataProductNodes.forEach((n: any) => {
       nodes.set(n.id, nodes.has(n.id) ? merge(nodes.get(n.id), n) : n);
@@ -322,6 +328,7 @@ export const getNodesAndEdges = async ({
       mode,
       group: true,
       channelRenderMode,
+      layout: false,
     });
     subDomainNodes.forEach((n) => {
       nodes.set(n.id, nodes.has(n.id) ? merge(nodes.get(n.id), n) : n);
@@ -336,6 +343,10 @@ export const getNodesAndEdges = async ({
     nodes.forEach((n) => {
       nodes.set(n.id, { ...n, data: { ...n.data, group: { type: 'Domain', value: domain?.data.name, id: domain?.data.id } } });
     });
+  }
+
+  if (layout) {
+    dagre.layout(flow);
   }
 
   return {

--- a/packages/core/eventcatalog/src/utils/node-graphs/services-node-graph.ts
+++ b/packages/core/eventcatalog/src/utils/node-graphs/services-node-graph.ts
@@ -119,6 +119,7 @@ interface Props {
   channelRenderMode?: 'single' | 'flat';
   renderMessages?: boolean;
   collection?: 'agents' | 'services';
+  layout?: boolean;
 }
 
 const getResourceContextMenu = (resource: CollectionEntry<'agents'> | CollectionEntry<'services'>) => {
@@ -178,6 +179,7 @@ export const getNodesAndEdges = async ({
   channelRenderMode = 'flat',
   renderMessages = true,
   collection = 'services',
+  layout = true,
 }: Props) => {
   const flow = defaultFlow || createDagreGraph({ ranksep: 300, nodesep: 50 });
   let nodes = [] as any,
@@ -598,9 +600,13 @@ export const getNodesAndEdges = async ({
     });
   });
 
-  const uniqueNodes = nodes.filter(
-    (node: any, index: number, self: any[]) => index === self.findIndex((n: any) => n.id === node.id)
-  );
+  const uniqueNodesById = new Map<string, any>();
+  nodes.forEach((node: any) => {
+    if (!uniqueNodesById.has(node.id)) {
+      uniqueNodesById.set(node.id, node);
+    }
+  });
+  const uniqueNodes = Array.from(uniqueNodesById.values());
 
   uniqueNodes.forEach((node: any) => {
     flow.setNode(node.id, { width: DEFAULT_NODE_WIDTH, height: DEFAULT_NODE_HEIGHT });
@@ -610,12 +616,15 @@ export const getNodesAndEdges = async ({
     flow.setEdge(edge.source, edge.target);
   });
 
-  // Render the diagram in memory getting the X and Y
-  dagre.layout(flow);
+  if (layout) {
+    // Render the diagram in memory getting the X and Y
+    dagre.layout(flow);
+  }
 
   // Find any duplicated edges, and merge them into one edge
-  const uniqueEdges = edges.reduce((acc: any[], edge: any) => {
-    const existingEdge = acc.find((e: any) => e.id === edge.id);
+  const uniqueEdgesById = new Map<string, any>();
+  edges.forEach((edge: any) => {
+    const existingEdge = uniqueEdgesById.get(edge.id);
     if (existingEdge) {
       if (edge.data?.customColor || existingEdge.data?.customColor) {
         // Add custom colors to the existing edge when grouped message paths converge.
@@ -629,10 +638,10 @@ export const getNodesAndEdges = async ({
         };
       }
     } else {
-      acc.push(edge);
+      uniqueEdgesById.set(edge.id, edge);
     }
-    return acc;
-  }, []);
+  });
+  const uniqueEdges = Array.from(uniqueEdgesById.values());
 
   return {
     nodes: calculatedNodes(flow, uniqueNodes),


### PR DESCRIPTION
## What This PR Does

Improves node graph generation performance. The domains node graph composes other graphs (services, agents, data products, sub-domains) by reusing their `getNodesAndEdges` helpers. Previously each sub-graph ran the expensive `dagre.layout()` pass independently, and the parent ran it again — wasting work. This PR adds a `layout` option so sub-graphs skip layout and the parent runs a single layout pass at the end. It also replaces O(n²) `find`-based de-duplication of nodes and edges with O(n) `Map`-based lookups.

## Changes Overview

### Key Changes
- Add `layout?: boolean` (default `true`) to the `getNodesAndEdges` props for `services`, `domains`, and `data-products` node graphs.
- `domains-node-graph` now passes `layout: false` to each composed sub-graph and runs a single `dagre.layout(flow)` after all nodes/edges are collected.
- Replace `Array.reduce` + `find` de-duplication of edges (and nodes, in services) with `Map`-based de-duplication.

## How It Works

`getNodesAndEdges` gates the `dagre.layout(flow)` call behind the new `layout` flag. When the domains graph builds its composite layout, it calls the service/agent/data-product/sub-domain helpers with `layout: false` so they only contribute nodes and edges to the shared `flow` without laying it out. After everything is collected, the domains graph performs one layout pass. Behavior for standalone graphs is unchanged because `layout` defaults to `true`.

The de-duplication change keys nodes and edges by `id` in a `Map`, avoiding the repeated linear `find` scans. The services graph preserves its existing custom-color merge logic when duplicate edges converge.

## Breaking Changes

None. The new option is additive and defaults preserve existing behavior.

## Additional Notes

No editor (`eventcatalog/eventcatalog-editor`) change is needed — these utilities are internal to `@eventcatalog/core`.