### PR TITLE
Fix cropped and colorless visualiser image exports

### DIFF
--- a/.changeset/tidy-otters-export.md
+++ b/.changeset/tidy-otters-export.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/visualiser": patch
+---
+
+Fix visualiser image export (download visual) so grouped graphs are no longer cropped and SVG edges/labels keep their colors in the exported PNG

--- a/packages/visualiser/src/components/DownloadButton.tsx
+++ b/packages/visualiser/src/components/DownloadButton.tsx
@@ -1,11 +1,10 @@
-import {
-  Panel,
-  useReactFlow,
-  getNodesBounds,
-  getViewportForBounds,
-} from "@xyflow/react";
+import { useReactFlow, useStoreApi, getNodesBounds } from "@xyflow/react";
 import { toPng } from "html-to-image";
 import { DocumentArrowDownIcon } from "@heroicons/react/24/outline";
+import {
+  getExportImageDimensions,
+  injectExportStyles,
+} from "../utils/export-image";
 
 function downloadImage(dataUrl: string, filename?: string) {
   const a = document.createElement("a");
@@ -15,9 +14,6 @@ function downloadImage(dataUrl: string, filename?: string) {
   a.click();
 }
 
-const imageWidth = 1024;
-const imageHeight = 768;
-
 function DownloadButton({
   filename,
   addPadding = true,
@@ -26,20 +22,14 @@ function DownloadButton({
   addPadding?: boolean;
 }) {
   const { getNodes } = useReactFlow();
+  const storeApi = useStoreApi();
   const onClick = () => {
-    const nodesBounds = getNodesBounds(getNodes());
-    const width =
-      imageWidth > nodesBounds.width ? imageWidth : nodesBounds.width;
-    const height =
-      imageHeight > nodesBounds.height ? imageHeight : nodesBounds.height;
-    const viewport = getViewportForBounds(
-      nodesBounds,
-      width,
-      height,
-      0.5,
-      2,
-      0,
-    );
+    // nodeLookup resolves child node positions (relative to their parent
+    // group) to absolute coordinates — without it grouped graphs get cropped
+    const nodesBounds = getNodesBounds(getNodes(), {
+      nodeLookup: storeApi.getState().nodeLookup,
+    });
+    const { width, height, viewport } = getExportImageDimensions(nodesBounds);
 
     // Hide the button
     // @ts-ignore
@@ -47,23 +37,31 @@ function DownloadButton({
     // @ts-ignore
     document.querySelector(".react-flow__controls").style.display = "none";
 
-    // @ts-ignore
-    toPng(document.querySelector(".react-flow__viewport"), {
+    const viewportElement = document.querySelector(
+      ".react-flow__viewport",
+    ) as HTMLElement;
+    const removeExportStyles = injectExportStyles(viewportElement);
+
+    toPng(viewportElement, {
       backgroundColor: "#f1f1f1",
       width,
       height,
       style: {
-        width,
-        height,
+        width: `${width}px`,
+        height: `${height}px`,
         transform: `translate(${viewport.x}px, ${viewport.y}px) scale(${viewport.zoom})`,
       },
-    }).then((dataUrl: string) => {
-      downloadImage(dataUrl, filename);
-      // @ts-ignore
-      document.getElementById("download-visual").style.display = "block";
-      // @ts-ignore
-      document.querySelector(".react-flow__controls").style.display = "block";
-    });
+    })
+      .then((dataUrl: string) => {
+        downloadImage(dataUrl, filename);
+      })
+      .finally(() => {
+        removeExportStyles();
+        // @ts-ignore
+        document.getElementById("download-visual").style.display = "block";
+        // @ts-ignore
+        document.querySelector(".react-flow__controls").style.display = "block";
+      });
   };
 
   return (

--- a/packages/visualiser/src/components/NodeGraph.tsx
+++ b/packages/visualiser/src/components/NodeGraph.tsx
@@ -22,8 +22,8 @@ import {
   type Node,
   type NodeChange,
   useReactFlow,
+  useStoreApi,
   getNodesBounds,
-  getViewportForBounds,
   type NodeTypes,
   MarkerType,
 } from "@xyflow/react";
@@ -99,6 +99,10 @@ import { useChannelVisibility } from "../hooks/use-channel-visibility";
 import VisualizerDropdownContent from "./VisualizerDropdownContent";
 import NodeContextMenu from "./NodeContextMenu";
 import { convertToMermaid } from "../utils/export-mermaid";
+import {
+  getExportImageDimensions,
+  injectExportStyles,
+} from "../utils/export-image";
 import { copyToClipboard } from "../utils/clipboard";
 import { layoutGraph } from "../utils/layout";
 import { packNodesAroundBounds } from "../utils/local-packing";
@@ -493,6 +497,7 @@ const NodeGraphBuilder = ({
   const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
   const { fitView, getNodes, getIntersectingNodes, getZoom, setCenter } =
     useReactFlow();
+  const storeApi = useStoreApi();
 
   // Sync when parent passes new nodes/edges (e.g. playground re-parse)
   useEffect(() => {
@@ -1927,21 +1932,12 @@ const NodeGraphBuilder = ({
   }, [fitView]);
 
   const handleExportVisual = useCallback(() => {
-    const imageWidth = 1024;
-    const imageHeight = 768;
-    const nodesBounds = getNodesBounds(getNodes());
-    const width =
-      imageWidth > nodesBounds.width ? imageWidth : nodesBounds.width;
-    const height =
-      imageHeight > nodesBounds.height ? imageHeight : nodesBounds.height;
-    const viewport = getViewportForBounds(
-      nodesBounds,
-      width,
-      height,
-      0.5,
-      2,
-      0,
-    );
+    // nodeLookup resolves child node positions (relative to their parent
+    // group) to absolute coordinates — without it grouped graphs get cropped
+    const nodesBounds = getNodesBounds(getNodes(), {
+      nodeLookup: storeApi.getState().nodeLookup,
+    });
+    const { width, height, viewport } = getExportImageDimensions(nodesBounds);
 
     // Hide controls during export
     const controls = document.querySelector(
@@ -1949,21 +1945,29 @@ const NodeGraphBuilder = ({
     ) as HTMLElement;
     if (controls) controls.style.display = "none";
 
-    toPng(document.querySelector(".react-flow__viewport") as HTMLElement, {
+    const viewportElement = document.querySelector(
+      ".react-flow__viewport",
+    ) as HTMLElement;
+    const removeExportStyles = injectExportStyles(viewportElement);
+
+    toPng(viewportElement, {
       backgroundColor: "#f1f1f1",
       width,
       height,
       style: {
-        width: width.toString(),
-        height: height.toString(),
+        width: `${width}px`,
+        height: `${height}px`,
         transform: `translate(${viewport.x}px, ${viewport.y}px) scale(${viewport.zoom})`,
       },
-    }).then((dataUrl: string) => {
-      downloadImage(dataUrl, title);
-      // Restore controls
-      if (controls) controls.style.display = "block";
-    });
-  }, [getNodes, downloadImage, title]);
+    })
+      .then((dataUrl: string) => {
+        downloadImage(dataUrl, title);
+      })
+      .finally(() => {
+        removeExportStyles();
+        if (controls) controls.style.display = "block";
+      });
+  }, [getNodes, storeApi, downloadImage, title]);
 
   const handleLegendClick = useCallback(
     (collectionType: string, groupId?: string) => {

--- a/packages/visualiser/src/utils/export-image.test.ts
+++ b/packages/visualiser/src/utils/export-image.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import {
+  getExportImageDimensions,
+  EXPORT_PADDING,
+  extractEcVarNames,
+  buildExportCss,
+} from "./export-image";
+
+describe("getExportImageDimensions", () => {
+  it("adds padding around large graphs so edge nodes are not flush against the image border", () => {
+    // Graph larger than the minimum image size
+    const nodesBounds = { x: 100, y: 200, width: 3000, height: 2000 };
+    const { width, height, viewport } = getExportImageDimensions(nodesBounds);
+
+    expect(width).toBe(3000 + EXPORT_PADDING * 2);
+    expect(height).toBe(2000 + EXPORT_PADDING * 2);
+    expect(viewport.zoom).toBe(1);
+
+    // The leftmost/topmost node should be rendered EXPORT_PADDING px inside
+    // the image, not at 0,0 (which clips badges/icons rendered above and
+    // shadows rendered around the measured node rects)
+    expect(viewport.x + nodesBounds.x * viewport.zoom).toBe(EXPORT_PADDING);
+    expect(viewport.y + nodesBounds.y * viewport.zoom).toBe(EXPORT_PADDING);
+  });
+
+  it("keeps the whole graph inside the image (no clipping at the far edges)", () => {
+    const nodesBounds = { x: -500, y: -250, width: 4200, height: 1500 };
+    const { width, height, viewport } = getExportImageDimensions(nodesBounds);
+
+    const rightEdge =
+      viewport.x + (nodesBounds.x + nodesBounds.width) * viewport.zoom;
+    const bottomEdge =
+      viewport.y + (nodesBounds.y + nodesBounds.height) * viewport.zoom;
+
+    expect(rightEdge).toBeLessThanOrEqual(width - EXPORT_PADDING);
+    expect(bottomEdge).toBeLessThanOrEqual(height - EXPORT_PADDING);
+  });
+
+  it("uses the minimum image size for small graphs and centers the content", () => {
+    const nodesBounds = { x: 0, y: 0, width: 200, height: 100 };
+    const { width, height, viewport } = getExportImageDimensions(nodesBounds);
+
+    expect(width).toBe(1024);
+    expect(height).toBe(768);
+    // Zoom is clamped to 2 for small graphs (existing behaviour)
+    expect(viewport.zoom).toBe(2);
+
+    // Content is centered horizontally: distance from left edge equals
+    // distance from right edge
+    const left = viewport.x + nodesBounds.x * viewport.zoom;
+    const right =
+      width -
+      (viewport.x + (nodesBounds.x + nodesBounds.width) * viewport.zoom);
+    expect(left).toBeCloseTo(right, 5);
+  });
+
+  it("extracts --ec-* variable names from stylesheet text", () => {
+    const css = `
+      :root { --ec-card-bg: 255 255 255; --ec-page-text: 23 23 23; }
+      .react-flow__edge-path { stroke: var(--ec-edge-stroke, #6b7280); }
+      .other { color: red; --not-ec: 1; }
+    `;
+    expect(extractEcVarNames(css).sort()).toEqual([
+      "--ec-card-bg",
+      "--ec-edge-stroke",
+      "--ec-page-text",
+    ]);
+  });
+
+  it("builds export CSS that pins theme variables and edge styles", () => {
+    const css = buildExportCss({
+      "--ec-card-bg": "255 255 255",
+      "--ec-page-text": "23 23 23",
+    });
+
+    // Variables must apply to every element so they reach the deep-cloned
+    // SVG subtree (html-to-image copies SVG without inlining styles)
+    expect(css).toContain("--ec-card-bg: 255 255 255;");
+    expect(css).toContain("--ec-page-text: 23 23 23;");
+    expect(css).toMatch(/\*\s*\{/);
+
+    // Edge paths lose their stylesheet rule in the clone — it must be inlined
+    expect(css).toContain(".react-flow__edge-path");
+    expect(css).toContain("stroke:");
+  });
+
+  it("rounds image dimensions up to whole pixels", () => {
+    const nodesBounds = { x: 0, y: 0, width: 3000.4, height: 2000.6 };
+    const { width, height } = getExportImageDimensions(nodesBounds);
+
+    expect(Number.isInteger(width)).toBe(true);
+    expect(Number.isInteger(height)).toBe(true);
+    expect(width).toBeGreaterThanOrEqual(3000.4 + EXPORT_PADDING * 2);
+    expect(height).toBeGreaterThanOrEqual(2000.6 + EXPORT_PADDING * 2);
+  });
+});

--- a/packages/visualiser/src/utils/export-image.ts
+++ b/packages/visualiser/src/utils/export-image.ts
@@ -1,0 +1,134 @@
+import { getViewportForBounds, type Rect, type Viewport } from "@xyflow/react";
+
+const MIN_IMAGE_WIDTH = 1024;
+const MIN_IMAGE_HEIGHT = 768;
+
+// Nodes render decorations outside their measured rects (type badges at
+// -top-2.5, actor icons at -top-4, box shadows), so the exported image needs
+// breathing room around getNodesBounds() or edge nodes get clipped.
+export const EXPORT_PADDING = 40;
+
+export function getExportImageDimensions(nodesBounds: Rect): {
+  width: number;
+  height: number;
+  viewport: Viewport;
+} {
+  const paddedBounds = {
+    x: nodesBounds.x - EXPORT_PADDING,
+    y: nodesBounds.y - EXPORT_PADDING,
+    width: nodesBounds.width + EXPORT_PADDING * 2,
+    height: nodesBounds.height + EXPORT_PADDING * 2,
+  };
+
+  const width = Math.max(MIN_IMAGE_WIDTH, Math.ceil(paddedBounds.width));
+  const height = Math.max(MIN_IMAGE_HEIGHT, Math.ceil(paddedBounds.height));
+
+  const viewport = getViewportForBounds(paddedBounds, width, height, 0.5, 2, 0);
+
+  return { width, height, viewport };
+}
+
+// html-to-image deep-clones <svg> subtrees without inlining computed styles,
+// so var()-based fills (edge label pills, label text) and stylesheet rules
+// (.react-flow__edge-path) resolve to nothing in the capture — labels render
+// black and edges lose their color. Injecting a <style> that pins the resolved
+// theme variables and mirrors the edge rules fixes the capture in both themes.
+
+export function extractEcVarNames(cssText: string): string[] {
+  return Array.from(new Set(cssText.match(/--ec-[a-z0-9-]+/g) ?? []));
+}
+
+export function buildExportCss(themeVars: Record<string, string>): string {
+  const varDeclarations = Object.entries(themeVars)
+    .map(([name, value]) => `${name}: ${value};`)
+    .join(" ");
+
+  return [
+    // Applied to every element so the variables reach the cloned SVG subtree
+    `* { ${varDeclarations} }`,
+    // Mirrors .react-flow__edge-path in styles.css, which is lost in the clone
+    `.react-flow__edge-path { stroke: var(--ec-edge-stroke, #6b7280); stroke-width: 1.5; fill: none; }`,
+  ].join("\n");
+}
+
+function collectThemeCssVars(scope: Element): Record<string, string> {
+  const names = new Set<string>();
+  for (const sheet of Array.from(document.styleSheets)) {
+    let rules: CSSRuleList;
+    try {
+      rules = sheet.cssRules;
+    } catch {
+      continue; // cross-origin stylesheet
+    }
+    for (const rule of Array.from(rules)) {
+      for (const name of extractEcVarNames(rule.cssText)) {
+        names.add(name);
+      }
+    }
+  }
+
+  const computed = window.getComputedStyle(scope);
+  const vars: Record<string, string> = {};
+  for (const name of names) {
+    const value = computed.getPropertyValue(name).trim();
+    if (value) vars[name] = value;
+  }
+  return vars;
+}
+
+// html-to-image deep-clones <svg> elements via cloneNode(true) and skips
+// computed-style inlining for everything inside them (cloneChildren returns
+// early for SVG). Styles that SVG content gets from stylesheets or var()-based
+// presentation attributes are therefore lost in the capture. Inlining the
+// resolved values directly onto each SVG element before capture is the only
+// approach that survives the clone in every browser.
+const SVG_EXPORT_STYLE_PROPERTIES = [
+  "fill",
+  "fill-opacity",
+  "stroke",
+  "stroke-width",
+  "stroke-dasharray",
+  "stroke-linecap",
+  "stroke-linejoin",
+  "opacity",
+  "font-family",
+  "font-size",
+  "font-weight",
+  "letter-spacing",
+  "text-anchor",
+  "dominant-baseline",
+];
+
+function inlineSvgComputedStyles(viewport: HTMLElement): () => void {
+  const restores: Array<() => void> = [];
+  const svgElements = viewport.querySelectorAll("svg, svg *");
+  svgElements.forEach((element) => {
+    if (!(element instanceof SVGElement)) return;
+    const computed = window.getComputedStyle(element);
+    const originalStyle = element.getAttribute("style");
+    for (const property of SVG_EXPORT_STYLE_PROPERTIES) {
+      const value = computed.getPropertyValue(property);
+      if (value) element.style.setProperty(property, value);
+    }
+    restores.push(() => {
+      if (originalStyle === null) {
+        element.removeAttribute("style");
+      } else {
+        element.setAttribute("style", originalStyle);
+      }
+    });
+  });
+  return () => restores.forEach((restore) => restore());
+}
+
+// Returns a cleanup function that removes the injected styles.
+export function injectExportStyles(viewport: HTMLElement): () => void {
+  const styleElement = document.createElement("style");
+  styleElement.textContent = buildExportCss(collectThemeCssVars(viewport));
+  viewport.appendChild(styleElement);
+  const restoreSvgStyles = inlineSvgComputedStyles(viewport);
+  return () => {
+    restoreSvgStyles();
+    styleElement.remove();
+  };
+}


### PR DESCRIPTION
Closes [#1813](https://github.com/event-catalog/eventcatalog/issues/1813)

## What This PR Does

Fixes the "download visual" image export in the visualiser. Previously, exporting a graph that contained groups (nested nodes) produced a cropped image, and the exported PNG lost all edge and label colors — edges rendered without their theme color and labels came out black. This PR makes exports capture the full graph and preserve theme colors in both light and dark mode.

## Changes Overview

### Key Changes

- Extract the shared export logic into a new `utils/export-image.ts` module used by both `DownloadButton` and `NodeGraph`.
- Compute export bounds with `nodeLookup` so child node positions inside groups resolve to absolute coordinates (fixes cropping).
- Add consistent padding around the graph bounds so decorations rendered outside node rects (type badges, actor icons, shadows) aren't clipped.
- Inject resolved theme CSS variables and inline SVG computed styles before capture so edges and labels keep their colors through `html-to-image`'s SVG clone.
- Restore all injected styles and hidden controls via `finally()` so the DOM is cleaned up even if capture fails.
- Add unit tests for the new export utilities.

## How It Works

`html-to-image` deep-clones `<svg>` subtrees without inlining computed styles, so `var()`-based fills and stylesheet rules (like `.react-flow__edge-path`) resolve to nothing in the capture. The new module collects the resolved `--ec-*` theme variables from the active stylesheets, pins them via an injected `<style>`, and inlines computed SVG presentation styles onto each SVG element before capture — then removes them afterward. Separately, `getNodesBounds` is now called with the React Flow `nodeLookup` from the store so grouped graphs report correct absolute bounds, and padding is added around those bounds before deriving the viewport.

## Breaking Changes

None.

## Additional Notes

No corresponding change is needed in the editor repository — this is a self-contained fix in the standalone `@eventcatalog/visualiser` package.