### PR TITLE
feat(sdk): add support for architecture decision records

### DIFF
--- a/.changeset/sdk-adr-support.md
+++ b/.changeset/sdk-adr-support.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/sdk": patch
+---
+
+Add SDK support for architecture decision records.

--- a/packages/sdk/src/adrs.ts
+++ b/packages/sdk/src/adrs.ts
@@ -1,0 +1,55 @@
+import fs from 'node:fs/promises';
+import { join } from 'node:path';
+import { findFileById, invalidateFileCache } from './internal/utils';
+import type { Adr } from './types';
+import {
+  addFileToResource,
+  getResource,
+  getResources,
+  rmResourceById,
+  versionResource,
+  writeResource,
+} from './internal/resources';
+
+export const getAdr =
+  (directory: string) =>
+  async (id: string, version?: string): Promise<Adr> =>
+    getResource(directory, id, version, { type: 'adr' }) as Promise<Adr>;
+
+export const getAdrs =
+  (directory: string) =>
+  async (options?: { latestOnly?: boolean }): Promise<Adr[]> =>
+    getResources(directory, { type: 'adrs', latestOnly: options?.latestOnly }) as Promise<Adr[]>;
+
+export const writeAdr =
+  (directory: string) =>
+  async (
+    adr: Adr,
+    options: { path?: string; override?: boolean; versionExistingContent?: boolean; format?: 'md' | 'mdx' } = {
+      path: '',
+      override: false,
+      format: 'mdx',
+    }
+  ) =>
+    writeResource(directory, { ...adr }, { ...options, type: 'adr' });
+
+export const rmAdr = (directory: string) => async (path: string) => {
+  await fs.rm(join(directory, path), { recursive: true });
+  invalidateFileCache();
+};
+
+export const rmAdrById = (directory: string) => async (id: string, version?: string, persistFiles?: boolean) => {
+  await rmResourceById(directory, id, version, { type: 'adr', persistFiles });
+};
+
+export const versionAdr = (directory: string) => async (id: string) => versionResource(directory, id);
+
+export const adrHasVersion = (directory: string) => async (id: string, version?: string) => {
+  const file = await findFileById(directory, id, version);
+  return !!file;
+};
+
+export const addFileToAdr =
+  (directory: string) =>
+  async (id: string, file: { content: string; fileName: string }, version?: string): Promise<void> =>
+    addFileToResource(directory, id, file, version, { type: 'adr' });

--- a/packages/sdk/src/docs.ts
+++ b/packages/sdk/src/docs.ts
@@ -44,4 +44,5 @@ export * from './flow-builder';
 export * from './data-stores';
 export * from './data-products';
 export * from './diagrams';
+export * from './adrs';
 export * from './changelogs';

--- a/packages/sdk/src/eventcatalog.ts
+++ b/packages/sdk/src/eventcatalog.ts
@@ -103,6 +103,7 @@ export const dumpCatalog =
       getEntities,
       getDataStores,
       getFlows,
+      getAdrs,
     } = utils(directory);
 
     const { includeMarkdown = true } = options || {};
@@ -121,6 +122,7 @@ export const dumpCatalog =
     const entities = await getEntities();
     const containers = await getDataStores();
     const flows = await getFlows();
+    const adrs = await getAdrs();
 
     const [
       hydratedDomains,
@@ -136,6 +138,7 @@ export const dumpCatalog =
       hydratedEntities,
       hydratedContainers,
       hydratedFlows,
+      hydratedAdrs,
     ] = await Promise.all([
       hydrateResource(directory, domains),
       hydrateResource(directory, systems),
@@ -150,6 +153,7 @@ export const dumpCatalog =
       hydrateResource(directory, entities),
       hydrateResource(directory, containers),
       hydrateResource(directory, flows),
+      hydrateResource(directory, adrs),
     ]);
 
     return {
@@ -172,6 +176,7 @@ export const dumpCatalog =
         entities: filterCollection(hydratedEntities, { includeMarkdown }),
         containers: filterCollection(hydratedContainers, { includeMarkdown }),
         flows: filterCollection(hydratedFlows, { includeMarkdown }),
+        adrs: filterCollection(hydratedAdrs, { includeMarkdown }),
       },
     };
   };

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -217,6 +217,8 @@ import {
   addFileToDiagram,
 } from './diagrams';
 
