### PR TITLE
Count custom pages and API routes in build analytics

### DIFF
--- a/.changeset/brave-otters-count.md
+++ b/.changeset/brave-otters-count.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Count custom pages and custom API routes in build analytics resource inventory

--- a/packages/core/src/analytics/count-resources.js
+++ b/packages/core/src/analytics/count-resources.js
@@ -20,6 +20,14 @@ const RESOURCE_PATTERNS = {
   ubiquitousLanguages: ['domains/*/ubiquitous-language.@(md|mdx)', 'domains/*/subdomains/*/ubiquitous-language.@(md|mdx)'],
 };
 
+const CUSTOM_ROUTE_PATTERNS = {
+  customPages: ['pages/**/*.astro'],
+  customApis: ['pages/**/*.@(ts|js|mjs)'],
+};
+
+const DEFAULT_IGNORES = ['**/versioned/**', '**/dist/**', '**/node_modules/**'];
+const CUSTOM_ROUTE_IGNORES = [...DEFAULT_IGNORES, 'pages/**/_*/**', 'pages/**/_*'];
+
 /**
  * Count resources in the catalog directory using glob patterns
  * @param {string} projectDir - Path to the catalog directory
@@ -27,12 +35,12 @@ const RESOURCE_PATTERNS = {
  */
 export async function countResources(projectDir) {
   const counts = {};
-  for (const [type, patterns] of Object.entries(RESOURCE_PATTERNS)) {
+  for (const [type, patterns] of Object.entries({ ...RESOURCE_PATTERNS, ...CUSTOM_ROUTE_PATTERNS })) {
     let total = 0;
     for (const pattern of patterns) {
       const files = await glob(pattern, {
         cwd: projectDir,
-        ignore: ['**/versioned/**', '**/dist/**', '**/node_modules/**'],
+        ignore: type in CUSTOM_ROUTE_PATTERNS ? CUSTOM_ROUTE_IGNORES : DEFAULT_IGNORES,
       });
       total += files.length;
     }

--- a/packages/core/src/analytics/log-build.js
+++ b/packages/core/src/analytics/log-build.js
@@ -60,6 +60,8 @@ const toCloudResourceCounts = (counts) => ({
   designs: counts.designs || 0,
   diagrams: counts.diagrams || 0,
   ubiquitousLanguages: counts.ubiquitousLanguages || 0,
+  customPages: counts.customPages || 0,
+  customApis: counts.customApis || 0,
 });
 
 const reportCloudResourceInventory = async (configFile, resourceCounts) => {


### PR DESCRIPTION
## What This PR Does

Extends the build analytics resource inventory to include custom pages and custom API routes that users add to their catalog's `pages/` directory. This gives visibility into how many catalogs make use of custom routes, alongside the existing resource counts (events, services, domains, etc.).

## Changes Overview

### Key Changes
- `packages/core/src/analytics/count-resources.js`: Adds `CUSTOM_ROUTE_PATTERNS` for counting custom pages (`pages/**/*.astro`) and custom APIs (`pages/**/*.@(ts|js|mjs)`). Custom route counting uses extended ignore patterns that also exclude underscore-prefixed files and directories (`pages/**/_*`), which Astro treats as non-routable.
- `packages/core/src/analytics/log-build.js`: Adds `customPages` and `customApis` to the resource counts reported to the cloud inventory.

## How It Works

`countResources` now merges the custom route patterns with the existing resource patterns and iterates over them the same way. Each pattern type picks its ignore list: standard resources keep the default ignores (`versioned`, `dist`, `node_modules`), while custom route patterns additionally ignore underscore-prefixed paths so private/partial files are not counted as routes. The counts flow through the existing `toCloudResourceCounts` mapping with a fallback of 0.

## Breaking Changes

None

## Additional Notes

No change is needed in the editor repository — this only touches build-time analytics in the core package.