### PR TITLE
Restrict EntityMap collection prop to domains or services

### DIFF
--- a/.changeset/quiet-otters-jump.md
+++ b/.changeset/quiet-otters-jump.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Restrict EntityMap MDX component collection prop to domains or services

--- a/packages/core/eventcatalog/src/components/MDX/components.tsx
+++ b/packages/core/eventcatalog/src/components/MDX/components.tsx
@@ -42,6 +42,11 @@ import { jsx } from 'astro/jsx-runtime';
 import RemoteSchema from '@components/MDX/RemoteSchema.astro';
 import Visibility from '@components/MDX/Visibility';
 
+const getEntityMapCollection = (props: any, mdxProp: any) => {
+  const collection = mdxProp.collection ?? props.collection;
+  return collection === 'domains' || collection === 'services' ? collection : undefined;
+};
+
 const components = (props: any) => {
   return {
     Attachments: (mdxProp: any) => jsx(Attachments, { ...props, ...mdxProp }),
@@ -63,7 +68,7 @@ const components = (props: any) => {
     ComponentDiagram: (mdxProp: any) => jsx(NodeGraphPortal, { ...props.data, ...mdxProp, props, mdxProp }),
     ContextDiagram: (mdxProp: any) => jsx(ContextDiagramPortal, { ...props.data, ...mdxProp, props, mdxProp }),
     SystemContextMap: (mdxProp: any) => jsx(SystemContextMapPortal, { ...mdxProp }),
-    EntityMap: (mdxProp: any) => jsx(EntityMap, { ...props, ...mdxProp }),
+    EntityMap: (mdxProp: any) => jsx(EntityMap, { ...props, ...mdxProp, collection: getEntityMapCollection(props, mdxProp) }),
     OpenAPI,
     Prompt: (mdxProp: any) => jsx(Prompt, { ...props, ...mdxProp }),
     ResourceGroupTable: (mdxProp: any) => jsx(ResourceGroupTable, { ...props, ...mdxProp }),

--- a/packages/core/eventcatalog/src/types/picomatch.d.ts
+++ b/packages/core/eventcatalog/src/types/picomatch.d.ts
@@ -1,0 +1,13 @@
+declare module 'picomatch' {
+  export interface Options {
+    [key: string]: unknown;
+  }
+
+  interface Picomatch {
+    (globs: string | string[], options?: Options): (input: string) => boolean;
+    isMatch(input: string | string[], glob: string | string[], options?: Options): boolean;
+  }
+
+  const picomatch: Picomatch;
+  export default picomatch;
+}


### PR DESCRIPTION
## What This PR Does

The `EntityMap` MDX component previously received whatever `collection` value was passed through from the surrounding props or MDX prop. This PR adds a small helper that normalizes the `collection` prop so it only ever resolves to `'domains'` or `'services'` (falling back to `undefined` for anything else). It also adds a local type declaration for the `picomatch` module so TypeScript can resolve its default export and `isMatch` API.

## Changes Overview

### Key Changes

- Add `getEntityMapCollection` helper in `components.tsx` that reads `collection` from the MDX prop first, then the parent props, and only returns it when it is `'domains'` or `'services'`.
- Pass the normalized `collection` into the `EntityMap` component render.
- Add `src/types/picomatch.d.ts` declaring the `picomatch` module (default export + `isMatch`).

## How It Works

When MDX renders an `EntityMap`, the component builder now computes the collection via `getEntityMapCollection(props, mdxProp)`. The MDX-level prop takes precedence over the page-level prop, and any value other than `'domains'` or `'services'` is discarded so the component receives a well-defined, supported collection value.

## Breaking Changes

None.

## Additional Notes

No corresponding change is needed in the editor repository — this is scoped to the core MDX component wiring and a local type shim.