### PR TITLE
Add custom documentation tools to AI Chat and MCP Server

### DIFF
--- a/.changeset/curious-otters-search.md
+++ b/.changeset/curious-otters-search.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Add custom documentation tools (getCustomDocs, searchCustomDocs, getCustomDoc) to AI Chat and MCP Server, with section-level full-text search powered by MiniSearch

--- a/packages/core/eventcatalog/src/enterprise/ai/chat-api.ts
+++ b/packages/core/eventcatalog/src/enterprise/ai/chat-api.ts
@@ -18,6 +18,9 @@ import {
   getDataProductInputs as getDataProductInputsImpl,
   getDataProductOutputs as getDataProductOutputsImpl,
   getArchitectureDiagramAsMermaid as getArchitectureDiagramImpl,
+  getCustomDocs as getCustomDocsImpl,
+  searchCustomDocs as searchCustomDocsImpl,
+  getCustomDoc as getCustomDocImpl,
   collectionSchema,
   resourceCollectionSchema,
   messageCollectionSchema,
@@ -72,6 +75,9 @@ const builtInToolsMetadata = [
   { name: 'getDataProductInputs', description: 'Get the inputs (resources consumed) for a data product' },
   { name: 'getDataProductOutputs', description: 'Get the outputs (resources produced) for a data product with data contracts' },
   { name: 'getArchitectureDiagramAsMermaid', description: 'Get the architecture diagram for a resource as Mermaid code' },
+  { name: 'getCustomDocs', description: 'List custom documentation pages (guides, runbooks, architecture notes)' },
+  { name: 'searchCustomDocs', description: 'Search the full text of custom documentation pages' },
+  { name: 'getCustomDoc', description: 'Get the markdown content of a custom documentation page' },
 ];
 
 // Get extended tools metadata from user configuration
@@ -348,6 +354,36 @@ export const POST = async ({ request }: APIContext<{ question: string; messages:
           }),
           execute: async ({ resourceId, resourceVersion, resourceCollection }) => {
             return await getArchitectureDiagramImpl({ resourceId, resourceVersion, resourceCollection });
+          },
+        }),
+        getCustomDocs: tool({
+          description: toolDescriptions.getCustomDocs,
+          inputSchema: z.object({
+            cursor: z.string().optional().describe('Pagination cursor from previous response'),
+            search: z.string().optional().describe('Search term to filter docs by title, id, or summary (case-insensitive)'),
+          }),
+          execute: async ({ cursor, search }) => {
+            return await getCustomDocsImpl({ cursor, search });
+          },
+        }),
+        searchCustomDocs: tool({
+          description: toolDescriptions.searchCustomDocs,
+          inputSchema: z.object({
+            query: z.string().describe('Full-text search query, e.g. keywords describing the topic to find'),
+            limit: z.number().optional().describe('Maximum number of results to return (default 10)'),
+          }),
+          execute: async ({ query, limit }) => {
+            return await searchCustomDocsImpl({ query, limit });
+          },
+        }),
+        getCustomDoc: tool({
+          description: toolDescriptions.getCustomDoc,
+          inputSchema: z.object({
+            id: z.string().describe('The id or slug of the custom documentation page'),
+            section: z.string().optional().describe('Optional section heading to return only that section of the page'),
+          }),
+          execute: async ({ id, section }) => {
+            return await getCustomDocImpl({ id, section });
           },
         }),
         suggestFollowUpQuestions: tool({

--- a/packages/core/eventcatalog/src/enterprise/custom-documentation/__tests__/docs-search.spec.ts
+++ b/packages/core/eventcatalog/src/enterprise/custom-documentation/__tests__/docs-search.spec.ts
@@ -1,0 +1,135 @@
+/**
+ * Licensed under the EventCatalog Commercial License.
+ * See /packages/core/eventcatalog/src/enterprise/LICENSE
+ */
+
+import { describe, it, expect } from 'vitest';
+import { chunkMarkdownByHeadings, buildDocsSearchIndex, extractSnippet } from '../utils/docs-search';
+
+describe('chunkMarkdownByHeadings', () => {
+  it('splits markdown into sections by headings, keeping heading text and content', () => {
+    const markdown = [
+      'Some intro text before any heading.',
+      '',
+      '## Refund failures',
+      'How to handle refund failures.',
+      '',
+      '### Escalation',
+      'Escalate to the payments team.',
+      '',
+      '## Chargeback handling',
+      'Chargebacks are handled weekly.',
+    ].join('\n');
+
+    const chunks = chunkMarkdownByHeadings(markdown);
+
+    expect(chunks).toEqual([
+      { heading: null, content: 'Some intro text before any heading.' },
+      { heading: 'Refund failures', content: 'How to handle refund failures.' },
+      { heading: 'Escalation', content: 'Escalate to the payments team.' },
+      { heading: 'Chargeback handling', content: 'Chargebacks are handled weekly.' },
+    ]);
+  });
+
+  it('returns a single chunk with null heading when there are no headings', () => {
+    const chunks = chunkMarkdownByHeadings('Just a short doc with no headings.');
+    expect(chunks).toEqual([{ heading: null, content: 'Just a short doc with no headings.' }]);
+  });
+
+  it('does not treat lines inside fenced code blocks as headings', () => {
+    const markdown = ['## Setup', '```bash', '# this is a comment, not a heading', 'echo hello', '```', 'Done.'].join('\n');
+
+    const chunks = chunkMarkdownByHeadings(markdown);
+
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].heading).toBe('Setup');
+    expect(chunks[0].content).toContain('# this is a comment, not a heading');
+  });
+
+  it('returns no chunks for empty markdown', () => {
+    expect(chunkMarkdownByHeadings('')).toEqual([]);
+  });
+});
+
+describe('buildDocsSearchIndex', () => {
+  const docs = [
+    {
+      id: 'docs/payments/runbook',
+      title: 'Payment Runbook',
+      summary: 'How we operate payments',
+      body: [
+        '## Refund failures',
+        'When a refund fails, retry the refund three times.',
+        '## Chargeback handling',
+        'Chargebacks are disputed via the acquirer portal.',
+      ].join('\n'),
+    },
+    {
+      id: 'docs/onboarding',
+      title: 'Onboarding Guide',
+      summary: 'Getting started as a new engineer',
+      body: ['## First week', 'Set up your laptop and request access to the acquirer portal.'].join('\n'),
+    },
+    {
+      id: 'docs/chargebacks',
+      title: 'Chargeback Policy',
+      summary: 'Company policy for chargebacks',
+      body: 'We follow the network rules for all disputes.',
+    },
+  ];
+
+  it('finds documents by terms in the body and returns the matched section heading', () => {
+    const index = buildDocsSearchIndex(docs);
+    const results = index.search('refund fails');
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].docId).toBe('docs/payments/runbook');
+    expect(results[0].heading).toBe('Refund failures');
+    expect(results[0].title).toBe('Payment Runbook');
+  });
+
+  it('ranks title matches above body-only matches', () => {
+    const index = buildDocsSearchIndex(docs);
+    const results = index.search('chargeback');
+
+    // 'Chargeback Policy' matches on title; runbook only matches in a section
+    expect(results[0].docId).toBe('docs/chargebacks');
+  });
+
+  it('includes a snippet containing the matched term', () => {
+    const index = buildDocsSearchIndex(docs);
+    const results = index.search('acquirer portal');
+
+    expect(results[0].snippet.toLowerCase()).toContain('acquirer portal');
+  });
+
+  it('returns an empty array when nothing matches', () => {
+    const index = buildDocsSearchIndex(docs);
+    expect(index.search('zzzzz-nonexistent-term')).toEqual([]);
+  });
+
+  it('respects the limit option', () => {
+    const index = buildDocsSearchIndex(docs);
+    const results = index.search('chargeback', { limit: 1 });
+    expect(results).toHaveLength(1);
+  });
+});
+
+describe('extractSnippet', () => {
+  it('returns text around the first matched term with ellipses for long content', () => {
+    const padding = 'lorem ipsum dolor sit amet '.repeat(20);
+    const content = `${padding}the acquirer portal is used for disputes ${padding}`;
+
+    const snippet = extractSnippet(content, 'acquirer');
+
+    expect(snippet).toContain('acquirer portal');
+    expect(snippet.length).toBeLessThan(content.length);
+    expect(snippet.startsWith('…')).toBe(true);
+    expect(snippet.endsWith('…')).toBe(true);
+  });
+
+  it('falls back to the start of the content when no term matches', () => {
+    const content = 'A short description of something.';
+    expect(extractSnippet(content, 'nonexistent')).toBe('A short description of something.');
+  });
+});

