### PR TITLE
Fix SchemaViewer portal targeting for duplicate schema ids

### DIFF
--- a/.changeset/purple-schemas-render.md
+++ b/.changeset/purple-schemas-render.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Fix SchemaViewer portal targeting when multiple schemas share the same id on a page, so each schema renders into its correct container.

--- a/packages/core/eventcatalog/src/components/MDX/SchemaViewer/SchemaViewerRoot.astro
+++ b/packages/core/eventcatalog/src/components/MDX/SchemaViewer/SchemaViewerRoot.astro
@@ -105,7 +105,8 @@ try {
 
   function moveSchemaViewerToPortal(schema) {
     const schemaViewerContainers = document.querySelectorAll(`[data-schema-viewer-portal-id="${schema.id}"]`);
-    const schemaViewerContainer = schemaViewerContainers[schema.index];
+    const schemaPortalIndex = schemas.slice(0, schema.index).filter((previousSchema) => previousSchema.id === schema.id).length;
+    const schemaViewerContainer = schemaViewerContainers[schemaPortalIndex];
     const schemaViewerClient = document.getElementById(`${schema.id}-${schema.index}-SchemaViewer-client`);
 
     if (schemaViewerContainer && schemaViewerClient) {


### PR DESCRIPTION
## What This PR Does

Fixes a bug in the SchemaViewer where multiple schemas sharing the same `id` on a single page could render into the wrong portal container. The portal lookup previously used the schema's global index, which did not line up with the per-id list of portal containers returned by the DOM query.

## Changes Overview

### Key Changes
- `SchemaViewerRoot.astro`: compute a per-id portal index by counting earlier schemas with the same `id`, and use that to select the matching portal container.

## How It Works

`document.querySelectorAll('[data-schema-viewer-portal-id="..."]')` returns only the containers for a given schema `id`, so indexing that list with the schema's global `index` was incorrect whenever the same `id` appeared more than once. The fix derives the correct position by slicing the schemas up to the current one and counting how many share the same `id`, giving the true index into the id-scoped container list.

## Breaking Changes

None

## Additional Notes

No editor repository change is needed for this fix.