### PR TITLE
Install EventCatalog Skills when scaffolding a new project

### DIFF
--- a/.changeset/quiet-donkeys-shave.md
+++ b/.changeset/quiet-donkeys-shave.md
@@ -1,0 +1,6 @@
+---
+'@eventcatalog/create-eventcatalog': patch
+'@eventcatalog/core': patch
+---
+
+feat(create-eventcatalog): optionally install EventCatalog Skills when scaffolding a new project, and surface the skills repo in the CLI banner

--- a/packages/core/src/utils/cli-logger.ts
+++ b/packages/core/src/utils/cli-logger.ts
@@ -20,6 +20,10 @@ export const logger = {
       pc.dim('If you like the project, we would appreciate a star on GitHub ❤️ - ') +
         pc.bold('https://github.com/event-catalog/eventcatalog/stargazers')
     );
+    console.log(
+      pc.dim('Using AI? Install EventCatalog Skills to help you manage your catalog - ') +
+        pc.bold('https://github.com/event-catalog/skills')
+    );
     console.log();
   },
   info: (message: string, tag: string = 'info') => {

--- a/packages/create-eventcatalog/create-app.ts
+++ b/packages/create-eventcatalog/create-app.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 import path from 'path';
 import { makeDir } from './helpers/make-dir';
 import { tryGitInit } from './helpers/git';
+import { installEventCatalogSkills } from './helpers/install-skills';
 
 import { isFolderEmpty } from './helpers/is-folder-empty';
 import { getOnline } from './helpers/is-online';
@@ -23,6 +24,7 @@ export async function createApp({
   experimentalApp,
   organizationName,
   initEmptyProject,
+  installSkills,
   template: templateName,
 }: {
   appPath: string;
@@ -34,6 +36,7 @@ export async function createApp({
   experimentalApp: boolean;
   organizationName: string;
   initEmptyProject: boolean;
+  installSkills: boolean;
   template?: TemplateType;
 }): Promise<void> {
   let repoInfo: any | undefined;
@@ -78,6 +81,8 @@ export async function createApp({
     organizationName,
   });
 
+  const skillsInstalled = installSkills ? await installEventCatalogSkills(root) : false;
+
   const gitInitialized = tryGitInit(root);
 
   let cdpath: string;
@@ -92,6 +97,9 @@ export async function createApp({
   console.log(chalk.green('  Project initialized!'));
   console.log(`    ${chalk.dim('■')} Template copied`);
   console.log(`    ${chalk.dim('■')} Dependencies installed`);
+  if (skillsInstalled) {
+    console.log(`    ${chalk.dim('■')} EventCatalog Skills installed`);
+  }
   if (gitInitialized) {
     console.log(`    ${chalk.dim('■')} Git initialized`);
   }

--- a/packages/create-eventcatalog/helpers/install-skills.ts
+++ b/packages/create-eventcatalog/helpers/install-skills.ts
@@ -1,0 +1,26 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import spawn from 'cross-spawn';
+
+export function installEventCatalogSkills(root: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const isInteractive = Boolean(process.stdin.isTTY && process.stdout.isTTY);
+
+    const child = spawn('npx', ['skills', 'add', 'event-catalog/skills'], {
+      cwd: root,
+      stdio: isInteractive ? 'inherit' : 'ignore',
+      env: {
+        ...process.env,
+        ADBLOCK: '1',
+        DISABLE_OPENCOLLECTIVE: '1',
+      },
+    });
+
+    child.on('error', () => {
+      resolve(false);
+    });
+
+    child.on('close', (code) => {
+      resolve(code === 0);
+    });
+  });
+}

--- a/packages/create-eventcatalog/index.ts
+++ b/packages/create-eventcatalog/index.ts
@@ -12,6 +12,7 @@ import packageJson from './package.json';
 
 let projectPath: string = '';
 let organizationName: string = '';
+let installSkills: boolean = false;
 
 const program = new Commander.Command(packageJson.name)
   .version(packageJson.version)
@@ -161,6 +162,15 @@ async function run(): Promise<void> {
     }
   }
 
+  const installSkillsResponse = await prompts({
+    type: 'confirm',
+    name: 'installSkills',
+    message: 'Would you like to install EventCatalog Skills?',
+    initial: true,
+  });
+
+  installSkills = installSkillsResponse.installSkills ?? false;
+
   console.log();
 
   const template = program.template || 'default';
@@ -197,6 +207,7 @@ async function run(): Promise<void> {
       experimentalApp: false,
       organizationName: organizationName,
       initEmptyProject,
+      installSkills,
       template: template,
     });
   } catch (reason) {
@@ -224,6 +235,7 @@ async function run(): Promise<void> {
       organizationName: organizationName,
       experimentalApp: program.experimentalApp,
       initEmptyProject,
+      installSkills,
     });
   }
 }


### PR DESCRIPTION
## What This PR Does

Adds an optional step to the `create-eventcatalog` CLI that installs the [EventCatalog Skills](https://github.com/event-catalog/skills) into a newly scaffolded project. Users are prompted during setup and can opt out. The core CLI banner now also points people at the skills repo so existing catalogs can find them.

## Changes Overview

### Key Changes

- New helper `packages/create-eventcatalog/helpers/install-skills.ts` that shells out to `npx skills add event-catalog/skills` inside the freshly created project.
- `index.ts` prompts `Would you like to install EventCatalog Skills?` (defaults to yes) and threads the answer through to `createApp`.
- `create-app.ts` runs the install before `git init` and reports `EventCatalog Skills installed` in the post-setup summary when it succeeds.
- `packages/core/src/utils/cli-logger.ts` adds a line to the startup banner linking to the skills repo.

## How It Works

`installEventCatalogSkills` spawns `npx skills add event-catalog/skills` with the new project directory as its cwd. Stdio is inherited when running in a TTY so the user sees the installer's own output and can respond to any of its prompts; in non-interactive environments (CI, piped shells) output is silenced instead. The promise resolves to `false` on spawn error or a non-zero exit code, so a failed or unavailable installer never breaks project creation — it just omits the "Skills installed" line from the summary.

The install runs after the template is copied and dependencies are installed, but before `tryGitInit`, so any files the skills installer writes are captured in the initial commit.

## Breaking Changes

None. The prompt defaults to yes but is skippable, and a failing install is non-fatal.

## Additional Notes

- The install depends on `npx skills` resolving at runtime; there is no version pin, so the CLI always pulls the latest skills package.
- No changes needed in the `eventcatalog/eventcatalog-editor` repository — this is scaffolding and CLI-banner only.