### PR TITLE
Persist Discover table filters in the URL

### DIFF
--- a/.changeset/wise-otters-filter.md
+++ b/.changeset/wise-otters-filter.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Persist Discover table filters in the URL so searches, filters, and toggles survive page reloads and can be shared via link

--- a/packages/core/eventcatalog/src/components/Tables/Discover/DiscoverTable.tsx
+++ b/packages/core/eventcatalog/src/components/Tables/Discover/DiscoverTable.tsx
@@ -20,6 +20,7 @@ import { resolveIconUrl } from '@utils/icon';
 import { FilterDropdown, CheckboxItem } from './FilterComponents';
 import { getDiscoverColumns } from './columns';
 import { formatAdrStatus, type AdrStatus } from '@utils/collections/adr-constants';
+import { buildDiscoverFilterSearch, filterKnownValues, parseDiscoverFilterSearch } from './url-filters';
 
 export type CollectionType =
   | 'agents'
@@ -161,6 +162,9 @@ const AgentProviderIcon = ({ provider, className }: { provider: string; classNam
   return <img src={providerIconUrls.default} alt="" className={className} loading="lazy" />;
 };
 
+const areStringArraysEqual = (left: string[], right: string[]) =>
+  left.length === right.length && left.every((value, index) => value === right[index]);
+
 export function DiscoverTable<T extends DiscoverTableData>({
   data: initialData,
   collectionType,
@@ -185,34 +189,6 @@ export function DiscoverTable<T extends DiscoverTableData>({
     () => getDiscoverColumns(collectionType, tableConfiguration ?? { columns: {} }),
     [collectionType, tableConfiguration]
   );
-  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
-  const [sorting, setSorting] = useState<SortingState>([]);
-  const [tableFilter, setTableFilter] = useState('');
-  const PAGE_SIZE_OPTIONS = [10, 25, 50, 100];
-  const PAGE_SIZE_STORAGE_KEY = 'eventcatalog-discover-page-size';
-  const [pageSize, setPageSize] = useState<number>(() => {
-    if (typeof window === 'undefined') return 10;
-    const stored = Number(window.localStorage.getItem(PAGE_SIZE_STORAGE_KEY));
-    return PAGE_SIZE_OPTIONS.includes(stored) ? stored : 10;
-  });
-  useEffect(() => {
-    if (typeof window !== 'undefined') {
-      window.localStorage.setItem(PAGE_SIZE_STORAGE_KEY, String(pageSize));
-    }
-  }, [pageSize]);
-  const [showOnlyLatest, setShowOnlyLatest] = useState(true);
-  const [onlyShowDrafts, setOnlyShowDrafts] = useState(false);
-  const [selectedDomains, setSelectedDomains] = useState<string[]>([]);
-  const [selectedOwners, setSelectedOwners] = useState<string[]>([]);
-  const [selectedProducers, setSelectedProducers] = useState<string[]>([]);
-  const [selectedConsumers, setSelectedConsumers] = useState<string[]>([]);
-  const [selectedAgentProviders, setSelectedAgentProviders] = useState<string[]>([]);
-  const [selectedAgentModels, setSelectedAgentModels] = useState<string[]>([]);
-  const [selectedBadges, setSelectedBadges] = useState<string[]>([]);
-  const [selectedProperties, setSelectedProperties] = useState<string[]>([]);
-  const [selectedStatuses, setSelectedStatuses] = useState<string[]>([]);
-  const selectedKind = collectionKinds.find((kind) => kind.id === collectionType);
-
   // Collect unique badges from all items
   const allBadges = useMemo(() => {
     const badgeMap = new Map<string, { content: string; backgroundColor?: string; textColor?: string; count: number }>();
@@ -234,6 +210,168 @@ export function DiscoverTable<T extends DiscoverTableData>({
     });
     return Array.from(badgeMap.values()).sort((a, b) => b.count - a.count);
   }, [initialData]);
+  const statusCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    initialData.forEach((item) => {
+      const status = item.data.status;
+      if (status) counts[status] = (counts[status] || 0) + 1;
+    });
+    return counts;
+  }, [initialData]);
+
+  const statusOptions = useMemo(
+    () =>
+      Object.keys(statusCounts)
+        .map((status) => ({
+          id: status,
+          name: formatAdrStatus(status as AdrStatus),
+          count: statusCounts[status],
+        }))
+        .sort((a, b) => a.name.localeCompare(b.name)),
+    [statusCounts]
+  );
+  const [initialUrlFilters] = useState(() =>
+    parseDiscoverFilterSearch(typeof window === 'undefined' ? '' : window.location.search)
+  );
+  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+  const [sorting, setSorting] = useState<SortingState>([]);
+  const [tableFilter, setTableFilter] = useState(initialUrlFilters.q);
+  const PAGE_SIZE_OPTIONS = [10, 25, 50, 100];
+  const PAGE_SIZE_STORAGE_KEY = 'eventcatalog-discover-page-size';
+  const [pageSize, setPageSize] = useState<number>(() => {
+    if (typeof window === 'undefined') return 10;
+    const stored = Number(window.localStorage.getItem(PAGE_SIZE_STORAGE_KEY));
+    return PAGE_SIZE_OPTIONS.includes(stored) ? stored : 10;
+  });
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(PAGE_SIZE_STORAGE_KEY, String(pageSize));
+    }
+  }, [pageSize]);
+  const [showOnlyLatest, setShowOnlyLatest] = useState(initialUrlFilters.showOnlyLatest);
+  const [onlyShowDrafts, setOnlyShowDrafts] = useState(initialUrlFilters.onlyShowDrafts);
+  const [selectedDomains, setSelectedDomains] = useState<string[]>(() =>
+    showDomainsFilter ? filterKnownValues(initialUrlFilters.domains, new Set(domains.map((domain) => domain.id))) : []
+  );
+  const [selectedOwners, setSelectedOwners] = useState<string[]>(() =>
+    showOwnersFilter ? filterKnownValues(initialUrlFilters.owners, new Set(owners.map((owner) => owner.id))) : []
+  );
+  const [selectedProducers, setSelectedProducers] = useState<string[]>(() =>
+    showProducersFilter ? filterKnownValues(initialUrlFilters.producers, new Set(producers.map((producer) => producer.id))) : []
+  );
+  const [selectedConsumers, setSelectedConsumers] = useState<string[]>(() =>
+    showConsumersFilter ? filterKnownValues(initialUrlFilters.consumers, new Set(consumers.map((consumer) => consumer.id))) : []
+  );
+  const [selectedAgentProviders, setSelectedAgentProviders] = useState<string[]>(() =>
+    collectionType === 'agents'
+      ? filterKnownValues(initialUrlFilters.agentProviders, new Set(agentProviders.map((provider) => provider.id)))
+      : []
+  );
+  const [selectedAgentModels, setSelectedAgentModels] = useState<string[]>(() =>
+    collectionType === 'agents'
+      ? filterKnownValues(initialUrlFilters.agentModels, new Set(agentModels.map((model) => model.id)))
+      : []
+  );
+  const [selectedBadges, setSelectedBadges] = useState<string[]>(() =>
+    filterKnownValues(initialUrlFilters.badges, new Set(allBadges.map((badge) => badge.content)))
+  );
+  const [selectedProperties, setSelectedProperties] = useState<string[]>(() =>
+    filterKnownValues(initialUrlFilters.properties, new Set(propertyOptions.map((property) => property.id)))
+  );
+  const [selectedStatuses, setSelectedStatuses] = useState<string[]>(() =>
+    collectionType === 'adrs'
+      ? filterKnownValues(initialUrlFilters.statuses, new Set(statusOptions.map((status) => status.id)))
+      : []
+  );
+  const selectedKind = collectionKinds.find((kind) => kind.id === collectionType);
+  const knownFilterValues = useMemo(
+    () => ({
+      domains: showDomainsFilter ? new Set(domains.map((domain) => domain.id)) : new Set<string>(),
+      owners: showOwnersFilter ? new Set(owners.map((owner) => owner.id)) : new Set<string>(),
+      producers: showProducersFilter ? new Set(producers.map((producer) => producer.id)) : new Set<string>(),
+      consumers: showConsumersFilter ? new Set(consumers.map((consumer) => consumer.id)) : new Set<string>(),
+      agentProviders: collectionType === 'agents' ? new Set(agentProviders.map((provider) => provider.id)) : new Set<string>(),
+      agentModels: collectionType === 'agents' ? new Set(agentModels.map((model) => model.id)) : new Set<string>(),
+      badges: new Set(allBadges.map((badge) => badge.content)),
+      properties: new Set(propertyOptions.map((property) => property.id)),
+      statuses: collectionType === 'adrs' ? new Set(statusOptions.map((status) => status.id)) : new Set<string>(),
+    }),
+    [
+      agentModels,
+      agentProviders,
+      allBadges,
+      collectionType,
+      consumers,
+      domains,
+      owners,
+      producers,
+      propertyOptions,
+      showConsumersFilter,
+      showDomainsFilter,
+      showOwnersFilter,
+      showProducersFilter,
+      statusOptions,
+    ]
+  );
+  const currentUrlFilters = useMemo(
+    () => ({
+      q: tableFilter,
+      domains: selectedDomains,
+      owners: selectedOwners,
+      producers: selectedProducers,
+      consumers: selectedConsumers,
+      agentProviders: selectedAgentProviders,
+      agentModels: selectedAgentModels,
+      badges: selectedBadges,
+      properties: selectedProperties,
+      statuses: selectedStatuses,
+      showOnlyLatest,
+      onlyShowDrafts,
+    }),
+    [
+      onlyShowDrafts,
+      selectedAgentModels,
+      selectedAgentProviders,
+      selectedBadges,
+      selectedConsumers,
+      selectedDomains,
+      selectedOwners,
+      selectedProducers,
+      selectedProperties,
+      selectedStatuses,
+      showOnlyLatest,
+      tableFilter,
+    ]
+  );
+
+  useEffect(() => {
+    const pruneState = (values: string[], knownValues: Set<string>) => {
+      const nextValues = filterKnownValues(values, knownValues);
+      return areStringArraysEqual(values, nextValues) ? values : nextValues;
+    };
+
+    setSelectedDomains((values) => pruneState(values, knownFilterValues.domains));
+    setSelectedOwners((values) => pruneState(values, knownFilterValues.owners));
+    setSelectedProducers((values) => pruneState(values, knownFilterValues.producers));
+    setSelectedConsumers((values) => pruneState(values, knownFilterValues.consumers));
+    setSelectedAgentProviders((values) => pruneState(values, knownFilterValues.agentProviders));
+    setSelectedAgentModels((values) => pruneState(values, knownFilterValues.agentModels));
+    setSelectedBadges((values) => pruneState(values, knownFilterValues.badges));
+    setSelectedProperties((values) => pruneState(values, knownFilterValues.properties));
+    setSelectedStatuses((values) => pruneState(values, knownFilterValues.statuses));
+  }, [knownFilterValues]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const nextSearch = buildDiscoverFilterSearch(currentUrlFilters, window.location.search);
+    const nextUrl = `${window.location.pathname}${nextSearch}${window.location.hash}`;
+    const currentUrl = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+
+    if (nextUrl !== currentUrl) {
+      window.history.replaceState(window.history.state, '', nextUrl);
+    }
+  }, [currentUrlFilters]);
 
   // Filter data based on all filter states
   const filteredData = useMemo(() => {
@@ -514,27 +652,6 @@ export function DiscoverTable<T extends DiscoverTableData>({
     return counts;
   }, [initialData]);
 
-  const statusCounts = useMemo(() => {
-    const counts: Record<string, number> = {};
-    initialData.forEach((item) => {
-      const status = item.data.status;
-      if (status) counts[status] = (counts[status] || 0) + 1;
-    });
-    return counts;
-  }, [initialData]);
-
-  const statusOptions = useMemo(
-    () =>
-      Object.keys(statusCounts)
-        .map((status) => ({
-          id: status,
-          name: formatAdrStatus(status as AdrStatus),
-          count: statusCounts[status],
-        }))
-        .sort((a, b) => a.name.localeCompare(b.name)),
-    [statusCounts]
-  );
-
   const toggleDomain = (domainId: string) => {
     setSelectedDomains((prev) => (prev.includes(domainId) ? prev.filter((id) => id !== domainId) : [...prev, domainId]));
   };
@@ -576,7 +693,7 @@ export function DiscoverTable<T extends DiscoverTableData>({
   const navigateToKind = (kindId: CollectionType) => {
     const selectedKind = collectionKinds.find((kind) => kind.id === kindId);
     if (!selectedKind || selectedKind.id === collectionType) return;
-    window.location.href = selectedKind.href;
+    window.location.href = `${selectedKind.href}${buildDiscoverFilterSearch(currentUrlFilters)}`;
   };
 
   const clearAllFilters = () => {
@@ -606,7 +723,8 @@ export function DiscoverTable<T extends DiscoverTableData>({
     selectedStatuses.length +
     selectedProperties.length +
     (!showOnlyLatest ? 1 : 0) +
-    (onlyShowDrafts ? 1 : 0);
+    (onlyShowDrafts ? 1 : 0) +
+    (tableFilter ? 1 : 0);
 
   // Get selected domain names for display
   const selectedDomainNames = selectedDomains.map((id) => domains.find((d) => d.id === id)?.name || id);

--- a/packages/core/eventcatalog/src/components/Tables/Discover/__tests__/url-filters.spec.ts
+++ b/packages/core/eventcatalog/src/components/Tables/Discover/__tests__/url-filters.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { buildDiscoverFilterSearch, filterKnownValues, parseDiscoverFilterSearch } from '../url-filters';
+
+describe('discover filter URL helpers', () => {
+  it('parses repeated filter params from the URL', () => {
+    expect(
+      parseDiscoverFilterSearch('?q=orders&domain=Sales&domain=Payments&owner=team-a&property=hasOwners&latest=false&drafts=true')
+    ).toEqual({
+      q: 'orders',
+      domains: ['Sales', 'Payments'],
+      owners: ['team-a'],
+      producers: [],
+      consumers: [],
+      agentProviders: [],
+      agentModels: [],
+      badges: [],
+      properties: ['hasOwners'],
+      statuses: [],
+      showOnlyLatest: false,
+      onlyShowDrafts: true,
+    });
+  });
+
+  it('writes only non-default filter params and preserves unrelated params', () => {
+    expect(
+      buildDiscoverFilterSearch(
+        {
+          q: 'orders',
+          domains: ['Sales'],
+          owners: [],
+          producers: [],
+          consumers: [],
+          agentProviders: [],
+          agentModels: [],
+          badges: ['Critical'],
+          properties: ['hasOwners'],
+          statuses: [],
+          showOnlyLatest: false,
+          onlyShowDrafts: false,
+        },
+        '?environment=prod&domain=Old'
+      )
+    ).toBe('?environment=prod&q=orders&domain=Sales&badge=Critical&property=hasOwners&latest=false');
+  });
+
+  it('filters stale values against the options available on the current page', () => {
+    expect(filterKnownValues(['Sales', 'Deleted'], new Set(['Sales', 'Payments']))).toEqual(['Sales']);
+  });
+});

--- a/packages/core/eventcatalog/src/components/Tables/Discover/url-filters.ts
+++ b/packages/core/eventcatalog/src/components/Tables/Discover/url-filters.ts
@@ -1,0 +1,85 @@
+export interface DiscoverFilterQueryState {
+  q: string;
+  domains: string[];
+  owners: string[];
+  producers: string[];
+  consumers: string[];
+  agentProviders: string[];
+  agentModels: string[];
+  badges: string[];
+  properties: string[];
+  statuses: string[];
+  showOnlyLatest: boolean;
+  onlyShowDrafts: boolean;
+}
+
+const FILTER_PARAM_NAMES = [
+  'q',
+  'domain',
+  'owner',
+  'producer',
+  'consumer',
+  'agentProvider',
+  'agentModel',
+  'badge',
+  'property',
+  'status',
+  'latest',
+  'drafts',
+];
+
+const uniqueNonEmpty = (values: string[]) => Array.from(new Set(values.map((value) => value.trim()).filter(Boolean)));
+
+const getValues = (params: URLSearchParams, paramName: string) => uniqueNonEmpty(params.getAll(paramName));
+
+const isFalse = (value: string | null) => value === 'false' || value === '0';
+
+const isTrue = (value: string | null) => value === 'true' || value === '1';
+
+export const parseDiscoverFilterSearch = (search: string): DiscoverFilterQueryState => {
+  const params = new URLSearchParams(search);
+
+  return {
+    q: params.get('q')?.trim() ?? '',
+    domains: getValues(params, 'domain'),
+    owners: getValues(params, 'owner'),
+    producers: getValues(params, 'producer'),
+    consumers: getValues(params, 'consumer'),
+    agentProviders: getValues(params, 'agentProvider'),
+    agentModels: getValues(params, 'agentModel'),
+    badges: getValues(params, 'badge'),
+    properties: getValues(params, 'property'),
+    statuses: getValues(params, 'status'),
+    showOnlyLatest: !isFalse(params.get('latest')),
+    onlyShowDrafts: isTrue(params.get('drafts')),
+  };
+};
+
+export const filterKnownValues = (values: string[], knownValues: Set<string>) => values.filter((value) => knownValues.has(value));
+
+export const buildDiscoverFilterSearch = (filters: DiscoverFilterQueryState, currentSearch = '') => {
+  const params = new URLSearchParams(currentSearch);
+  FILTER_PARAM_NAMES.forEach((paramName) => params.delete(paramName));
+
+  const appendValues = (paramName: string, values: string[]) => {
+    uniqueNonEmpty(values).forEach((value) => params.append(paramName, value));
+  };
+
+  const q = filters.q.trim();
+  if (q) params.set('q', q);
+  appendValues('domain', filters.domains);
+  appendValues('owner', filters.owners);
+  appendValues('producer', filters.producers);
+  appendValues('consumer', filters.consumers);
+  appendValues('agentProvider', filters.agentProviders);
+  appendValues('agentModel', filters.agentModels);
+  appendValues('badge', filters.badges);
+  appendValues('property', filters.properties);
+  appendValues('status', filters.statuses);
+
+  if (!filters.showOnlyLatest) params.set('latest', 'false');
+  if (filters.onlyShowDrafts) params.set('drafts', 'true');
+
+  const search = params.toString();
+  return search ? `?${search}` : '';
+};


### PR DESCRIPTION
## What This PR Does

The Discover table now stores its active search, filters, and toggles in the URL query string. When a user filters, searches, or changes the "only latest" / "drafts" toggles, the URL updates in place — so reloading the page keeps the current view, and the link can be shared to reproduce the exact same filtered state. Switching between collection kinds also carries the filters across.

## Changes Overview

### Key Changes
- Added `url-filters.ts` with pure helpers to parse the query string into filter state (`parseDiscoverFilterSearch`), serialize filter state back into a query string (`buildDiscoverFilterSearch`), and drop values that no longer exist in the dataset (`filterKnownValues`).
- Initialised `DiscoverTable` filter state from the URL on first render, including the free-text search box.
- Added an effect that writes the current filter state back to the URL via `history.replaceState` (no new history entries).
- Added an effect that prunes selected filter values when the underlying known values change, so stale selections don't linger.
- Carried filters over when navigating to a different collection kind.
- Counted an active free-text search toward the active-filter badge count.
- Added unit tests for the parse/build/prune helpers.

## How It Works

Filter state lives in React state as before. On mount, the state is seeded from `window.location.search`, guarding against unknown values (e.g. a `domain` in the URL that no longer exists). A `useEffect` watching the combined filter state rebuilds the query string and calls `history.replaceState` only when the URL actually changes, avoiding redundant history writes. The serialization/parsing logic is isolated in `url-filters.ts` and covered by unit tests, keeping the component focused on wiring.

## Breaking Changes

None.

## Additional Notes

The URL uses short param names (`domain`, `owner`, `q`, `latest`, `drafts`, etc.) and supports repeated params for multi-select filters. Boolean toggles are only written when they differ from their defaults, keeping shared URLs clean.