### PR TITLE
Serve user-defined pages and API routes from the catalog

### DIFF
--- a/.changeset/quiet-pandas-wander.md
+++ b/.changeset/quiet-pandas-wander.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": minor
+---
+
+Custom pages: `.astro` and API route files in your catalog's `pages/` directory are now served as routes under a configurable prefix (`pages.prefix`, defaults to `custom`). Requires the Scale plan.

--- a/examples/default/tsconfig.json
+++ b/examples/default/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  // Editor support (IntelliSense, go-to-definition) for custom pages.
+  // These aliases mirror the ones the EventCatalog build provides at runtime.
+  // In a real catalog the paths point into .eventcatalog-core instead.
+  "compilerOptions": {
+    "baseUrl": ".",
+    "allowJs": true,
+    "jsx": "preserve",
+    "paths": {
+      "@catalog/components/*": ["components/*"],
+      "@catalog/layouts/*": ["../../packages/core/eventcatalog/src/toolkit/layouts/*"],
+      "@catalog/utils": ["../../packages/core/eventcatalog/src/toolkit/utils/index.ts"],
+      "@catalog/utils/*": ["../../packages/core/eventcatalog/src/toolkit/utils/*"],
+      "@components/*": ["../../packages/core/eventcatalog/src/components/*"],
+      "@layouts/*": ["../../packages/core/eventcatalog/src/layouts/*"],
+      "@utils/*": ["../../packages/core/eventcatalog/src/utils/*"],
+      "@enterprise/*": ["../../packages/core/eventcatalog/src/enterprise/*"],
+      "@icons/*": ["../../packages/core/eventcatalog/src/icons/*"],
+      "@stores/*": ["../../packages/core/eventcatalog/src/stores/*"],
+      "@types": ["../../packages/core/eventcatalog/src/types/index.ts"],
+      "@config": ["eventcatalog.config.js"],
+      "@eventcatalog": ["../../packages/core/eventcatalog/src/utils/eventcatalog-config/catalog.ts"]
+    }
+  },
+  "include": ["pages/**/*", "components/**/*"]
+}

