### PR TITLE
Fix static builds failing with `TypeError: Missing parameter: id` when `trailingSlash: true`

### DIFF
--- a/.changeset/tidy-poems-repair.md
+++ b/.changeset/tidy-poems-repair.md
@@ -1,0 +1,14 @@
+---
+'@eventcatalog/core': patch
+---
+
+fix(core): builds failing with `TypeError: Missing parameter: id` when `trailingSlash: true` is set
+
+Astro 7.0.4 (withastro/astro PR #17224) changed route patterns for dynamic file
+endpoints (e.g. `/docs/teams/[id].md`) to never accept a trailing slash, but the
+prerender path generator still appends one when `trailingSlash: 'always'` is
+configured. The generated path (`/docs/teams/customer-platform.md/`) no longer
+matches the route pattern, so static builds crash. A Vite plugin now patches
+Astro's param extraction to retry with the trailing slash flipped when no route
+pattern matches — a no-op on unaffected Astro versions and once the regression
+is fixed upstream.

--- a/packages/core/eventcatalog/astro.config.mjs
+++ b/packages/core/eventcatalog/astro.config.mjs
@@ -15,6 +15,7 @@ import remarkComment from 'remark-comment';
 import rehypeSlug from 'rehype-slug';
 import rehypeAutolinkHeadings from 'rehype-autolink-headings';
 import { eventCatalogLikeC4 } from './src/plugins/likec4';
+import { astroTrailingSlashEndpointFix } from './src/plugins/astro-trailing-slash-endpoint-fix';
 
 import rehypeExpressiveCode from 'rehype-expressive-code';
 
@@ -116,7 +117,11 @@ export default defineConfig({
     eventCatalogIntegration(),
   ].filter(Boolean),
   vite: {
-    plugins: [tailwindcss(), ...(await eventCatalogLikeC4(projectDirectory))],
+    plugins: [
+      tailwindcss(),
+      ...(await eventCatalogLikeC4(projectDirectory)),
+      ...(config.trailingSlash === true ? [astroTrailingSlashEndpointFix()] : []),
+    ],
     define: {
       /**
        * Trailing slash is exposed as global variable here principally for `@utils/url-builder`.

--- a/packages/core/eventcatalog/src/plugins/__tests__/astro-trailing-slash-endpoint-fix.test.ts
+++ b/packages/core/eventcatalog/src/plugins/__tests__/astro-trailing-slash-endpoint-fix.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { join, dirname } from 'node:path';
+import { applyGetParamsTrailingSlashFix } from '../astro-trailing-slash-endpoint-fix';
+
+// From astro 7.0.3 - 7.0.6 (dist/core/render/params-and-props.js)
+const GET_PARAMS_7_0_3 = `function getParams(route, pathname) {
+  if (!route.params.length) return {};
+  const path = pathname.endsWith(".html") && route.type === "page" && !routeHasHtmlExtension(route) ? pathname.slice(0, -5) : pathname;
+  const allPatterns = [route, ...route.fallbackRoutes].map((r) => r.pattern);
+  const paramsMatch = allPatterns.map((pattern) => pattern.exec(path)).find((x) => x);
+  if (!paramsMatch) return {};
+}`;
+
+// From astro 7.0.7 - the same line was refactored to use \`let\`
+const GET_PARAMS_7_0_7 = `function getParams(route, pathname) {
+  if (!route.params.length) return {};
+  const hasHtmlSuffix = pathname.endsWith(".html") && !routeHasHtmlExtension(route);
+  const path = hasHtmlSuffix && route.type === "page" ? pathname.slice(0, -".html".length) : pathname;
+  const allPatterns = [route, ...route.fallbackRoutes].map((r) => r.pattern);
+  let paramsMatch = allPatterns.map((pattern) => pattern.exec(path)).find((x) => x);
+  if (!paramsMatch) return {};
+}`;
+
+describe('astro-trailing-slash-endpoint-fix', () => {
+  it('patches the astro 7.0.3-7.0.6 getParams source (const paramsMatch)', () => {
+    const patched = applyGetParamsTrailingSlashFix(GET_PARAMS_7_0_3);
+    expect(patched).toBeDefined();
+    expect(patched).toContain("path.endsWith('/') ? path.slice(0, -1) : path + '/'");
+    expect(patched).toContain('let paramsMatch = allPatterns');
+  });
+
+  it('patches the astro 7.0.7 getParams source (let paramsMatch)', () => {
+    const patched = applyGetParamsTrailingSlashFix(GET_PARAMS_7_0_7);
+    expect(patched).toBeDefined();
+    expect(patched).toContain("path.endsWith('/') ? path.slice(0, -1) : path + '/'");
+  });
+
+  it('returns undefined when the source does not match', () => {
+    expect(applyGetParamsTrailingSlashFix('const somethingElse = true;')).toBeUndefined();
+  });
+
+  // Canary: if this fails after an astro bump, astro refactored getParams and the
+  // fix in ../astro-trailing-slash-endpoint-fix.ts needs updating (or removing, if
+  // withastro/astro PR #17224's regression has been fixed upstream).
+  it('applies to the installed astro version', () => {
+    const require = createRequire(import.meta.url);
+    const astroRoot = dirname(require.resolve('astro/package.json'));
+    const source = readFileSync(join(astroRoot, 'dist/core/render/params-and-props.js'), 'utf8');
+    expect(applyGetParamsTrailingSlashFix(source)).toBeDefined();
+  });
+});

--- a/packages/core/eventcatalog/src/plugins/astro-trailing-slash-endpoint-fix.ts
+++ b/packages/core/eventcatalog/src/plugins/astro-trailing-slash-endpoint-fix.ts
@@ -1,0 +1,52 @@
+import type { Plugin } from 'vite';
+
+// Works around a regression in Astro >= 7.0.4 (withastro/astro PR #17224).
+//
+// With `trailingSlash: 'always'`, Astro's prerender path generation
+// (dist/runtime/prerender/static-paths.js) appends a trailing slash to every
+// generated path, including dynamic file endpoints such as
+// /docs/teams/[id].md -> /docs/teams/customer-platform.md/. Since 7.0.4 the
+// route *pattern* for those endpoints no longer accepts a trailing slash, so
+// at render time `getParams` fails to extract any params and static builds
+// crash with `TypeError: Missing parameter: id`.
+//
+// The generation side runs in the Astro CLI process and cannot be patched
+// here, but `getParams` (dist/core/render/params-and-props.js) is bundled
+// through Vite into the prerender/server entries. This plugin rewrites it to
+// retry with the trailing slash flipped when no route pattern matches - a
+// no-op on unaffected Astro versions and once the regression is fixed
+// upstream.
+//
+// The regex below matches Astro 7.0.3 (`const paramsMatch`) through 7.0.7
+// (`let paramsMatch`). A unit test asserts it still applies to the installed
+// Astro version so a future refactor is caught in CI rather than as a broken
+// user build.
+const GET_PARAMS_PATTERN =
+  /(?:const|let)( paramsMatch = allPatterns\.map\(\(pattern\) => pattern\.exec\(path\)\)\.find\(\(x\) => x\);)/;
+
+export const applyGetParamsTrailingSlashFix = (code: string): string | undefined => {
+  if (!GET_PARAMS_PATTERN.test(code)) return undefined;
+  return code.replace(
+    GET_PARAMS_PATTERN,
+    `let$1
+  if (!paramsMatch) {
+    const flipped = path.endsWith('/') ? path.slice(0, -1) : path + '/';
+    paramsMatch = allPatterns.map((p) => p.exec(flipped)).find((x) => x);
+  }`
+  );
+};
+
+export const astroTrailingSlashEndpointFix = (): Plugin => ({
+  name: 'eventcatalog:astro-trailing-slash-endpoint-fix',
+  transform(code, id) {
+    if (!id.replace(/\\/g, '/').includes('astro/dist/core/render/params-and-props.js')) return;
+    const patched = applyGetParamsTrailingSlashFix(code);
+    if (!patched) {
+      console.warn(
+        '[eventcatalog] Could not apply the Astro trailing-slash endpoint fix; builds with trailingSlash: true may fail. Please raise an issue at https://github.com/event-catalog/eventcatalog/issues'
+      );
+      return;
+    }
+    return { code: patched, map: null };
+  },
+});


### PR DESCRIPTION
## What This PR Does

Catalogs configured with `trailingSlash: true` currently fail to build on Astro 7.0.4 and above, crashing with `TypeError: Missing parameter: id`. This PR adds a small Vite plugin that patches Astro's `getParams` so it retries route matching with the trailing slash flipped, unblocking those builds. The plugin is only registered when `trailingSlash: true` is set, and is a no-op on Astro versions that aren't affected.

## Changes Overview

### Key Changes

- New Vite plugin `src/plugins/astro-trailing-slash-endpoint-fix.ts` that rewrites Astro's `getParams` at transform time.
- Registered in `astro.config.mjs`, guarded behind `config.trailingSlash === true` so no other catalog is affected.
- Unit tests covering the Astro 7.0.3–7.0.6 (`const paramsMatch`) and 7.0.7 (`let paramsMatch`) source shapes, the non-matching case, and a canary test that asserts the patch still applies to the installed Astro version.

## How It Works

Astro 7.0.4 (withastro/astro#17224) changed route patterns for dynamic file endpoints such as `/docs/teams/[id].md` so they no longer accept a trailing slash. The prerender path generator, however, still appends one when `trailingSlash: 'always'` is configured, producing paths like `/docs/teams/customer-platform.md/` that match no route pattern. At render time `getParams` extracts no params and the static build crashes.

The generation side runs in the Astro CLI process and can't be reached from a Vite plugin, but `getParams` (`dist/core/render/params-and-props.js`) is bundled through Vite into the prerender and server entries. The plugin matches that one line and appends a fallback: if no pattern matched, retry once with the trailing slash flipped. On an Astro version where the line has been refactored or the regression is fixed, the regex simply doesn't match and the plugin logs a warning and leaves the source untouched.

The canary test resolves the installed `astro` package and asserts the patch still applies to it, so a future Astro bump that refactors `getParams` fails in CI rather than as a broken user build.

## Breaking Changes

None.

## Additional Notes

This is a workaround for an upstream regression, not a permanent fix. Once Astro corrects the mismatch between path generation and route patterns, both the plugin and its registration in `astro.config.mjs` should be deleted; the canary test is there to make the next Astro bump a good moment to check.

No corresponding change is needed in the editor repository (`eventcatalog/eventcatalog-editor`) — this is entirely internal to the core catalog's build pipeline.