### PR TITLE
Add "Top level diagrams" sidebar group for System Context Map

### DIFF
--- a/.changeset/swift-otters-dream.md
+++ b/.changeset/swift-otters-dream.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": minor
+---
+
+Add a dedicated "Top level diagrams" navigation group that surfaces the System Context Map below top-level domains in the sidebar.

--- a/examples/default/eventcatalog.config.js
+++ b/examples/default/eventcatalog.config.js
@@ -34,36 +34,36 @@ export default {
     limit: 15,
   },
 
-  navigation: {
-    pages: [
-      {
-        type: "group",
-        title: "Domains",
-        icon: "Boxes",
-        pages: [
-          "domain:catalog",
-          "domain:customer",
-          "domain:shopping",
-          "domain:ordering",
-          "domain:payments",
-          "domain:fulfilment",
-          "domain:reviews",
-        ],
-      },
-      {
-        type: "group",
-        title: "Top level diagrams",
-        icon: "Workflow",
-        pages: [
-          {
-            type: "item",
-            title: "System Context Map",
-            href: "/visualiser/system-context-map",
-          },
-        ],
-      },
-    ],
-  },
+  // navigation: {
+  //   pages: [
+  //     {
+  //       type: "group",
+  //       title: "Domains",
+  //       icon: "Boxes",
+  //       pages: [
+  //         "domain:catalog",
+  //         "domain:customer",
+  //         "domain:shopping",
+  //         "domain:ordering",
+  //         "domain:payments",
+  //         "domain:fulfilment",
+  //         "domain:reviews",
+  //       ],
+  //     },
+  //     {
+  //       type: "group",
+  //       title: "Top level diagrams",
+  //       icon: "Workflow",
+  //       pages: [
+  //         {
+  //           type: "item",
+  //           title: "System Context Map",
+  //           href: "/visualiser/system-context-map",
+  //         },
+  //       ],
+  //     },
+  //   ],
+  // },
 
   customDocs: {
     sidebar: [

--- a/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/sidebar-builder.spec.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/sidebar-builder.spec.ts
@@ -230,6 +230,41 @@ describe('getNestedSideBarData', () => {
       expect(domainNode.leftIcon).toBeUndefined();
     });
 
+    it('renders top-level diagrams with the System Context Map below top-level domains', async () => {
+      const { writeDomain } = utils(CATALOG_FOLDER);
+
+      await writeDomain({
+        id: 'Shipping',
+        name: 'Shipping',
+        version: '0.0.1',
+        markdown: 'Shipping',
+      });
+
+      mockSystems.push({
+        id: 'CoreMonolith',
+        name: 'Core Monolith',
+        version: '1.0.0',
+        summary: 'The legacy core monolith',
+      });
+
+      const navigationData = await getNestedSideBarData();
+      const diagramsNode = getNavigationConfigurationByKey('list:top-level-diagrams', navigationData);
+
+      expect(navigationData.roots).toEqual(['list:top-level-domains', 'list:top-level-diagrams', 'list:all']);
+      expect(diagramsNode).toEqual({
+        type: 'group',
+        title: 'Top level diagrams',
+        icon: 'Workflow',
+        pages: [
+          {
+            type: 'item',
+            title: 'System Context Map',
+            href: '/visualiser/system-context-map',
+          },
+        ],
+      });
+    });
+
     it('uses the domain style icon when one is configured', async () => {
       const { writeDomain } = utils(CATALOG_FOLDER);
 

--- a/packages/core/eventcatalog/src/stores/sidebar-store/state.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/state.ts
@@ -808,6 +808,7 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
     {} as Record<string, NavNode>
   );
 
+  const visualiserEnabled = config?.visualiser?.enabled !== false;
   const rootDomainsNodes: Record<string, NavNode> = {};
 
   if (rootDomains.length > 0) {
@@ -818,6 +819,22 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
       pages: sortByResourceName(rootDomains).map((domain) => `domain:${domain.data.id}:${domain.data.version}`),
     };
   }
+
+  const topLevelDiagramsNode =
+    visualiserEnabled && systems.length > 0
+      ? {
+          type: 'group' as const,
+          title: 'Top level diagrams',
+          icon: 'Workflow',
+          pages: [
+            {
+              type: 'item' as const,
+              title: 'System Context Map',
+              href: buildUrl('/visualiser/system-context-map'),
+            },
+          ],
+        }
+      : undefined;
 
   const createLeaf = (items: any[], node: NavNode) => (items.length > 0 ? node : undefined);
 
@@ -1084,7 +1101,6 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
 
   // System-level views (only show if visualiser is enabled and there are domains)
   const systemNode: Record<string, NavNode> = {};
-  const visualiserEnabled = config?.visualiser?.enabled !== false;
 
   if (visualiserEnabled && domains.length > 0) {
     systemNode['list:system'] = {
@@ -1097,22 +1113,13 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
           title: 'Domain Map',
           href: buildUrl('/visualiser/domain-integrations'),
         },
-        // Global context map across every system in the catalog.
-        ...(systems.length > 0
-          ? [
-              {
-                type: 'item' as const,
-                title: 'System Context Map',
-                href: buildUrl('/visualiser/system-context-map'),
-              },
-            ]
-          : []),
       ],
     };
   }
 
   const allGeneratedNodes = {
     ...rootDomainsNodes,
+    ...(topLevelDiagramsNode ? { 'list:top-level-diagrams': topLevelDiagramsNode } : {}),
     ...domainNodes,
     ...systemNodes,
     ...agentNodes,
@@ -1134,9 +1141,8 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
 
   // only filter if child is string
   const defaultPages = ['list:top-level-domains', 'list:all'];
-  // Add system section if it exists
-  if (systemNode['list:system']) {
-    defaultPages.push('list:system');
+  if (topLevelDiagramsNode) {
+    defaultPages.splice(1, 0, 'list:top-level-diagrams');
   }
   const rootNavigationConfig = config?.navigation?.pages || defaultPages;
 


### PR DESCRIPTION
## What This PR Does

Promotes the **System Context Map** to its own top-level navigation group in the sidebar, rendered directly below the top-level domains. Previously the link lived inside the system-level views section, making it harder to discover. The new group only appears when the visualiser is enabled and the catalog has at least one system.

## Changes Overview

### Key Changes

- Introduce a `Top level diagrams` navigation group (`list:top-level-diagrams`) containing the System Context Map link.
- Render the group below top-level domains and remove the System Context Map link from the system-level views section.
- Hoist the `visualiserEnabled` check so it can gate the new group.
- Add a test verifying the group renders in the correct order and shape.
- Comment out the `navigation` override in the default example config so the new default navigation is used.

## How It Works

`getNestedSideBarData` now builds a `topLevelDiagramsNode` when the visualiser is enabled and there are systems in the catalog. When present, it is added to the generated nodes under the `list:top-level-diagrams` key and inserted into the default page order at index 1 (between `list:top-level-domains` and `list:all`). The System Context Map entry was removed from the `list:system` group to avoid duplication.

## Breaking Changes

None.

## Additional Notes

- No corresponding change is needed in the editor repository (`eventcatalog/eventcatalog-editor`) — this is a core sidebar/navigation change only.
- The default example config's explicit `navigation` block is commented out so the example catalog exercises the new default navigation behavior.