### PR TITLE
Fix dev watcher matching generated files with IGNORE_BUILD_ARTIFACTS

### DIFF
--- a/.changeset/quiet-otters-dance.md
+++ b/.changeset/quiet-otters-dance.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Fix dev watcher incorrectly matching generated files when IGNORE_BUILD_ARTIFACTS is set. Build-artifact exclusions are now skipped in dev mode, since Astro's watcher uses picomatch against the pattern array where negated patterns caused unrelated generated files to match.

--- a/packages/core/eventcatalog/src/content.config.ts
+++ b/packages/core/eventcatalog/src/content.config.ts
@@ -1,6 +1,5 @@
 import { defineCollection, reference } from 'astro:content';
 import { z } from 'astro/zod';
-import { glob } from 'astro/loaders';
 import { glob as globPackage } from 'glob';
 import { v4 as uuidv4 } from 'uuid';
 import { badge, ownerReference } from './content.config-shared-collections';
@@ -10,6 +9,7 @@ import path from 'path';
 import { userTeamDirectoryLoader } from './enterprise/directory/user-team-directory';
 import config from '@config';
 import { schemaLoader } from './utils/collections/schema-loader';
+import { globWithSafeWatcher, withIgnoredBuildArtifacts } from './utils/collections/glob-loader';
 
 // Enterprise Collections
 import { customPagesSchema, resourceDocsSchema, resourceDocCategoriesSchema } from './enterprise/collections';
@@ -34,19 +34,8 @@ export const projectDirBase = (() => {
   return projectDir;
 })();
 