--- a/packages/core/eventcatalog/.gitignore
+++ b/packages/core/eventcatalog/.gitignore
@@ -13,6 +13,7 @@ src/content/*
 public/generated/*
 src/catalog-files/*
 src/custom-defined-components/*
+src/custom-pages/*
 src/snippets/*
 
 eventcatalog.config.js

--- a/packages/core/eventcatalog/src/enterprise/custom-pages/__tests__/routes.spec.ts
+++ b/packages/core/eventcatalog/src/enterprise/custom-pages/__tests__/routes.spec.ts
@@ -1,0 +1,135 @@
+/**
+ * Licensed under the EventCatalog Commercial License.
+ * See /packages/core/eventcatalog/src/enterprise/LICENSE
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { expect, describe, it, beforeEach, afterEach } from 'vitest';
+import { deriveRoutePattern, getCustomPageRoutes, isApiRoute, listCustomPageFiles, resolveCustomPagesPrefix } from '../routes';
+
+describe('custom-pages routes', () => {
+  describe('resolveCustomPagesPrefix', () => {
+    it('defaults to "custom" when no prefix is configured', () => {
+      expect(resolveCustomPagesPrefix(undefined)).toBe('custom');
+    });
+
+    it('normalizes leading and trailing slashes', () => {
+      expect(resolveCustomPagesPrefix('/internal/')).toBe('internal');
+    });
+
+    it('allows nested prefixes', () => {
+      expect(resolveCustomPagesPrefix('internal/tools')).toBe('internal/tools');
+    });
+
+    it('throws when the prefix is empty', () => {
+      expect(() => resolveCustomPagesPrefix('/')).toThrow('cannot be empty');
+    });
+
+    it('throws when the prefix contains unsafe characters', () => {
+      expect(() => resolveCustomPagesPrefix('my pages')).toThrow('invalid');
+    });
+
+    it('throws when the prefix shadows a core route', () => {
+      expect(() => resolveCustomPagesPrefix('docs')).toThrow('reserved');
+      expect(() => resolveCustomPagesPrefix('api/things')).toThrow('reserved');
+      expect(() => resolveCustomPagesPrefix('Visualiser')).toThrow('reserved');
+    });
+  });
+
+  describe('deriveRoutePattern', () => {
+    it('derives patterns under the prefix', () => {
+      expect(deriveRoutePattern('reports.astro', 'custom')).toBe('/custom/reports');
+      expect(deriveRoutePattern(path.join('team', 'oncall.astro'), 'custom')).toBe('/custom/team/oncall');
+    });
+
+    it('maps index files to their directory', () => {
+      expect(deriveRoutePattern('index.astro', 'custom')).toBe('/custom');
+      expect(deriveRoutePattern(path.join('reports', 'index.astro'), 'custom')).toBe('/custom/reports');
+    });
+
+    it('keeps dynamic segments untouched', () => {
+      expect(deriveRoutePattern(path.join('reports', '[id].astro'), 'custom')).toBe('/custom/reports/[id]');
+      expect(deriveRoutePattern(path.join('docs', '[...slug].astro'), 'custom')).toBe('/custom/docs/[...slug]');
+    });
+
+    it('keeps compound extensions for endpoints', () => {
+      expect(deriveRoutePattern('data.json.ts', 'custom')).toBe('/custom/data.json');
+    });
+  });
+
+  describe('getCustomPageRoutes', () => {
+    let customPagesDir: string;
+
+    beforeEach(() => {
+      customPagesDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ec-custom-pages-'));
+    });
+
+    afterEach(() => {
+      fs.rmSync(customPagesDir, { recursive: true, force: true });
+    });
+
+    const write = (relativePath: string, content = '') => {
+      const fullPath = path.join(customPagesDir, relativePath);
+      fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+      fs.writeFileSync(fullPath, content);
+    };
+
+    it('returns no routes when the directory does not exist', () => {
+      expect(getCustomPageRoutes(path.join(customPagesDir, 'missing'), 'custom')).toEqual([]);
+    });
+
+    it('returns routes for pages and endpoints', () => {
+      write('reports.astro');
+      write('api/teams.ts');
+
+      const routes = getCustomPageRoutes(customPagesDir, 'custom');
+
+      expect(routes).toEqual(
+        expect.arrayContaining([
+          { pattern: '/custom/reports', file: 'reports.astro', type: 'page' },
+          { pattern: '/custom/api/teams', file: path.join('api', 'teams.ts'), type: 'endpoint' },
+        ])
+      );
+      expect(routes).toHaveLength(2);
+    });
+
+    it('skips the custom landing page', () => {
+      write('homepage.astro');
+      expect(getCustomPageRoutes(customPagesDir, 'custom')).toEqual([]);
+    });
+
+    it('skips underscore-prefixed files and directories', () => {
+      write('_partial.astro');
+      write('_components/Card.astro');
+      write('team/_helpers.ts');
+      write('team/index.astro');
+
+      const routes = getCustomPageRoutes(customPagesDir, 'custom');
+      expect(routes).toEqual([{ pattern: '/custom/team', file: path.join('team', 'index.astro'), type: 'page' }]);
+    });
+
+    it('ignores non-code files', () => {
+      write('notes.md');
+      write('diagram.png');
+      expect(getCustomPageRoutes(customPagesDir, 'custom')).toEqual([]);
+    });
+
+    it('lists routable files sorted, excluding partials and non-code files (used for the dev restart manifest)', () => {
+      write('zebra.astro');
+      write('api/teams.ts');
+      write('_partial.astro');
+      write('notes.md');
+
+      expect(listCustomPageFiles(customPagesDir)).toEqual([path.join('api', 'teams.ts'), 'zebra.astro']);
+    });
+  });
+
+  describe('isApiRoute', () => {
+    it('detects routes in the api directory', () => {
+      expect(isApiRoute({ pattern: '/custom/api/teams', file: path.join('api', 'teams.ts'), type: 'endpoint' })).toBe(true);
+      expect(isApiRoute({ pattern: '/custom/reports', file: 'reports.astro', type: 'page' })).toBe(false);
+    });
+  });
+});

--- a/packages/core/eventcatalog/src/enterprise/custom-pages/routes.ts
+++ b/packages/core/eventcatalog/src/enterprise/custom-pages/routes.ts
@@ -1,0 +1,142 @@
+/**
+ * Licensed under the EventCatalog Commercial License.
+ * See /packages/core/eventcatalog/src/enterprise/LICENSE
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+export interface CustomPageRoute {
+  /** Route pattern including the configured prefix, e.g. /custom/reports/[id] */
+  pattern: string;
+  /** File path relative to the custom pages directory */
+  file: string;
+  type: 'page' | 'endpoint';
+}
+
+export const DEFAULT_CUSTOM_PAGES_PREFIX = 'custom';
+
+/**
+ * Tracks the routable files during dev so route injection re-runs when files
+ * are added or removed. Never a route itself.
+ */
+export const CUSTOM_PAGES_MANIFEST_FILENAME = '.routes-manifest.json';
+
+const CUSTOM_PAGE_EXTENSIONS = /\.(astro|ts|js|mjs|json)$/i;
+
+/**
+ * Top-level route segments owned by EventCatalog. The custom pages prefix
+ * cannot start with any of these — everything else is collision-free because
+ * all user routes live under the prefix.
+ */
+const RESERVED_PREFIXES = [
+  'api',
+  'api-catalog',
+  'architecture',
+  'auth',
+  'diagrams',
+  'directory',
+  'discover',
+  'docs',
+  'icepanel',
+  'miro',
+  'rss',
+  'schemas',
+  'settings',
+  'studio',
+  'unauthorized',
+  'visualiser',
+  '.well-known',
+];
+
+/**
+ * Normalizes and validates the configured prefix (e.g. 'custom', 'internal/tools').
+ * Throws when the prefix is empty, contains unsafe characters or shadows a core route.
+ */
+export const resolveCustomPagesPrefix = (prefix: string | undefined): string => {
+  const normalized = (prefix ?? DEFAULT_CUSTOM_PAGES_PREFIX).replace(/^\/+|\/+$/g, '');
+
+  if (normalized.length === 0) {
+    throw new Error('[EventCatalog] pages.prefix cannot be empty.');
+  }
+
+  if (!/^[a-zA-Z0-9-_]+(\/[a-zA-Z0-9-_]+)*$/.test(normalized)) {
+    throw new Error(
+      `[EventCatalog] pages.prefix "${prefix}" is invalid. Use URL-safe characters (letters, numbers, - and _), optionally separated by "/".`
+    );
+  }
+
+  const firstSegment = normalized.split('/')[0].toLowerCase();
+  if (RESERVED_PREFIXES.includes(firstSegment)) {
+    throw new Error(`[EventCatalog] pages.prefix "${prefix}" is reserved by EventCatalog. Choose a different prefix.`);
+  }
+
+  return normalized;
+};
+
+/**
+ * Derives an Astro route pattern from a file path relative to the custom pages
+ * directory. Dynamic segments ([id], [...slug]) pass through untouched.
+ */
+export const deriveRoutePattern = (relativeFilePath: string, prefix: string): string => {
+  const withoutExtension = relativeFilePath.replace(CUSTOM_PAGE_EXTENSIONS, '');
+  const segments = withoutExtension.split(/[\\/]/).filter(Boolean);
+
+  if (segments[segments.length - 1] === 'index') {
+    segments.pop();
+  }
+
+  return `/${[prefix, ...segments].join('/')}`;
+};
+
+const walkDirectory = (directory: string, relativeTo: string): string[] => {
+  const files: string[] = [];
+
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const fullPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walkDirectory(fullPath, relativeTo));
+    } else if (entry.isFile()) {
+      files.push(path.relative(relativeTo, fullPath));
+    }
+  }
+
+  return files;
+};
+
+/**
+ * Lists the routable code files in the custom pages directory (sorted, relative paths).
+ * Underscore-prefixed files and directories follow the Astro convention: they are
+ * never routable (partials, helpers, colocated components).
+ */
+export const listCustomPageFiles = (customPagesDir: string): string[] => {
+  if (!fs.existsSync(customPagesDir)) return [];
+
+  return walkDirectory(customPagesDir, customPagesDir)
+    .filter((file) => CUSTOM_PAGE_EXTENSIONS.test(file))
+    .filter((file) => file !== CUSTOM_PAGES_MANIFEST_FILENAME)
+    .filter((file) => !file.split(path.sep).some((segment) => segment.startsWith('_')))
+    .sort();
+};
+
+/**
+ * Reads the custom pages directory and returns the routes to inject.
+ */
+export const getCustomPageRoutes = (customPagesDir: string, prefix: string): CustomPageRoute[] => {
+  const routes: CustomPageRoute[] = [];
+
+  for (const file of listCustomPageFiles(customPagesDir)) {
+    // pages/homepage.astro is the custom landing page, rendered by src/pages/index.astro
+    if (file === 'homepage.astro') continue;
+
+    routes.push({
+      pattern: deriveRoutePattern(file, prefix),
+      file,
+      type: file.toLowerCase().endsWith('.astro') ? 'page' : 'endpoint',
+    });
+  }
+
+  return routes;
+};
+
+export const isApiRoute = (route: CustomPageRoute): boolean => route.file.split(path.sep)[0] === 'api';

