### PR TITLE
Compare any two schema versions in the Schema Explorer

### DIFF
--- a/.changeset/quiet-otters-compare.md
+++ b/.changeset/quiet-otters-compare.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Schema Explorer version comparison now lets you pick any two versions to diff using From/To selectors instead of only showing consecutive-version diffs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,3 +48,7 @@ Use `<type>(<scope>): <imperative summary>` when possible. For PRs:
 - Link related issues.
 - Include screenshots/GIFs for UI changes.
 - Add a changeset (`pnpm changeset`) for publishable package changes unless the change is internal-only.
+
+## Important
+
+Never start the catalog, the catalog is already running.

--- a/examples/default/domains/Ordering/systems/order-management-system/services/OrderService/events/OrderCreated/schema.json
+++ b/examples/default/domains/Ordering/systems/order-management-system/services/OrderService/events/OrderCreated/schema.json
@@ -20,10 +20,36 @@
       "type": "string",
       "pattern": "^[A-Z]{3}$"
     },
+    "status": {
+      "type": "string",
+      "enum": ["created"],
+      "description": "Initial lifecycle status for the order"
+    },
+    "items": {
+      "type": "array",
+      "description": "Line items captured at order creation time",
+      "items": {
+        "type": "object",
+        "properties": {
+          "sku": {
+            "type": "string"
+          },
+          "quantity": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "unitPrice": {
+            "type": "integer",
+            "description": "Unit price in minor units (e.g. cents)"
+          }
+        },
+        "required": ["sku", "quantity", "unitPrice"]
+      }
+    },
     "createdAt": {
       "type": "string",
       "format": "date-time"
     }
   },
-  "required": ["orderId", "customerId", "total", "currency", "createdAt"]
+  "required": ["orderId", "customerId", "total", "currency", "status", "items", "createdAt"]
 }

--- a/examples/default/domains/Ordering/systems/order-management-system/services/OrderService/events/OrderCreated/versioned/0.3.0/index.mdx
+++ b/examples/default/domains/Ordering/systems/order-management-system/services/OrderService/events/OrderCreated/versioned/0.3.0/index.mdx
@@ -1,0 +1,25 @@
+---
+id: order-created
+name: Order Created
+version: 0.3.0
+summary: |
+  Published when a new order has been created. This early contract only included identifiers and the creation timestamp.
+owners:
+  - ordering-platform
+badges:
+  - content: 'Broker:Kafka'
+    backgroundColor: blue
+    textColor: blue
+    icon: BoltIcon
+schemaPath: schema.json
+---
+
+import Footer from '@catalog/components/footer.astro';
+
+## Overview
+
+`OrderCreated` version `0.3.0` was the first stable order creation event contract used by downstream fulfilment consumers.
+
+<SchemaViewer file="schema.json" title="JSON Schema" maxHeight="500" />
+
+<Footer />

--- a/examples/default/domains/Ordering/systems/order-management-system/services/OrderService/events/OrderCreated/versioned/0.3.0/schema.json
+++ b/examples/default/domains/Ordering/systems/order-management-system/services/OrderService/events/OrderCreated/versioned/0.3.0/schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "OrderCreated",
+  "description": "Published when a new order has been created",
+  "type": "object",
+  "properties": {
+    "orderId": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "customerId": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "createdAt": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "required": ["orderId", "customerId", "createdAt"]
+}

--- a/examples/default/domains/Ordering/systems/order-management-system/services/OrderService/events/OrderCreated/versioned/0.6.0/index.mdx
+++ b/examples/default/domains/Ordering/systems/order-management-system/services/OrderService/events/OrderCreated/versioned/0.6.0/index.mdx
@@ -1,0 +1,25 @@
+---
+id: order-created
+name: Order Created
+version: 0.6.0
+summary: |
+  Published when a new order has been created. This version added the order total and currency for payment reconciliation.
+owners:
+  - ordering-platform
+badges:
+  - content: 'Broker:Kafka'
+    backgroundColor: blue
+    textColor: blue
+    icon: BoltIcon
+schemaPath: schema.json
+---
+
+import Footer from '@catalog/components/footer.astro';
+
+## Overview
+
+`OrderCreated` version `0.6.0` added monetary fields so consumers could reconcile order totals without calling the Order API.
+
+<SchemaViewer file="schema.json" title="JSON Schema" maxHeight="500" />
+
+<Footer />

