### PR TITLE
Fix linter loading dependencies from ESM eventcatalog.config.js

### DIFF
--- a/.changeset/fix-linter-esm-dependencies.md
+++ b/.changeset/fix-linter-esm-dependencies.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/linter': patch
+---
+
+Fix loading dependencies from ESM `eventcatalog.config.js` files.

--- a/packages/linter/src/config/index.ts
+++ b/packages/linter/src/config/index.ts
@@ -70,6 +70,17 @@ const PLURAL_TO_SINGULAR: Record<string, string> = {
   diagrams: 'diagram',
 };
 
+const unwrapDefaultExport = (config: unknown): Record<string, any> => {
+  if (config && typeof config === 'object' && 'default' in config) {
+    const defaultExport = (config as Record<string, unknown>).default;
+    if (defaultExport && typeof defaultExport === 'object') {
+      return defaultExport as Record<string, any>;
+    }
+  }
+
+  return config as Record<string, any>;
+};
+
 export const loadEventCatalogConfig = (rootDir: string): CatalogDependencies => {
   const configPath = path.join(rootDir, 'eventcatalog.config.js');
 
@@ -79,7 +90,7 @@ export const loadEventCatalogConfig = (rootDir: string): CatalogDependencies => 
 
   try {
     delete require.cache[require.resolve(configPath)];
-    const config = require(configPath);
+    const config = unwrapDefaultExport(require(configPath));
 
     if (!config.dependencies || typeof config.dependencies !== 'object') {
       return {};
@@ -118,7 +129,7 @@ export const loadConfig = (rootDir: string): LinterConfig => {
   try {
     // Clear module cache to ensure fresh load
     delete require.cache[require.resolve(configPath)];
-    const config = require(configPath);
+    const config = unwrapDefaultExport(require(configPath));
 
     // Merge with defaults
     const mergedConfig: LinterConfig = {

--- a/packages/linter/tests/cli-integration.test.ts
+++ b/packages/linter/tests/cli-integration.test.ts
@@ -11,16 +11,19 @@ describe('CLI Integration with Configuration', () => {
   let tempDir: string;
   let servicesDir: string;
   let eventsDir: string;
+  let usersDir: string;
   let configPath: string;
 
   beforeEach(() => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'eventcatalog-cli-test-'));
     servicesDir = path.join(tempDir, 'services');
     eventsDir = path.join(tempDir, 'events');
+    usersDir = path.join(tempDir, 'users');
     configPath = path.join(tempDir, '.eventcatalogrc.js');
 
     fs.mkdirSync(servicesDir, { recursive: true });
     fs.mkdirSync(eventsDir, { recursive: true });
+    fs.mkdirSync(usersDir, { recursive: true });
   });
 
   afterEach(() => {
@@ -39,6 +42,10 @@ describe('CLI Integration with Configuration', () => {
     const eventDir = path.join(eventsDir, name);
     fs.mkdirSync(eventDir, { recursive: true });
     fs.writeFileSync(path.join(eventDir, 'index.mdx'), content);
+  };
+
+  const createUserFile = (name: string, content: string) => {
+    fs.writeFileSync(path.join(usersDir, `${name}.mdx`), content);
   };
 
   const runLinter = async (args: string = '') => {
@@ -288,5 +295,54 @@ version: 1.0.0
 
     // Check that files were processed correctly
     expect(result.stdout).toContain('file checked'); // Should check files (exact count may vary)
+  });
+
+  it('does not report missing service message references when they are declared as external dependencies in an ESM eventcatalog.config.js', async () => {
+    fs.writeFileSync(
+      path.join(tempDir, 'eventcatalog.config.js'),
+      `
+export default {
+  dependencies: {
+    events: [
+      { id: 'my.company.LocationSyncEvent' },
+      { id: 'my.company.CarrierSyncEvent' },
+    ],
+  },
+};
+`
+    );
+
+    createUserFile(
+      'catalog-owner',
+      `---
+id: catalog-owner
+name: Catalog Owner
+summary: Owns the catalog
+---
+# Catalog Owner
+`
+    );
+
+    createServiceFile(
+      'oms-scs',
+      `---
+id: oms-scs
+name: OMS SCS
+summary: OMS SCS
+owners:
+  - catalog-owner
+receives:
+  - id: my.company.LocationSyncEvent
+  - id: my.company.CarrierSyncEvent
+---
+# OMS SCS
+`
+    );
+
+    const result = await runLinter();
+
+    expect(result.success).toBe(true);
+    expect(result.stdout).not.toContain('Referenced event/command/query');
+    expect(result.stdout).toContain('2 files checked');
   });
 });


### PR DESCRIPTION
Fixes #2293

## What This PR Does

The linter's `refs/resource-exists` rule reported false errors when message dependencies were declared in an ESM-style `eventcatalog.config.js` (using `export default`). This PR unwraps the module's default export when loading the config so declared external dependencies are recognized and no longer flagged as missing.

## Changes Overview

### Key Changes
- Add an `unwrapDefaultExport` helper in `packages/linter/src/config/index.ts` that returns the `default` export when present, falling back to the module object otherwise.
- Apply the helper in both `loadEventCatalogConfig` and `loadConfig` so ESM and CommonJS config files are handled uniformly.
- Add a CLI integration test reproducing the issue: an ESM `eventcatalog.config.js` with `export default` declaring event dependencies, asserting the linter no longer reports missing references.

## How It Works

When `require()` loads an ESM-transpiled or `export default` config file, the actual config object is nested under a `default` property. The linter previously read fields like `dependencies` directly off the required module, so they were `undefined` for ESM configs. `unwrapDefaultExport` detects a `default` object and returns it, keeping CommonJS configs unchanged.

## Breaking Changes

None.

## Additional Notes

This addresses a regression previously reported against the old linter repo (event-catalog/linter#18). No editor repo change is needed.