### PR TITLE
Resolve JSON Schema $ref pointers in remote files

### DIFF
--- a/.changeset/quiet-schemas-resolve.md
+++ b/.changeset/quiet-schemas-resolve.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Resolve JSON Schema `$ref` pointers (local and remote) when rendering remote JSON schemas, so referenced definitions are inlined instead of shown as unresolved `$ref` values.

--- a/packages/core/eventcatalog/src/components/MDX/RemoteFile.astro
+++ b/packages/core/eventcatalog/src/components/MDX/RemoteFile.astro
@@ -4,6 +4,7 @@ import JSONSchemaViewer from '@components/SchemaExplorer/JSONSchemaViewer';
 import { Code } from 'astro-expressive-code/components';
 import { isPrivateRemoteSchemaEnabled } from '@utils/feature';
 import { resolveTemplateVariables } from '@utils/remote-file';
+import { resolveSchemaRefs } from '@utils/json-schema-refs';
 
 const {
   url,
@@ -89,6 +90,10 @@ try {
   if (isValidJSON(content)) {
     contentType = 'json';
     processedData = JSON.parse(content);
+    processedData = await resolveSchemaRefs(processedData, {
+      baseUrl: String(resolvedUrl),
+      headers: resolvedHeaders as HeadersInit,
+    });
 
     // Check if it's a JSON Schema
     isSchema = isJSONSchema(processedData);

--- a/packages/core/eventcatalog/src/utils/__tests__/json-schema-refs.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/json-schema-refs.spec.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from 'vitest';
+import { resolveSchemaRefs } from '@utils/json-schema-refs';
+
+const createJsonResponse = (body: unknown) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: {
+      'content-type': 'application/json',
+    },
+  });
+
+describe('resolveSchemaRefs', () => {
+  it('resolves external JSON schema refs and nested local refs in the external document', async () => {
+    const schema = {
+      type: 'object',
+      required: ['data'],
+      properties: {
+        data: {
+          description: 'Template draft payload.',
+          $ref: 'http://example.com/common-schema.json#/components/schemas/TemplateDraftedData',
+        },
+      },
+    };
+    const commonSchema = {
+      components: {
+        schemas: {
+          TemplateDraftedData: {
+            type: 'object',
+            required: ['templateId', 'content'],
+            properties: {
+              templateId: { type: 'string' },
+              content: {
+                $ref: '#/components/schemas/TemplateContent',
+              },
+            },
+          },
+          TemplateContent: {
+            type: 'object',
+            required: ['subject'],
+            properties: {
+              subject: { type: 'string' },
+            },
+          },
+        },
+      },
+    };
+    const fetcher = vi.fn(async () => createJsonResponse(commonSchema));
+
+    await expect(
+      resolveSchemaRefs(schema, {
+        baseUrl: 'http://example.com/event-schema.json',
+        fetcher,
+      })
+    ).resolves.toEqual({
+      type: 'object',
+      required: ['data'],
+      properties: {
+        data: {
+          type: 'object',
+          description: 'Template draft payload.',
+          required: ['templateId', 'content'],
+          properties: {
+            templateId: { type: 'string' },
+            content: {
+              type: 'object',
+              required: ['subject'],
+              properties: {
+                subject: { type: 'string' },
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(fetcher).toHaveBeenCalledWith('http://example.com/common-schema.json', { headers: undefined });
+  });
+
+  it('resolves relative external refs from the current schema URL', async () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        user: {
+          $ref: './shared/user.json#/User',
+        },
+      },
+    };
+    const fetcher = vi.fn(async () =>
+      createJsonResponse({
+        User: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+          },
+        },
+      })
+    );
+
+    await expect(
+      resolveSchemaRefs(schema, {
+        baseUrl: 'http://example.com/schemas/event.json',
+        fetcher,
+      })
+    ).resolves.toEqual({
+      type: 'object',
+      properties: {
+        user: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+          },
+        },
+      },
+    });
+    expect(fetcher).toHaveBeenCalledWith('http://example.com/schemas/shared/user.json', { headers: undefined });
+  });
+});

--- a/packages/core/eventcatalog/src/utils/json-schema-refs.ts
+++ b/packages/core/eventcatalog/src/utils/json-schema-refs.ts
@@ -1,0 +1,158 @@
+type Fetcher = (input: string | URL, init?: RequestInit) => Promise<Response>;
+
+type ResolveSchemaRefsOptions = {
+  baseUrl: string;
+  headers?: HeadersInit;
+  fetcher?: Fetcher;
+  maxDepth?: number;
+};
+
+type ResolveContext = Required<Pick<ResolveSchemaRefsOptions, 'baseUrl' | 'fetcher' | 'maxDepth'>> & {
+  headers?: HeadersInit;
+  cache: Map<string, unknown>;
+};
+
+type RefTarget = {
+  schema: unknown;
+  root: unknown;
+  baseUrl: string;
+  refKey: string;
+};
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const decodeJsonPointerSegment = (segment: string) => decodeURIComponent(segment).replace(/~1/g, '/').replace(/~0/g, '~');
+
+const resolveJsonPointer = (document: unknown, pointer: string): unknown => {
+  if (!pointer || pointer === '#') return document;
+
+  const path = pointer.startsWith('#') ? pointer.slice(1) : pointer;
+  if (!path) return document;
+  if (!path.startsWith('/')) return undefined;
+
+  return path
+    .slice(1)
+    .split('/')
+    .map(decodeJsonPointerSegment)
+    .reduce<unknown>((current, segment) => {
+      if (current === undefined || current === null) return undefined;
+      if (Array.isArray(current)) return current[Number(segment)];
+      if (isObject(current)) return current[segment];
+      return undefined;
+    }, document);
+};
+
+const splitRef = (ref: string, baseUrl: string) => {
+  const [urlPart = '', fragmentPart = ''] = ref.split('#');
+  const url = urlPart ? new URL(urlPart, baseUrl).toString() : baseUrl;
+  return {
+    url,
+    fragment: `#${fragmentPart}`,
+    refKey: `${url}#${fragmentPart}`,
+  };
+};
+
+const loadRemoteDocument = async (url: string, context: ResolveContext) => {
+  if (context.cache.has(url)) return context.cache.get(url);
+
+  const response = await context.fetcher(url, {
+    headers: context.headers,
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch referenced schema: ${response.status} ${response.statusText}`);
+  }
+
+  const document = await response.json();
+  context.cache.set(url, document);
+  return document;
+};
+
+const resolveRef = async (
+  ref: string,
+  root: unknown,
+  currentBaseUrl: string,
+  context: ResolveContext
+): Promise<RefTarget | undefined> => {
+  const { url, fragment, refKey } = splitRef(ref, currentBaseUrl);
+  const isCurrentDocument = url === currentBaseUrl;
+  const document = isCurrentDocument ? root : await loadRemoteDocument(url, context);
+  const schema = resolveJsonPointer(document, fragment);
+
+  if (schema === undefined) return undefined;
+
+  return {
+    schema,
+    root: document,
+    baseUrl: url,
+    refKey,
+  };
+};
+
+const resolveNode = async (
+  node: unknown,
+  root: unknown,
+  currentBaseUrl: string,
+  context: ResolveContext,
+  seenRefs: Set<string>,
+  depth: number
+): Promise<unknown> => {
+  if (depth > context.maxDepth) return node;
+
+  if (Array.isArray(node)) {
+    return Promise.all(node.map((item) => resolveNode(item, root, currentBaseUrl, context, seenRefs, depth)));
+  }
+
+  if (!isObject(node)) return node;
+
+  const ref = typeof node.$ref === 'string' ? node.$ref : undefined;
+  if (ref) {
+    const target = await resolveRef(ref, root, currentBaseUrl, context);
+    if (!target || seenRefs.has(target.refKey)) return { ...node };
+
+    const nextSeenRefs = new Set(seenRefs);
+    nextSeenRefs.add(target.refKey);
+
+    const resolvedSchema = await resolveNode(target.schema, target.root, target.baseUrl, context, nextSeenRefs, depth + 1);
+    const siblingEntries = Object.entries(node).filter(([key]) => key !== '$ref');
+    const resolvedSiblings = Object.fromEntries(
+      await Promise.all(
+        siblingEntries.map(async ([key, value]) => [
+          key,
+          await resolveNode(value, root, currentBaseUrl, context, seenRefs, depth),
+        ])
+      )
+    );
+
+    if (isObject(resolvedSchema)) {
+      return {
+        ...resolvedSchema,
+        ...resolvedSiblings,
+      };
+    }
+
+    return Object.keys(resolvedSiblings).length > 0 ? resolvedSiblings : resolvedSchema;
+  }
+
+  return Object.fromEntries(
+    await Promise.all(
+      Object.entries(node).map(async ([key, value]) => [
+        key,
+        await resolveNode(value, root, currentBaseUrl, context, seenRefs, depth),
+      ])
+    )
+  );
+};
+
+export const resolveSchemaRefs = async (schema: unknown, options: ResolveSchemaRefsOptions): Promise<unknown> => {
+  const context: ResolveContext = {
+    baseUrl: options.baseUrl,
+    headers: options.headers,
+    fetcher: options.fetcher ?? fetch,
+    maxDepth: options.maxDepth ?? 25,
+    cache: new Map([[options.baseUrl, schema]]),
+  };
+
+  return resolveNode(schema, schema, options.baseUrl, context, new Set(), 0);
+};


### PR DESCRIPTION
Closes #1689

## What This PR Does

When a remote JSON file rendered by `RemoteFile.astro` is a JSON Schema, any `$ref` pointers it contains are now resolved and inlined before the schema is displayed. Previously, referenced definitions (both local `#/...` pointers and external URL references) were left unresolved, so the viewer showed raw `$ref` values instead of the actual schema content. This adds a dedicated `resolveSchemaRefs` utility and wires it into the remote file rendering flow.

## Changes Overview

### Key Changes

- Add `@utils/json-schema-refs` with `resolveSchemaRefs`, which walks a parsed JSON Schema and resolves `$ref` pointers.
- Support both local JSON Pointer refs (`#/definitions/...`) and remote document refs (relative/absolute URLs), fetching remote documents with the same headers used for the base file.
- Handle nested/recursive refs safely: per-branch cycle detection via a `seenRefs` set, a configurable `maxDepth` (default 25), and a document cache to avoid refetching.
- Preserve sibling keys alongside a `$ref` (merged over the resolved schema) per JSON Schema semantics.
- Wire resolution into `RemoteFile.astro` so parsed JSON is passed through `resolveSchemaRefs` before schema detection/rendering.
- Add unit tests in `json-schema-refs.spec.ts`.

## How It Works

`resolveSchemaRefs` builds a resolve context (base URL, headers, fetcher, max depth, and a cache seeded with the root document) and recursively visits every node. For each object with a string `$ref`, it splits the ref into a URL + JSON Pointer fragment, loads the target document (the root itself for same-document refs, otherwise a cached fetch), and resolves the pointer. The resolved schema is then recursively resolved and merged with any sibling keys. Cycles are broken by tracking resolved ref keys per branch, and depth is bounded by `maxDepth`. The fetcher is injectable to keep the utility testable.

## Breaking Changes

None.

## Additional Notes

- The fetcher is injectable (defaults to global `fetch`), which is what the unit tests exercise.
- Remote ref fetches reuse the resolved headers from the base request, so authenticated/private remote schemas continue to work.