+import { addFileToAdr, adrHasVersion, getAdr, getAdrs, rmAdr, rmAdrById, versionAdr, writeAdr } from './adrs';
+
 // Export the types
 export type * from './types';
 export type * from './snapshot-types';
@@ -1684,6 +1686,20 @@ export default (path: string) => {
      * @returns
      */
     addFileToDiagram: addFileToDiagram(join(path)),
+
+    /**
+     * ================================
+     *            ADRs
+     * ================================
+     */
+    getAdr: getAdr(join(path)),
+    getAdrs: getAdrs(join(path)),
+    writeAdr: writeAdr(join(path, 'adrs')),
+    rmAdr: rmAdr(join(path, 'adrs')),
+    rmAdrById: rmAdrById(join(path)),
+    versionAdr: versionAdr(join(path)),
+    adrHasVersion: adrHasVersion(join(path)),
+    addFileToAdr: addFileToAdr(join(path)),
 
     /**
      * ================================

--- a/packages/sdk/src/internal/resources.ts
+++ b/packages/sdk/src/internal/resources.ts
@@ -12,13 +12,13 @@ import {
 import matter from 'gray-matter';
 import fs from 'node:fs/promises';
 import fsSync from 'node:fs';
-import { Message, Service, CustomDoc } from '../types';
+import { Adr, Message, Service, CustomDoc } from '../types';
 import { satisfies } from 'semver';
 import { lock, unlock } from 'proper-lockfile';
 import { basename } from 'node:path';
 import path from 'node:path';
 
-type Resource = Service | Message | CustomDoc;
+type Resource = Service | Message | CustomDoc | Adr;
 
 export const versionResource = async (catalogDir: string, id: string) => {
   // Find all the events in the directory

--- a/packages/sdk/src/test/adrs.test.ts
+++ b/packages/sdk/src/test/adrs.test.ts
@@ -1,0 +1,455 @@
+import { expect, it, describe, beforeEach, afterEach } from 'vitest';
+import utils from '../index';
+import path from 'node:path';
+import fs from 'node:fs';
+
+const CATALOG_PATH = path.join(__dirname, 'catalog-adrs');
+
+const { writeAdr, getAdr, getAdrs, rmAdr, rmAdrById, versionAdr, adrHasVersion, addFileToAdr } = utils(CATALOG_PATH);
+
+beforeEach(() => {
+  fs.rmSync(CATALOG_PATH, { recursive: true, force: true });
+  fs.mkdirSync(CATALOG_PATH, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(CATALOG_PATH, { recursive: true, force: true });
+});
+
+describe('ADRs SDK', () => {
+  describe('getAdr', () => {
+    it('returns the given ADR id from EventCatalog and the latest version when no version is given', async () => {
+      await writeAdr({
+        id: 'use-transactional-outbox',
+        name: 'Use Transactional Outbox',
+        version: '1.0.0',
+        summary: 'Use the transactional outbox pattern for integration events',
+        status: 'accepted',
+        date: '2024-01-15',
+        decisionMakers: ['platform-team', 'dboyne'],
+        appliesTo: [{ id: 'OrdersService', version: '1.0.0', type: 'service' }],
+        markdown: '# Use Transactional Outbox',
+      });
+
+      const adr = await getAdr('use-transactional-outbox');
+
+      expect(adr).toEqual({
+        id: 'use-transactional-outbox',
+        name: 'Use Transactional Outbox',
+        version: '1.0.0',
+        summary: 'Use the transactional outbox pattern for integration events',
+        status: 'accepted',
+        date: '2024-01-15',
+        decisionMakers: ['platform-team', 'dboyne'],
+        appliesTo: [{ id: 'OrdersService', version: '1.0.0', type: 'service' }],
+        markdown: '# Use Transactional Outbox',
+      });
+    });
+
+    it('returns the given ADR id from EventCatalog and the requested version when a version is given', async () => {
+      await writeAdr({
+        id: 'use-transactional-outbox',
+        name: 'Use Transactional Outbox',
+        version: '1.0.0',
+        status: 'accepted',
+        date: '2024-01-15',
+        markdown: '# Use Transactional Outbox',
+      });
+
+      await versionAdr('use-transactional-outbox');
+
+      await writeAdr({
+        id: 'use-transactional-outbox',
+        name: 'Use Transactional Outbox',
+        version: '2.0.0',
+        status: 'superseded',
+        date: '2024-02-15',
+        markdown: '# Use Transactional Outbox v2',
+      });
+
+      const adr = await getAdr('use-transactional-outbox', '1.0.0');
+
+      expect(adr).toEqual({
+        id: 'use-transactional-outbox',
+        name: 'Use Transactional Outbox',
+        version: '1.0.0',
+        status: 'accepted',
+        date: '2024-01-15',
+        markdown: '# Use Transactional Outbox',
+      });
+    });
+
+    it('returns undefined when a given resource is not found', async () => {
+      const adr = await getAdr('missing-adr');
+      expect(adr).toEqual(undefined);
+    });
+  });
+
+  describe('getAdrs', () => {
+    it('returns all ADRs from the catalog', async () => {
+      await writeAdr({
+        id: 'use-transactional-outbox',
+        name: 'Use Transactional Outbox',
+        version: '1.0.0',
+        status: 'accepted',
+        date: '2024-01-15',
+        markdown: '# Use Transactional Outbox',
+      });
+
+      await writeAdr({
+        id: 'use-postgres',
+        name: 'Use Postgres',
+        version: '1.0.0',
+        status: 'proposed',
+        date: '2024-01-20',
+        markdown: '# Use Postgres',
+      });
+
+      const adrs = await getAdrs();
+      expect(adrs).toHaveLength(2);
+      expect(adrs.map((adr) => adr.id).sort()).toEqual(['use-postgres', 'use-transactional-outbox']);
+    });
+
+    it('returns only latest versions when latestOnly is true', async () => {
+      await writeAdr({
+        id: 'use-transactional-outbox',
+        name: 'Use Transactional Outbox',
+        version: '1.0.0',
+        status: 'accepted',
+        date: '2024-01-15',
+        markdown: '# Use Transactional Outbox',
+      });
+
+      await versionAdr('use-transactional-outbox');
+
+      await writeAdr({
+        id: 'use-transactional-outbox',
+        name: 'Use Transactional Outbox',
+        version: '2.0.0',
+        status: 'superseded',
+        date: '2024-02-15',
+        markdown: '# Use Transactional Outbox v2',
+      });
+
+      const adrs = await getAdrs({ latestOnly: true });
+      expect(adrs).toHaveLength(1);
+      expect(adrs[0].version).toBe('2.0.0');
+    });
+  });
+
+  describe('writeAdr', () => {
+    it('writes the given ADR to the file system', async () => {
+      await writeAdr({
+        id: 'use-transactional-outbox',
+        name: 'Use Transactional Outbox',
+        version: '1.0.0',
+        summary: 'Use the transactional outbox pattern for integration events',
+        status: 'accepted',
+        date: '2024-01-15',
+        supersedes: [{ id: 'publish-after-commit', version: '1.0.0' }],
+        related: [{ id: 'use-postgres' }],
+        markdown: '# Use Transactional Outbox',
+      });
+
+      const adr = await getAdr('use-transactional-outbox');
+
+      expect(adr).toEqual({
+        id: 'use-transactional-outbox',
+        name: 'Use Transactional Outbox',
+        version: '1.0.0',
+        summary: 'Use the transactional outbox pattern for integration events',
+        status: 'accepted',
+        date: '2024-01-15',
+        supersedes: [{ id: 'publish-after-commit', version: '1.0.0' }],
+        related: [{ id: 'use-postgres' }],
+        markdown: '# Use Transactional Outbox',
+      });
+    });
+
+    it('writes the ADR to a custom path when path is provided', async () => {
+      await writeAdr(
+        {
+          id: 'use-transactional-outbox',
+          name: 'Use Transactional Outbox',
+          version: '1.0.0',
+          status: 'accepted',
+          date: '2024-01-15',
+          markdown: '# Use Transactional Outbox',
+        },
+        { path: '/technical/use-transactional-outbox' }
+      );
+
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'adrs/technical/use-transactional-outbox', 'index.mdx'))).toBe(true);
+      expect(await getAdr('use-transactional-outbox')).toEqual({
+        id: 'use-transactional-outbox',
+        name: 'Use Transactional Outbox',
+        version: '1.0.0',
+        status: 'accepted',
+        date: '2024-01-15',
+        markdown: '# Use Transactional Outbox',
+      });
+    });
+
+    it('throws an error when trying to write an ADR that already exists', async () => {
+      await writeAdr({
+        id: 'use-transactional-outbox',
+        name: 'Use Transactional Outbox',
+        version: '1.0.0',
+        status: 'accepted',
+        date: '2024-01-15',
+        markdown: '# Use Transactional Outbox',
+      });
+
+      await expect(
+        writeAdr({
+          id: 'use-transactional-outbox',
+          name: 'Use Transactional Outbox',
+          version: '1.0.0',
+          status: 'accepted',
+          date: '2024-01-15',
+          markdown: '# Use Transactional Outbox',
+        })
+      ).rejects.toThrowError('Failed to write use-transactional-outbox (adr) as the version 1.0.0 already exists');
+    });
+
+    it('overrides the ADR when trying to write an ADR that already exists and override is true', async () => {
+      await writeAdr({
+        id: 'use-transactional-outbox',
+        name: 'Use Transactional Outbox',
+        version: '1.0.0',
+        status: 'accepted',
+        date: '2024-01-15',
+        markdown: '# Use Transactional Outbox',
+      });
+
+      await writeAdr(
+        {
+          id: 'use-transactional-outbox',
+          name: 'Use Transactional Outbox',
+          version: '1.0.0',
+          status: 'accepted',
+          date: '2024-01-15',
+          markdown: 'Overridden content',
+        },
+        { override: true }
+      );
+
+      const adr = await getAdr('use-transactional-outbox');
+
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'adrs/use-transactional-outbox', 'index.mdx'))).toBe(true);
+      expect(adr.markdown).toBe('Overridden content');
+    });
+
+    it('versions the previous ADR when trying to write an ADR that already exists and versionExistingContent is true', async () => {
+      await writeAdr({
+        id: 'use-transactional-outbox',
+        name: 'Use Transactional Outbox',
+        version: '1.0.0',
+        status: 'accepted',
+        date: '2024-01-15',
+        markdown: '# Use Transactional Outbox',
+      });
+
+      await writeAdr(
+        {
+          id: 'use-transactional-outbox',
+          name: 'Use Transactional Outbox',
+          version: '2.0.0',
+          status: 'accepted',
+          date: '2024-02-15',
+          markdown: '# Use Transactional Outbox v2',
+        },
+        { versionExistingContent: true }
+      );
+
+      const adr = await getAdr('use-transactional-outbox');
+      expect(adr.version).toBe('2.0.0');
+      expect(adr.markdown).toBe('# Use Transactional Outbox v2');
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'adrs/use-transactional-outbox/versioned/1.0.0', 'index.mdx'))).toBe(true);
+    });
+
+    it('writes the ADR as md when format is md', async () => {
+      await writeAdr(
+        {
+          id: 'use-transactional-outbox',
+          name: 'Use Transactional Outbox',
+          version: '1.0.0',
+          status: 'accepted',
+          date: '2024-01-15',
+          markdown: '# Use Transactional Outbox',
+        },
+        { format: 'md' }
+      );
+
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'adrs/use-transactional-outbox', 'index.md'))).toBe(true);
+    });
+  });
+
+  describe('rmAdr', () => {
+    it('removes an ADR by its path', async () => {
+      await writeAdr({
+        id: 'use-transactional-outbox',
+        name: 'Use Transactional Outbox',
+        version: '1.0.0',
+        status: 'accepted',
+        date: '2024-01-15',
+        markdown: '# Use Transactional Outbox',
+      });
+
+      await rmAdr('/use-transactional-outbox');
+
+      expect(await getAdr('use-transactional-outbox')).toEqual(undefined);
+    });
+  });
+
+  describe('rmAdrById', () => {
+    it('removes an ADR by its id', async () => {
+      await writeAdr({
+        id: 'use-transactional-outbox',
+        name: 'Use Transactional Outbox',
+        version: '1.0.0',
+        status: 'accepted',
+        date: '2024-01-15',
+        markdown: '# Use Transactional Outbox',
+      });
+
+      await rmAdrById('use-transactional-outbox');
+
+      expect(await getAdr('use-transactional-outbox')).toEqual(undefined);
+    });
+
+    it('removes a specific version of an ADR by its id and version', async () => {
+      await writeAdr({
+        id: 'use-transactional-outbox',
+        name: 'Use Transactional Outbox',
+        version: '1.0.0',
+        status: 'accepted',
+        date: '2024-01-15',
+        markdown: '# Use Transactional Outbox',
+      });
+
+      await versionAdr('use-transactional-outbox');
+
+      await writeAdr({
+        id: 'use-transactional-outbox',
+        name: 'Use Transactional Outbox',
+        version: '2.0.0',
+        status: 'superseded',
+        date: '2024-02-15',
+        markdown: '# Use Transactional Outbox v2',
+      });
+
+      await rmAdrById('use-transactional-outbox', '1.0.0');
+
+      expect(await getAdr('use-transactional-outbox', '1.0.0')).toEqual(undefined);
+      expect(await getAdr('use-transactional-outbox', '2.0.0')).toEqual({
+        id: 'use-transactional-outbox',
+        name: 'Use Transactional Outbox',
+        version: '2.0.0',
+        status: 'superseded',
+        date: '2024-02-15',
+        markdown: '# Use Transactional Outbox v2',
+      });
+    });
+  });
+
+  describe('versionAdr', () => {
+    it('versions an ADR by moving it to a versioned directory', async () => {
+      await writeAdr({
+        id: 'use-transactional-outbox',
+        name: 'Use Transactional Outbox',
+        version: '1.0.0',
+        status: 'accepted',
+        date: '2024-01-15',
+        markdown: '# Use Transactional Outbox',
+      });
+
+      await versionAdr('use-transactional-outbox');
+
+      expect(await getAdr('use-transactional-outbox', '1.0.0')).toEqual({
+        id: 'use-transactional-outbox',
+        name: 'Use Transactional Outbox',
+        version: '1.0.0',
+        status: 'accepted',
+        date: '2024-01-15',
+        markdown: '# Use Transactional Outbox',
+      });
+    });
+  });
+
+  describe('adrHasVersion', () => {
+    it('returns true if ADR version exists', async () => {
+      await writeAdr({
+        id: 'use-transactional-outbox',
+        name: 'Use Transactional Outbox',
+        version: '1.0.0',
+        status: 'accepted',
+        date: '2024-01-15',
+        markdown: '# Use Transactional Outbox',
+      });
+
+      expect(await adrHasVersion('use-transactional-outbox', '1.0.0')).toBe(true);
+    });
+
+    it('returns false if ADR version does not exist', async () => {
+      await writeAdr({
+        id: 'use-transactional-outbox',
+        name: 'Use Transactional Outbox',
+        version: '1.0.0',
+        status: 'accepted',
+        date: '2024-01-15',
+        markdown: '# Use Transactional Outbox',
+      });
+
+      expect(await adrHasVersion('use-transactional-outbox', '2.0.0')).toBe(false);
+    });
+
+    it('returns false if ADR does not exist', async () => {
+      expect(await adrHasVersion('missing-adr', '1.0.0')).toBe(false);
+    });
+  });
+
+  describe('addFileToAdr', () => {
+    it('adds a file to the ADR', async () => {
+      await writeAdr({
+        id: 'use-transactional-outbox',
+        name: 'Use Transactional Outbox',
+        version: '1.0.0',
+        status: 'accepted',
+        date: '2024-01-15',
+        markdown: '# Use Transactional Outbox',
+      });
+
+      await addFileToAdr('use-transactional-outbox', { content: 'decision context', fileName: 'context.txt' });
+
+      const filePath = path.join(CATALOG_PATH, 'adrs/use-transactional-outbox', 'context.txt');
+      expect(fs.existsSync(filePath)).toBe(true);
+      expect(fs.readFileSync(filePath, 'utf-8')).toBe('decision context');
+    });
+
+    it('adds a file to a specific version of the ADR', async () => {
+      await writeAdr({
+        id: 'use-transactional-outbox',
+        name: 'Use Transactional Outbox',
+        version: '1.0.0',
+        status: 'accepted',
+        date: '2024-01-15',
+        markdown: '# Use Transactional Outbox',
+      });
+
+      await versionAdr('use-transactional-outbox');
+
+      await addFileToAdr('use-transactional-outbox', { content: 'decision context v1', fileName: 'context.txt' }, '1.0.0');
+
+      const filePath = path.join(CATALOG_PATH, 'adrs/use-transactional-outbox/versioned/1.0.0', 'context.txt');
+      expect(fs.existsSync(filePath)).toBe(true);
+      expect(fs.readFileSync(filePath, 'utf-8')).toBe('decision context v1');
+    });
+
+    it('throws an error when trying to write to an ADR that does not exist', async () => {
+      await expect(addFileToAdr('missing-adr', { content: 'hello', fileName: 'test.txt' })).rejects.toThrowError(
+        'Cannot find directory to write file to'
+      );
+    });
+  });
+});

--- a/packages/sdk/src/test/catalog-eventcatalog/adrs/adr-001-use-transactional-outbox/index.mdx
+++ b/packages/sdk/src/test/catalog-eventcatalog/adrs/adr-001-use-transactional-outbox/index.mdx
@@ -1,0 +1,18 @@
+---
+id: adr-001-use-transactional-outbox
+name: Use Transactional Outbox
+version: 1.0.0
+summary: Publish integration events through an outbox table.
+status: accepted
+date: '2024-01-15'
+decisionMakers:
+  - dboyne
+appliesTo:
+  - id: OrdersService
+    version: 0.0.1
+    type: service
+---
+
+# Use Transactional Outbox
+
+We will publish integration events through an outbox table owned by the service.

--- a/packages/sdk/src/test/eventcatalog.test.ts
+++ b/packages/sdk/src/test/eventcatalog.test.ts
@@ -198,6 +198,28 @@ describe('EventCatalog', () => {
         expect(dump.resources.flows?.[0].markdown).toBeUndefined();
       });
     });
+
+    describe('adrs', () => {
+      it('returns a list of ADRs from the catalog', async () => {
+        const dump = await dumpCatalog();
+        expect(dump.resources.adrs).toHaveLength(1);
+
+        const adr = dump.resources.adrs?.find((a: any) => a.id === 'adr-001-use-transactional-outbox');
+        expect(adr).toEqual(
+          expect.objectContaining({
+            id: 'adr-001-use-transactional-outbox',
+            name: 'Use Transactional Outbox',
+            version: '1.0.0',
+            status: 'accepted',
+          })
+        );
+      });
+
+      it('should not include markdown for ADRs if the includeMarkdown option is false', async () => {
+        const dump = await dumpCatalog({ includeMarkdown: false });
+        expect(dump.resources.adrs?.[0].markdown).toBeUndefined();
+      });
+    });
   });
 
   describe('getEventCatalogConfigurationFile', () => {

--- a/packages/sdk/src/types.d.ts
+++ b/packages/sdk/src/types.d.ts
@@ -408,6 +408,54 @@ export interface Diagram extends BaseSchema {
   };
 }
 
+export type AdrStatus = 'proposed' | 'accepted' | 'rejected' | 'deprecated' | 'superseded';
+
+export type AdrPointer = {
+  id: string;
+  version?: string;
+};
+
+export type AdrResourcePointer = AdrPointer & {
+  type:
+    | 'agent'
+    | 'service'
+    | 'event'
+    | 'command'
+    | 'query'
+    | 'flow'
+    | 'channel'
+    | 'domain'
+    | 'system'
+    | 'user'
+    | 'team'
+    | 'container'
+    | 'entity'
+    | 'diagram'
+    | 'data-product';
+};
+
+export interface Adr extends BaseSchema {
+  status: AdrStatus;
+  date: Date | string;
+  decisionMakers?: string[];
+  appliesTo?: AdrResourcePointer[];
+  supersedes?: AdrPointer[];
+  supersededBy?: AdrPointer[];
+  amends?: AdrPointer[];
+  amendedBy?: AdrPointer[];
+  related?: AdrPointer[];
+  detailsPanel?: {
+    status?: DetailPanelProperty;
+    date?: DetailPanelProperty;
+    decisionMakers?: DetailPanelProperty;
+    appliesTo?: DetailPanelProperty;
+    relationships?: DetailPanelProperty;
+    owners?: DetailPanelProperty;
+    repository?: DetailPanelProperty;
+    changelog?: DetailPanelProperty;
+  };
+}
+
 export type DataProductOutputPointer = {
   id: string;
   version?: string;
@@ -520,6 +568,7 @@ export type EventCatalog = {
     entities?: ExportedResource<Entity>[];
     containers?: ExportedResource<Container>[];
     flows?: ExportedResource<Flow>[];
+    adrs?: ExportedResource<Adr>[];
     customDocs?: ExportedResource<CustomDoc>[];
   };
 };


### PR DESCRIPTION
Closes #2658

## What This PR Does

Adds first-class support for Architecture Decision Records (ADRs) to the `@eventcatalog/sdk`. Consumers can now programmatically read, write, version, and manage ADR resources the same way they already do for events, services, domains, and other catalog resources. ADRs are also now included in the catalog dump output.

## Changes Overview

### Key Changes
- New `adrs.ts` module exposing the full ADR API: `getAdr`, `getAdrs`, `writeAdr`, `rmAdr`, `rmAdrById`, `versionAdr`, `adrHasVersion`, and `addFileToAdr`.
- Wired the new ADR functions into the SDK's main factory in `index.ts`, with `adrs` stored under the `adrs` directory.
- Added `Adr` to the shared `Resource` union in `internal/resources.ts` so ADRs flow through the existing read/write/version machinery.
- Added the `Adr` type and related definitions to `types.d.ts`.
- Included ADRs in `dumpCatalog` (`eventcatalog.ts`) so they are hydrated and returned alongside other resources.
- Re-exported the ADR module from `docs.ts`.
- Added test coverage: a dedicated `adrs.test.ts` suite plus additional assertions in `eventcatalog.test.ts`, and a fixture ADR under the test catalog.

## How It Works

ADRs reuse the existing generic resource helpers (`getResource`, `getResources`, `writeResource`, `versionResource`, `rmResourceById`, `addFileToResource`) by passing a `type: 'adr'` discriminator. The `Adr` type was added to the internal `Resource` union so no bespoke read/write logic was needed. In the SDK factory, ADR read operations are scoped to the catalog root while write/remove operations are scoped to the `adrs/` subdirectory, matching the convention used by other resource types. `dumpCatalog` fetches and hydrates ADRs in parallel with the other collections and includes them in the resources payload.

## Breaking Changes

None. This is purely additive.

## Additional Notes

- The changeset targets `@eventcatalog/sdk` with a `patch` bump.
- No changes required in the editor repository (`eventcatalog/eventcatalog-editor`) for this SDK addition.