--- a/packages/core/eventcatalog/src/enterprise/feature.ts
+++ b/packages/core/eventcatalog/src/enterprise/feature.ts
@@ -53,6 +53,9 @@ export const isEventCatalogUpgradeEnabled = () => !isEventCatalogStarterEnabled(
 // Custom landing pages are always enabled now.
 export const isCustomLandingPageEnabled = () => true;
 
+// User-defined pages and API routes (pages/*.astro, pages/api/*.ts)
+export const isCustomPagesEnabled = () => isEventCatalogScaleEnabled();
+
 export const isAuthEnabled = () => {
   const isAuthEnabledInCatalog = config?.auth?.enabled ?? false;
   const directory = process.env.PROJECT_DIR || process.cwd();

--- a/packages/core/eventcatalog/src/enterprise/integrations/eventcatalog-features.ts
+++ b/packages/core/eventcatalog/src/enterprise/integrations/eventcatalog-features.ts
@@ -4,23 +4,80 @@
  */
 
 import type { AstroIntegration } from 'astro';
+import fs from 'node:fs';
 import path from 'path';
 import config from '../../../eventcatalog.config.js';
 import {
   isEventCatalogChatEnabled,
   isAuthEnabled,
   isEventCatalogScaleEnabled,
-  isEventCatalogStarterEnabled,
   isEventCatalogMCPEnabled,
   isEventCatalogMCPAuthEnabled,
   isFullCatalogAPIEnabled,
   isDevMode,
   isIntegrationsEnabled,
   isCustomDocsEnabled,
+  isCustomPagesEnabled,
   isSSR,
 } from '../../utils/feature';
+import {
+  CUSTOM_PAGES_MANIFEST_FILENAME,
+  getCustomPageRoutes,
+  isApiRoute,
+  listCustomPageFiles,
+  resolveCustomPagesPrefix,
+} from '../custom-pages/routes';
 
 const catalogDirectory = process.env.CATALOG_DIR || process.cwd();
+const customPagesDirectory = path.join(catalogDirectory, 'src/custom-pages');
+
+// Routes are injected at astro:config:setup, so adding or removing a custom page
+// file needs a full Astro restart before its route exists. This manifest is
+// registered via addWatchFile — rewriting it with a changed file list triggers
+// that restart (a Vite-level server.restart() does NOT re-run route injection).
+const customPagesManifest = path.join(customPagesDirectory, CUSTOM_PAGES_MANIFEST_FILENAME);
+
+const writeCustomPagesManifest = () => {
+  const content = JSON.stringify(listCustomPageFiles(customPagesDirectory));
+
+  try {
+    if (fs.existsSync(customPagesManifest) && fs.readFileSync(customPagesManifest, 'utf-8') === content) {
+      return;
+    }
+
+    fs.mkdirSync(customPagesDirectory, { recursive: true });
+    fs.writeFileSync(customPagesManifest, content);
+  } catch (error: any) {
+    console.warn(`[EventCatalog] Could not update the custom pages manifest: ${error.message}`);
+  }
+};
+
+const configureCustomPages = (params: {
+  command: 'dev' | 'build' | 'preview' | 'sync';
+  injectRoute: (route: { pattern: string; entrypoint: string }) => void;
+}) => {
+  const prefix = resolveCustomPagesPrefix(config.pages?.prefix);
+  const routes = getCustomPageRoutes(customPagesDirectory, prefix);
+
+  const apiRoutes = routes.filter(isApiRoute);
+  if (apiRoutes.length > 0 && !isSSR()) {
+    const message = `Custom API routes (${apiRoutes.map((route) => `pages/${route.file}`).join(', ')}) require EventCatalog to run in server mode. Set output: 'server' in your eventcatalog.config.js or remove the pages/api directory.`;
+
+    // The dev server serves endpoints dynamically regardless of output mode,
+    // so only fail the build — but warn early during development.
+    if (params.command === 'build') {
+      throw new Error(`[EventCatalog] ${message}`);
+    }
+    console.warn(`[EventCatalog] ${message}`);
+  }
+
+  for (const route of routes) {
+    params.injectRoute({
+      pattern: route.pattern,
+      entrypoint: path.join(customPagesDirectory, route.file),
+    });
+  }
+};
 
 const configureAuthentication = (params: {
   injectRoute: (route: { pattern: string; entrypoint: string }) => void;
@@ -148,6 +205,18 @@ export default function eventCatalogIntegration(): AstroIntegration {
           });
         }
 
+        // User-defined pages and API routes (Scale plan)
+        if (isCustomPagesEnabled()) {
+          configureCustomPages(params);
+        } else if (listCustomPageFiles(customPagesDirectory).length > 0) {
+          console.warn('[EventCatalog] Custom pages require the Scale plan. The routes for your pages will not be served.');
+        }
+
+        // Keep routes in sync during dev — a manifest change restarts the dev
+        // server so injectRoute runs again with the new file list
+        writeCustomPagesManifest();
+        params.addWatchFile(customPagesManifest);
+
         // Warn if integrations are configured without Scale plan
         if (config.integrations && !isIntegrationsEnabled()) {
           console.warn('[EventCatalog] Integrations require the Scale plan. Analytics integrations will not be loaded.');
@@ -164,6 +233,20 @@ export default function eventCatalogIntegration(): AstroIntegration {
             entrypoint: path.join(catalogDirectory, 'src/enterprise/visualizer-layout/reset.ts'),
           });
         }
+      },
+      'astro:server:setup': ({ server }) => {
+        // When custom page files appear or disappear, refresh the manifest.
+        // A content change restarts the dev server (via addWatchFile above),
+        // which re-runs route injection. Unchanged content writes nothing,
+        // so events from the watcher's initial scan are no-ops.
+        const onCustomPageChange = (file: string) => {
+          if (!path.resolve(file).startsWith(customPagesDirectory + path.sep)) return;
+          if (!/\.(astro|ts|js|mjs)$/i.test(file)) return;
+          writeCustomPagesManifest();
+        };
+
+        server.watcher.on('add', onCustomPageChange);
+        server.watcher.on('unlink', onCustomPageChange);
       },
     },
   };

