### PR TITLE
Expose getResources utility on the SDK

### DIFF
--- a/.changeset/swift-otters-gather.md
+++ b/.changeset/swift-otters-gather.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/sdk": patch
+---
+
+Expose `getResources` utility on the SDK for fetching catalog resources by type

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -123,7 +123,7 @@ import {
   getSchemaForMessage,
 } from './messages';
 
-import { getResourcePath, getResourceFolderName } from './internal/resources';
+import { getResourcePath, getResourceFolderName, getResources } from './internal/resources';
 
 import { writeCustomDoc, getCustomDoc, getCustomDocs, rmCustomDoc } from './custom-docs';
 
@@ -1162,6 +1162,11 @@ export default (path: string) => {
      * Returns the folder name of a given resource
      */
     getResourceFolderName: getResourceFolderName,
+
+    /**
+     * Returns resources from the catalog for a given type
+     */
+    getResources: getResources,
 
     /**
      * ================================


### PR DESCRIPTION
## What This PR Does

Exposes the internal `getResources` helper as a public utility on the EventCatalog SDK. This lets SDK consumers fetch catalog resources by type (events, services, domains, etc.) using the same underlying helper the SDK uses internally, alongside the existing `getResourcePath` and `getResourceFolderName` utilities.

## Changes Overview

### Key Changes
- Import `getResources` from `./internal/resources` in `packages/sdk/src/index.ts`
- Add `getResources` to the returned SDK object under the "Resources Utils" section, next to `getResourcePath` and `getResourceFolderName`

## How It Works

The SDK already imported `getResources` but did not surface it on the public SDK object, leaving it an unused import. This PR completes the wiring by adding `getResources: getResources` to the returned object, so consumers can call it directly. The function accepts a catalog directory and an options object (`type`, `latestOnly`, `ignore`, `pattern`, `attachSchema`) and returns the matching resources.

## Breaking Changes

None. This is purely additive.

## Additional Notes

No corresponding change is needed in the `eventcatalog/eventcatalog-editor` repository — this is an internal SDK utility surface change with no editor impact.