--- a/packages/core/eventcatalog/src/enterprise/custom-documentation/utils/docs-search.ts
+++ b/packages/core/eventcatalog/src/enterprise/custom-documentation/utils/docs-search.ts
@@ -1,0 +1,144 @@
+/**
+ * Licensed under the EventCatalog Commercial License.
+ * See /packages/core/eventcatalog/src/enterprise/LICENSE
+ */
+
+import MiniSearch from 'minisearch';
+
+export type MarkdownChunk = {
+  heading: string | null;
+  content: string;
+};
+
+export type DocForIndexing = {
+  id: string;
+  title: string;
+  summary?: string;
+  body?: string;
+};
+
+export type DocsSearchHit = {
+  docId: string;
+  title: string;
+  heading: string | null;
+  snippet: string;
+  score: number;
+};
+
+export type DocsSearchIndex = {
+  search: (query: string, options?: { limit?: number }) => DocsSearchHit[];
+};
+
+const DEFAULT_SEARCH_LIMIT = 10;
+const SNIPPET_RADIUS = 100;
+
+/**
+ * Splits markdown into section chunks at ATX headings (any level).
+ * Content before the first heading becomes a chunk with a null heading.
+ * Headings inside fenced code blocks are ignored.
+ */
+export const chunkMarkdownByHeadings = (markdown: string): MarkdownChunk[] => {
+  const chunks: MarkdownChunk[] = [];
+  let heading: string | null = null;
+  let buffer: string[] = [];
+  let insideCodeFence = false;
+
+  const flush = () => {
+    const content = buffer.join('\n').trim();
+    if (heading !== null || content) {
+      chunks.push({ heading, content });
+    }
+    buffer = [];
+  };
+
+  for (const line of markdown.split('\n')) {
+    if (/^(```|~~~)/.test(line.trim())) {
+      insideCodeFence = !insideCodeFence;
+    }
+
+    const headingMatch = insideCodeFence ? null : line.match(/^#{1,6}\s+(.+)$/);
+    if (headingMatch) {
+      flush();
+      heading = headingMatch[1].trim();
+    } else {
+      buffer.push(line);
+    }
+  }
+
+  flush();
+  return chunks;
+};
+
+/**
+ * Returns a short excerpt of the content centred on the first query term found.
+ * Falls back to the start of the content when no term matches.
+ */
+export const extractSnippet = (content: string, query: string, radius: number = SNIPPET_RADIUS): string => {
+  const normalized = content.replace(/\s+/g, ' ').trim();
+  const lowercased = normalized.toLowerCase();
+  const terms = query.toLowerCase().split(/\s+/).filter(Boolean);
+
+  let matchIndex = -1;
+  for (const term of terms) {
+    matchIndex = lowercased.indexOf(term);
+    if (matchIndex !== -1) break;
+  }
+
+  if (matchIndex === -1) {
+    return normalized.length <= radius * 2 ? normalized : `${normalized.slice(0, radius * 2)}…`;
+  }
+
+  const start = Math.max(0, matchIndex - radius);
+  const end = Math.min(normalized.length, matchIndex + radius);
+  return `${start > 0 ? '…' : ''}${normalized.slice(start, end)}${end < normalized.length ? '…' : ''}`;
+};
+
+/**
+ * Builds an in-memory BM25 search index over custom documentation.
+ * Each document is indexed as one entry per markdown section, so search hits
+ * point at the specific section of a document rather than the whole document.
+ */
+export const buildDocsSearchIndex = (docs: DocForIndexing[]): DocsSearchIndex => {
+  const miniSearch = new MiniSearch({
+    fields: ['title', 'summary', 'heading', 'content'],
+    storeFields: ['docId', 'title', 'heading', 'content'],
+    searchOptions: {
+      boost: { title: 3, heading: 2, summary: 2 },
+      prefix: true,
+    },
+  });
+
+  const sections = docs.flatMap((doc) => {
+    const chunks = chunkMarkdownByHeadings(doc.body ?? '');
+    // Documents with an empty body should still be searchable by title/summary
+    const indexableChunks = chunks.length > 0 ? chunks : [{ heading: null, content: '' }];
+
+    return indexableChunks.map((chunk, index) => ({
+      id: `${doc.id}#${index}`,
+      docId: doc.id,
+      title: doc.title,
+      summary: doc.summary,
+      heading: chunk.heading,
+      content: chunk.content,
+    }));
+  });
+
+  miniSearch.addAll(sections);
+
+  return {
+    search: (query, options = {}) => {
+      const limit = options.limit ?? DEFAULT_SEARCH_LIMIT;
+
+      return miniSearch
+        .search(query)
+        .slice(0, limit)
+        .map((result) => ({
+          docId: result.docId,
+          title: result.title,
+          heading: result.heading ?? null,
+          snippet: extractSnippet(result.content ?? '', query),
+          score: result.score,
+        }));
+    },
+  };
+};