--- a/packages/core/eventcatalog/src/pages/index.astro
+++ b/packages/core/eventcatalog/src/pages/index.astro
@@ -21,7 +21,7 @@ const props = Astro.props;
 const pathToUserDefinedLandingPage = path.join(process.env.PROJECT_DIR || '', 'pages/homepage.astro');
 
 if (existsSync(pathToUserDefinedLandingPage) && isCustomLandingPageEnabled()) {
-  const customPages = import.meta.glob('/**/homepage.astro', { eager: true });
+  const customPages = import.meta.glob('/src/custom-pages/homepage.astro', { eager: true });
   // @ts-ignore
   CustomContent = Object.values(customPages)[0]?.default || null;
 

--- a/packages/core/eventcatalog/src/toolkit/layouts/Layout.astro
+++ b/packages/core/eventcatalog/src/toolkit/layouts/Layout.astro
@@ -1,0 +1,25 @@
+---
+/**
+ * Public layout shell for user-defined custom pages, imported by catalog
+ * authors as `@catalog/layouts/Layout.astro`.
+ *
+ * The props here are a documented, stable interface — internal layouts can
+ * change freely, this contract cannot.
+ */
+interface Props {
+  title: string;
+  description?: string;
+  /** Render the resource sidebar (domains, services, messages). Defaults to true. */
+  sidebar?: boolean;
+  /** Show the EventCatalog header (search, navigation). Defaults to true. */
+  showHeader?: boolean;
+}
+
+import VerticalSideBarLayout from '@layouts/VerticalSideBarLayout.astro';
+
+const { title, description, sidebar = true, showHeader = true } = Astro.props;
+---
+
+<VerticalSideBarLayout title={title} description={description} showHeader={showHeader} showNestedSideBar={sidebar}>
+  <slot />
+</VerticalSideBarLayout>

--- a/packages/core/eventcatalog/src/toolkit/utils/index.ts
+++ b/packages/core/eventcatalog/src/toolkit/utils/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Public utilities for user-defined custom pages, imported by catalog
+ * authors as `@catalog/utils`.
+ *
+ * These re-exports are a documented, stable interface — internal utils can
+ * change freely, this contract cannot. Getters return hydrated, cached
+ * collection entries (pass { getAllVersions: false } for latest versions only).
+ */
+export { getDomains } from '@utils/collections/domains';
+export { getServices } from '@utils/collections/services';
+export { getSystems } from '@utils/collections/systems';
+export { getEvents } from '@utils/collections/events';
+export { getCommands } from '@utils/collections/commands';
+export { getQueries } from '@utils/collections/queries';
+export { getFlows } from '@utils/collections/flows';
+export { getChannels } from '@utils/collections/channels';
+export { getEntities } from '@utils/collections/entities';
+export { getAgents } from '@utils/collections/agents';
+export { getContainers } from '@utils/collections/containers';
+export { getDataProducts } from '@utils/collections/data-products';
+export { getAdrs } from '@utils/collections/adrs';
+export { getTeams } from '@utils/collections/teams';
+export { getUsers } from '@utils/collections/users';
+
+// Resolve a specific version (semver) or the latest version of items in a collection
+export { getItemsFromCollectionByIdAndSemverOrLatest } from '@utils/collections/util';

--- a/packages/core/eventcatalog/src/utils/feature.ts
+++ b/packages/core/eventcatalog/src/utils/feature.ts
@@ -25,6 +25,7 @@ export {
   isEventCatalogChatEnabled,
   isEventCatalogUpgradeEnabled,
   isCustomLandingPageEnabled,
+  isCustomPagesEnabled,
   isAuthEnabled,
   isCustomStylesEnabled,
   isEventCatalogMCPEnabled,

--- a/packages/core/eventcatalog/tsconfig.json
+++ b/packages/core/eventcatalog/tsconfig.json
@@ -9,6 +9,9 @@
       "@icons/*": ["src/icons/*"],
       "@components/*": ["src/components/*"],
       "@catalog/components/*": ["src/custom-defined-components/*"],
+      "@catalog/layouts/*": ["src/toolkit/layouts/*"],
+      "@catalog/utils": ["src/toolkit/utils/index.ts"],
+      "@catalog/utils/*": ["src/toolkit/utils/*"],
       "@catalog/snippets/*": ["src/snippets/*"],
       "@types": ["src/types/index.ts"],
       "@utils/*": ["src/utils/*"],
@@ -22,5 +25,6 @@
     "jsxImportSource": "react",
     "types": ["vitest/globals"]
   },
-  "include": ["src/**/*", "*.config.*"]
+  "include": ["src/**/*", "*.config.*"],
+  "exclude": ["src/custom-pages"]
 }

