### PR TITLE
Add domain type filter and nested subdomains to Discover table

### DIFF
--- a/.changeset/swift-otters-wander.md
+++ b/.changeset/swift-otters-wander.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Add a domain type filter (root domains / subdomains) to the Discover table and show subdomains nested under their parent domain in the name column.

--- a/packages/core/eventcatalog/src/components/Tables/Discover/DiscoverTable.tsx
+++ b/packages/core/eventcatalog/src/components/Tables/Discover/DiscoverTable.tsx
@@ -54,6 +54,7 @@ export interface DiscoverTableData {
   hasServices?: boolean;
   hasFlows?: boolean;
   isSubdomain?: boolean;
+  parentDomains?: Array<{ id: string; name: string; version: string }>;
   data: {
     id: string;
     name: string;
@@ -84,6 +85,7 @@ export interface DiscoverTableData {
     model?: any;
     agents?: Array<any>;
     services?: Array<any>;
+    domains?: Array<any>;
     flows?: Array<any>;
     servicesThatWriteToContainer?: Array<any>;
     servicesThatReadFromContainer?: Array<any>;
@@ -164,6 +166,11 @@ const AgentProviderIcon = ({ provider, className }: { provider: string; classNam
 
 const areStringArraysEqual = (left: string[], right: string[]) =>
   left.length === right.length && left.every((value, index) => value === right[index]);
+
+const DOMAIN_TYPE_OPTIONS = [
+  { id: 'root', label: 'Root domains' },
+  { id: 'subdomain', label: 'Subdomains' },
+];
 
 export function DiscoverTable<T extends DiscoverTableData>({
   data: initialData,
@@ -272,6 +279,13 @@ export function DiscoverTable<T extends DiscoverTableData>({
       ? filterKnownValues(initialUrlFilters.agentModels, new Set(agentModels.map((model) => model.id)))
       : []
   );
+  const [selectedDomainTypes, setSelectedDomainTypes] = useState<string[]>(() =>
+    collectionType === 'domains'
+      ? initialUrlFilters.domainTypes.length > 0
+        ? filterKnownValues(initialUrlFilters.domainTypes, new Set(DOMAIN_TYPE_OPTIONS.map((option) => option.id)))
+        : ['root']
+      : []
+  );
   const [selectedBadges, setSelectedBadges] = useState<string[]>(() =>
     filterKnownValues(initialUrlFilters.badges, new Set(allBadges.map((badge) => badge.content)))
   );
@@ -292,6 +306,7 @@ export function DiscoverTable<T extends DiscoverTableData>({
       consumers: showConsumersFilter ? new Set(consumers.map((consumer) => consumer.id)) : new Set<string>(),
       agentProviders: collectionType === 'agents' ? new Set(agentProviders.map((provider) => provider.id)) : new Set<string>(),
       agentModels: collectionType === 'agents' ? new Set(agentModels.map((model) => model.id)) : new Set<string>(),
+      domainTypes: collectionType === 'domains' ? new Set(DOMAIN_TYPE_OPTIONS.map((option) => option.id)) : new Set<string>(),
       badges: new Set(allBadges.map((badge) => badge.content)),
       properties: new Set(propertyOptions.map((property) => property.id)),
       statuses: collectionType === 'adrs' ? new Set(statusOptions.map((status) => status.id)) : new Set<string>(),
@@ -325,6 +340,7 @@ export function DiscoverTable<T extends DiscoverTableData>({
       badges: selectedBadges,
       properties: selectedProperties,
       statuses: selectedStatuses,
+      domainTypes: selectedDomainTypes,
       showOnlyLatest,
       onlyShowDrafts,
     }),
@@ -334,6 +350,7 @@ export function DiscoverTable<T extends DiscoverTableData>({
       selectedAgentProviders,
       selectedBadges,
       selectedConsumers,
+      selectedDomainTypes,
       selectedDomains,
       selectedOwners,
       selectedProducers,
@@ -356,6 +373,7 @@ export function DiscoverTable<T extends DiscoverTableData>({
     setSelectedConsumers((values) => pruneState(values, knownFilterValues.consumers));
     setSelectedAgentProviders((values) => pruneState(values, knownFilterValues.agentProviders));
     setSelectedAgentModels((values) => pruneState(values, knownFilterValues.agentModels));
+    setSelectedDomainTypes((values) => pruneState(values, knownFilterValues.domainTypes));
     setSelectedBadges((values) => pruneState(values, knownFilterValues.badges));
     setSelectedProperties((values) => pruneState(values, knownFilterValues.properties));
     setSelectedStatuses((values) => pruneState(values, knownFilterValues.statuses));
@@ -398,6 +416,15 @@ export function DiscoverTable<T extends DiscoverTableData>({
         const itemDomains = row.domains || [];
         const hasMatchingDomain = itemDomains.some((d) => selectedDomains.includes(d.id));
         if (!hasMatchingDomain) {
+          return false;
+        }
+      }
+
+      // Domain type filter
+      if (collectionType === 'domains' && selectedDomainTypes.length > 0) {
+        const matchesRoot = selectedDomainTypes.includes('root') && !row.isSubdomain;
+        const matchesSubdomain = selectedDomainTypes.includes('subdomain') && row.isSubdomain;
+        if (!matchesRoot && !matchesSubdomain) {
           return false;
         }
       }
@@ -541,6 +568,7 @@ export function DiscoverTable<T extends DiscoverTableData>({
     selectedOwners,
     selectedProducers,
     selectedConsumers,
+    selectedDomainTypes,
     selectedAgentProviders,
     selectedAgentModels,
     selectedBadges,
@@ -652,6 +680,18 @@ export function DiscoverTable<T extends DiscoverTableData>({
     return counts;
   }, [initialData]);
 
+  const domainTypeCounts = useMemo(() => {
+    const counts: Record<string, number> = { root: 0, subdomain: 0 };
+    initialData.forEach((item) => {
+      if (item.isSubdomain) {
+        counts.subdomain++;
+      } else {
+        counts.root++;
+      }
+    });
+    return counts;
+  }, [initialData]);
+
   const toggleDomain = (domainId: string) => {
     setSelectedDomains((prev) => (prev.includes(domainId) ? prev.filter((id) => id !== domainId) : [...prev, domainId]));
   };
@@ -676,6 +716,12 @@ export function DiscoverTable<T extends DiscoverTableData>({
 
   const toggleAgentModel = (modelId: string) => {
     setSelectedAgentModels((prev) => (prev.includes(modelId) ? prev.filter((id) => id !== modelId) : [...prev, modelId]));
+  };
+
+  const toggleDomainType = (domainType: string) => {
+    setSelectedDomainTypes((prev) =>
+      prev.includes(domainType) ? prev.filter((id) => id !== domainType) : [...prev, domainType]
+    );
   };
 
   const toggleBadge = (badgeContent: string) => {
@@ -703,6 +749,7 @@ export function DiscoverTable<T extends DiscoverTableData>({
     setSelectedConsumers([]);
     setSelectedAgentProviders([]);
     setSelectedAgentModels([]);
+    setSelectedDomainTypes(collectionType === 'domains' ? ['root'] : []);
     setSelectedBadges([]);
     setSelectedStatuses([]);
     setSelectedProperties([]);
@@ -719,6 +766,7 @@ export function DiscoverTable<T extends DiscoverTableData>({
     selectedConsumers.length +
     selectedAgentProviders.length +
     selectedAgentModels.length +
+    selectedDomainTypes.length +
     selectedBadges.length +
     selectedStatuses.length +
     selectedProperties.length +
@@ -742,6 +790,9 @@ export function DiscoverTable<T extends DiscoverTableData>({
     (id) => agentProviders.find((provider) => provider.id === id)?.name || id
   );
   const selectedAgentModelNames = selectedAgentModels.map((id) => agentModels.find((model) => model.id === id)?.name || id);
+  const selectedDomainTypeNames = selectedDomainTypes.map(
+    (id) => DOMAIN_TYPE_OPTIONS.find((option) => option.id === id)?.label || id
+  );
   const selectedStatusNames = selectedStatuses.map((id) => statusOptions.find((status) => status.id === id)?.name || id);
 
   // Filter producers/consumers to only show those with count > 0
@@ -853,6 +904,33 @@ export function DiscoverTable<T extends DiscoverTableData>({
 
           {/* Catalog Filters Section */}
           <div className="space-y-3">
+            {collectionType === 'domains' && (
+              <div>
+                <label className="block text-xs font-medium text-[rgb(var(--ec-page-text)/0.8)] mb-1.5">
+                  Filter by Domain type
+                </label>
+                <FilterDropdown
+                  label="All domains"
+                  selectedItems={selectedDomainTypeNames}
+                  onClear={() => setSelectedDomainTypes([])}
+                  onRemoveItem={(label) => {
+                    const option = DOMAIN_TYPE_OPTIONS.find((item) => item.label === label);
+                    if (option) toggleDomainType(option.id);
+                  }}
+                >
+                  {DOMAIN_TYPE_OPTIONS.map((option) => (
+                    <CheckboxItem
+                      key={option.id}
+                      label={option.label}
+                      checked={selectedDomainTypes.includes(option.id)}
+                      onChange={() => toggleDomainType(option.id)}
+                      count={domainTypeCounts[option.id] || 0}
+                    />
+                  ))}
+                </FilterDropdown>
+              </div>
+            )}
+
             {collectionType === 'agents' && (filteredAgentProviders.length > 0 || filteredAgentModels.length > 0) && (
               <>
                 {filteredAgentProviders.length > 0 && (

--- a/packages/core/eventcatalog/src/components/Tables/Discover/__tests__/url-filters.spec.ts
+++ b/packages/core/eventcatalog/src/components/Tables/Discover/__tests__/url-filters.spec.ts
@@ -4,7 +4,9 @@ import { buildDiscoverFilterSearch, filterKnownValues, parseDiscoverFilterSearch
 describe('discover filter URL helpers', () => {
   it('parses repeated filter params from the URL', () => {
     expect(
-      parseDiscoverFilterSearch('?q=orders&domain=Sales&domain=Payments&owner=team-a&property=hasOwners&latest=false&drafts=true')
+      parseDiscoverFilterSearch(
+        '?q=orders&domain=Sales&domain=Payments&owner=team-a&domainType=subdomain&property=hasOwners&latest=false&drafts=true'
+      )
     ).toEqual({
       q: 'orders',
       domains: ['Sales', 'Payments'],
@@ -13,6 +15,7 @@ describe('discover filter URL helpers', () => {
       consumers: [],
       agentProviders: [],
       agentModels: [],
+      domainTypes: ['subdomain'],
       badges: [],
       properties: ['hasOwners'],
       statuses: [],
@@ -32,6 +35,7 @@ describe('discover filter URL helpers', () => {
           consumers: [],
           agentProviders: [],
           agentModels: [],
+          domainTypes: ['root'],
           badges: ['Critical'],
           properties: ['hasOwners'],
           statuses: [],
@@ -40,7 +44,7 @@ describe('discover filter URL helpers', () => {
         },
         '?environment=prod&domain=Old'
       )
-    ).toBe('?environment=prod&q=orders&domain=Sales&badge=Critical&property=hasOwners&latest=false');
+    ).toBe('?environment=prod&q=orders&domain=Sales&domainType=root&badge=Critical&property=hasOwners&latest=false');
   });
 
   it('filters stale values against the options available on the current page', () => {

--- a/packages/core/eventcatalog/src/components/Tables/Discover/columns.tsx
+++ b/packages/core/eventcatalog/src/components/Tables/Discover/columns.tsx
@@ -19,6 +19,7 @@ import { favoritesStore, toggleFavorite, type FavoriteItem } from '../../../stor
 import type { DiscoverTableData, CollectionType } from './DiscoverTable';
 import type { TableConfiguration } from '@types';
 import { formatAdrDate, isAdrCollection } from '@utils/collections/adr-constants';
+import { CornerDownRight } from 'lucide-react';
 
 const columnHelper = createColumnHelper<DiscoverTableData>();
 
@@ -121,22 +122,48 @@ const ResourceNameCell = ({ item }: { item: DiscoverTableData }) => {
   const { color, Icon } = getColorAndIconForCollection(item.collection);
   const resourceIcon = item.data.icon;
   const resourceIconUrl = isIconPath(resourceIcon) ? resolveIconUrl(resourceIcon) : null;
+  const isDomain = item.collection === 'domains';
+  const subdomains = isDomain ? item.data.domains || [] : [];
 
   return (
-    <a
-      href={buildUrl(`/docs/${item.collection}/${item.data.id}/${item.data.version}`)}
-      className="group inline-flex items-center gap-2.5 hover:text-[rgb(var(--ec-accent))] transition-colors"
-    >
-      {resourceIconUrl ? (
-        <img src={resourceIconUrl} alt="" className="h-5 w-5 flex-shrink-0 rounded-sm object-contain" />
-      ) : (
-        <Icon className={`h-4 w-4 flex-shrink-0 ${getCollectionTextColorClass(color, 'text-[rgb(var(--ec-icon-color))]')}`} />
+    <div className="flex min-w-0 flex-col gap-2">
+      <a
+        href={buildUrl(`/docs/${item.collection}/${item.data.id}/${item.data.version}`)}
+        className="group inline-flex items-center gap-2.5 hover:text-[rgb(var(--ec-accent))] transition-colors"
+      >
+        {resourceIconUrl ? (
+          <img src={resourceIconUrl} alt="" className="h-5 w-5 flex-shrink-0 rounded-sm object-contain" />
+        ) : (
+          <Icon className={`h-4 w-4 flex-shrink-0 ${getCollectionTextColorClass(color, 'text-[rgb(var(--ec-icon-color))]')}`} />
+        )}
+        <span className="text-sm font-semibold text-[rgb(var(--ec-page-text))] group-hover:text-[rgb(var(--ec-accent))]">
+          {item.data.name}
+        </span>
+        {!isLatestVersion && <span className="text-xs text-[rgb(var(--ec-icon-color))]">v{item.data.version}</span>}
+        {item.isSubdomain && (
+          <span className="rounded-full border border-[rgb(var(--ec-page-border))] px-1.5 py-0.5 text-[10px] font-medium text-[rgb(var(--ec-page-text-muted))]">
+            Subdomain
+          </span>
+        )}
+      </a>
+
+      {subdomains.length > 0 && (
+        <div className="flex flex-col gap-1 pl-6">
+          {subdomains.map((domain: any) => (
+            <a
+              key={`${domain.data.id}-${domain.data.version}`}
+              href={buildUrl(`/docs/${domain.collection || 'domains'}/${domain.data.id}/${domain.data.version}`)}
+              className="group/subdomain inline-flex w-fit items-center gap-1.5 text-xs text-[rgb(var(--ec-page-text-muted))] hover:text-[rgb(var(--ec-accent))]"
+            >
+              <CornerDownRight className="h-3.5 w-3.5 flex-shrink-0 text-[rgb(var(--ec-icon-color))] group-hover/subdomain:text-[rgb(var(--ec-accent))]" />
+              <span className="font-medium text-[rgb(var(--ec-page-text))] group-hover/subdomain:text-[rgb(var(--ec-accent))]">
+                {domain.data.name}
+              </span>
+            </a>
+          ))}
+        </div>
       )}
-      <span className="text-sm font-semibold text-[rgb(var(--ec-page-text))] group-hover:text-[rgb(var(--ec-accent))]">
-        {item.data.name}
-      </span>
-      {!isLatestVersion && <span className="text-xs text-[rgb(var(--ec-icon-color))]">v{item.data.version}</span>}
-    </a>
+    </div>
   );
 };
 

--- a/packages/core/eventcatalog/src/components/Tables/Discover/url-filters.ts
+++ b/packages/core/eventcatalog/src/components/Tables/Discover/url-filters.ts
@@ -6,6 +6,7 @@ export interface DiscoverFilterQueryState {
   consumers: string[];
   agentProviders: string[];
   agentModels: string[];
+  domainTypes: string[];
   badges: string[];
   properties: string[];
   statuses: string[];
@@ -21,6 +22,7 @@ const FILTER_PARAM_NAMES = [
   'consumer',
   'agentProvider',
   'agentModel',
+  'domainType',
   'badge',
   'property',
   'status',
@@ -47,6 +49,7 @@ export const parseDiscoverFilterSearch = (search: string): DiscoverFilterQuerySt
     consumers: getValues(params, 'consumer'),
     agentProviders: getValues(params, 'agentProvider'),
     agentModels: getValues(params, 'agentModel'),
+    domainTypes: getValues(params, 'domainType'),
     badges: getValues(params, 'badge'),
     properties: getValues(params, 'property'),
     statuses: getValues(params, 'status'),
@@ -73,6 +76,7 @@ export const buildDiscoverFilterSearch = (filters: DiscoverFilterQueryState, cur
   appendValues('consumer', filters.consumers);
   appendValues('agentProvider', filters.agentProviders);
   appendValues('agentModel', filters.agentModels);
+  appendValues('domainType', filters.domainTypes);
   appendValues('badge', filters.badges);
   appendValues('property', filters.properties);
   appendValues('status', filters.statuses);

--- a/packages/core/eventcatalog/src/pages/discover/[type]/index.astro
+++ b/packages/core/eventcatalog/src/pages/discover/[type]/index.astro
@@ -93,7 +93,6 @@ const typeConfig: Record<
     propertyOptions: [
       { id: 'hasServices', label: 'Has Services' },
       { id: 'hasOwners', label: 'Has Owners' },
-      { id: 'isSubdomain', label: 'Is Subdomain' },
       { id: 'isDeprecated', label: 'Is Deprecated' },
     ],
   },
@@ -285,6 +284,21 @@ function resolvePointer(pointer: { id: string; version?: string }) {
 const allSubdomainIds = new Set(
   domains.flatMap((d: any) => (d.data?.domains || []).map((sd: any) => sd.data?.id || sd.id)).filter(Boolean)
 );
+const parentDomainsBySubdomainId = domains.reduce((parentsBySubdomain: Map<string, any[]>, domain: any) => {
+  (domain.data?.domains || []).forEach((subdomain: any) => {
+    const subdomainId = subdomain.data?.id || subdomain.id;
+    if (!subdomainId) return;
+
+    const parents = parentsBySubdomain.get(subdomainId) || [];
+    parents.push({
+      id: domain.data.id,
+      name: domain.data.name,
+      version: domain.data.version,
+    });
+    parentsBySubdomain.set(subdomainId, parents);
+  });
+  return parentsBySubdomain;
+}, new Map<string, any[]>());
 
 const isAgentLike = type === 'agents';
 const isServiceLike = type === 'services' || type === 'external-systems';
@@ -314,6 +328,7 @@ const tableData = enrichedData.map((d: any) => ({
   hasServices: type === 'domains' || type === 'systems' ? (d.data?.services || []).length > 0 : false,
   hasFlows: type === 'systems' ? (d.data?.flows || []).length > 0 : false,
   isSubdomain: type === 'domains' ? allSubdomainIds.has(d.data.id) : false,
+  parentDomains: type === 'domains' ? parentDomainsBySubdomainId.get(d.data.id) || [] : undefined,
   // Service-specific properties
   domains: isServiceOrAgentLike ? d.enrichedDomains : undefined,
   hasSpecifications: isServiceLike ? hasSpecifications(d) : false,
@@ -347,6 +362,7 @@ const tableData = enrichedData.map((d: any) => ({
     tools: d.data?.tools ?? [],
     agents: d.data?.agents?.map(mapToItem) ?? [],
     services: d.data?.services?.map(mapToItem) ?? [],
+    domains: d.data?.domains?.map(mapToItem) ?? [],
     flows: d.data?.flows?.map(mapToItem) ?? [],
     servicesThatWriteToContainer: d.data?.servicesThatWriteToContainer?.map(mapToItem) ?? [],
     servicesThatReadFromContainer: d.data?.servicesThatReadFromContainer?.map(mapToItem) ?? [],


### PR DESCRIPTION
## What This PR Does

Adds a **Domain type** filter to the Discover table for domains, letting users narrow the list to root domains or subdomains. It also improves the name column so that subdomains are displayed nested underneath their parent domain, making the domain hierarchy easier to understand at a glance. By default the table now shows only root domains.

## Changes Overview

### Key Changes

- New "Filter by Domain type" dropdown on the domains Discover page with `Root domains` and `Subdomains` options, including live counts.
- Domains table now nests each domain's subdomains under its name with a corner-down-right indicator and a `Subdomain` badge on subdomain rows.
- Domain type selection persists in the URL via a new `domainType` query param.
- Defaults to `root` domains when no filter is applied; clearing filters resets back to `root`.
- Removed the now-redundant `Is Subdomain` property option (replaced by the dedicated domain type filter).
- The page now computes parent-domain relationships and passes subdomain data into the table.

## How It Works

The `[type]/index.astro` page builds a map of subdomain IDs to their parent domains and passes each domain's subdomains and parent info into the table data. `DiscoverTable` adds `selectedDomainTypes` state (defaulting to `['root']` for the domains collection), a filter predicate that matches on `row.isSubdomain`, count aggregation, and a `FilterDropdown` UI rendered only for the domains collection. The URL helpers in `url-filters.ts` serialize and parse the new `domainType` param alongside existing filters. The `columns.tsx` name cell renders nested subdomain links when a domain has children.

## Breaking Changes

None.

## Additional Notes

- Unit tests in `url-filters.spec.ts` were updated to cover the new `domainType` param in both parse and build directions.
- No editor repo (`eventcatalog/eventcatalog-editor`) change is needed for this UI-only feature.