--- a/packages/core/eventcatalog/src/enterprise/mcp/__tests__/mcp-server.spec.ts
+++ b/packages/core/eventcatalog/src/enterprise/mcp/__tests__/mcp-server.spec.ts
@@ -155,7 +155,7 @@ describe('MCP Health Check Endpoint (GET /docs/mcp/)', () => {
   it('should verify toolDescriptions contains all expected tools', async () => {
     const { toolDescriptions } = await import('@enterprise/tools/catalog-tools');
 
-    // 19 built-in tools from toolDescriptions
+    // 22 built-in tools from toolDescriptions
     const expectedTools = [
       'getResources',
       'getResource',
@@ -176,12 +176,15 @@ describe('MCP Health Check Endpoint (GET /docs/mcp/)', () => {
       'getDataProductInputs',
       'getDataProductOutputs',
       'getArchitectureDiagramAsMermaid',
+      'getCustomDocs',
+      'searchCustomDocs',
+      'getCustomDoc',
     ];
 
     for (const tool of expectedTools) {
       expect(toolDescriptions[tool as keyof typeof toolDescriptions]).toBeDefined();
     }
-    expect(Object.keys(toolDescriptions).length).toBe(19);
+    expect(Object.keys(toolDescriptions).length).toBe(22);
   });
 });
 

--- a/packages/core/eventcatalog/src/enterprise/mcp/mcp-server.ts
+++ b/packages/core/eventcatalog/src/enterprise/mcp/mcp-server.ts
@@ -26,6 +26,9 @@ import {
   getUser,
   findMessageBySchemaId,
   explainUbiquitousLanguageTerms,
+  getCustomDocs,
+  searchCustomDocs,
+  getCustomDoc,
   collectionSchema,
   resourceCollectionSchema,
   messageCollectionSchema,
@@ -294,6 +297,42 @@ function createMcpServer() {
       }),
     },
     createToolHandler(explainUbiquitousLanguageTerms, 'Failed to get ubiquitous language terms')
+  );
+
+  server.registerTool(
+    'getCustomDocs',
+    {
+      description: toolDescriptions.getCustomDocs,
+      inputSchema: z.object({
+        cursor: z.string().optional().describe('Pagination cursor from previous response'),
+        search: z.string().optional().describe('Search term to filter docs by title, id, or summary (case-insensitive)'),
+      }),
+    },
+    createToolHandler(getCustomDocs, 'Failed to get custom documentation pages')
+  );
+
+  server.registerTool(
+    'searchCustomDocs',
+    {
+      description: toolDescriptions.searchCustomDocs,
+      inputSchema: z.object({
+        query: z.string().describe('Full-text search query, e.g. keywords describing the topic to find'),
+        limit: z.number().optional().describe('Maximum number of results to return (default 10)'),
+      }),
+    },
+    createToolHandler(searchCustomDocs, 'Failed to search custom documentation')
+  );
+
+  server.registerTool(
+    'getCustomDoc',
+    {
+      description: toolDescriptions.getCustomDoc,
+      inputSchema: z.object({
+        id: z.string().describe('The id or slug of the custom documentation page'),
+        section: z.string().optional().describe('Optional section heading to return only that section of the page'),
+      }),
+    },
+    createToolHandler(getCustomDoc, 'Failed to get custom documentation page')
   );
 
   // Register extended tools from user configuration

