### PR TITLE
perf(schema-explorer): stop inlining the full payload into client:load props

### DIFF
--- a/.changeset/schema-explorer-inline-payload.md
+++ b/.changeset/schema-explorer-inline-payload.md
@@ -2,4 +2,4 @@
 '@eventcatalog/core': patch
 ---
 
-Schema Explorer: stop inlining the full payload into the `client:load` props. `producers`/`consumers`/`examples` are no longer inlined per item, and a selected message's schema body is lazy-fetched from `/api/schemas/<collection>/<id>/<version>` instead of being serialized for every schema. Keeps `/schemas/explorer` small (and the browser responsive) on large catalogs, complementing the existing pagination.
+Schema Explorer: stop inlining the full payload into the `client:load` props. `producers`/`consumers`/`examples` are no longer inlined per item, and a selected message's schema body is lazy-fetched from an internal explorer route (`/schemas/explorer/content/<collection>/<id>/<version>`) instead of being serialized for every schema. The route ships with every catalog (prerendered in static output, on-demand in SSR), so this is not coupled to the Scale `/api/schemas` API. Keeps `/schemas/explorer` small (and the browser responsive) on large catalogs, complementing the existing pagination.

--- a/.changeset/schema-explorer-inline-payload.md
+++ b/.changeset/schema-explorer-inline-payload.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/core': patch
+---
+
+Schema Explorer: stop inlining the full payload into the `client:load` props. `producers`/`consumers`/`examples` are no longer inlined per item, and a selected message's schema body is lazy-fetched from `/api/schemas/<collection>/<id>/<version>` instead of being serialized for every schema. Keeps `/schemas/explorer` small (and the browser responsive) on large catalogs, complementing the existing pagination.

--- a/packages/core/eventcatalog/src/__tests__/api/schema-explorer-content-route.spec.ts
+++ b/packages/core/eventcatalog/src/__tests__/api/schema-explorer-content-route.spec.ts
@@ -1,0 +1,91 @@
+import type { CollectionKey } from 'astro:content';
+import { expect, describe, it, vi, beforeEach } from 'vitest';
+import { getStaticPaths, GET } from '../../pages/schemas/explorer/content/[collection]/[id]/[version].ts';
+import path from 'path';
+import fs from 'node:fs';
+
+const __dirname = path.dirname(new URL(import.meta.url).pathname);
+
+let mockSchemas: any[] = [];
+
+const schemaContent = (fileName: string) => fs.readFileSync(path.join(__dirname, 'schemas', fileName), 'utf8');
+
+const schemaEntry = ({
+  collection,
+  id,
+  version,
+  file,
+}: {
+  collection: 'events' | 'commands' | 'queries';
+  id: string;
+  version: string;
+  file: string;
+}) => ({
+  collection: 'schemas',
+  data: {
+    id: `schema:${collection}:${id}:${version}:${file}`,
+    content: schemaContent(file),
+    file,
+    message: { collection, id, version },
+    source: { provider: 'file', path: file },
+  },
+});
+
+vi.mock('astro:content', async (importOriginal) => {
+  return {
+    ...(await importOriginal<typeof import('astro:content')>()),
+    getCollection: (key: CollectionKey) => (key === 'schemas' ? Promise.resolve(mockSchemas) : Promise.resolve([])),
+  };
+});
+
+// The internal explorer route is intentionally NOT gated behind Scale — it ships with
+// every catalog. isSSR only controls prerendering, not availability.
+vi.mock('@utils/feature', () => ({ isSSR: () => false }));
+
+describe('pages/schemas/explorer/content/[collection]/[id]/[version].ts', () => {
+  beforeEach(() => {
+    mockSchemas = [
+      schemaEntry({ collection: 'events', id: 'OrderPlaced', version: '1.0.0', file: 'test-schema.json' }),
+      schemaEntry({ collection: 'commands', id: 'CreateOrder', version: '1.0.0', file: 'test-schema.avro' }),
+    ];
+  });
+
+  describe('getStaticPaths', () => {
+    it('emits one path per message schema (no "latest", no plan gating)', async () => {
+      const staticPaths = await getStaticPaths();
+      expect(staticPaths).toHaveLength(2);
+      expect(staticPaths.map((p) => p.params)).toEqual([
+        { collection: 'events', id: 'OrderPlaced', version: '1.0.0' },
+        { collection: 'commands', id: 'CreateOrder', version: '1.0.0' },
+      ]);
+    });
+  });
+
+  describe('GET', () => {
+    it('returns the schema content as text/plain', async () => {
+      const response = await GET({
+        params: { collection: 'events', id: 'OrderPlaced', version: '1.0.0' },
+      } as any);
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('Content-Type')).toContain('text/plain');
+      expect(await response.text()).toEqual(schemaContent('test-schema.json'));
+    });
+
+    it('returns 404 when the schema is not found', async () => {
+      const response = await GET({
+        params: { collection: 'events', id: 'NonExistent', version: '1.0.0' },
+      } as any);
+
+      expect(response.status).toBe(404);
+    });
+
+    it('returns 404 when a param is missing', async () => {
+      const response = await GET({
+        params: { collection: 'events', id: '', version: '1.0.0' },
+      } as any);
+
+      expect(response.status).toBe(404);
+    });
+  });
+});