--- a/packages/core/src/__tests__/map-catalog-to-astro.spec.ts
+++ b/packages/core/src/__tests__/map-catalog-to-astro.spec.ts
@@ -1,0 +1,68 @@
+import path from 'node:path';
+import { expect, describe, it } from 'vitest';
+import { mapCatalogToAstro } from '../map-catalog-to-astro';
+
+const PROJECT_DIR = path.join(__dirname, 'example-catalog');
+const ASTRO_DIR = path.join(__dirname, 'tmp-astro');
+
+const map = (relativeFilePath: string) =>
+  mapCatalogToAstro({
+    filePath: path.join(PROJECT_DIR, relativeFilePath),
+    astroDir: ASTRO_DIR,
+    projectDir: PROJECT_DIR,
+  });
+
+describe('map-catalog-to-astro', () => {
+  describe('custom pages (top-level pages directory)', () => {
+    it('maps .astro files to src/custom-pages instead of the public directory', () => {
+      expect(map('pages/homepage.astro')).toEqual([path.join(ASTRO_DIR, 'src', 'custom-pages', 'homepage.astro')]);
+      expect(map('pages/reports/[id].astro')).toEqual([path.join(ASTRO_DIR, 'src', 'custom-pages', 'reports', '[id].astro')]);
+    });
+
+    it('maps API endpoint files to src/custom-pages', () => {
+      expect(map('pages/api/teams.ts')).toEqual([path.join(ASTRO_DIR, 'src', 'custom-pages', 'api', 'teams.ts')]);
+      expect(map('pages/data.json.js')).toEqual([path.join(ASTRO_DIR, 'src', 'custom-pages', 'data.json.js')]);
+    });
+
+    it('maps directories to both custom-pages and public targets so deletes clean up both', () => {
+      expect(map('pages/reports')).toEqual([
+        path.join(ASTRO_DIR, 'src', 'custom-pages', 'reports'),
+        path.join(ASTRO_DIR, 'public', 'generated', 'pages', 'reports'),
+      ]);
+    });
+
+    it('keeps mapping non-code assets in pages to the public directory', () => {
+      expect(map('pages/diagram.png')).toEqual([path.join(ASTRO_DIR, 'public', 'generated', 'pages', 'diagram.png')]);
+    });
+
+    it('does not treat nested pages directories inside collections as custom pages', () => {
+      expect(map('domains/Orders/pages/overview.astro')).toEqual([
+        path.join(ASTRO_DIR, 'public', 'generated', 'pages', 'overview.astro'),
+      ]);
+    });
+  });
+
+  describe('collections', () => {
+    it('maps collection asset files to the public directory', () => {
+      expect(map('events/OrderAmended/schema.json')).toEqual([
+        path.join(ASTRO_DIR, 'public', 'generated', 'events', 'OrderAmended', 'schema.json'),
+      ]);
+    });
+
+    it('ignores LikeC4 source files', () => {
+      expect(map('events/OrderAmended/order-flow.c4')).toEqual([]);
+    });
+  });
+
+  describe('custom components', () => {
+    it('maps components to src/custom-defined-components', () => {
+      expect(map('components/MyComponent.astro')).toEqual([
+        path.join(ASTRO_DIR, 'src', 'custom-defined-components', 'MyComponent.astro'),
+      ]);
+    });
+  });
+
+  it('ignores files that are not catalog related', () => {
+    expect(map('README.txt')).toEqual([]);
+  });
+});