--- a/packages/core/eventcatalog/src/enterprise/tools/__tests__/catalog-tools.mocks.ts
+++ b/packages/core/eventcatalog/src/enterprise/tools/__tests__/catalog-tools.mocks.ts
@@ -594,6 +594,40 @@ export const mockSchemas = [
 ];
 
 // ============================================
+// Mock Custom Pages (custom documentation)
+// ============================================
+export const mockCustomPages = [
+  {
+    id: 'docs/payments/runbook',
+    collection: 'customPages',
+    body: [
+      'Intro to operating payments.',
+      '',
+      '## Refund failures',
+      'When a refund fails, retry the refund three times.',
+      '',
+      '## Chargeback handling',
+      'Chargebacks are disputed via the acquirer portal.',
+    ].join('\n'),
+    data: {
+      title: 'Payment Runbook',
+      summary: 'How we operate payments',
+      owners: ['payment-team'],
+    },
+  },
+  {
+    id: 'docs/onboarding',
+    collection: 'customPages',
+    body: 'Welcome to the team. Ask the order team for repository access.',
+    data: {
+      title: 'Onboarding Guide',
+      summary: 'Getting started as a new engineer',
+      slug: 'getting-started',
+    },
+  },
+];
+
+// ============================================
 // Helper to get all mocks by collection
 // ============================================
 export const mockCollections: Record<string, any[]> = {
@@ -614,4 +648,5 @@ export const mockCollections: Record<string, any[]> = {
   teams: mockTeams,
   users: mockUsers,
   ubiquitousLanguages: mockUbiquitousLanguages,
+  customPages: mockCustomPages,
 };

--- a/packages/core/eventcatalog/src/enterprise/tools/__tests__/catalog-tools.spec.ts
+++ b/packages/core/eventcatalog/src/enterprise/tools/__tests__/catalog-tools.spec.ts
@@ -131,6 +131,9 @@ import {
   findMessageBySchemaId,
   explainUbiquitousLanguageTerms,
   getC4Diagram,
+  getCustomDocs,
+  searchCustomDocs,
+  getCustomDoc,
 } from '../catalog-tools';
 import { getSchemasFromResource } from '@utils/collections/schemas';
 
@@ -1325,5 +1328,115 @@ describe('explainUbiquitousLanguageTerms', () => {
     if (!('error' in result)) {
       expect(result.subdomainCount).toBe(1);
     }
+  });
+});
+
+// ============================================
+// Custom Documentation Tools Tests
+// ============================================
+
+describe('getCustomDocs', () => {
+  it('returns all custom docs with metadata but no body', async () => {
+    const result = await getCustomDocs({});
+    expect('error' in result).toBe(false);
+    if (!('error' in result)) {
+      expect(result.totalCount).toBe(2);
+      expect(result.docs[0]).toEqual({
+        id: 'docs/payments/runbook',
+        title: 'Payment Runbook',
+        summary: 'How we operate payments',
+      });
+      expect(result.docs[1]).toEqual({
+        id: 'docs/onboarding',
+        title: 'Onboarding Guide',
+        summary: 'Getting started as a new engineer',
+        slug: 'getting-started',
+      });
+    }
+  });
+
+  it('filters docs with the search param (title, id, summary)', async () => {
+    const result = await getCustomDocs({ search: 'onboarding' });
+    expect('error' in result).toBe(false);
+    if (!('error' in result)) {
+      expect(result.totalCount).toBe(1);
+      expect(result.docs[0].id).toBe('docs/onboarding');
+    }
+  });
+
+  it('returns no nextCursor when all docs fit on one page', async () => {
+    const result = await getCustomDocs({});
+    expect('error' in result).toBe(false);
+    if (!('error' in result)) {
+      expect(result.nextCursor).toBeUndefined();
+    }
+  });
+});
+
+describe('searchCustomDocs', () => {
+  it('finds docs by body content and returns the matched section with a snippet', async () => {
+    const result = await searchCustomDocs({ query: 'refund fails' });
+    expect('error' in result).toBe(false);
+    if (!('error' in result)) {
+      expect(result.results.length).toBeGreaterThan(0);
+      expect(result.results[0].docId).toBe('docs/payments/runbook');
+      expect(result.results[0].heading).toBe('Refund failures');
+      expect(result.results[0].snippet.toLowerCase()).toContain('refund');
+    }
+  });
+
+  it('returns empty results when nothing matches', async () => {
+    const result = await searchCustomDocs({ query: 'zzzzz-nonexistent' });
+    expect('error' in result).toBe(false);
+    if (!('error' in result)) {
+      expect(result.results).toEqual([]);
+    }
+  });
+
+  it('returns an error for an empty query', async () => {
+    const result = await searchCustomDocs({ query: '   ' });
+    expect('error' in result).toBe(true);
+  });
+});
+
+describe('getCustomDoc', () => {
+  it('returns the full markdown and metadata for a doc by id', async () => {
+    const result = await getCustomDoc({ id: 'docs/payments/runbook' });
+    expect('error' in result).toBe(false);
+    if (!('error' in result)) {
+      expect(result.title).toBe('Payment Runbook');
+      expect(result.markdown).toContain('## Refund failures');
+      expect(result.markdown).toContain('acquirer portal');
+    }
+  });
+
+  it('resolves a doc by its custom slug', async () => {
+    const result = await getCustomDoc({ id: 'getting-started' });
+    expect('error' in result).toBe(false);
+    if (!('error' in result)) {
+      expect(result.title).toBe('Onboarding Guide');
+    }
+  });
+
+  it('returns only the requested section when a section is provided', async () => {
+    const result = await getCustomDoc({ id: 'docs/payments/runbook', section: 'Chargeback handling' });
+    expect('error' in result).toBe(false);
+    if (!('error' in result)) {
+      expect(result.markdown).toContain('acquirer portal');
+      expect(result.markdown).not.toContain('Refund failures');
+    }
+  });
+
+  it('returns an error listing available sections when the section is not found', async () => {
+    const result = await getCustomDoc({ id: 'docs/payments/runbook', section: 'Nope' });
+    expect('error' in result).toBe(true);
+    if ('error' in result) {
+      expect(result.error).toContain('Chargeback handling');
+    }
+  });
+
+  it('returns an error when the doc is not found', async () => {
+    const result = await getCustomDoc({ id: 'docs/does-not-exist' });
+    expect('error' in result).toBe(true);
   });
 });

