### PR TITLE
Respect base path for AI chat API URL

### DIFF
--- a/.changeset/fix-chat-base-url.md
+++ b/.changeset/fix-chat-base-url.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Fix the AI assistant API URL when EventCatalog is deployed with a custom base path (#1345).

--- a/packages/core/eventcatalog/src/components/ChatPanel/ChatPanel.tsx
+++ b/packages/core/eventcatalog/src/components/ChatPanel/ChatPanel.tsx
@@ -1,12 +1,14 @@
 import { useEffect, useRef, useCallback, useState, useMemo, memo } from 'react';
 import { X, Square, Trash2, BookOpen, Copy, Check, Maximize2, Minimize2, Wrench, ChevronDown, MessageSquare } from 'lucide-react';
 import { useChat } from '@ai-sdk/react';
+import { DefaultChatTransport } from 'ai';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { oneDark } from 'react-syntax-highlighter/dist/cjs/styles/prism';
 import * as Dialog from '@radix-ui/react-dialog';
 import * as Popover from '@radix-ui/react-popover';
+import { buildUrl } from '@utils/url-builder';
 
 interface ToolMetadata {
   name: string;
@@ -527,6 +529,8 @@ const ChatPanel = ({ isOpen, onClose }: ChatPanelProps) => {
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [tools, setTools] = useState<ToolMetadata[]>([]);
   const [showScrollButton, setShowScrollButton] = useState(false);
+  const chatApiUrl = useMemo(() => buildUrl('/api/chat', true), []);
+  const chatTransport = useMemo(() => new DefaultChatTransport({ api: chatApiUrl }), [chatApiUrl]);
 
   // Sort tools with custom ones first
   const sortedTools = useMemo(() => {
@@ -540,7 +544,7 @@ const ChatPanel = ({ isOpen, onClose }: ChatPanelProps) => {
   // Fetch available tools when panel opens
   useEffect(() => {
     if (isOpen && tools.length === 0) {
-      fetch('/api/chat')
+      fetch(chatApiUrl)
         .then((res) => res.json())
         .then((data) => {
           if (data.tools) {
@@ -597,7 +601,7 @@ const ChatPanel = ({ isOpen, onClose }: ChatPanelProps) => {
     setShowScrollButton(!isNearBottom);
   }, []);
 
-  const { messages, sendMessage, stop, status, setMessages, error } = useChat();
+  const { messages, sendMessage, stop, status, setMessages, error } = useChat({ transport: chatTransport });
 
   // Extract user-friendly error message
   const errorMessage = error?.message || 'Something went wrong. Please try again.';


### PR DESCRIPTION
Closes event-catalog/eventcatalog#1345

## What This PR Does

The AI assistant (Chat Panel) previously called the `/api/chat` endpoint using a hardcoded root-relative path. When EventCatalog is deployed under a custom base path (e.g. `https://example.com/docs`), these requests resolved to the wrong URL and failed. This PR builds the API URL with the configured base path so the chat feature works in sub-path deployments.

## Changes Overview

### Key Changes

- Build the chat API URL via `buildUrl('/api/chat', true)` so it honors the configured base path.
- Pass a `DefaultChatTransport` configured with the resolved URL into `useChat`, replacing the default transport that assumed a root-relative endpoint.
- Update the tools `fetch('/api/chat')` call to use the same base-path-aware URL.

## How It Works

The component computes `chatApiUrl` with the `buildUrl` utility (memoized) and constructs a memoized `DefaultChatTransport` pointing at that URL. Both the `useChat` hook and the tool-list fetch now use the base-path-aware URL, ensuring all chat requests target the correct endpoint regardless of deployment base path.

## Breaking Changes

None.

## Additional Notes

- No editor repository (`eventcatalog/eventcatalog-editor`) change is needed for this fix.