--- a/examples/default/domains/Ordering/systems/order-management-system/services/OrderService/events/OrderCreated/versioned/0.6.0/schema.json
+++ b/examples/default/domains/Ordering/systems/order-management-system/services/OrderService/events/OrderCreated/versioned/0.6.0/schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "OrderCreated",
+  "description": "Published when a new order has been created",
+  "type": "object",
+  "properties": {
+    "orderId": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "customerId": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "total": {
+      "type": "integer",
+      "description": "Order total in minor units (e.g. cents)"
+    },
+    "currency": {
+      "type": "string",
+      "pattern": "^[A-Z]{3}$"
+    },
+    "createdAt": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "required": ["orderId", "customerId", "total", "currency", "createdAt"]
+}

--- a/packages/core/eventcatalog/src/components/SchemaExplorer/DiffViewer.tsx
+++ b/packages/core/eventcatalog/src/components/SchemaExplorer/DiffViewer.tsx
@@ -122,10 +122,10 @@ export default function DiffViewer({ diffs, onOpenFullscreen, apiAccessEnabled =
       {isDark && <style dangerouslySetInnerHTML={{ __html: DIFF_DARK_STYLES }} />}
       <div className="mb-5 flex items-start justify-between">
         <div className="flex-1">
-          <h3 className="text-base font-semibold text-[rgb(var(--ec-page-text))] mb-1">Version History</h3>
+          <h3 className="text-base font-semibold text-[rgb(var(--ec-page-text))] mb-1">Version Comparison</h3>
           <p className="text-sm text-[rgb(var(--ec-page-text-muted))]">
             {apiAccessEnabled
-              ? `${diffs.length} version comparison${diffs.length !== 1 ? 's' : ''}`
+              ? `${diffs.length} selected comparison${diffs.length !== 1 ? 's' : ''}`
               : 'Compare schema versions side-by-side'}
           </p>
         </div>
@@ -142,21 +142,19 @@ export default function DiffViewer({ diffs, onOpenFullscreen, apiAccessEnabled =
       </div>
       {apiAccessEnabled ? (
         <div className={`space-y-6 ${isDark ? 'diff-dark-mode' : ''}`}>
-          {diffs.map((diff, index) => (
+          {diffs.map((diff) => (
             <div
-              key={`${diff.newerVersion}-${diff.olderVersion}`}
+              key={`${diff.fromVersion}-${diff.toVersion}`}
               className="border border-[rgb(var(--ec-page-border))] rounded-lg overflow-hidden"
             >
               <div className="bg-[rgb(var(--ec-content-hover))] border-b border-[rgb(var(--ec-page-border))] px-4 py-2.5">
                 <div className="flex items-center justify-between">
                   <div className="text-sm">
-                    <span className="font-semibold text-[rgb(var(--ec-page-text))]">v{diff.newerVersion}</span>
+                    <span className="font-semibold text-[rgb(var(--ec-page-text))]">v{diff.fromVersion}</span>
                     <span className="text-[rgb(var(--ec-page-text-muted))] mx-2">&rarr;</span>
-                    <span className="font-semibold text-[rgb(var(--ec-page-text))]">v{diff.olderVersion}</span>
+                    <span className="font-semibold text-[rgb(var(--ec-page-text))]">v{diff.toVersion}</span>
                   </div>
-                  <span className="text-xs text-[rgb(var(--ec-page-text-muted))]">
-                    {index === 0 ? 'Latest change' : `${index + 1} version${index + 1 !== 1 ? 's' : ''} ago`}
-                  </span>
+                  <span className="text-xs text-[rgb(var(--ec-page-text-muted))]">Selected comparison</span>
                 </div>
               </div>
               <div className="relative">

--- a/packages/core/eventcatalog/src/components/SchemaExplorer/SchemaDetailsPanel.tsx
+++ b/packages/core/eventcatalog/src/components/SchemaExplorer/SchemaDetailsPanel.tsx
@@ -64,43 +64,70 @@ export default function SchemaDetailsPanel({
   const consumers = message.data.consumers || [];
   const filename = message.data.schemaPath?.split('/').pop() || `${message.data.id}.${ext || 'json'}`;
 
-  // Generate diffs between all consecutive versions
-  const allDiffs: VersionDiff[] = useMemo(() => {
-    const diffs: VersionDiff[] = [];
-    if (!hasMultipleVersions) return diffs;
+  const uniqueAvailableVersions = useMemo(
+    () =>
+      availableVersions.filter(
+        (version, index, versions) => versions.findIndex((item) => item.data.version === version.data.version) === index
+      ),
+    [availableVersions]
+  );
+  const defaultToVersion = uniqueAvailableVersions[0]?.data.version || '';
+  const defaultFromVersion = uniqueAvailableVersions[1]?.data.version || defaultToVersion;
+  const [diffFromVersion, setDiffFromVersion] = useState(defaultFromVersion);
+  const [diffToVersion, setDiffToVersion] = useState(defaultToVersion);
+  const schemaResourceKey = [
+    message.collection,
+    message.data.id,
+    message.specType || '',
+    message.specFilenameWithoutExtension || message.specName || '',
+  ].join(':');
 
-    for (let i = 0; i < availableVersions.length - 1; i++) {
-      const newerVersion = availableVersions[i];
-      const olderVersion = availableVersions[i + 1];
+  useEffect(() => {
+    setDiffFromVersion(defaultFromVersion);
+    setDiffToVersion(defaultToVersion);
+    setIsDiffModalOpen(false);
+  }, [schemaResourceKey, defaultFromVersion, defaultToVersion]);
 
-      if (newerVersion.schemaContent && olderVersion.schemaContent) {
-        const diff = Diff.createTwoFilesPatch(
-          `v${olderVersion.data.version}`,
-          `v${newerVersion.data.version}`,
-          olderVersion.schemaContent,
-          newerVersion.schemaContent,
-          '',
-          '',
-          { context: 3 }
-        );
+  const diffFromItem = useMemo(
+    () => uniqueAvailableVersions.find((version) => version.data.version === diffFromVersion),
+    [diffFromVersion, uniqueAvailableVersions]
+  );
+  const diffToItem = useMemo(
+    () => uniqueAvailableVersions.find((version) => version.data.version === diffToVersion),
+    [diffToVersion, uniqueAvailableVersions]
+  );
+  const hasDiffFromContent = !!diffFromItem?.schemaContent?.trim();
+  const hasDiffToContent = !!diffToItem?.schemaContent?.trim();
+  const selectedDiff: VersionDiff | null = useMemo(() => {
+    if (!diffFromItem || !diffToItem) return null;
+    if (diffFromItem.data.version === diffToItem.data.version) return null;
+    if (!diffFromItem.schemaContent?.trim() || !diffToItem.schemaContent?.trim()) return null;
 
-        const diffHtml = html(diff, {
-          drawFileList: false,
-          matching: 'lines',
-          outputFormat: 'side-by-side',
-        });
+    const diff = Diff.createTwoFilesPatch(
+      `v${diffFromItem.data.version}`,
+      `v${diffToItem.data.version}`,
+      diffFromItem.schemaContent,
+      diffToItem.schemaContent,
+      '',
+      '',
+      { context: 3 }
+    );
 
-        diffs.push({
-          newerVersion: newerVersion.data.version,
-          olderVersion: olderVersion.data.version,
-          diffHtml,
-          newerContent: newerVersion.schemaContent,
-          olderContent: olderVersion.schemaContent,
-        });
-      }
-    }
-    return diffs;
-  }, [availableVersions]);
+    const diffHtml = html(diff, {
+      drawFileList: false,
+      matching: 'lines',
+      outputFormat: 'side-by-side',
+    });
+
+    return {
+      fromVersion: diffFromItem.data.version,
+      toVersion: diffToItem.data.version,
+      diffHtml,
+      fromContent: diffFromItem.schemaContent,
+      toContent: diffToItem.schemaContent,
+    };
+  }, [diffFromItem, diffToItem]);
+  const selectedDiffs = selectedDiff ? [selectedDiff] : [];
 
   // Check if this is a JSON schema
   const parsedSchema = useMemo(() => {
@@ -212,7 +239,7 @@ export default function SchemaDetailsPanel({
   if (examples.length > 0) {
     tabs.push({ id: 'examples', label: 'Usage Examples', icon: <BookOpenIcon className="h-3.5 w-3.5" /> });
   }
-  if (allDiffs.length > 0) {
+  if (hasMultipleVersions) {
     tabs.push({ id: 'diff', label: 'Changes', icon: <ClockIcon className="h-3.5 w-3.5" /> });
   }
   tabs.push({ id: 'api', label: 'API', icon: <GlobeAltIcon className="h-3.5 w-3.5" /> });
@@ -341,8 +368,67 @@ export default function SchemaDetailsPanel({
               copiedId={copiedId}
               apiAccessEnabled={apiAccessEnabled}
             />
-          ) : activeTab === 'diff' && allDiffs.length > 0 ? (
-            <DiffViewer diffs={allDiffs} onOpenFullscreen={() => setIsDiffModalOpen(true)} apiAccessEnabled={apiAccessEnabled} />
+          ) : activeTab === 'diff' && hasMultipleVersions ? (
+            <div className="flex h-full min-h-0 flex-col overflow-hidden">
+              <div className="mb-4 flex flex-shrink-0 flex-col gap-3 rounded-lg border border-[rgb(var(--ec-page-border))] bg-[rgb(var(--ec-content-hover)/0.45)] p-3 sm:flex-row sm:items-end sm:justify-between">
+                <div className="grid flex-1 grid-cols-1 gap-3 sm:grid-cols-2">
+                  <label className="flex flex-col gap-1.5">
+                    <span className="text-[11px] font-medium uppercase tracking-[0.14em] text-[rgb(var(--ec-page-text-muted))]">
+                      From
+                    </span>
+                    <select
+                      value={diffFromVersion}
+                      onChange={(event) => setDiffFromVersion(event.target.value)}
+                      className="h-9 rounded-md border border-[rgb(var(--ec-dropdown-border))] bg-[rgb(var(--ec-dropdown-bg))] px-3 text-sm font-mono tabular-nums text-[rgb(var(--ec-page-text))] outline-hidden transition-colors focus:border-[rgb(var(--ec-accent))] focus:ring-1 focus:ring-[rgb(var(--ec-accent)/0.3)]"
+                    >
+                      {uniqueAvailableVersions.map((version) => (
+                        <option key={`from-${version.data.version}`} value={version.data.version}>
+                          v{version.data.version}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  <label className="flex flex-col gap-1.5">
+                    <span className="text-[11px] font-medium uppercase tracking-[0.14em] text-[rgb(var(--ec-page-text-muted))]">
+                      To
+                    </span>
+                    <select
+                      value={diffToVersion}
+                      onChange={(event) => setDiffToVersion(event.target.value)}
+                      className="h-9 rounded-md border border-[rgb(var(--ec-dropdown-border))] bg-[rgb(var(--ec-dropdown-bg))] px-3 text-sm font-mono tabular-nums text-[rgb(var(--ec-page-text))] outline-hidden transition-colors focus:border-[rgb(var(--ec-accent))] focus:ring-1 focus:ring-[rgb(var(--ec-accent)/0.3)]"
+                    >
+                      {uniqueAvailableVersions.map((version) => (
+                        <option key={`to-${version.data.version}`} value={version.data.version}>
+                          v{version.data.version}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setIsDiffModalOpen(true)}
+                  disabled={!selectedDiff}
+                  className="inline-flex h-9 items-center justify-center gap-1.5 rounded-md border border-[rgb(var(--ec-page-border))] bg-[rgb(var(--ec-dropdown-bg))] px-3 text-xs font-medium text-[rgb(var(--ec-page-text-muted))] transition-colors hover:bg-[rgb(var(--ec-content-hover))] hover:text-[rgb(var(--ec-page-text))] disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5" />
+                  Expand
+                </button>
+              </div>
+              <div className="min-h-0 flex-1 overflow-hidden">
+                {diffFromVersion === diffToVersion ? (
+                  <div className="flex h-full items-center justify-center text-[rgb(var(--ec-page-text-muted))]">
+                    <p className="text-sm">Select two different versions</p>
+                  </div>
+                ) : !hasDiffFromContent || !hasDiffToContent ? (
+                  <div className="flex h-full items-center justify-center text-[rgb(var(--ec-page-text-muted))]">
+                    <p className="text-sm">No schema content available</p>
+                  </div>
+                ) : (
+                  <DiffViewer diffs={selectedDiffs} apiAccessEnabled={apiAccessEnabled} />
+                )}
+              </div>
+            </div>
           ) : (
             <SchemaContentViewer
               message={message}
@@ -507,7 +593,7 @@ export default function SchemaDetailsPanel({
       <VersionHistoryModal
         isOpen={isDiffModalOpen}
         onOpenChange={setIsDiffModalOpen}
-        diffs={allDiffs}
+        diffs={selectedDiffs}
         messageName={message.data.name}
         apiAccessEnabled={apiAccessEnabled}
       />

--- a/packages/core/eventcatalog/src/components/SchemaExplorer/VersionHistoryModal.tsx
+++ b/packages/core/eventcatalog/src/components/SchemaExplorer/VersionHistoryModal.tsx
@@ -28,7 +28,7 @@ export default function VersionHistoryModal({
             <div className="flex items-center gap-3">
               <ArrowsPointingOutIcon className="h-6 w-6 text-[rgb(var(--ec-icon-color))]" />
               <div>
-                <Dialog.Title className="text-xl font-semibold text-[rgb(var(--ec-page-text))]">Version History</Dialog.Title>
+                <Dialog.Title className="text-xl font-semibold text-[rgb(var(--ec-page-text))]">Version Comparison</Dialog.Title>
                 <Dialog.Description className="text-sm text-[rgb(var(--ec-page-text-muted))] mt-1">
                   {messageName}
                 </Dialog.Description>
@@ -51,7 +51,7 @@ export default function VersionHistoryModal({
               <DiffViewer diffs={diffs} apiAccessEnabled={apiAccessEnabled} />
             ) : (
               <div className="flex items-center justify-center h-full">
-                <p className="text-[rgb(var(--ec-page-text-muted))] text-center">No version history available</p>
+                <p className="text-[rgb(var(--ec-page-text-muted))] text-center">No version comparison available</p>
               </div>
             )}
           </div>

--- a/packages/core/eventcatalog/src/components/SchemaExplorer/types.ts
+++ b/packages/core/eventcatalog/src/components/SchemaExplorer/types.ts
@@ -45,9 +45,9 @@ export interface SchemaItem {
 }
 
 export interface VersionDiff {
-  newerVersion: string;
-  olderVersion: string;
+  fromVersion: string;
+  toVersion: string;
   diffHtml: string;
-  newerContent: string;
-  olderContent: string;
+  fromContent: string;
+  toContent: string;
 }


### PR DESCRIPTION
Refs https://github.com/event-catalog/eventcatalog/issues/2368

## What This PR Does

The Schema Explorer's **Changes** tab previously rendered a fixed set of diffs between every pair of consecutive versions. This PR replaces that with **From/To version selectors**, letting users diff any two schema versions they choose. It also expands the example catalog with additional versioned `OrderCreated` schemas so the comparison can be demonstrated end-to-end.

## Changes Overview

### Key Changes

- Added **From** and **To** dropdowns to the Changes tab so any two versions can be compared (previously only consecutive versions were diffed).
- Diff is now computed on demand for the selected version pair via a memoized `selectedDiff`.
- De-duplicates available versions before populating the selectors.
- Resets the selected versions and closes the fullscreen modal when the schema resource changes.
- Handles edge cases: same version selected on both sides, or missing schema content, show a helpful placeholder instead of an empty diff.
- Renamed the `VersionDiff` type fields (`newerVersion`/`olderVersion`/`newerContent`/`olderContent` → `fromVersion`/`toVersion`/`fromContent`/`toContent`) to match the new selection model.
- Relabelled UI copy from "Version History" to "Version Comparison".
- Added `OrderCreated` versioned schemas (`0.3.0`, `0.6.0`) and expanded the current `schema.json` (new `status` and `items` fields) in the default example catalog.
- Minor `AGENTS.md` note.

## How It Works

The panel derives a deduplicated list of available versions and defaults the **To** selector to the latest version and **From** to the previous one. A memoized `selectedDiff` builds the unified diff (via `Diff.createTwoFilesPatch` + `diff2html`) only for the currently selected pair, and feeds it to the existing `DiffViewer`/`VersionHistoryModal` as a single-item list. Selecting the same version, or a version without schema content, short-circuits to a placeholder message. The Changes tab now appears whenever the message has multiple versions rather than only when precomputed diffs exist.

## Breaking Changes

None. The `VersionDiff` interface fields were renamed, but this type is internal to the `SchemaExplorer` component.

## Additional Notes

- The version bump is intentionally `patch` per the request.
- No editor repository (`eventcatalog/eventcatalog-editor`) change is required for this UI-only enhancement.