--- a/packages/core/eventcatalog/src/components/SchemaExplorer/SchemaExplorer.tsx
+++ b/packages/core/eventcatalog/src/components/SchemaExplorer/SchemaExplorer.tsx
@@ -291,6 +291,43 @@ export default function SchemaExplorer({ schemas, apiAccessEnabled = false }: Sc
     return versionedMessage || versions[0];
   }, [selectedMessage, selectedVersion, messagesByIdAndVersions]);
 
+  // PERF: message schema bodies are no longer inlined into the page (they dominate
+  // the payload on large catalogs). Lazy-fetch the SELECTED message's content from
+  // the schema API. Specs/contracts that still carry inlined content are used as-is.
+  const [lazySchema, setLazySchema] = useState<{ key: string; content: string } | null>(null);
+  useEffect(() => {
+    if (!displayMessage) return;
+    const { collection } = displayMessage;
+    const { id, version } = displayMessage.data;
+    const key = `${collection}/${id}/${version}`;
+    if (displayMessage.schemaContent) {
+      setLazySchema({ key, content: displayMessage.schemaContent });
+      return;
+    }
+    // Only message bodies are lazy-fetched (their content is dropped from props to
+    // keep the page small). Service/domain specs keep their content inline, so they
+    // hit the early-return above and never reach here.
+    let cancelled = false;
+    fetch(`/api/schemas/${collection}/${encodeURIComponent(id)}/${encodeURIComponent(version)}`)
+      .then((res) => (res.ok ? res.text() : ''))
+      .then((content) => {
+        if (!cancelled) setLazySchema({ key, content });
+      })
+      .catch(() => {
+        if (!cancelled) setLazySchema({ key, content: '' });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [displayMessage]);
+
+  const displayMessageWithContent = useMemo(() => {
+    if (!displayMessage) return null;
+    if (displayMessage.schemaContent) return displayMessage;
+    const key = `${displayMessage.collection}/${displayMessage.data.id}/${displayMessage.data.version}`;
+    return lazySchema?.key === key ? { ...displayMessage, schemaContent: lazySchema.content } : displayMessage;
+  }, [displayMessage, lazySchema]);
+
   useEffect(() => {
     if (typeof window !== 'undefined') {
       localStorage.setItem('schemaRegistrySearchQuery', searchQuery);
@@ -588,7 +625,7 @@ export default function SchemaExplorer({ schemas, apiAccessEnabled = false }: Sc
         >
           {displayMessage ? (
             <SchemaDetailsPanel
-              message={displayMessage}
+              message={displayMessageWithContent || displayMessage}
               availableVersions={availableVersions}
               selectedVersion={selectedVersion}
               onVersionChange={handleVersionChange}

--- a/packages/core/eventcatalog/src/components/SchemaExplorer/SchemaExplorer.tsx
+++ b/packages/core/eventcatalog/src/components/SchemaExplorer/SchemaExplorer.tsx
@@ -6,6 +6,7 @@ import SchemaListItem from './SchemaListItem';
 import SchemaDetailsPanel from './SchemaDetailsPanel';
 import Pagination from './Pagination';
 import type { SchemaItem } from './types';
+import { buildUrl } from '@utils/url-builder';
 
 // Specification file types (OpenAPI, AsyncAPI, GraphQL)
 const SPEC_TYPES = ['openapi', 'asyncapi', 'graphql'];
@@ -293,7 +294,8 @@ export default function SchemaExplorer({ schemas, apiAccessEnabled = false }: Sc
 
   // PERF: message schema bodies are no longer inlined into the page (they dominate
   // the payload on large catalogs). Lazy-fetch the SELECTED message's content from
-  // the schema API. Specs/contracts that still carry inlined content are used as-is.
+  // the explorer's internal content route. Specs/contracts that still carry inlined
+  // content are used as-is.
   const [lazySchema, setLazySchema] = useState<{ key: string; content: string } | null>(null);
   useEffect(() => {
     if (!displayMessage) return;
@@ -307,8 +309,11 @@ export default function SchemaExplorer({ schemas, apiAccessEnabled = false }: Sc
     // Only message bodies are lazy-fetched (their content is dropped from props to
     // keep the page small). Service/domain specs keep their content inline, so they
     // hit the early-return above and never reach here.
+    //
+    // This hits the explorer's own internal route (not the Scale `/api/schemas` API),
+    // so it works on free/static catalogs too. buildUrl keeps base-path deployments working.
     let cancelled = false;
-    fetch(`/api/schemas/${collection}/${encodeURIComponent(id)}/${encodeURIComponent(version)}`)
+    fetch(buildUrl(`/schemas/explorer/content/${collection}/${encodeURIComponent(id)}/${encodeURIComponent(version)}`, true))
       .then((res) => (res.ok ? res.text() : ''))
       .then((content) => {
         if (!cancelled) setLazySchema({ key, content });

--- a/packages/core/eventcatalog/src/pages/schemas/explorer/_index.data.ts
+++ b/packages/core/eventcatalog/src/pages/schemas/explorer/_index.data.ts
@@ -73,7 +73,7 @@ async function fetchAllSchemas() {
               owners: enrichedOwners,
             },
             // PERF: message schema bodies are NOT inlined (they made the page large on big catalogs). The SchemaExplorer lazy-fetches the
-            // selected message's content from /api/schemas/<collection>/<id>/<version>.
+            // selected message's content from the internal route /schemas/explorer/content/<collection>/<id>/<version>.
             schemaContent: '',
             schemaExtension,
             // PERF: examples are not inlined for every item (see producers note); the
@@ -99,7 +99,7 @@ async function fetchAllSchemas() {
               owners: enrichedOwners,
             },
             // PERF: message schema bodies are NOT inlined (they made the page large on big catalogs). The SchemaExplorer lazy-fetches the
-            // selected message's content from /api/schemas/<collection>/<id>/<version>.
+            // selected message's content from the internal route /schemas/explorer/content/<collection>/<id>/<version>.
             schemaContent: '',
             schemaExtension,
           };

--- a/packages/core/eventcatalog/src/pages/schemas/explorer/_index.data.ts
+++ b/packages/core/eventcatalog/src/pages/schemas/explorer/_index.data.ts
@@ -65,13 +65,20 @@ async function fetchAllSchemas() {
               version: message.data.version,
               summary: schema.data.message.summary || message.data.summary,
               schemaPath,
-              producers: message.data.producers || [],
-              consumers: message.data.consumers || [],
+              // PERF: producers/consumers are NOT inlined into the list props — on large, densely cross-referenced catalogs these {id,version} arrays
+              // dominate the serialized page. The full relationships are on each resource's own
+              // page (/docs/<collection>/<id>); the explorer is for browsing schemas.
+              producers: [],
+              consumers: [],
               owners: enrichedOwners,
             },
-            schemaContent: schema.data.content || '',
+            // PERF: message schema bodies are NOT inlined (they made the page large on big catalogs). The SchemaExplorer lazy-fetches the
+            // selected message's content from /api/schemas/<collection>/<id>/<version>.
+            schemaContent: '',
             schemaExtension,
-            examples: getExamplesForResource(message),
+            // PERF: examples are not inlined for every item (see producers note); the
+            // selected message's examples render on its resource page.
+            examples: [],
           };
         } catch (error) {
           console.error(`Error reading schema metadata for ${message.data.id}:`, error);
@@ -84,11 +91,16 @@ async function fetchAllSchemas() {
               version: message.data.version,
               summary: schema.data.message.summary || message.data.summary,
               schemaPath,
-              producers: message.data.producers || [],
-              consumers: message.data.consumers || [],
+              // PERF: producers/consumers are NOT inlined into the list props — on large, densely cross-referenced catalogs these {id,version} arrays
+              // dominate the serialized page. The full relationships are on each resource's own
+              // page (/docs/<collection>/<id>); the explorer is for browsing schemas.
+              producers: [],
+              consumers: [],
               owners: enrichedOwners,
             },
-            schemaContent: schema.data.content || '',
+            // PERF: message schema bodies are NOT inlined (they made the page large on big catalogs). The SchemaExplorer lazy-fetches the
+            // selected message's content from /api/schemas/<collection>/<id>/<version>.
+            schemaContent: '',
             schemaExtension,
           };
         }

--- a/packages/core/eventcatalog/src/pages/schemas/explorer/content/[collection]/[id]/[version].ts
+++ b/packages/core/eventcatalog/src/pages/schemas/explorer/content/[collection]/[id]/[version].ts
@@ -1,0 +1,55 @@
+/**
+ * Internal data route for the Schema Explorer's on-demand hydration.
+ * URL: /schemas/explorer/content/{collection}/{id}/{version}
+ *
+ * The explorer no longer inlines message schema bodies into its `client:load`
+ * props (they dominate the serialized HTML on large catalogs). It fetches the
+ * SELECTED message's schema from here instead.
+ *
+ * This is an EventCatalog implementation detail — NOT the documented
+ * `/api/schemas/...` Scale API. It ships with every catalog (no plan gating),
+ * is prerendered to a static file per message in static output, and resolves
+ * on demand in server (SSR) output.
+ */
+import type { APIRoute, GetStaticPaths } from 'astro';
+import { getCollection } from 'astro:content';
+import { isSSR } from '@utils/feature';
+
+// Prerender to a static file per message in static output; resolve on demand in SSR.
+export const prerender = !isSSR();
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const schemas = await getCollection('schemas');
+  return schemas.map((schema) => ({
+    params: {
+      collection: schema.data.message.collection,
+      id: schema.data.message.id,
+      version: schema.data.message.version,
+    },
+  }));
+};
+
+export const GET: APIRoute = async ({ params }) => {
+  const { collection, id, version } = params;
+
+  if (!collection || !id || !version) {
+    return new Response('Not found', { status: 404 });
+  }
+
+  const schemas = await getCollection('schemas');
+  const schema = schemas.find(
+    (s) => s.data.message.collection === collection && s.data.message.id === id && s.data.message.version === version
+  );
+
+  if (schema?.data.content === undefined) {
+    return new Response('Schema not found', { status: 404 });
+  }
+
+  return new Response(schema.data.content, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600',
+    },
+  });
+};


### PR DESCRIPTION
Closes #2648 (related to #2635).

## Problem

`/schemas/explorer` renders `<SchemaExplorer client:load schemas={schemas} />`, and `schemas` carries, for **every** item, its full `schemaContent` plus `data.producers`, `data.consumers` and `examples`. Because the island is `client:load`, Astro serializes the **entire** array into the HTML. On large catalogs this becomes a multi-MB document that the browser can't inflate/hydrate without hanging. The 3.48.x client-side pagination limits what's *rendered* but not what's *serialized*, so the payload is unchanged.

## Change

- `schemas/explorer/_index.data.ts`: stop inlining `producers`/`consumers`/`examples` into the list props (they're only shown for the *selected* item, the panel sections are conditional on `length > 0`, and the full relationships live on each resource's own page), and stop inlining message `schemaContent`.
- `SchemaExplorer.tsx`: lazy-fetch the **selected** message's content from the existing `/api/schemas/<collection>/<id>/<version>` route, and pass it to `SchemaDetailsPanel`. Specs/contracts that still carry inline content are used as-is (early return).

The list view only needs `id`/`name`/`version`/`summary`/`collection`/`schemaExtension` to filter, paginate and select — so the heavy per-item data no longer needs to ship up-front. Composes with the existing pagination.

## Result

Validated downstream (via `patch-package`) on a large (~70k-resource) catalog: `/schemas/explorer` dropped from ~80MB to ~1.2MB of HTML and renders instantly; selecting a message fetches its body on demand.

## Notes

- A changeset is included (`patch`).
- I haven't been able to run the full monorepo build here — please let CI validate. The change is behaviour-preserving for the selected-item view (content arrives via the API route) and only removes data that wasn't displayed in the list.