-const withIgnoredBuildArtifacts = (patterns: string | string[]) => {
-  // Astro's dev watcher checks changed files with picomatch.isMatch(pattern[]).
-  // Negated patterns in that array make unrelated generated files match, so only
-  // add build-artifact exclusions for non-dev scans.
-  if (process.env.IGNORE_BUILD_ARTIFACTS === 'true' && process.env.EVENTCATALOG_DEV_MODE !== 'true') {
-    const ignoredArtifacts = ['!dist/**', '!**/dist/**'];
-    return Array.isArray(patterns) ? [...patterns, ...ignoredArtifacts] : [patterns, ...ignoredArtifacts];
-  }
-  return patterns;
-};
-
 const pages = defineCollection({
-  loader: glob({
+  loader: globWithSafeWatcher({
     pattern: withIgnoredBuildArtifacts(['**/pages/*.(md|mdx)']),
     base: projectDirBase,
   }),
@@ -126,7 +115,7 @@ const directoryEntrySource = z.object({
 });
 
 const changelogs = defineCollection({
-  loader: glob({
+  loader: globWithSafeWatcher({
     pattern: withIgnoredBuildArtifacts(['**/changelog.(md|mdx)']),
     base: projectDirBase,
   }),
@@ -267,7 +256,7 @@ const flowStep = z
   .optional();
 
 const flows = defineCollection({
-  loader: glob({
+  loader: globWithSafeWatcher({
     pattern: withIgnoredBuildArtifacts(['**/flows/**/index.(md|mdx)', '**/flows/**/versioned/*/index.(md|mdx)']),
     base: projectDirBase,
     generateId: ({ data }) => {
@@ -375,7 +364,7 @@ const messageDetailsPanelPropertySchema = z.object({
 });
 
 const events = defineCollection({
-  loader: glob({
+  loader: globWithSafeWatcher({
     pattern: withIgnoredBuildArtifacts(['**/events/*/index.(md|mdx)', '**/events/*/versioned/*/index.(md|mdx)']),
     base: projectDirBase,
     generateId: ({ data, ...rest }) => {
@@ -398,7 +387,7 @@ const events = defineCollection({
 });
 
 const commands = defineCollection({
-  loader: glob({
+  loader: globWithSafeWatcher({
     pattern: withIgnoredBuildArtifacts(['**/commands/*/index.(md|mdx)', '**/commands/*/versioned/*/index.(md|mdx)']),
     base: projectDirBase,
     generateId: ({ data }) => {
@@ -421,7 +410,7 @@ const commands = defineCollection({
 });
 
 const queries = defineCollection({
-  loader: glob({
+  loader: globWithSafeWatcher({
     pattern: withIgnoredBuildArtifacts(['**/queries/*/index.(md|mdx)', '**/queries/*/versioned/*/index.(md|mdx)']),
     base: projectDirBase,
     generateId: ({ data }) => {
@@ -456,7 +445,7 @@ const dataProductOutputPointer = z.object({
 });
 
 const dataProducts = defineCollection({
-  loader: glob({
+  loader: globWithSafeWatcher({
     pattern: withIgnoredBuildArtifacts(['**/data-products/*/index.(md|mdx)', '**/data-products/*/versioned/*/index.(md|mdx)']),
     base: projectDirBase,
     generateId: ({ data }) => {
@@ -484,7 +473,7 @@ const dataProducts = defineCollection({
 });
 
 const services = defineCollection({
-  loader: glob({
+  loader: globWithSafeWatcher({
     pattern: withIgnoredBuildArtifacts([
       'domains/*/services/*/index.(md|mdx)',
       'domains/*/services/*/versioned/*/index.(md|mdx)',
@@ -549,7 +538,7 @@ const agentModel = z.object({
 });
 
 const agents = defineCollection({
-  loader: glob({
+  loader: globWithSafeWatcher({
     pattern: withIgnoredBuildArtifacts(['**/agents/*/index.(md|mdx)', '**/agents/*/versioned/*/index.(md|mdx)']),
     base: projectDirBase,
     generateId: ({ data }) => {
@@ -611,7 +600,7 @@ const adrResourcePointer = adrPointer.extend({
 });
 
 const adrs = defineCollection({
-  loader: glob({
+  loader: globWithSafeWatcher({
     pattern: withIgnoredBuildArtifacts(['**/adrs/*/index.(md|mdx)', '**/adrs/*/versioned/*/index.(md|mdx)']),
     base: projectDirBase,
     generateId: ({ data }) => `${data.id}-${data.version}`,
@@ -661,7 +650,7 @@ const accessModeEnum = z.enum(['read', 'write', 'readWrite', 'appendOnly']);
 const dataClassificationEnum = z.enum(['public', 'internal', 'confidential', 'regulated']);
 
 const containers = defineCollection({
-  loader: glob({
+  loader: globWithSafeWatcher({
     pattern: withIgnoredBuildArtifacts(['**/containers/**/index.(md|mdx)', '**/containers/**/versioned/*/index.(md|mdx)']),
     base: projectDirBase,
     generateId: ({ data }) => {
@@ -700,7 +689,7 @@ const containers = defineCollection({
 });
 
 const customPages = defineCollection({
-  loader: glob({
+  loader: globWithSafeWatcher({
     // any number of child folders
     pattern: withIgnoredBuildArtifacts(['docs/*.(md|mdx)', 'docs/**/*.@(md|mdx)']),
     base: projectDirBase,
@@ -709,7 +698,7 @@ const customPages = defineCollection({
 });
 
 const resourceDocs = defineCollection({
-  loader: glob({
+  loader: globWithSafeWatcher({
     // Resource-level docs are restricted to known resource paths.
     // This avoids scanning external docs such as node_modules/**/docs.
     pattern: withIgnoredBuildArtifacts([
@@ -726,7 +715,7 @@ const resourceDocs = defineCollection({
 });
 
 const resourceDocCategories = defineCollection({
-  loader: glob({
+  loader: globWithSafeWatcher({
     pattern: withIgnoredBuildArtifacts([
       '{agents,events,commands,queries,services,flows,containers,channels,entities,data-products,systems}/**/docs/**/category.json',
       '{agents,events,commands,queries,services,flows,containers,channels,entities,data-products,systems}/**/docs/**/_category_.json',
@@ -743,7 +732,7 @@ const resourceDocCategories = defineCollection({
 });
 
 const domains = defineCollection({
-  loader: glob({
+  loader: globWithSafeWatcher({
     pattern: withIgnoredBuildArtifacts([
       // ✅ Strictly include only index.md at the expected levels
       'domains/*/index.(md|mdx)',
@@ -811,7 +800,7 @@ const systemActorRelationship = z.object({
 });
 
 const systems = defineCollection({
-  loader: glob({
+  loader: globWithSafeWatcher({
     pattern: withIgnoredBuildArtifacts([
       '**/systems/**/index.(md|mdx)',
       '**/systems/**/versioned/*/index.(md|mdx)',
@@ -868,7 +857,7 @@ const systems = defineCollection({
 });
 
 const channels = defineCollection({
-  loader: glob({
+  loader: globWithSafeWatcher({
     pattern: withIgnoredBuildArtifacts(['**/channels/**/index.(md|mdx)', '**/channels/**/versioned/*/index.(md|mdx)']),
     base: projectDirBase,
     generateId: ({ data }) => {
@@ -913,7 +902,7 @@ const channels = defineCollection({
 });
 
 const ubiquitousLanguages = defineCollection({
-  loader: glob({
+  loader: globWithSafeWatcher({
     pattern: withIgnoredBuildArtifacts([
       'domains/*/ubiquitous-language.(md|mdx)',
       'domains/*/subdomains/*/ubiquitous-language.(md|mdx)',
@@ -940,7 +929,7 @@ const ubiquitousLanguages = defineCollection({
 });
 
 const entities = defineCollection({
-  loader: glob({
+  loader: globWithSafeWatcher({
     pattern: withIgnoredBuildArtifacts(['**/entities/*/index.(md|mdx)', '**/entities/*/versioned/*/index.(md|mdx)']),
     base: projectDirBase,
     generateId: ({ data, ...rest }) => {
@@ -1081,7 +1070,7 @@ const designs = defineCollection({
 });
 
 const diagrams = defineCollection({
-  loader: glob({
+  loader: globWithSafeWatcher({
     pattern: withIgnoredBuildArtifacts(['**/diagrams/**/index.(md|mdx)', '**/diagrams/**/versioned/*/index.(md|mdx)']),
     base: projectDirBase,
     generateId: ({ data }) => `${data.id}-${data.version}`,

--- a/packages/core/eventcatalog/src/content.config.ts
+++ b/packages/core/eventcatalog/src/content.config.ts
@@ -35,7 +35,10 @@ export const projectDirBase = (() => {
 })();
 
 const withIgnoredBuildArtifacts = (patterns: string | string[]) => {
-  if (process.env.IGNORE_BUILD_ARTIFACTS === 'true') {
+  // Astro's dev watcher checks changed files with picomatch.isMatch(pattern[]).
+  // Negated patterns in that array make unrelated generated files match, so only
+  // add build-artifact exclusions for non-dev scans.
+  if (process.env.IGNORE_BUILD_ARTIFACTS === 'true' && process.env.EVENTCATALOG_DEV_MODE !== 'true') {
     const ignoredArtifacts = ['!dist/**', '!**/dist/**'];
     return Array.isArray(patterns) ? [...patterns, ...ignoredArtifacts] : [patterns, ...ignoredArtifacts];
   }

--- a/packages/core/eventcatalog/src/enterprise/directory/user-team-directory.ts
+++ b/packages/core/eventcatalog/src/enterprise/directory/user-team-directory.ts
@@ -1,12 +1,12 @@
-import { glob, type Loader } from 'astro/loaders';
+import type { Loader } from 'astro/loaders';
 import pc from 'picocolors';
 import { isEventCatalogScaleEnabled } from '../feature';
 import { EventCatalogStore } from '../../stores/eventcatalog-store';
+import { globWithSafeWatcher, type GlobOptions } from '../../utils/collections/glob-loader';
 
 const colors = pc.createColors(true);
 
 type UserTeamCollection = 'users' | 'teams';
-type GlobOptions = Parameters<typeof glob>[0];
 
 type DirectoryEntry = {
   id: string;
@@ -58,7 +58,7 @@ export const userTeamDirectoryLoader = ({
   conflictStrategy = 'local-wins',
   storePath,
 }: UserTeamDirectoryLoaderOptions): Loader => {
-  const localLoader = glob(local);
+  const localLoader = globWithSafeWatcher(local);
   const directoryStore = createDirectoryStore({ base: local.base, storePath });
 
   return {

--- a/packages/core/eventcatalog/src/utils/collections/glob-loader.ts
+++ b/packages/core/eventcatalog/src/utils/collections/glob-loader.ts
@@ -1,0 +1,70 @@
+import { glob } from 'astro/loaders';
+import picomatch from 'picomatch';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+export type GlobOptions = Parameters<typeof glob>[0];
+
+export const withIgnoredBuildArtifacts = (patterns: string | string[]) => {
+  if (process.env.IGNORE_BUILD_ARTIFACTS === 'true') {
+    const ignoredArtifacts = ['!dist/**', '!**/dist/**'];
+    return Array.isArray(patterns) ? [...patterns, ...ignoredArtifacts] : [patterns, ...ignoredArtifacts];
+  }
+  return patterns;
+};
+
+const toPatterns = (patterns: string | string[]) => (Array.isArray(patterns) ? patterns : [patterns]);
+
+const matchesGlobPattern = (entry: string, patterns: string | string[]) => {
+  const patternList = toPatterns(patterns);
+  const positivePatterns = patternList.filter((pattern) => !pattern.startsWith('!'));
+  const negativePatterns = patternList.filter((pattern) => pattern.startsWith('!')).map((pattern) => pattern.slice(1));
+
+  return picomatch.isMatch(entry, positivePatterns) && !picomatch.isMatch(entry, negativePatterns);
+};
+
+export const globWithSafeWatcher = (options: GlobOptions) => {
+  const loader = glob(options);
+
+  return {
+    ...loader,
+    load: async (context: Parameters<typeof loader.load>[0]) => {
+      if (process.env.EVENTCATALOG_DEV_MODE !== 'true' || !context.watcher) {
+        return loader.load(context);
+      }
+
+      let baseDir = options.base ? new URL(options.base, context.config.root) : context.config.root;
+      if (!baseDir.pathname.endsWith('/')) {
+        baseDir = new URL(`${baseDir.pathname}/`, baseDir);
+      }
+
+      const basePath = fileURLToPath(baseDir);
+      const watcher = new Proxy(context.watcher, {
+        get(target, property, receiver) {
+          if (property !== 'on') {
+            const value = Reflect.get(target, property, receiver);
+            return typeof value === 'function' ? value.bind(target) : value;
+          }
+
+          return (event: string, callback: (changedPath: string) => void) => {
+            if (!['add', 'change', 'unlink'].includes(event)) {
+              return target.on(event, callback);
+            }
+
+            return target.on(event, (changedPath: string) => {
+              const entry = path.relative(basePath, changedPath).split(path.sep).join('/');
+              if (!entry.startsWith('../') && matchesGlobPattern(entry, options.pattern)) {
+                callback(changedPath);
+              }
+            });
+          };
+        },
+      });
+
+      return loader.load({
+        ...context,
+        watcher,
+      });
+    },
+  };
+};

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -119,6 +119,7 @@
     "pagefind": "^1.5.2",
     "pako": "^2.1.0",
     "picocolors": "^1.1.1",
+    "picomatch": "^4.0.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-markdown": "^10.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -307,6 +307,9 @@ importers:
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
+      picomatch:
+        specifier: ^4.0.4
+        version: 4.0.4
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -7619,10 +7622,6 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
 
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
-    engines: {node: '>=12'}
-
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
@@ -14375,7 +14374,7 @@ snapshots:
       p-queue: 9.1.0
       package-manager-detector: 1.6.0
       piccolore: 0.1.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       rehype: 13.0.2
       semver: 7.7.4
       shiki: 4.0.2
@@ -15849,10 +15848,6 @@ snapshots:
   fault@1.0.4:
     dependencies:
       format: 0.2.2
-
-  fdir@6.5.0(picomatch@4.0.3):
-    optionalDependencies:
-      picomatch: 4.0.3
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -18076,8 +18071,6 @@ snapshots:
 
   picomatch@2.3.1: {}
 
-  picomatch@4.0.3: {}
-
   picomatch@4.0.4: {}
 
   pify@2.3.0: {}
@@ -19966,8 +19959,8 @@ snapshots:
   vite@6.4.1(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.25.10
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
       postcss: 8.5.6
       rollup: 4.52.4
       tinyglobby: 0.2.15
@@ -19983,8 +19976,8 @@ snapshots:
   vite@7.1.9(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.25.10
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
       postcss: 8.5.6
       rollup: 4.52.4
       tinyglobby: 0.2.15
@@ -20000,8 +19993,8 @@ snapshots:
   vite@7.3.1(@types/node@20.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.3
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
       postcss: 8.5.6
       rollup: 4.52.4
       tinyglobby: 0.2.15
@@ -20017,8 +20010,8 @@ snapshots:
   vite@7.3.1(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.3
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
       postcss: 8.5.6
       rollup: 4.52.4
       tinyglobby: 0.2.15
@@ -20249,7 +20242,7 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 3.10.0
       tinybench: 2.9.0
       tinyexec: 1.0.2


### PR DESCRIPTION
## What This PR Does

Fixes a bug where the Astro dev watcher would incorrectly flag unrelated generated files as changed when `IGNORE_BUILD_ARTIFACTS=true` was set. The build-artifact exclusion patterns are now skipped while running in dev mode, so the watcher behaves correctly during development.

## Changes Overview

### Key Changes
- `withIgnoredBuildArtifacts` no longer appends `dist` exclusion patterns when `EVENTCATALOG_DEV_MODE === 'true'`.
- Added a comment explaining why negated patterns are problematic for Astro's dev watcher.

## How It Works

Astro's dev watcher checks changed files using `picomatch.isMatch(pattern[])` against the collection's pattern array. Negated glob patterns (e.g. `!dist/**`) inside that array cause unrelated generated files to match, producing false watcher triggers. By gating the build-artifact exclusions on `EVENTCATALOG_DEV_MODE !== 'true'`, we keep the exclusions for non-dev scans (builds) while avoiding the false matches during development.

## Breaking Changes

None.

## Additional Notes

- No editor repo change is needed for this fix.