--- a/packages/core/src/catalog-to-astro-content-directory.js
+++ b/packages/core/src/catalog-to-astro-content-directory.js
@@ -43,6 +43,22 @@ const copyFiles = async (source, target) => {
   }
 };
 
+const clearCustomPages = async (target) => {
+  const customPagesDir = path.join(target, 'src', 'custom-pages');
+  if (fs.existsSync(customPagesDir)) fs.rmSync(customPagesDir, { recursive: true });
+
+  // Older versions copied pages/ code files (e.g. homepage.astro) into public/generated,
+  // serving their source as static assets. Clean up any stale copies.
+  const staleCodeFiles = await glob(path.join(target, 'public', 'generated', 'pages', '**/*.{astro,ts,js,mjs}'), {
+    nodir: true,
+    windowsPathsNoEscape: os.platform() == 'win32',
+  });
+
+  for (const file of staleCodeFiles) {
+    fs.rmSync(file);
+  }
+};
+
 const removeGeneratedLikeC4Sources = async (target) => {
   const generatedDir = path.join(target, 'public', 'generated');
   const files = await glob(path.join(generatedDir, '**/*.{c4,likec4}'), {
@@ -72,6 +88,7 @@ export const catalogToAstro = async (source, astroDir) => {
     fs.writeFileSync(path.join(source, 'eventcatalog.styles.css'), '');
   }
 
+  await clearCustomPages(astroDir);
   await removeGeneratedLikeC4Sources(astroDir);
   await copyFiles(source, astroDir);
 };

--- a/packages/core/src/eventcatalog.config.ts
+++ b/packages/core/src/eventcatalog.config.ts
@@ -286,6 +286,14 @@ export interface Config {
   };
   mdxOptimize?: boolean;
   compress?: boolean;
+  pages?: {
+    /**
+     * URL prefix that user-defined pages (pages/*.astro, pages/api/*.ts) are served under,
+     * e.g. pages/reports.astro is served at /custom/reports.
+     * @default 'custom'
+     */
+    prefix?: string;
+  };
   navigation?: {
     pages?: NavigationPage[];
     /**

--- a/packages/core/src/map-catalog-to-astro.js
+++ b/packages/core/src/map-catalog-to-astro.js
@@ -1,5 +1,9 @@
 import path from 'node:path';
 
+// Code files in the top-level `pages/` directory become routes in the Astro app
+// (custom pages). Everything else in `pages/` keeps the collection behaviour.
+const CUSTOM_PAGE_EXTENSIONS = ['.astro', '.ts', '.js', '.mjs'];
+
 const COLLECTION_KEYS = [
   'agents',
   'events',
@@ -38,6 +42,11 @@ export function mapCatalogToAstro({ filePath, astroDir, projectDir }) {
     return [];
   }
 
+  const customPageTargetPaths = getCustomPageTargetPaths(relativeFilePath, astroDir);
+  if (customPageTargetPaths) {
+    return customPageTargetPaths;
+  }
+
   const baseTargetPaths = getBaseTargetPaths(relativeFilePath);
   const relativeTargetPath = getRelativeTargetPath(relativeFilePath);
 
@@ -66,6 +75,42 @@ function isCollectionKey(key) {
 
 function isLikeC4Source(filePath) {
   return filePath.endsWith('.c4') || filePath.endsWith('.likec4');
+}
+
+// This is a workaround to differentiate between a file and a directory.
+// Of course this is not the best solution. But how differentiate? `fs.stats`
+// could be used, but sometimes the filePath references a deleted file/directory
+// which causes an error when using `fs.stats`.
+const hasExtension = (str) => /\.[a-zA-Z0-9]{2,}$/.test(str);
+
+/**
+ * Maps files in the user's top-level `pages/` directory.
+ * Code files (.astro/.ts/.js/.mjs) become custom pages (routes) in the Astro app,
+ * they must never land in `public/` where their source would be served.
+ * @param {string} filePath - The file path without the projectDir prefix.
+ * @param {string} astroDir - The astro directory.
+ * @returns {string[]|null} Target paths, or null when the path is not a top-level pages path.
+ */
+function getCustomPageTargetPaths(filePath, astroDir) {
+  const filePathArr = filePath.split(path.sep).filter(Boolean);
+
+  if (filePathArr[0] !== 'pages') {
+    return null;
+  }
+
+  const customPagePath = path.join(astroDir, 'src', 'custom-pages', ...filePathArr.slice(1));
+
+  if (CUSTOM_PAGE_EXTENSIONS.includes(path.extname(filePath).toLowerCase())) {
+    return [customPagePath];
+  }
+
+  // Directories map to both targets so watcher deletes clean up both copies
+  if (!hasExtension(filePath)) {
+    return [customPagePath, path.join(astroDir, 'public', 'generated', ...filePathArr)];
+  }
+
+  // Other assets keep the existing public/generated behaviour
+  return [path.join(astroDir, 'public', 'generated', ...filePathArr)];
 }
 
 /**
@@ -103,12 +148,6 @@ function getBaseTargetPaths(filePath) {
 
   // Collection
   if (isCollectionKey(filePathArr[0])) {
-    // This is a workaround to differentiate between a file and a directory.
-    // Of course this is not the best solution. But how differentiate? `fs.stats`
-    // could be used, but sometimes the filePath references a deleted file/directory
-    // which causes an error when using `fs.stats`.
-    const hasExtension = (str) => /\.[a-zA-Z0-9]{2,}$/.test(str);
-
     // Assets files
     if (hasExtension(filePath)) {
       return [path.join('public', 'generated')];


### PR DESCRIPTION
# PR: Serve user-defined pages and API routes from the catalog

## What This PR Does

Catalog authors can now drop `.astro` pages and API route handlers into their catalog's top-level `pages/` directory and have EventCatalog serve them as real routes. Pages are served under a configurable URL prefix (`pages.prefix`, defaulting to `custom`), so `pages/reports.astro` becomes `/custom/reports` and `pages/api/stats.ts` becomes `/custom/api/stats`.

Alongside the routing, this adds a small public "toolkit" — a stable `@catalog/utils` and `@catalog/layouts/Layout.astro` surface — so authors can query catalog collections and reuse the EventCatalog page shell without reaching into internal modules that are free to change.

The feature is gated behind the Scale plan.

## Changes Overview

### Key Changes

- **Route discovery and injection** — new `enterprise/custom-pages/routes.ts` walks the custom pages directory, derives Astro route patterns from file paths (dynamic segments like `[id]` and `[...slug]` pass through), and skips underscore-prefixed files/directories per Astro convention. The `eventcatalog-features` integration injects those routes at `astro:config:setup`.
- **Prefix validation** — `pages.prefix` is normalized and validated. Empty prefixes, non-URL-safe characters, and prefixes that shadow a core EventCatalog route (`api`, `docs`, `visualiser`, …) all throw with an actionable message.
- **File mapping fix** — `map-catalog-to-astro.js` now routes code files under `pages/` into `src/custom-pages/` rather than `public/generated/`. Previously a `homepage.astro` was copied into `public/`, which served its **source** as a static asset.
- **Stale-copy cleanup** — `catalog-to-astro-content-directory.js` clears `src/custom-pages` on each build and deletes any code files older versions left behind in `public/generated/pages/`.
- **Dev-server route sync** — added/removed page files rewrite a `.routes-manifest.json` that is registered via `addWatchFile`, restarting Astro so route injection re-runs. (A Vite `server.restart()` does not re-run route injection.)
- **Public toolkit** — `src/toolkit/utils/index.ts` re-exports the collection getters; `src/toolkit/layouts/Layout.astro` wraps `VerticalSideBarLayout` behind a narrow prop contract. Both are reachable via new `@catalog/*` tsconfig aliases.
- **Editor support** — `examples/default/tsconfig.json` mirrors the runtime aliases so custom pages get IntelliSense and go-to-definition in a real catalog.

### Tests

26 tests across two new suites: `map-catalog-to-astro.spec.ts` (9) covering the new `pages/` mapping, and `custom-pages/__tests__/routes.spec.ts` (17) covering prefix resolution, route derivation, and file listing.

## How It Works

User `pages/` files are copied into the Astro app at `src/custom-pages/` during the catalog→Astro sync. At `astro:config:setup` the integration lists the routable files there, derives a route pattern for each, and calls `injectRoute` with the configured prefix. `pages/homepage.astro` is deliberately excluded — it remains the custom landing page rendered by `src/pages/index.astro`, which now globs that exact path instead of a repo-wide `/**/homepage.astro`.

API routes need SSR. Because Astro's dev server serves endpoints dynamically regardless of `output` mode, a static-output catalog containing `pages/api/*` only **warns** during `dev` but **fails the build** — surfacing the misconfiguration early without blocking local iteration.

Route injection only happens once, at config setup. To keep dev usable, the integration writes a manifest of the routable file list and watches it; when a page file is added or removed the manifest content changes, which triggers a full Astro restart and a fresh injection pass. Writes are content-compared first, so the watcher's initial scan is a no-op.

## Breaking Changes

None for existing catalogs.

One behavior change worth calling out: code files in `pages/` are no longer copied to `public/generated/pages/`. That old behavior served page **source** as a static asset — an information leak rather than a feature — so nothing should depend on it. Stale copies from prior versions are cleaned up automatically on the next build.

## Additional Notes

**For reviewers:**

- `.changeset/pre.json` was present and untracked in the working tree when this branch was cut. It is a repo-wide changesets pre-release switch (tag `beta`), not part of this feature, so it was deliberately **left out** of this commit. It still sits uncommitted locally — worth deciding separately whether the repo should be in pre-release mode.
- The `RESERVED_PREFIXES` list in `routes.ts` is maintained by hand against the top-level route segments in `src/pages/`. It will need updating whenever a new top-level core route is added; there is no automated check tying the two together.
- `@catalog/utils` and `@catalog/layouts/Layout.astro` are now a public contract. Changes to their exports/props are user-facing breaking changes even though the underlying internals are not.

**Follow-up work:**

- Documentation for `pages.prefix` and the `@catalog/*` toolkit surface.
- No editor-repo (`eventcatalog/eventcatalog-editor`) change is needed for this PR.