--- a/packages/core/eventcatalog/src/enterprise/tools/catalog-tools.ts
+++ b/packages/core/eventcatalog/src/enterprise/tools/catalog-tools.ts
@@ -30,6 +30,11 @@ import { convertToMermaid } from '@utils/node-graphs/export-mermaid';
 import config from '@config';
 import { glob } from 'glob';
 import path from 'node:path';
+import {
+  buildDocsSearchIndex,
+  chunkMarkdownByHeadings,
+  type DocsSearchIndex,
+} from '@enterprise/custom-documentation/utils/docs-search';
 
 const MESSAGE_COLLECTIONS = new Set(['events', 'commands', 'queries']);
 const LIKEC4_SOURCE_PATTERN = '**/*.{c4,likec4}';
@@ -1092,6 +1097,132 @@ export async function getArchitectureDiagramAsMermaid(params: {
 }
 
 // ============================================
+// Custom Documentation Tools
+// ============================================
+
+const CACHE_ENABLED = process.env.DISABLE_EVENTCATALOG_CACHE !== 'true';
+let cachedDocsSearchIndex: DocsSearchIndex | null = null;
+
+const findCustomDocByIdOrSlug = (docs: any[], idOrSlug: string) => {
+  const normalized = idOrSlug.toLowerCase().trim();
+  return (
+    docs.find((doc) => doc.id.toLowerCase() === normalized) ?? docs.find((doc) => doc.data.slug?.toLowerCase() === normalized)
+  );
+};
+
+const getDocsSearchIndex = async (): Promise<DocsSearchIndex> => {
+  if (CACHE_ENABLED && cachedDocsSearchIndex) {
+    return cachedDocsSearchIndex;
+  }
+
+  const docs = await getCollection('customPages');
+  cachedDocsSearchIndex = buildDocsSearchIndex(
+    docs.map((doc: any) => ({
+      id: doc.id,
+      title: doc.data.title,
+      summary: doc.data.summary,
+      body: doc.body,
+    }))
+  );
+
+  return cachedDocsSearchIndex;
+};
+
+/**
+ * List custom documentation pages (metadata only, no page content)
+ */
+export async function getCustomDocs(params: { cursor?: string; search?: string }) {
+  const docs = await getCollection('customPages');
+  let allResults = docs.map((doc: any) => ({
+    id: doc.id,
+    title: doc.data.title,
+    summary: doc.data.summary,
+    ...(doc.data.slug && { slug: doc.data.slug }),
+  }));
+
+  if (params.search) {
+    const searchTerm = params.search.toLowerCase().trim();
+    allResults = allResults.filter(
+      (doc: any) =>
+        doc.id?.toLowerCase().includes(searchTerm) ||
+        doc.title?.toLowerCase().includes(searchTerm) ||
+        doc.summary?.toLowerCase().includes(searchTerm)
+    );
+  }
+
+  const paginatedResult = paginate(allResults, params.cursor);
+
+  if ('error' in paginatedResult) {
+    return paginatedResult;
+  }
+
+  return {
+    docs: paginatedResult.items,
+    nextCursor: paginatedResult.nextCursor,
+    totalCount: paginatedResult.totalCount,
+  };
+}
+
+/**
+ * Full-text search across custom documentation pages.
+ * Matches at the section level so results point at the relevant part of a page.
+ */
+export async function searchCustomDocs(params: { query: string; limit?: number }) {
+  const query = params.query?.trim();
+
+  if (!query) {
+    return { error: 'A search query is required' };
+  }
+
+  const index = await getDocsSearchIndex();
+  const results = index.search(query, { limit: params.limit });
+
+  return { results, totalCount: results.length };
+}
+
+/**
+ * Get the full markdown content of a custom documentation page by id or slug.
+ * Pass a section heading to get just that section of the page.
+ */
+export async function getCustomDoc(params: { id: string; section?: string }) {
+  const docs = await getCollection('customPages');
+  const doc = findCustomDocByIdOrSlug(docs, params.id);
+
+  if (!doc) {
+    return { error: `Custom documentation page not found: ${params.id}` };
+  }
+
+  const { title, summary, slug, owners } = doc.data;
+  const metadata = {
+    id: doc.id,
+    title,
+    summary,
+    ...(slug && { slug }),
+    ...(owners && { owners }),
+  };
+
+  if (params.section) {
+    const requestedSection = params.section.toLowerCase().trim();
+    const sections = chunkMarkdownByHeadings(doc.body ?? '');
+    const section = sections.find((chunk) => chunk.heading?.toLowerCase() === requestedSection);
+
+    if (!section) {
+      const availableSections = sections
+        .map((chunk) => chunk.heading)
+        .filter(Boolean)
+        .join(', ');
+      return {
+        error: `Section "${params.section}" not found in ${doc.id}. Available sections: ${availableSections || 'none'}`,
+      };
+    }
+
+    return { ...metadata, section: section.heading, markdown: section.content };
+  }
+
+  return { ...metadata, markdown: doc.body ?? '' };
+}
+
+// ============================================
 // Tool metadata (descriptions)
 // ============================================
 
@@ -1131,4 +1262,10 @@ export const toolDescriptions = {
     'Use this tool to get the outputs (resources produced) for a data product. Returns fully hydrated output resources with their id, version, name, summary, collection type, and data contracts (if defined). Data contracts include the contract name, path, format, type, and content.',
   getArchitectureDiagramAsMermaid:
     'Use this tool to get the architecture diagram for a resource as Mermaid flowchart code. This shows how the resource connects to other resources (agents, services, systems, events, channels, etc.) in the architecture. The mermaid code can be rendered to visualize the architecture or used to understand relationships. Supported collections: events, commands, queries, agents, services, domains, systems, flows, containers, data-products.',
+  getCustomDocs:
+    'Use this tool to list the custom documentation pages in EventCatalog (guides, runbooks, architecture notes, onboarding docs, etc.). Returns page ids, titles, and summaries without page content. Supports pagination via cursor and filtering by search term (searches title, id, and summary).',
+  searchCustomDocs:
+    'Use this tool to search the full text of custom documentation pages in EventCatalog. Returns the best matching sections, each with the page id, section heading, and a short snippet. To read more, call getCustomDoc with the returned page id (and optionally the section heading). Reformulate the query and search again if the first results are not relevant. If you are unsure where to find something, or the structured catalog tools have not answered the question, search here - custom documentation often contains guides, runbooks, and context not captured elsewhere in the catalog. An empty result may simply mean the catalog has no custom documentation on the topic.',
+  getCustomDoc:
+    'Use this tool to get the full markdown content of a custom documentation page by its id or slug. Optionally pass a section heading to get only that section - prefer this for large pages to keep responses small.',
 };

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -115,6 +115,7 @@
     "marked": "^15.0.6",
     "mdast-util-find-and-replace": "^3.0.2",
     "mermaid": "^11.12.3",
+    "minisearch": "^7.2.0",
     "nanostores": "^1.1.0",
     "pagefind": "^1.5.2",
     "pako": "^2.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -295,6 +295,9 @@ importers:
       mermaid:
         specifier: ^11.12.3
         version: 11.12.3
+      minisearch:
+        specifier: ^7.2.0
+        version: 7.2.0
       nanostores:
         specifier: ^1.1.0
         version: 1.1.0
@@ -7270,6 +7273,9 @@ packages:
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  minisearch@7.2.0:
+    resolution: {integrity: sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==}
 
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
@@ -17711,6 +17717,8 @@ snapshots:
   minipass@7.1.2: {}
 
   minipass@7.1.3: {}
+
+  minisearch@7.2.0: {}
 
   mlly@1.8.0:
     dependencies:


### PR DESCRIPTION
## What This PR Does

Exposes EventCatalog's custom documentation pages (guides, runbooks, architecture notes, onboarding docs) to both the AI Chat and the MCP Server through three new tools. This lets AI assistants discover, search, and read the free-form documentation that lives in the catalog but isn't captured by the structured resource tools. Full-text search is powered by MiniSearch and operates at the markdown-section level, so results point at the specific part of a page rather than the whole document.

## Changes Overview

### Key Changes

- New shared tool implementations in `catalog-tools.ts`:
  - `getCustomDocs` — lists custom documentation pages (metadata only), with cursor pagination and an optional case-insensitive filter over title/id/summary.
  - `searchCustomDocs` — section-level full-text (BM25) search returning the best matching sections with page id, heading, snippet, and score.
  - `getCustomDoc` — returns the full markdown of a page by id or slug, or just a single section when a heading is provided.
- New `docs-search.ts` utility with:
  - `chunkMarkdownByHeadings` — splits markdown into section chunks at ATX headings (ignoring headings inside fenced code blocks).
  - `extractSnippet` — builds a query-centred excerpt for search results.
  - `buildDocsSearchIndex` — constructs an in-memory MiniSearch index, one entry per section, with field boosts and prefix matching.
- Registered all three tools in both the AI Chat API (`chat-api.ts`) and the MCP Server (`mcp-server.ts`) with matching Zod input schemas and tool descriptions.
- Added `minisearch` (`^7.2.0`) as a dependency of `@eventcatalog/core`.
- Added unit tests for the search utilities and the catalog tools, plus MCP server registration coverage.

## How It Works

Custom documentation pages come from the `customPages` collection. The list and get tools read directly from the collection; the search tool lazily builds a MiniSearch index (cached unless `DISABLE_EVENTCATALOG_CACHE=true`) that indexes each page as one entry per markdown section. Search matches are boosted by title/heading/summary and support prefix matching, and each hit is returned with a snippet centred on the query. `getCustomDoc` can return either the whole page or a single section, keeping responses small for large pages.

## Breaking Changes

None.

## Additional Notes

- Tools live in `@enterprise/tools/catalog-tools.ts` following the shared-implementation pattern, so AI Chat and MCP Server stay in sync.
- No changes are needed in the editor repo (`eventcatalog/eventcatalog-editor`) — this is server-side tooling for AI Chat and the MCP Server only.