### PR TITLE
Message trigger paths, lineage views, and graph focus indicators

### DIFF
--- a/.changeset/curly-pandas-trigger.md
+++ b/.changeset/curly-pandas-trigger.md
@@ -1,0 +1,7 @@
+---
+"@eventcatalog/core": minor
+"@eventcatalog/sdk": minor
+"@eventcatalog/visualiser": minor
+---
+
+Allow services, domains, and agents to document messages triggered by any received message and show both sides of those relationships in message sidebars and node graphs. Messages with documented trigger relationships include a dedicated Trigger paths page with one visual row per path and its optional scenarios; messages without paths do not generate the page. The SDK supports trigger pointers and includes domains when resolving message producers and consumers. Message, service, and data store visualizers now keep the currently viewed resource visibly marked as the graph's focus, and resource context menus can focus another node in its own map. Edge labels now render above graph edges so intersecting paths do not obscure their text.

--- a/examples/default/domains/Customer/systems/customer-management-system/services/CustomerAPI/index.mdx
+++ b/examples/default/domains/Customer/systems/customer-management-system/services/CustomerAPI/index.mdx
@@ -11,8 +11,16 @@ owners:
 receives:
   - id: register-customer
     version: 1.0.0
+    triggers:
+      - id: customer-registered
+        version: 1.0.0
+        condition: When the customer registration is validated and persisted
   - id: update-customer
     version: 1.0.0
+    triggers:
+      - id: customer-updated
+        version: 1.0.0
+        condition: When the customer profile changes are persisted
   - id: get-customer
     version: 1.0.0
 sends:

--- a/examples/default/domains/Fulfilment/systems/inventory-system/services/InventoryService/index.mdx
+++ b/examples/default/domains/Fulfilment/systems/inventory-system/services/InventoryService/index.mdx
@@ -11,6 +11,13 @@ owners:
 receives:
   - id: reserve-inventory
     version: 1.0.0
+    triggers:
+      - id: inventory-reserved
+        version: 1.0.0
+        condition: When sufficient stock is available
+      - id: inventory-unavailable
+        version: 1.0.0
+        condition: When there is not enough stock to fulfil the reservation
   - id: release-inventory
     version: 1.0.0
   - id: get-stock-level

--- a/examples/default/domains/Ordering/systems/order-management-system/services/OrderService/index.mdx
+++ b/examples/default/domains/Ordering/systems/order-management-system/services/OrderService/index.mdx
@@ -11,8 +11,16 @@ owners:
 receives:
   - id: create-order
     version: 1.0.0
+    triggers:
+      - id: order-created
+        version: 1.0.0
+        condition: When the order is validated and persisted
   - id: cancel-order
     version: 1.0.0
+    triggers:
+      - id: order-cancelled
+        version: 1.0.0
+        condition: When the order can be cancelled successfully
   - id: get-order
     version: 1.0.0
 sends:

--- a/examples/default/domains/Reviews/index.mdx
+++ b/examples/default/domains/Reviews/index.mdx
@@ -30,6 +30,10 @@ flows:
 receives:
   - id: submit-review
     version: 1.0.0
+    triggers:
+      - id: review-submitted
+        version: 1.0.0
+        condition: When the review passes submission validation
   - id: flag-review
     version: 1.0.0
   - id: vote-review-helpful

--- a/examples/default/domains/Reviews/services/ReviewAPI/index.mdx
+++ b/examples/default/domains/Reviews/services/ReviewAPI/index.mdx
@@ -11,10 +11,22 @@ owners:
 receives:
   - id: submit-review
     version: 1.0.0
+    triggers:
+      - id: review-submitted
+        version: 1.0.0
+        condition: When the review passes submission validation
   - id: flag-review
     version: 1.0.0
+    triggers:
+      - id: review-flagged
+        version: 1.0.0
+        condition: When a customer reports a published review
   - id: vote-review-helpful
     version: 1.0.0
+    triggers:
+      - id: review-helpful-voted
+        version: 1.0.0
+        condition: When a helpful vote is recorded successfully
   - id: get-product-reviews
     version: 1.0.0
 sends:

--- a/examples/default/domains/Reviews/services/ReviewModerationWorker/index.mdx
+++ b/examples/default/domains/Reviews/services/ReviewModerationWorker/index.mdx
@@ -11,6 +11,37 @@ owners:
 receives:
   - id: review-submitted
     version: 1.0.0
+    triggers:
+      - id: review-published
+        version: 1.0.0
+        condition: When automated moderation passes with a high confidence score
+      - id: review-published
+        version: 1.0.0
+        condition: When a human moderator approves a queued review
+      - id: review-published
+        version: 1.0.0
+        condition: When a trusted reviewer qualifies for the fast-track policy
+      - id: review-published
+        version: 1.0.0
+        condition: When a verified-purchase review passes all policy checks
+      - id: review-published
+        version: 1.0.0
+        condition: When a resubmitted review clears its original moderation warning
+      - id: review-rejected
+        version: 1.0.0
+        condition: When the content is classified as spam
+      - id: review-rejected
+        version: 1.0.0
+        condition: When prohibited or abusive language exceeds the policy threshold
+      - id: review-rejected
+        version: 1.0.0
+        condition: When the review duplicates an existing submission
+      - id: review-rejected
+        version: 1.0.0
+        condition: When reviewer-risk signals fail the authenticity checks
+      - id: review-rejected
+        version: 1.0.0
+        condition: When a human moderator rejects a queued review
   - id: review-flagged
     version: 1.0.0
 sends:

--- a/packages/core/eventcatalog/src/components/Lineage/LineageScenarioSwitcher.tsx
+++ b/packages/core/eventcatalog/src/components/Lineage/LineageScenarioSwitcher.tsx
@@ -1,0 +1,65 @@
+import { CheckIcon, ChevronDownIcon } from '@heroicons/react/20/solid';
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
+import { useState } from 'react';
+
+interface Props {
+  conditions: string[];
+}
+
+export default function LineageScenarioSwitcher({ conditions }: Props) {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const selectedCondition = conditions[selectedIndex];
+
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger asChild>
+        <button
+          type="button"
+          className="group inline-flex max-w-full items-center gap-1.5 rounded-md border border-[rgb(var(--ec-dropdown-border)/0.8)] bg-[rgb(var(--ec-dropdown-bg))] px-2 py-1 align-middle text-sm font-semibold text-[rgb(var(--ec-page-text))] shadow-sm transition-colors hover:border-[rgb(var(--ec-accent)/0.5)] hover:bg-[rgb(var(--ec-dropdown-hover))] focus:outline-hidden focus:ring-2 focus:ring-[rgb(var(--ec-accent)/0.3)]"
+          aria-label={`Select scenario. Scenario ${selectedIndex + 1} of ${conditions.length}: ${selectedCondition}`}
+        >
+          <span className="min-w-0 max-w-xl truncate">{selectedCondition}</span>
+          <span className="shrink-0 rounded bg-[rgb(var(--ec-accent-subtle))] px-1.5 py-0.5 text-[10px] font-semibold tabular-nums text-[rgb(var(--ec-accent-text))]">
+            {selectedIndex + 1}/{conditions.length}
+          </span>
+          <ChevronDownIcon className="h-3.5 w-3.5 shrink-0 text-[rgb(var(--ec-page-text-muted))] transition-transform group-data-[state=open]:rotate-180" />
+        </button>
+      </DropdownMenu.Trigger>
+
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content
+          align="start"
+          sideOffset={6}
+          collisionPadding={12}
+          className="z-[1000] max-h-80 w-[min(36rem,calc(100vw-1.5rem))] overflow-y-auto rounded-xl border border-[rgb(var(--ec-dropdown-border)/0.8)] bg-[rgb(var(--ec-dropdown-bg))] p-1.5 shadow-[0_20px_56px_rgb(0_0_0/0.22)]"
+        >
+          <div className="px-2.5 pb-2 pt-1.5">
+            <p className="text-xs font-semibold text-[rgb(var(--ec-dropdown-text))]">Choose a scenario</p>
+            <p className="pt-0.5 text-[11px] font-normal text-[rgb(var(--ec-page-text-muted))]">
+              This message path is shared by {conditions.length} conditions.
+            </p>
+          </div>
+          <DropdownMenu.Separator className="mb-1 h-px bg-[rgb(var(--ec-dropdown-border)/0.7)]" />
+          <DropdownMenu.RadioGroup value={String(selectedIndex)} onValueChange={(value) => setSelectedIndex(Number(value))}>
+            {conditions.map((condition, index) => (
+              <DropdownMenu.RadioItem
+                key={`${condition}-${index}`}
+                value={String(index)}
+                className="relative flex cursor-pointer select-none items-start gap-2.5 rounded-lg px-2.5 py-2 pr-9 text-sm font-normal leading-5 text-[rgb(var(--ec-dropdown-text))] outline-hidden transition-colors data-[highlighted]:bg-[rgb(var(--ec-dropdown-hover))]"
+              >
+                <span className="mt-0.5 flex h-5 min-w-5 items-center justify-center rounded-md bg-[rgb(var(--ec-accent-subtle))] px-1 text-[10px] font-semibold tabular-nums text-[rgb(var(--ec-accent-text))]">
+                  {index + 1}
+                </span>
+                <span>{condition}</span>
+                <DropdownMenu.ItemIndicator className="absolute right-2.5 top-2.5 text-[rgb(var(--ec-accent))]">
+                  <CheckIcon className="h-4 w-4" />
+                </DropdownMenu.ItemIndicator>
+              </DropdownMenu.RadioItem>
+            ))}
+          </DropdownMenu.RadioGroup>
+          <DropdownMenu.Arrow className="fill-[rgb(var(--ec-dropdown-bg))]" />
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  );
+}

--- a/packages/core/eventcatalog/src/content.config.ts
+++ b/packages/core/eventcatalog/src/content.config.ts
@@ -87,11 +87,18 @@ const sendsPointer = z.object({
     .optional(),
 });
 
+const triggersPointer = z.object({
+  id: z.string(),
+  version: z.string().optional().default('latest'),
+  condition: z.string().optional(),
+});
+
 const receivesPointer = z.object({
   id: z.string(),
   version: z.string().optional().default('latest'),
   fields: z.array(z.string()).optional(),
   group: z.string().optional(),
+  triggers: z.array(triggersPointer).optional(),
   from: z
     .array(
       z.object({
@@ -355,6 +362,8 @@ const operationSchema = z
 const messageDetailsPanelPropertySchema = z.object({
   producers: detailPanelPropertySchema.optional(),
   consumers: detailPanelPropertySchema.optional(),
+  triggers: detailPanelPropertySchema.optional(),
+  triggeredBy: detailPanelPropertySchema.optional(),
   channels: detailPanelPropertySchema.optional(),
   versions: detailPanelPropertySchema.optional(),
   repository: detailPanelPropertySchema.optional(),

--- a/packages/core/eventcatalog/src/pages/triggers/[type]/[id]/[version]/_index.data.ts
+++ b/packages/core/eventcatalog/src/pages/triggers/[type]/[id]/[version]/_index.data.ts
@@ -1,0 +1,66 @@
+import { getCollection, type CollectionEntry } from 'astro:content';
+import { getMessagesWithTriggerPaths, type MessageReceiver } from '@utils/collections/message-triggers';
+import { isSSR } from '@utils/feature';
+import { HybridPage } from '@utils/page-loaders/hybrid-page';
+import type { CollectionMessageTypes } from '@types';
+
+const MESSAGE_TYPES: CollectionMessageTypes[] = ['events', 'commands', 'queries'];
+
+const loadTriggerPathResources = async () => {
+  const { pageDataLoader } = await import('@utils/page-loaders/page-data-loader');
+  const [messageCollections, services, agents, domains] = await Promise.all([
+    Promise.all(MESSAGE_TYPES.map((type) => pageDataLoader[type]())),
+    getCollection('services'),
+    getCollection('agents'),
+    getCollection('domains'),
+  ]);
+
+  return {
+    allMessages: messageCollections.flat() as CollectionEntry<CollectionMessageTypes>[],
+    receivers: [...services, ...agents, ...domains] as MessageReceiver[],
+  };
+};
+
+export class Page extends HybridPage {
+  static get prerender(): boolean {
+    return !isSSR();
+  }
+
+  static async getStaticPaths(): Promise<Array<{ params: any; props: any }>> {
+    if (isSSR()) return [];
+
+    const { allMessages, receivers } = await loadTriggerPathResources();
+    const messagesWithTriggerPaths = getMessagesWithTriggerPaths(receivers, allMessages);
+
+    return messagesWithTriggerPaths.map((item) => ({
+      params: {
+        type: item.collection,
+        id: item.data.id,
+        version: item.data.version,
+      },
+      props: {
+        type: item.collection,
+        ...item,
+      },
+    }));
+  }
+
+  protected static async fetchData(params: any) {
+    const { type, id, version } = params;
+    if (!type || !id || !version || !MESSAGE_TYPES.includes(type)) return null;
+
+    const { allMessages, receivers } = await loadTriggerPathResources();
+    const item = allMessages.find((entry) => entry.collection === type && entry.data.id === id && entry.data.version === version);
+    if (!item) return null;
+
+    const hasTriggerPaths = getMessagesWithTriggerPaths(receivers, allMessages).includes(item);
+    return hasTriggerPaths ? { type, ...item } : null;
+  }
+
+  protected static createNotFoundResponse(): Response {
+    return new Response(null, {
+      status: 404,
+      statusText: 'Message trigger paths not found',
+    });
+  }
+}

--- a/packages/core/eventcatalog/src/pages/triggers/[type]/[id]/[version]/index.astro
+++ b/packages/core/eventcatalog/src/pages/triggers/[type]/[id]/[version]/index.astro
@@ -1,0 +1,201 @@
+---
+import { getCollection, type CollectionEntry } from 'astro:content';
+
+import LineageScenarioSwitcher from '@components/Lineage/LineageScenarioSwitcher';
+import AstroNodeGraph from '@components/MDX/NodeGraph/AstroNodeGraph';
+import ResourceRef from '@components/MDX/ResourceRef/ResourceRef.astro';
+import Footer from '@layouts/Footer.astro';
+import VerticalSideBarLayout from '@layouts/VerticalSideBarLayout.astro';
+import { getTriggeredByOfMessage, getTriggersOfMessage, type MessageReceiver } from '@utils/collections/message-triggers';
+import { buildMessageLineageGraph, groupMessageLineageGraphs } from '@utils/node-graphs/message-lineage';
+import type { CollectionMessageTypes } from '@types';
+
+import { Page } from './_index.data';
+
+export const prerender = Page.prerender;
+export const getStaticPaths = Page.getStaticPaths;
+
+const props = await Page.getData(Astro);
+const { data } = props as CollectionEntry<CollectionMessageTypes>;
+const currentMessage = props as CollectionEntry<CollectionMessageTypes>;
+
+const [events, commands, queries, services, agents, domains] = await Promise.all([
+  getCollection('events'),
+  getCollection('commands'),
+  getCollection('queries'),
+  getCollection('services'),
+  getCollection('agents'),
+  getCollection('domains'),
+]);
+
+const allMessages = [...events, ...commands, ...queries] as CollectionEntry<CollectionMessageTypes>[];
+const receivers = [...services, ...agents, ...domains] as MessageReceiver[];
+
+const triggeredByRows = groupMessageLineageGraphs(
+  getTriggeredByOfMessage(receivers, currentMessage, allMessages).map((relation) =>
+    buildMessageLineageGraph({ currentMessage, relation, direction: 'triggeredBy' })
+  )
+);
+const triggerRows = groupMessageLineageGraphs(
+  getTriggersOfMessage(receivers, currentMessage, allMessages).map((relation) =>
+    buildMessageLineageGraph({ currentMessage, relation, direction: 'triggers' })
+  )
+);
+
+const resourceTypeByCollection = {
+  events: 'event',
+  commands: 'command',
+  queries: 'query',
+  services: 'service',
+  domains: 'domain',
+  agents: 'agent',
+} as const;
+const resourceType = (resource: CollectionEntry<CollectionMessageTypes> | MessageReceiver) =>
+  resourceTypeByCollection[resource.collection];
+const conditionText = (condition: string) => condition.replace(/^when\s+/i, '');
+const scenarioConditions = (row: (typeof triggeredByRows)[number]) =>
+  row.scenarios.map(({ condition }) => (condition ? conditionText(condition) : 'No condition specified'));
+---
+
+<VerticalSideBarLayout title={`Trigger paths | ${data.name}`} description={`Message trigger paths for ${data.name}`}>
+  <main class="w-full min-h-full bg-[rgb(var(--ec-page-bg))] py-8">
+    <header class="border-b border-[rgb(var(--ec-page-border))] py-5">
+      <div class="text-sm font-semibold text-[rgb(var(--ec-accent))]">Trigger paths</div>
+      <h1 class="pt-3 text-2xl md:text-4xl font-bold text-[rgb(var(--ec-page-text))]">{data.name}</h1>
+      <p class="pt-3 text-base text-[rgb(var(--ec-page-text-muted))] font-light">
+        Explore the direct messages that trigger this message and the messages it can trigger.
+      </p>
+    </header>
+
+    <div class="space-y-10 py-8">
+      {
+        triggeredByRows.length > 0 && (
+          <section aria-labelledby="triggered-by-heading">
+            <div class="space-y-5">
+              {triggeredByRows.map((row, index) => (
+                <article class="lineage-row overflow-hidden rounded-xl border border-[rgb(var(--ec-page-border))] bg-[rgb(var(--ec-card-bg))] shadow-sm">
+                  <div class="border-b border-[rgb(var(--ec-page-border))] px-5 py-4">
+                    <h3 class="text-sm md:text-base font-medium text-[rgb(var(--ec-page-text))]">
+                      <ResourceRef type={resourceType(row.target)} version={row.target.data.version}>
+                        {row.target.data.id}
+                      </ResourceRef>{' '}
+                      is triggered by{' '}
+                      <ResourceRef type={resourceType(row.source)} version={row.source.data.version}>
+                        {row.source.data.id}
+                      </ResourceRef>
+                      {row.scenarios.length === 1 && row.scenarios[0].condition && (
+                        <>
+                          {' '}
+                          when <span class="font-semibold">{conditionText(row.scenarios[0].condition)}</span>
+                        </>
+                      )}
+                      {row.scenarios.length > 1 && (
+                        <>
+                          {' '}
+                          when <LineageScenarioSwitcher client:visible conditions={scenarioConditions(row)} />
+                        </>
+                      )}{' '}
+                      via{' '}
+                      <ResourceRef type={resourceType(row.receiver)} version={row.receiver.data.version}>
+                        {row.receiver.data.id}
+                      </ResourceRef>
+                    </h3>
+                  </div>
+                  <div
+                    id={`${data.id}-triggered-by-${index}-portal`}
+                    class="lineage-graph h-[250px] w-full bg-[rgb(var(--ec-page-bg))]"
+                  />
+                  <AstroNodeGraph
+                    client:only="react"
+                    id={`${data.id}-triggered-by-${index}`}
+                    portalId={`${data.id}-triggered-by-${index}-portal`}
+                    nodes={row.nodes}
+                    edges={row.edges}
+                    mode="simple"
+                    linkTo="docs"
+                    includeKey={false}
+                    showSearch={false}
+                    zoomOnScroll={false}
+                    disableMessageAnimation={true}
+                  />
+                </article>
+              ))}
+            </div>
+          </section>
+        )
+      }
+
+      {
+        triggerRows.length > 0 && (
+          <section aria-label="Messages triggered by this message">
+            <div class="space-y-5">
+              {triggerRows.map((row, index) => (
+                <article class="lineage-row overflow-hidden rounded-xl border border-[rgb(var(--ec-page-border))] bg-[rgb(var(--ec-card-bg))] shadow-sm">
+                  <div class="border-b border-[rgb(var(--ec-page-border))] px-5 py-4">
+                    <h3 class="text-sm md:text-base font-medium text-[rgb(var(--ec-page-text))]">
+                      <ResourceRef type={resourceType(row.target)} version={row.target.data.version}>
+                        {row.target.data.id}
+                      </ResourceRef>{' '}
+                      is triggered by{' '}
+                      <ResourceRef type={resourceType(row.source)} version={row.source.data.version}>
+                        {row.source.data.id}
+                      </ResourceRef>
+                      {row.scenarios.length === 1 && row.scenarios[0].condition && (
+                        <>
+                          {' '}
+                          when <span class="font-semibold">{conditionText(row.scenarios[0].condition)}</span>
+                        </>
+                      )}
+                      {row.scenarios.length > 1 && (
+                        <>
+                          {' '}
+                          when <LineageScenarioSwitcher client:visible conditions={scenarioConditions(row)} />
+                        </>
+                      )}{' '}
+                      via{' '}
+                      <ResourceRef type={resourceType(row.receiver)} version={row.receiver.data.version}>
+                        {row.receiver.data.id}
+                      </ResourceRef>
+                    </h3>
+                  </div>
+                  <div
+                    id={`${data.id}-triggers-${index}-portal`}
+                    class="lineage-graph h-[250px] w-full bg-[rgb(var(--ec-page-bg))]"
+                  />
+                  <AstroNodeGraph
+                    client:only="react"
+                    id={`${data.id}-triggers-${index}`}
+                    portalId={`${data.id}-triggers-${index}-portal`}
+                    nodes={row.nodes}
+                    edges={row.edges}
+                    mode="simple"
+                    linkTo="docs"
+                    includeKey={false}
+                    showSearch={false}
+                    zoomOnScroll={false}
+                    disableMessageAnimation={true}
+                  />
+                </article>
+              ))}
+            </div>
+          </section>
+        )
+      }
+    </div>
+
+    <Footer />
+  </main>
+</VerticalSideBarLayout>
+
+<style is:global>
+  .lineage-row {
+    content-visibility: auto;
+    contain-intrinsic-size: 330px;
+  }
+
+  .lineage-graph .react-flow__panel.top,
+  .lineage-graph .react-flow__controls,
+  .lineage-graph .react-flow__attribution {
+    display: none;
+  }
+</style>

--- a/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/message-triggers.spec.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/message-triggers.spec.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { CollectionEntry } from 'astro:content';
+import { buildMessageNode } from '../builders/message';
+
+vi.mock('@utils/feature', () => ({
+  isVisualiserEnabled: () => true,
+  isChangelogEnabled: () => false,
+}));
+
+vi.mock('@utils/url-builder', () => ({
+  buildUrl: (path: string) => path,
+  buildEditUrlForResource: () => undefined,
+}));
+
+const createMessage = (collection: 'events' | 'commands' | 'queries', id: string) =>
+  ({
+    id: `${collection}/${id}/index.mdx`,
+    collection,
+    data: { id, version: '1.0.0', name: id, producers: [], consumers: [] },
+  }) as unknown as CollectionEntry<'events' | 'commands' | 'queries'>;
+
+const createService = (id: string) =>
+  ({
+    id: `services/${id}/index.mdx`,
+    collection: 'services',
+    data: { id, version: '1.0.0', name: id },
+  }) as unknown as CollectionEntry<'services'>;
+
+const context = {
+  schemas: [],
+  resourceDocs: [],
+  resourceDocCategories: [],
+  diagrams: [],
+} as any;
+
+const findGroup = (node: any, title: string) => node.pages.find((page: any) => page?.type === 'group' && page.title === title);
+
+describe('message trigger sidebar sections', () => {
+  it('does not add trigger paths when the message has no trigger relationships', () => {
+    const node = buildMessageNode(createMessage('commands', 'CreateUser'), [], context);
+    const quickReference = findGroup(node, 'Quick Reference');
+    const architecture = findGroup(node, 'Architecture');
+
+    expect(quickReference?.pages).toEqual([{ type: 'item', title: 'Overview', href: '/docs/commands/CreateUser/1.0.0' }]);
+    expect(architecture?.pages).toEqual([{ type: 'item', title: 'Map', href: '/visualiser/commands/CreateUser/1.0.0' }]);
+  });
+
+  it('adds trigger paths below the message map when a relationship exists', () => {
+    const command = createMessage('commands', 'CreateUser');
+    const event = createMessage('events', 'UserCreated');
+    const userService = createService('UserService');
+    const node = buildMessageNode(command, [], context, false, [], {
+      triggers: [{ receiver: userService, message: event, condition: 'on success' }],
+      triggeredBy: [],
+    });
+
+    expect(findGroup(node, 'Architecture')?.pages).toEqual([
+      { type: 'item', title: 'Map', href: '/visualiser/commands/CreateUser/1.0.0' },
+      { type: 'item', title: 'Trigger paths', href: '/triggers/commands/CreateUser/1.0.0' },
+    ]);
+  });
+
+  it('lists each triggered message once', () => {
+    const command = createMessage('commands', 'CreateUser');
+    const event = createMessage('events', 'UserCreated');
+    const userService = createService('UserService');
+    const auditService = createService('AuditService');
+
+    const node = buildMessageNode(command, [], context, false, [], {
+      triggers: [
+        { receiver: userService, message: event, condition: 'on success' },
+        { receiver: auditService, message: event },
+      ],
+      triggeredBy: [],
+    });
+
+    expect(findGroup(node, 'Triggers')).toEqual({
+      type: 'group',
+      title: 'Triggers',
+      icon: 'Mail',
+      pages: ['event:UserCreated:1.0.0'],
+      visible: true,
+    });
+  });
+
+  it('lists each triggering message once', () => {
+    const command = createMessage('commands', 'CreateUser');
+    const event = createMessage('events', 'UserCreated');
+    const userService = createService('UserService');
+    const auditService = createService('AuditService');
+
+    const node = buildMessageNode(event, [], context, false, [], {
+      triggers: [],
+      triggeredBy: [
+        { receiver: userService, message: command, condition: 'on success' },
+        { receiver: auditService, message: command },
+      ],
+    });
+
+    expect(findGroup(node, 'Triggered by')).toEqual({
+      type: 'group',
+      title: 'Triggered by',
+      icon: 'Mail',
+      pages: ['command:CreateUser:1.0.0'],
+      visible: true,
+    });
+  });
+
+  it('renders relationships between arbitrary message types', () => {
+    const query = createMessage('queries', 'GetUser');
+    const command = createMessage('commands', 'RefreshUser');
+
+    const node = buildMessageNode(query, [], context, false, [], {
+      triggers: [{ receiver: createService('UserService'), message: command }],
+      triggeredBy: [],
+    });
+
+    expect(findGroup(node, 'Triggers')?.pages).toEqual(['command:RefreshUser:1.0.0']);
+  });
+
+  it('does not render trigger sections when there are no relationships', () => {
+    const node = buildMessageNode(createMessage('queries', 'GetUser'), [], context);
+
+    expect(findGroup(node, 'Triggers')).toBeUndefined();
+    expect(findGroup(node, 'Triggered by')).toBeUndefined();
+  });
+
+  it('allows both sections to be hidden through detailsPanel configuration', () => {
+    const query = createMessage('queries', 'GetUser');
+    query.data.detailsPanel = { triggers: { visible: false }, triggeredBy: { visible: false } } as any;
+    const command = createMessage('commands', 'RefreshUser');
+    const event = createMessage('events', 'UserCreated');
+
+    const node = buildMessageNode(query, [], context, false, [], {
+      triggers: [{ receiver: createService('UserService'), message: command }],
+      triggeredBy: [{ receiver: createService('AuditService'), message: event }],
+    });
+
+    expect(findGroup(node, 'Triggers')).toBeUndefined();
+    expect(findGroup(node, 'Triggered by')).toBeUndefined();
+  });
+});

--- a/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/sidebar-builder.spec.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/sidebar-builder.spec.ts
@@ -3153,6 +3153,84 @@ describe('getNestedSideBarData', () => {
       });
     });
 
+    describe('triggers section', () => {
+      it('lists events triggered by a command when a service receives it', async () => {
+        const { writeCommand, writeEvent, writeService } = utils(CATALOG_FOLDER);
+
+        await writeCommand({
+          id: 'CreateUser',
+          name: 'Create User',
+          version: '1.0.0',
+          markdown: 'Create User',
+        });
+        await writeEvent({
+          id: 'UserCreated',
+          name: 'User Created',
+          version: '1.0.0',
+          markdown: 'User Created',
+        });
+        await writeService({
+          id: 'UserService',
+          name: 'User Service',
+          version: '1.0.0',
+          markdown: 'User Service',
+          receives: [
+            {
+              id: 'CreateUser',
+              version: '1.0.0',
+              triggers: [{ id: 'UserCreated', version: '1.0.0', condition: 'on success' }],
+            },
+          ],
+        } as any);
+
+        const navigationData = await getNestedSideBarData();
+        const commandNode = getNavigationConfigurationByKey('command:CreateUser:1.0.0', navigationData);
+        const eventNode = getNavigationConfigurationByKey('event:UserCreated:1.0.0', navigationData);
+        const triggersSection = getChildNodeByTitle('Triggers', commandNode.pages ?? []);
+        const triggeredBySection = getChildNodeByTitle('Triggered by', eventNode.pages ?? []);
+
+        expect(triggersSection.pages).toEqual(['event:UserCreated:1.0.0']);
+        expect(triggeredBySection.pages).toEqual(['command:CreateUser:1.0.0']);
+      });
+
+      it('lists relationships declared by a domain', async () => {
+        const { writeCommand, writeDomain, writeEvent } = utils(CATALOG_FOLDER);
+
+        await writeCommand({
+          id: 'CreateShipment',
+          name: 'Create Shipment',
+          version: '1.0.0',
+          markdown: 'Create Shipment',
+        });
+        await writeEvent({
+          id: 'ShipmentCreated',
+          name: 'Shipment Created',
+          version: '1.0.0',
+          markdown: 'Shipment Created',
+        });
+        await writeDomain({
+          id: 'Shipping',
+          name: 'Shipping',
+          version: '1.0.0',
+          markdown: 'Shipping',
+          receives: [
+            {
+              id: 'CreateShipment',
+              version: '1.0.0',
+              triggers: [{ id: 'ShipmentCreated', version: '1.0.0' }],
+            },
+          ],
+        } as any);
+
+        const navigationData = await getNestedSideBarData();
+        const commandNode = getNavigationConfigurationByKey('command:CreateShipment:1.0.0', navigationData);
+        const eventNode = getNavigationConfigurationByKey('event:ShipmentCreated:1.0.0', navigationData);
+
+        expect(getChildNodeByTitle('Triggers', commandNode.pages ?? []).pages).toEqual(['event:ShipmentCreated:1.0.0']);
+        expect(getChildNodeByTitle('Triggered by', eventNode.pages ?? []).pages).toEqual(['command:CreateShipment:1.0.0']);
+      });
+    });
+
     describe('flows section', () => {
       it('is not listed if no flows reference the message', async () => {
         const { writeEvent } = utils(CATALOG_FOLDER);

--- a/packages/core/eventcatalog/src/stores/sidebar-store/builders/message.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/builders/message.ts
@@ -14,6 +14,7 @@ import {
 import { isVisualiserEnabled, isChangelogEnabled } from '@utils/feature';
 import { iconFieldsForResource } from '@utils/icon';
 import { collectionToResourceMap } from '@utils/collections/util';
+import type { MessageTrigger } from '@utils/collections/message-triggers';
 
 type MessageSchemaEntry = CollectionEntry<'schemas'>;
 
@@ -47,16 +48,22 @@ export const buildMessageNode = (
   owners: any[],
   context: ResourceGroupContext,
   hasFieldUsage: boolean = false,
-  flowRefs: string[] = []
+  flowRefs: string[] = [],
+  messageTriggers: { triggers: MessageTrigger[]; triggeredBy: MessageTrigger[] } = { triggers: [], triggeredBy: [] }
 ): NavNode => {
   const producers = message.data.producers || [];
   const consumers = message.data.consumers || [];
   const collection = message.collection;
+  const triggerRefs = [...new Set(messageTriggers.triggers.map(({ message }) => getProducerConsumerPageRef(message)))];
+  const triggeredByRefs = [...new Set(messageTriggers.triggeredBy.map(({ message }) => getProducerConsumerPageRef(message)))];
 
   const renderProducers = producers.length > 0 && shouldRenderSideBarSection(message, 'producers');
   const renderConsumers = consumers.length > 0 && shouldRenderSideBarSection(message, 'consumers');
+  const renderTriggers = triggerRefs.length > 0 && shouldRenderSideBarSection(message, 'triggers');
+  const renderTriggeredBy = triggeredByRefs.length > 0 && shouldRenderSideBarSection(message, 'triggeredBy');
   const renderFlows = flowRefs.length > 0 && shouldRenderSideBarSection(message, 'flows');
   const renderRepository = message.data.repository && shouldRenderSideBarSection(message, 'repository');
+  const hasTriggerPaths = messageTriggers.triggers.length > 0 || messageTriggers.triggeredBy.length > 0;
 
   // Determine badge based on collection type
   const badgeMap: Record<string, string> = {
@@ -124,6 +131,15 @@ export const buildMessageNode = (
             title: 'Map',
             href: buildUrl(`/visualiser/${collection}/${message.data.id}/${message.data.version}`),
           },
+          ...(hasTriggerPaths
+            ? [
+                {
+                  type: 'item' as const,
+                  title: 'Trigger paths',
+                  href: buildUrl(`/triggers/${collection}/${message.data.id}/${message.data.version}`),
+                },
+              ]
+            : []),
         ],
       },
       hasDiagrams && {
@@ -162,6 +178,20 @@ export const buildMessageNode = (
         icon: 'Server',
         pages: consumers.map(getProducerConsumerPageRef),
         visible: consumers.length > 0,
+      },
+      renderTriggeredBy && {
+        type: 'group',
+        title: 'Triggered by',
+        icon: 'Mail',
+        pages: triggeredByRefs,
+        visible: triggeredByRefs.length > 0,
+      },
+      renderTriggers && {
+        type: 'group',
+        title: 'Triggers',
+        icon: 'Mail',
+        pages: triggerRefs,
+        visible: triggerRefs.length > 0,
       },
       renderFlows && {
         type: 'group',

--- a/packages/core/eventcatalog/src/stores/sidebar-store/state.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/state.ts
@@ -8,6 +8,7 @@ import { getDomains } from '@utils/collections/domains';
 import { getSystems } from '@utils/collections/systems';
 import { getServices } from '@utils/collections/services';
 import { getMessages, pluralizeMessageType } from '@utils/collections/messages';
+import { getTriggeredByOfMessage, getTriggersOfMessage } from '@utils/collections/message-triggers';
 import { getOwner } from '@utils/collections/owners';
 import { getFlows } from '@utils/collections/flows';
 import { getUsers } from '@utils/collections/users';
@@ -451,10 +452,14 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
     {} as Record<string, NavNode | string>
   );
 
-  const rawAgents = await getCollection('agents');
+  const [rawAgents, rawServices, rawDomains] = await Promise.all([
+    getCollection('agents'),
+    getCollection('services'),
+    getCollection('domains'),
+  ]);
+  const messageReceivers = [...rawServices, ...rawAgents, ...rawDomains];
 
   // Compute channels for each service from raw sends[].to / receives[].from pointers
-  const rawServices = await getCollection('services');
   const channelMap = createVersionedMap(channels);
   const serviceChannelsMap = new Map<string, CollectionEntry<'channels'>[]>();
 
@@ -560,7 +565,7 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
     {} as Record<string, NavNode | string>
   );
 
-  // Build a set of message IDs that have field usage declared by any service or agent.
+  // Build a set of message IDs that have field usage declared by any resource that can receive messages.
   // We use raw collections because the hydrated resources replace
   // sends/receives pointers with resolved message entries, which strips the fields property.
   const messagesWithFieldUsage = new Set<string>();
@@ -580,6 +585,14 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
       if (pointer.fields?.length) messagesWithFieldUsage.add(pointer.id);
     }
   }
+  for (const domain of rawDomains) {
+    for (const pointer of domain.data.sends || []) {
+      if (pointer.fields?.length) messagesWithFieldUsage.add(pointer.id);
+    }
+    for (const pointer of domain.data.receives || []) {
+      if (pointer.fields?.length) messagesWithFieldUsage.add(pointer.id);
+    }
+  }
 
   const flowRefsByMessage = buildFlowReferencesByMessage({ flows, events, commands, queries });
 
@@ -588,8 +601,13 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
       const type = pluralizeMessageType(message as any);
       const versionedKey = `${type}:${message.data.id}:${message.data.version}`;
       const hasFieldUsage = messagesWithFieldUsage.has(message.data.id);
+      const triggers = getTriggersOfMessage(messageReceivers, message, messages);
+      const triggeredBy = getTriggeredByOfMessage(messageReceivers, message, messages);
       acc[versionedKey] = withArchitectureDecisionsSection(
-        buildMessageNode(message, owners, context, hasFieldUsage, flowRefsByMessage.get(versionedKey) || []),
+        buildMessageNode(message, owners, context, hasFieldUsage, flowRefsByMessage.get(versionedKey) || [], {
+          triggers,
+          triggeredBy,
+        }),
         message,
         adrs
       );

--- a/packages/core/eventcatalog/src/utils/__tests__/containers/node-graph.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/containers/node-graph.spec.ts
@@ -31,7 +31,17 @@ describe('Containers NodeGraph', () => {
           id: 'OrderDatabase-1.0.0',
           sourcePosition: 'right',
           targetPosition: 'left',
-          data: expect.objectContaining({ mode: 'simple', data: { ...mockContainers[0].data } }),
+          data: expect.objectContaining({
+            mode: 'simple',
+            isFocused: true,
+            data: { ...mockContainers[0].data },
+            contextMenu: expect.arrayContaining([
+              expect.objectContaining({
+                label: 'Focus node',
+                href: '/visualiser/containers/OrderDatabase/1.0.0',
+              }),
+            ]),
+          }),
           position: { x: 525, y: 60 },
           type: 'data',
         },

--- a/packages/core/eventcatalog/src/utils/__tests__/flows/node-graph.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/flows/node-graph.spec.ts
@@ -140,6 +140,10 @@ describe('Flows NodeGraph', () => {
             label: 'Read documentation',
             href: expect.stringContaining('/docs/events/PaymentProcessed/0.0.1'),
           }),
+          expect.objectContaining({
+            label: 'Focus node',
+            href: expect.stringContaining('/visualiser/events/PaymentProcessed/0.0.1'),
+          }),
           expect.objectContaining({ label: 'Read changelog' }),
         ])
       );
@@ -155,6 +159,10 @@ describe('Flows NodeGraph', () => {
           expect.objectContaining({
             label: 'Read documentation',
             href: expect.stringContaining('/docs/services/SubscriptionService/0.0.1'),
+          }),
+          expect.objectContaining({
+            label: 'Focus node',
+            href: expect.stringContaining('/visualiser/services/SubscriptionService/0.0.1'),
           }),
         ])
       );
@@ -177,6 +185,10 @@ describe('Flows NodeGraph', () => {
               expect.objectContaining({
                 label: 'Read documentation',
                 href: expect.stringContaining('/docs/agents/FraudReviewAgent/1.0.0'),
+              }),
+              expect.objectContaining({
+                label: 'Focus node',
+                href: expect.stringContaining('/visualiser/agents/FraudReviewAgent/1.0.0'),
               }),
             ]),
           }),
@@ -207,6 +219,10 @@ describe('Flows NodeGraph', () => {
                 label: 'Read documentation',
                 href: expect.stringContaining('/docs/containers/OrdersDB/1.0.0'),
               }),
+              expect.objectContaining({
+                label: 'Focus node',
+                href: expect.stringContaining('/visualiser/containers/OrdersDB/1.0.0'),
+              }),
             ]),
           }),
         })
@@ -230,6 +246,10 @@ describe('Flows NodeGraph', () => {
               expect.objectContaining({
                 label: 'Read documentation',
                 href: expect.stringContaining('/docs/data-products/OrderAnalytics/1.0.0'),
+              }),
+              expect.objectContaining({
+                label: 'Focus node',
+                href: expect.stringContaining('/visualiser/data-products/OrderAnalytics/1.0.0'),
               }),
             ]),
           }),

--- a/packages/core/eventcatalog/src/utils/__tests__/messages/message-lineage.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/messages/message-lineage.spec.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import type { CollectionEntry } from 'astro:content';
+import { buildMessageLineageGraph, groupMessageLineageGraphs } from '@utils/node-graphs/message-lineage';
+
+const createMessage = (collection: 'events' | 'commands' | 'queries', id: string) =>
+  ({
+    collection,
+    data: { id, name: id, version: '1.0.0' },
+  }) as CollectionEntry<'events' | 'commands' | 'queries'>;
+
+const createReceiver = (collection: 'services' | 'domains' | 'agents', id: string) =>
+  ({
+    collection,
+    data: { id, name: id, version: '1.0.0' },
+  }) as CollectionEntry<'services' | 'domains' | 'agents'>;
+
+describe('message lineage graphs', () => {
+  it('builds a focused message to receiver to triggered message row', () => {
+    const command = createMessage('commands', 'CreateOrder');
+    const event = createMessage('events', 'OrderCreated');
+    const service = createReceiver('services', 'OrderService');
+
+    const graph = buildMessageLineageGraph({
+      currentMessage: command,
+      direction: 'triggers',
+      relation: { receiver: service, message: event, condition: 'when the order is valid' },
+    });
+
+    expect(graph.condition).toBe('when the order is valid');
+    expect(graph.nodes.map((node) => node.id)).toEqual(['CreateOrder-1.0.0', 'OrderService-1.0.0', 'OrderCreated-1.0.0']);
+    expect(graph.nodes[0].data.isFocused).toBe(true);
+    expect(graph.nodes[2].data.isFocused).toBeUndefined();
+    expect(graph.edges.map((edge) => [edge.source, edge.target])).toEqual([
+      ['CreateOrder-1.0.0', 'OrderService-1.0.0'],
+      ['OrderService-1.0.0', 'OrderCreated-1.0.0'],
+    ]);
+  });
+
+  it('builds an arbitrary triggering message through a domain to the focused message', () => {
+    const query = createMessage('queries', 'CheckOrder');
+    const event = createMessage('events', 'OrderReviewed');
+    const domain = createReceiver('domains', 'Ordering');
+
+    const graph = buildMessageLineageGraph({
+      currentMessage: event,
+      direction: 'triggeredBy',
+      relation: { receiver: domain, message: query },
+    });
+
+    expect(graph.source).toBe(query);
+    expect(graph.target).toBe(event);
+    expect(graph.nodes[0].data.isFocused).toBeUndefined();
+    expect(graph.nodes[2].data.isFocused).toBe(true);
+    expect(graph.nodes[1].type).toBe('domains');
+  });
+
+  it('groups conditions that share the same source, receiver, and target path into scenarios', () => {
+    const source = createMessage('events', 'ReviewSubmitted');
+    const target = createMessage('events', 'ReviewPublished');
+    const service = createReceiver('services', 'ReviewModerationWorker');
+    const otherService = createReceiver('services', 'OtherModerationWorker');
+
+    const graphs = [
+      buildMessageLineageGraph({
+        currentMessage: target,
+        direction: 'triggeredBy',
+        relation: { receiver: service, message: source, condition: 'when automated moderation passes' },
+      }),
+      buildMessageLineageGraph({
+        currentMessage: target,
+        direction: 'triggeredBy',
+        relation: { receiver: service, message: source, condition: 'when a human moderator approves it' },
+      }),
+      buildMessageLineageGraph({
+        currentMessage: target,
+        direction: 'triggeredBy',
+        relation: { receiver: otherService, message: source, condition: 'when a second system approves it' },
+      }),
+    ];
+
+    const groups = groupMessageLineageGraphs(graphs);
+
+    expect(groups).toHaveLength(2);
+    expect(groups[0].scenarios).toEqual([
+      { condition: 'when automated moderation passes' },
+      { condition: 'when a human moderator approves it' },
+    ]);
+    expect(groups[0].nodes).toBe(graphs[0].nodes);
+    expect(groups[1].receiver).toBe(otherService);
+  });
+});

--- a/packages/core/eventcatalog/src/utils/__tests__/messages/message-triggers.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/messages/message-triggers.spec.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+import { getMessagesWithTriggerPaths, getTriggeredByOfMessage, getTriggersOfMessage } from '@utils/collections/message-triggers';
+
+const message = (collection: 'events' | 'commands' | 'queries', id: string, version: string, latestVersion: string = version) =>
+  ({ id, collection, data: { id, version, latestVersion } }) as any;
+const service = (id: string, receives: any[]) =>
+  ({ id, collection: 'services', data: { id, version: '1.0.0', receives } }) as any;
+const domain = (id: string, receives: any[]) => ({ id, collection: 'domains', data: { id, version: '1.0.0', receives } }) as any;
+const agent = (id: string, receives: any[]) => ({ id, collection: 'agents', data: { id, version: '1.0.0', receives } }) as any;
+
+const userCreated = message('events', 'UserCreated', '1.0.0');
+const previousUserCreated = message('events', 'UserCreated', '0.5.0', '1.0.0');
+const userCreationFailed = message('events', 'UserCreationFailed', '1.0.0');
+const createUser = message('commands', 'CreateUser', '2.0.0');
+const getUser = message('queries', 'GetUser', '1.0.0');
+const refreshUser = message('commands', 'RefreshUser', '1.0.0');
+const allMessages = [userCreated, previousUserCreated, userCreationFailed, createUser, getUser, refreshUser];
+
+describe('getTriggersOfMessage', () => {
+  it('returns every message triggered when a service receives the source message', () => {
+    const userService = service('UserService', [
+      {
+        id: 'CreateUser',
+        version: '2.0.0',
+        triggers: [
+          { id: 'UserCreated', version: 'latest', condition: 'on success' },
+          { id: 'UserCreationFailed', version: '1.0.0' },
+        ],
+      },
+    ]);
+
+    expect(getTriggersOfMessage([userService], createUser, allMessages)).toEqual([
+      { receiver: userService, message: userCreated, condition: 'on success' },
+      { receiver: userService, message: userCreationFailed, condition: undefined },
+    ]);
+  });
+
+  it('allows queries to trigger commands', () => {
+    const userService = service('UserService', [
+      { id: 'GetUser', version: '1.0.0', triggers: [{ id: 'RefreshUser', version: '1.0.0' }] },
+    ]);
+
+    expect(getTriggersOfMessage([userService], getUser, allMessages)).toEqual([
+      { receiver: userService, message: refreshUser, condition: undefined },
+    ]);
+  });
+
+  it('finds relationships declared by domains', () => {
+    const usersDomain = domain('Users', [
+      { id: 'CreateUser', version: '2.0.0', triggers: [{ id: 'UserCreated', version: '1.0.0' }] },
+    ]);
+
+    expect(getTriggersOfMessage([usersDomain], createUser, allMessages)).toEqual([
+      { receiver: usersDomain, message: userCreated, condition: undefined },
+    ]);
+  });
+
+  it('finds relationships declared by agents', () => {
+    const userAgent = agent('UserAgent', [
+      { id: 'GetUser', version: '1.0.0', triggers: [{ id: 'RefreshUser', version: '1.0.0' }] },
+    ]);
+
+    expect(getTriggersOfMessage([userAgent], getUser, allMessages)).toEqual([
+      { receiver: userAgent, message: refreshUser, condition: undefined },
+    ]);
+  });
+
+  it('supports semver ranges on the received message', () => {
+    const userService = service('UserService', [
+      { id: 'CreateUser', version: '^2.0.0', triggers: [{ id: 'UserCreated', version: 'latest' }] },
+    ]);
+
+    expect(getTriggersOfMessage([userService], createUser, allMessages)).toHaveLength(1);
+  });
+
+  it('only matches a latest receive pointer against the latest source version', () => {
+    const userService = service('UserService', [
+      { id: 'UserCreated', version: 'latest', triggers: [{ id: 'RefreshUser', version: 'latest' }] },
+    ]);
+
+    expect(getTriggersOfMessage([userService], previousUserCreated, allMessages)).toEqual([]);
+  });
+
+  it('ignores trigger pointers that do not resolve to a message', () => {
+    const userService = service('UserService', [
+      { id: 'CreateUser', version: '2.0.0', triggers: [{ id: 'DoesNotExist', version: 'latest' }] },
+    ]);
+
+    expect(getTriggersOfMessage([userService], createUser, allMessages)).toEqual([]);
+  });
+});
+
+describe('getTriggeredByOfMessage', () => {
+  it('returns every message that can trigger the target message', () => {
+    const userService = service('UserService', [
+      {
+        id: 'CreateUser',
+        version: '2.0.0',
+        triggers: [{ id: 'UserCreated', version: '1.0.0', condition: 'on success' }],
+      },
+    ]);
+
+    expect(getTriggeredByOfMessage([userService], userCreated, allMessages)).toEqual([
+      { receiver: userService, message: createUser, condition: 'on success' },
+    ]);
+  });
+
+  it('resolves reverse relationships across arbitrary message types', () => {
+    const userService = service('UserService', [
+      { id: 'GetUser', version: 'latest', triggers: [{ id: 'RefreshUser', version: 'latest' }] },
+    ]);
+
+    expect(getTriggeredByOfMessage([userService], refreshUser, allMessages)).toEqual([
+      { receiver: userService, message: getUser, condition: undefined },
+    ]);
+  });
+
+  it('only matches a latest trigger pointer against the latest target version', () => {
+    const userService = service('UserService', [
+      { id: 'CreateUser', version: 'latest', triggers: [{ id: 'UserCreated', version: 'latest' }] },
+    ]);
+
+    expect(getTriggeredByOfMessage([userService], previousUserCreated, allMessages)).toEqual([]);
+  });
+});
+
+describe('getMessagesWithTriggerPaths', () => {
+  it('returns source and target messages but excludes messages without resolved paths', () => {
+    const userService = service('UserService', [
+      { id: 'CreateUser', version: '2.0.0', triggers: [{ id: 'UserCreated', version: '1.0.0' }] },
+    ]);
+
+    expect(getMessagesWithTriggerPaths([userService], allMessages)).toEqual([userCreated, createUser]);
+  });
+
+  it('returns no messages when trigger pointers do not resolve', () => {
+    const userService = service('UserService', [
+      { id: 'CreateUser', version: '2.0.0', triggers: [{ id: 'MissingMessage', version: '1.0.0' }] },
+    ]);
+
+    expect(getMessagesWithTriggerPaths([userService], allMessages)).toEqual([]);
+  });
+});

--- a/packages/core/eventcatalog/src/utils/__tests__/messages/node-graph.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/messages/node-graph.spec.ts
@@ -1,6 +1,11 @@
-import { getNodesAndEdgesForConsumedMessage, getNodesAndEdgesForProducedMessage } from '../../node-graphs/message-node-graph';
+import {
+  getNodesAndEdgesForCommands,
+  getNodesAndEdgesForConsumedMessage,
+  getNodesAndEdgesForEvents,
+  getNodesAndEdgesForProducedMessage,
+} from '../../node-graphs/message-node-graph';
 import { expect, describe, it, vi, beforeEach } from 'vitest';
-import { mockEvents, mockServices, mockChannels, mockAgents } from './mocks';
+import { mockEvents, mockServices, mockChannels, mockAgents, mockCommands } from './mocks';
 import type { CollectionMessageTypes } from '@types';
 import type { CollectionEntry } from 'astro:content';
 import utils from '@eventcatalog/sdk';
@@ -9,6 +14,8 @@ import fs from 'fs';
 import { getProducersOfMessage, getConsumersOfMessage } from '@utils/collections/services';
 
 const CATALOG_FOLDER = path.join(__dirname, 'catalog');
+const triggerReceivers: any[] = [];
+const triggerDomains: any[] = [];
 
 const toAstroCollection = (item: any, collection: string) => {
   return {
@@ -24,7 +31,7 @@ vi.mock('astro:content', async (importOriginal) => {
     // this will only affect "foo" outside of the original module
     getCollection: (key: string) => {
       if (key === 'services') {
-        return Promise.resolve(mockServices);
+        return Promise.resolve([...mockServices, ...triggerReceivers]);
       }
       if (key === 'agents') {
         return Promise.resolve(mockAgents);
@@ -34,6 +41,12 @@ vi.mock('astro:content', async (importOriginal) => {
       }
       if (key === 'events') {
         return Promise.resolve(mockEvents);
+      }
+      if (key === 'commands') {
+        return Promise.resolve(mockCommands);
+      }
+      if (key === 'domains') {
+        return Promise.resolve(triggerDomains);
       }
       return Promise.resolve([]);
     },
@@ -46,6 +59,108 @@ describe('Message NodeGraph', () => {
     // Clear the catalog folder but not the folder itself
     fs.rmSync(CATALOG_FOLDER, { recursive: true, force: true });
     fs.mkdirSync(CATALOG_FOLDER, { recursive: true });
+    triggerReceivers.length = 0;
+    triggerDomains.length = 0;
+  });
+
+  describe('message triggers', () => {
+    it('completes the command to service to event chain from either message graph', async () => {
+      triggerReceivers.push({
+        id: 'PaymentService',
+        collection: 'services',
+        data: {
+          id: 'PaymentService',
+          name: 'Payment Service',
+          version: '1.0.0',
+          receives: [
+            {
+              id: 'ProcessPayment',
+              version: '0.0.1',
+              triggers: [{ id: 'PaymentProcessed', version: '0.0.1' }],
+            },
+          ],
+          sends: [{ id: 'PaymentProcessed', version: '0.0.1' }],
+        },
+      });
+
+      const eventGraph = await getNodesAndEdgesForEvents({ id: 'PaymentProcessed', version: '0.0.1', mode: 'simple' });
+      const commandGraph = await getNodesAndEdgesForCommands({ id: 'ProcessPayment', version: '0.0.1', mode: 'simple' });
+
+      expect(eventGraph.nodes.find((node) => node.id === 'PaymentProcessed-0.0.1')?.data.isFocused).toBe(true);
+      expect(eventGraph.nodes.find((node) => node.id === 'ProcessPayment-0.0.1')?.data.isFocused).toBeUndefined();
+      expect(commandGraph.nodes.find((node) => node.id === 'ProcessPayment-0.0.1')?.data.isFocused).toBe(true);
+      expect(commandGraph.nodes.find((node) => node.id === 'PaymentProcessed-0.0.1')?.data.isFocused).toBeUndefined();
+      expect(eventGraph.nodes.find((node) => node.id === 'ProcessPayment-0.0.1')?.data.contextMenu).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            label: 'Focus node',
+            href: '/visualiser/commands/ProcessPayment/0.0.1',
+          }),
+        ])
+      );
+
+      for (const graph of [eventGraph, commandGraph]) {
+        expect(graph.nodes).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ id: 'ProcessPayment-0.0.1', type: 'commands' }),
+            expect.objectContaining({ id: 'PaymentService-1.0.0', type: 'services' }),
+            expect.objectContaining({ id: 'PaymentProcessed-0.0.1', type: 'events' }),
+          ])
+        );
+        expect(graph.edges).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              id: 'ProcessPayment-0.0.1-PaymentService-1.0.0',
+              source: 'ProcessPayment-0.0.1',
+              target: 'PaymentService-1.0.0',
+            }),
+            expect.objectContaining({
+              id: 'PaymentService-1.0.0-PaymentProcessed-0.0.1',
+              source: 'PaymentService-1.0.0',
+              target: 'PaymentProcessed-0.0.1',
+            }),
+          ])
+        );
+      }
+    });
+
+    it('renders domains that own a trigger relationship', async () => {
+      triggerDomains.push({
+        id: 'Payments',
+        collection: 'domains',
+        data: {
+          id: 'Payments',
+          name: 'Payments',
+          version: '1.0.0',
+          receives: [
+            {
+              id: 'ProcessPayment',
+              version: '0.0.1',
+              triggers: [{ id: 'PaymentProcessed', version: '0.0.1' }],
+            },
+          ],
+        },
+      });
+
+      const graph = await getNodesAndEdgesForEvents({ id: 'PaymentProcessed', version: '0.0.1', mode: 'full' });
+
+      expect(graph.nodes).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: 'ProcessPayment-0.0.1', type: 'commands' }),
+          expect.objectContaining({
+            id: 'Payments-1.0.0',
+            type: 'domains',
+            data: expect.objectContaining({ domain: expect.objectContaining({ collection: 'domains' }) }),
+          }),
+        ])
+      );
+      expect(graph.edges).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ source: 'ProcessPayment-0.0.1', target: 'Payments-1.0.0' }),
+          expect.objectContaining({ source: 'Payments-1.0.0', target: 'PaymentProcessed-0.0.1' }),
+        ])
+      );
+    });
   });
 
   describe('getNodesAndEdgesForConsumedMessage', () => {

--- a/packages/core/eventcatalog/src/utils/__tests__/services/node-graph.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/services/node-graph.spec.ts
@@ -58,7 +58,7 @@ describe('Services NodeGraph', () => {
         id: 'OrderService-1.0.0',
         sourcePosition: 'right',
         targetPosition: 'left',
-        data: expect.objectContaining({ mode: 'simple', service: { ...mockServices[0].data } }),
+        data: expect.objectContaining({ mode: 'simple', isFocused: true, service: { ...mockServices[0].data } }),
         position: { x: expect.any(Number), y: expect.any(Number) },
         type: 'services',
       };
@@ -406,9 +406,11 @@ describe('Services NodeGraph', () => {
 
       const hasMessages = nodes.some((node) => node.type === 'events' || node.type === 'commands' || node.type === 'queries');
       const hasChannels = nodes.some((node) => node.type === 'channels');
+      const focusedService = nodes.find((node) => node.id === 'PaymentService-1.0.0');
 
       expect(hasMessages).toBe(false);
       expect(hasChannels).toBe(false);
+      expect(focusedService?.data.isFocused).toBe(true);
     });
 
     it('will render any container (data) that the service writes to or reads from', async () => {

--- a/packages/core/eventcatalog/src/utils/collections/commands.ts
+++ b/packages/core/eventcatalog/src/utils/collections/commands.ts
@@ -20,7 +20,7 @@ export const getCommands = async ({ getAllVersions = true, hydrateServices = tru
   const cacheKey = `${getAllVersions ? 'allVersions' : 'currentVersions'}-${hydrateServices ? 'hydrated' : 'minimal'}`;
 
   // Check cache
-  if (memoryCache[cacheKey] && memoryCache[cacheKey].length > 0) {
+  if (memoryCache[cacheKey] && memoryCache[cacheKey].length > 0 && CACHE_ENABLED) {
     // console.timeEnd('✅ New getCommands');
     return memoryCache[cacheKey];
   }

--- a/packages/core/eventcatalog/src/utils/collections/message-triggers.ts
+++ b/packages/core/eventcatalog/src/utils/collections/message-triggers.ts
@@ -1,0 +1,118 @@
+import type { CollectionEntry } from 'astro:content';
+import type { CollectionMessageTypes } from '@types';
+import { getItemsFromCollectionByIdAndSemverOrLatest, versionMatches } from './util';
+
+type Message = CollectionEntry<CollectionMessageTypes>;
+export type MessageReceiver = CollectionEntry<'services'> | CollectionEntry<'domains'> | CollectionEntry<'agents'>;
+
+interface TriggerPointer {
+  id: string;
+  version?: string;
+  condition?: string;
+}
+
+interface ReceivePointer {
+  id: string;
+  version?: string;
+  triggers?: TriggerPointer[];
+}
+
+export interface MessageTrigger {
+  receiver: MessageReceiver;
+  message: Message;
+  condition?: string;
+}
+
+const messageMatchesPointer = (message: Message, pointer: { id: string; version?: string }) => {
+  if (pointer.id !== message.data.id) return false;
+
+  if (!pointer.version || pointer.version === 'latest') {
+    return !message.data.latestVersion || message.data.version === message.data.latestVersion;
+  }
+
+  return versionMatches(message.data.version, pointer.version);
+};
+
+/**
+ * Returns the messages triggered when a resource receives the given message.
+ *
+ * Receivers must be raw collection entries because hydration replaces receive
+ * pointers with messages and therefore removes trigger metadata.
+ */
+export const getTriggersOfMessage = (
+  receivers: MessageReceiver[],
+  message: Message,
+  allMessages: Message[]
+): MessageTrigger[] => {
+  const triggers: MessageTrigger[] = [];
+
+  for (const receiver of receivers) {
+    const receives = (receiver.data.receives as ReceivePointer[]) ?? [];
+
+    for (const receive of receives) {
+      if (!receive.triggers?.length || !messageMatchesPointer(message, receive)) continue;
+
+      for (const trigger of receive.triggers) {
+        const target = getItemsFromCollectionByIdAndSemverOrLatest(allMessages, trigger.id, trigger.version)[0];
+        if (!target) continue;
+
+        triggers.push({ receiver, message: target, condition: trigger.condition });
+      }
+    }
+  }
+
+  return triggers;
+};
+
+/**
+ * Returns the messages whose handling can trigger the given message.
+ *
+ * Receivers must be raw collection entries because hydration replaces receive
+ * pointers with messages and therefore removes trigger metadata.
+ */
+export const getTriggeredByOfMessage = (
+  receivers: MessageReceiver[],
+  message: Message,
+  allMessages: Message[]
+): MessageTrigger[] => {
+  const triggeredBy: MessageTrigger[] = [];
+
+  for (const receiver of receivers) {
+    const receives = (receiver.data.receives as ReceivePointer[]) ?? [];
+
+    for (const receive of receives) {
+      for (const trigger of receive.triggers ?? []) {
+        if (!messageMatchesPointer(message, trigger)) continue;
+
+        const source = getItemsFromCollectionByIdAndSemverOrLatest(allMessages, receive.id, receive.version)[0];
+        if (!source) continue;
+
+        triggeredBy.push({ receiver, message: source, condition: trigger.condition });
+      }
+    }
+  }
+
+  return triggeredBy;
+};
+
+const getMessageKey = (message: Message) => `${message.collection}:${message.data.id}:${message.data.version}`;
+
+/**
+ * Returns only messages that participate in at least one resolved trigger path.
+ * Both the source and target are included so empty trigger pages are never generated.
+ */
+export const getMessagesWithTriggerPaths = (receivers: MessageReceiver[], allMessages: Message[]): Message[] => {
+  const messageKeysWithPaths = new Set<string>();
+
+  for (const source of allMessages) {
+    const triggers = getTriggersOfMessage(receivers, source, allMessages);
+    if (triggers.length === 0) continue;
+
+    messageKeysWithPaths.add(getMessageKey(source));
+    for (const trigger of triggers) {
+      messageKeysWithPaths.add(getMessageKey(trigger.message));
+    }
+  }
+
+  return allMessages.filter((message) => messageKeysWithPaths.has(getMessageKey(message)));
+};

--- a/packages/core/eventcatalog/src/utils/node-graphs/container-node-graph.ts
+++ b/packages/core/eventcatalog/src/utils/node-graphs/container-node-graph.ts
@@ -143,11 +143,12 @@ export const getNodesAndEdges = async ({
     targetPosition: 'left',
     data: {
       mode,
+      isFocused: true,
       data: {
         ...container.data,
       },
       contextMenu: buildContextMenuForResource({
-        collection: 'entities',
+        collection: 'containers',
         id: container.data.id,
         version: container.data.version,
       }),

--- a/packages/core/eventcatalog/src/utils/node-graphs/message-lineage.ts
+++ b/packages/core/eventcatalog/src/utils/node-graphs/message-lineage.ts
@@ -1,0 +1,131 @@
+import type { CollectionEntry } from 'astro:content';
+import type { Edge, Node } from '@xyflow/react';
+import type { CollectionMessageTypes } from '@types';
+import type { MessageTrigger } from '@utils/collections/message-triggers';
+import {
+  createEdge,
+  createNode,
+  generateIdForNode,
+  generatedIdForEdge,
+  getColorFromString,
+  getEdgeLabelForMessageAsSource,
+  getEdgeLabelForServiceAsTarget,
+} from './utils/utils';
+import { createTriggerMessageNode, getTriggerReceiverNodeData } from './message-node-graph';
+
+type Message = CollectionEntry<CollectionMessageTypes>;
+
+export type MessageLineageDirection = 'triggeredBy' | 'triggers';
+
+export interface MessageLineageGraph {
+  direction: MessageLineageDirection;
+  condition?: string;
+  source: Message;
+  receiver: MessageTrigger['receiver'];
+  target: Message;
+  relatedMessage: Message;
+  nodes: Node[];
+  edges: Edge[];
+}
+
+export interface MessageLineageScenario {
+  condition?: string;
+}
+
+export interface MessageLineageGroup extends Omit<MessageLineageGraph, 'condition'> {
+  scenarios: MessageLineageScenario[];
+}
+
+const createLineageEdge = (source: any, target: any, label: string, colorMessage: Message): Edge =>
+  createEdge({
+    id: generatedIdForEdge(source, target),
+    source: generateIdForNode(source),
+    target: generateIdForNode(target),
+    label,
+    animated: false,
+    data: {
+      animated: false,
+      customColor: getColorFromString(colorMessage.data.id),
+      rootSourceAndTarget: {
+        source: { id: generateIdForNode(source), collection: source.collection },
+        target: { id: generateIdForNode(target), collection: target.collection },
+      },
+    },
+  });
+
+export const buildMessageLineageGraph = ({
+  currentMessage,
+  relation,
+  direction,
+}: {
+  currentMessage: Message;
+  relation: MessageTrigger;
+  direction: MessageLineageDirection;
+}): MessageLineageGraph => {
+  const source = direction === 'triggeredBy' ? relation.message : currentMessage;
+  const target = direction === 'triggeredBy' ? currentMessage : relation.message;
+  const mode = 'simple';
+
+  const nodes: Node[] = [
+    {
+      ...createTriggerMessageNode(source, mode, source === currentMessage),
+      position: { x: 0, y: 0 },
+    },
+    createNode({
+      id: generateIdForNode(relation.receiver),
+      type: relation.receiver.collection,
+      data: getTriggerReceiverNodeData(relation.receiver, mode),
+      position: { x: 320, y: 0 },
+    }),
+    {
+      ...createTriggerMessageNode(target, mode, target === currentMessage),
+      position: { x: 640, y: 0 },
+    },
+  ];
+
+  return {
+    direction,
+    condition: relation.condition,
+    source,
+    receiver: relation.receiver,
+    target,
+    relatedMessage: relation.message,
+    nodes,
+    edges: [
+      createLineageEdge(source, relation.receiver, getEdgeLabelForMessageAsSource(source), source),
+      createLineageEdge(relation.receiver, target, getEdgeLabelForServiceAsTarget(target), target),
+    ],
+  };
+};
+
+const getResourceKey = (resource: Message | MessageTrigger['receiver']) =>
+  `${resource.collection}:${resource.data.id}:${resource.data.version}`;
+
+export const groupMessageLineageGraphs = (graphs: MessageLineageGraph[]): MessageLineageGroup[] => {
+  const groups = new Map<string, MessageLineageGroup>();
+
+  for (const graph of graphs) {
+    const key = [
+      graph.direction,
+      getResourceKey(graph.source),
+      getResourceKey(graph.receiver),
+      getResourceKey(graph.target),
+    ].join('>');
+    const existingGroup = groups.get(key);
+
+    if (existingGroup) {
+      if (!existingGroup.scenarios.some((scenario) => scenario.condition === graph.condition)) {
+        existingGroup.scenarios.push({ condition: graph.condition });
+      }
+      continue;
+    }
+
+    const { condition, ...lineage } = graph;
+    groups.set(key, {
+      ...lineage,
+      scenarios: [{ condition }],
+    });
+  }
+
+  return [...groups.values()];
+};

--- a/packages/core/eventcatalog/src/utils/node-graphs/message-node-graph.ts
+++ b/packages/core/eventcatalog/src/utils/node-graphs/message-node-graph.ts
@@ -1,6 +1,6 @@
 // import { getColor } from '@utils/colors';
 import { getEvents } from '@utils/collections/events';
-import type { CollectionEntry } from 'astro:content';
+import { getCollection, type CollectionEntry } from 'astro:content';
 import dagre from 'dagre';
 import {
   calculatedNodes,
@@ -42,6 +42,7 @@ import {
 import { getNodesAndEdgesForChannelChain } from './channel-node-graph';
 import { getChannelChain, isChannelsConnected } from '@utils/collections/channels';
 import { getChannels } from '@utils/collections/channels';
+import { getTriggeredByOfMessage, getTriggersOfMessage, type MessageReceiver } from '@utils/collections/message-triggers';
 
 type DagreGraph = any;
 type RoutableResource = CollectionEntry<'agents'> | CollectionEntry<'services'>;
@@ -166,6 +167,52 @@ const getDataProductNodeData = (resource: CollectionEntry<'data-products'>, mode
   contextMenu: buildContextMenuForResource({ collection: 'data-products', id: resource.data.id, version: resource.data.version }),
 });
 
+export const getTriggerReceiverNodeData = (receiver: MessageReceiver, mode: 'simple' | 'full') => {
+  if (receiver.collection !== 'domains') return getRoutableNodeData(receiver, mode);
+
+  return {
+    title: receiver.data.id,
+    mode,
+    domain: {
+      ...receiver,
+      data: {
+        ...receiver.data,
+        // Raw domain entries contain service pointers, while the visualiser's
+        // domain node expects hydrated services in full mode.
+        services: [],
+      },
+    },
+    contextMenu: buildContextMenuForResource({
+      collection: 'domains',
+      id: receiver.data.id,
+      version: receiver.data.version,
+    }),
+  };
+};
+
+export const createTriggerMessageNode = (
+  message: CollectionEntry<CollectionMessageTypes>,
+  mode: 'simple' | 'full',
+  isFocused = false
+) =>
+  createNode({
+    id: generateIdForNode(message),
+    type: message.collection,
+    data: {
+      mode,
+      ...(isFocused ? { isFocused: true } : {}),
+      message: { ...message.data, ...getOperationFields(message.data) },
+      contextMenu: buildContextMenuForMessage({
+        id: message.data.id,
+        version: message.data.version,
+        name: message.data.name,
+        collection: message.collection,
+        schemaPath: (message.data as any).schemaPath,
+      }),
+    },
+    position: { x: 0, y: 0 },
+  });
+
 const getNodesAndEdges = async ({
   id,
   version,
@@ -194,6 +241,19 @@ const getNodesAndEdges = async ({
   // Pre-calculate channel map for O(1) lookups
   const channelMap = createVersionedMap(channels);
 
+  // Trigger metadata lives on raw receive pointers. Hydrated resources replace
+  // those pointers with messages, so load the raw collections for this relation.
+  const [events, commands, queries, services, agents, domains] = await Promise.all([
+    getCollection('events'),
+    getCollection('commands'),
+    getCollection('queries'),
+    getCollection('services'),
+    getCollection('agents'),
+    getCollection('domains'),
+  ]);
+  const allMessages = [...events, ...commands, ...queries] as CollectionEntry<CollectionMessageTypes>[];
+  const messageReceivers = [...services, ...agents, ...domains] as MessageReceiver[];
+
   // We always render the message itself
   nodes.push({
     id: generateIdForNode(message),
@@ -201,6 +261,7 @@ const getNodesAndEdges = async ({
     targetPosition: 'left',
     data: {
       mode,
+      isFocused: true,
       message: {
         ...message.data,
         ...getOperationFields(message.data),
@@ -563,6 +624,63 @@ const getNodesAndEdges = async ({
       );
     }
   });
+
+  const appendNode = (node: Node) => {
+    if (!nodes.some((existingNode: Node) => existingNode.id === node.id)) nodes.push(node);
+  };
+  const appendEdge = (source: any, target: any, label: string, colorMessage: CollectionEntry<CollectionMessageTypes>) => {
+    const id = generatedIdForEdge(source, target);
+    if (edges.some((edge: Edge) => edge.id === id)) return;
+
+    edges.push(
+      createEdge({
+        id,
+        source: generateIdForNode(source),
+        target: generateIdForNode(target),
+        label,
+        data: {
+          customColor: getColorFromString(colorMessage.data.id),
+          rootSourceAndTarget: {
+            source: { id: generateIdForNode(source), collection: source.collection },
+            target: { id: generateIdForNode(target), collection: target.collection },
+          },
+        },
+      })
+    );
+  };
+  const appendReceiver = (receiver: MessageReceiver) => {
+    const receiverId = generateIdForNode(receiver);
+    if (nodes.some((node: Node) => node.id === receiverId)) return;
+
+    appendNode(
+      createNode({
+        id: receiverId,
+        type: receiver.collection,
+        data: getTriggerReceiverNodeData(receiver, mode),
+        position: { x: 0, y: 0 },
+      })
+    );
+
+    if (receiver.collection !== 'domains') {
+      appendAgentToolNodesAndEdges({ agent: receiver, nodes, edges, mode });
+    }
+  };
+
+  // Complete both sides of a trigger chain around the focused message:
+  // triggering message -> receiver -> triggered message.
+  for (const relation of getTriggeredByOfMessage(messageReceivers, message, allMessages)) {
+    appendNode(createTriggerMessageNode(relation.message, mode));
+    appendReceiver(relation.receiver);
+    appendEdge(relation.message, relation.receiver, getEdgeLabelForMessageAsSource(relation.message), relation.message);
+    appendEdge(relation.receiver, message, getEdgeLabelForServiceAsTarget(message), message);
+  }
+
+  for (const relation of getTriggersOfMessage(messageReceivers, message, allMessages)) {
+    appendReceiver(relation.receiver);
+    appendNode(createTriggerMessageNode(relation.message, mode));
+    appendEdge(message, relation.receiver, getEdgeLabelForMessageAsSource(message), message);
+    appendEdge(relation.receiver, relation.message, getEdgeLabelForServiceAsTarget(relation.message), relation.message);
+  }
 
   nodes.forEach((node: any) => {
     flow.setNode(node.id, { width: DEFAULT_NODE_WIDTH, height: DEFAULT_NODE_HEIGHT });

--- a/packages/core/eventcatalog/src/utils/node-graphs/services-node-graph.ts
+++ b/packages/core/eventcatalog/src/utils/node-graphs/services-node-graph.ts
@@ -347,7 +347,10 @@ export const getNodesAndEdges = async ({
     id: generateIdForNode(service),
     sourcePosition: 'right',
     targetPosition: 'left',
-    data: getResourceNodeData(service, mode),
+    data: {
+      ...getResourceNodeData(service, mode),
+      isFocused: service.collection === 'services',
+    },
     type: service.collection,
   });
 
@@ -606,6 +609,17 @@ export const getNodesAndEdges = async ({
       uniqueNodesById.set(node.id, node);
     }
   });
+
+  // Inbound message processing may create the service node before the primary
+  // node is added. Mark the surviving copy after deduplication so the service
+  // currently being viewed always retains its focus treatment.
+  if (service.collection === 'services') {
+    const focusedServiceNode = uniqueNodesById.get(generateIdForNode(service));
+    if (focusedServiceNode) {
+      focusedServiceNode.data = { ...focusedServiceNode.data, isFocused: true };
+    }
+  }
+
   const uniqueNodes = Array.from(uniqueNodesById.values());
 
   uniqueNodes.forEach((node: any) => {

--- a/packages/core/eventcatalog/src/utils/node-graphs/utils/utils.ts
+++ b/packages/core/eventcatalog/src/utils/node-graphs/utils/utils.ts
@@ -162,7 +162,10 @@ export const buildContextMenuForMessage = ({
   collection: string;
   schemaPath?: string;
 }): ContextMenuItem[] => {
-  const items: ContextMenuItem[] = [{ label: 'Read documentation', href: buildUrl(`/docs/${collection}/${id}/${version}`) }];
+  const items: ContextMenuItem[] = [
+    { label: 'Read documentation', href: buildUrl(`/docs/${collection}/${id}/${version}`) },
+    { label: 'Focus node', href: buildUrl(`/visualiser/${collection}/${id}/${version}`) },
+  ];
 
   if (schemaPath) {
     items.push({
@@ -250,7 +253,10 @@ export const buildContextMenuForService = ({
   specifications?: unknown;
   repository?: { url: string };
 }): ContextMenuItem[] => {
-  const items: ContextMenuItem[] = [{ label: 'Read documentation', href: buildUrl(`/docs/services/${id}/${version}`) }];
+  const items: ContextMenuItem[] = [
+    { label: 'Read documentation', href: buildUrl(`/docs/services/${id}/${version}`) },
+    { label: 'Focus node', href: buildUrl(`/visualiser/services/${id}/${version}`) },
+  ];
 
   const specItems = getSpecMenuItems(specifications, id, version);
   items.push(...specItems);
@@ -283,7 +289,10 @@ export const buildContextMenuForAgent = ({
   version: string;
   repository?: { url: string };
 }): ContextMenuItem[] => {
-  const items: ContextMenuItem[] = [{ label: 'Read documentation', href: buildUrl(`/docs/agents/${id}/${version}`) }];
+  const items: ContextMenuItem[] = [
+    { label: 'Read documentation', href: buildUrl(`/docs/agents/${id}/${version}`) },
+    { label: 'Focus node', href: buildUrl(`/visualiser/agents/${id}/${version}`) },
+  ];
 
   if (repository?.url) {
     items.push({
@@ -315,6 +324,7 @@ export const buildContextMenuForResource = ({
 }): ContextMenuItem[] => {
   return [
     { label: 'Read documentation', href: buildUrl(`/docs/${collection}/${id}/${version}`) },
+    { label: 'Focus node', href: buildUrl(`/visualiser/${collection}/${id}/${version}`) },
     {
       label: 'Read changelog',
       href: buildUrl(`/docs/${collection}/${id}/${version}/changelog`),
@@ -331,7 +341,7 @@ export const buildContextMenuForResource = ({
 export const buildContextMenuForSystem = ({ id, version }: { id: string; version: string }): ContextMenuItem[] => {
   return [
     { label: 'Read documentation', href: buildUrl(`/docs/systems/${id}/${version}`) },
-    { label: 'View map', href: buildUrl(`/visualiser/systems/${id}/${version}`) },
+    { label: 'Focus node', href: buildUrl(`/visualiser/systems/${id}/${version}`) },
     { label: 'View context', href: buildUrl(`/visualiser/systems/${id}/${version}/context`) },
   ];
 };

--- a/packages/sdk/src/agents.ts
+++ b/packages/sdk/src/agents.ts
@@ -1,4 +1,4 @@
-import type { Agent } from './types';
+import type { Agent, MessagePointerInput } from './types';
 import fs from 'node:fs/promises';
 import { extname, join, relative } from 'node:path';
 import {
@@ -115,13 +115,7 @@ export const addFileToAgent =
     addFileToResource(directory, id, file, version);
 
 export const addMessageToAgent =
-  (directory: string) =>
-  async (
-    id: string,
-    direction: string,
-    message: { id: string; version: string; fields?: string[]; group?: string },
-    version?: string
-  ) => {
+  (directory: string) => async (id: string, direction: string, message: MessagePointerInput, version?: string) => {
     const agent: Agent = await getAgent(directory)(id, version);
 
     if (direction === 'sends') {
@@ -143,7 +137,7 @@ export const addMessageToAgent =
           return;
         }
       }
-      agent.receives.push(buildMessagePointer(message));
+      agent.receives.push(buildMessagePointer(message, { includeTriggers: true }));
     } else {
       throw new Error(`Direction ${direction} is invalid, only 'receives' and 'sends' are supported`);
     }

--- a/packages/sdk/src/domains.ts
+++ b/packages/sdk/src/domains.ts
@@ -1,4 +1,4 @@
-import type { Domain, UbiquitousLanguageDictionary } from './types';
+import type { Domain, MessagePointerInput, UbiquitousLanguageDictionary } from './types';
 import fs from 'node:fs/promises';
 import path, { join } from 'node:path';
 import fsSync from 'node:fs';
@@ -612,13 +612,7 @@ export const addDataProductToDomain =
  * ```
  */
 export const addMessageToDomain =
-  (directory: string) =>
-  async (
-    id: string,
-    direction: string,
-    message: { id: string; version: string; fields?: string[]; group?: string },
-    version?: string
-  ) => {
+  (directory: string) => async (id: string, direction: string, message: MessagePointerInput, version?: string) => {
     let domain: Domain = await getDomain(directory)(id, version);
     const domainPath = await getResourcePath(directory, id, version);
     const extension = path.extname(domainPath?.fullPath || '');
@@ -644,7 +638,7 @@ export const addMessageToDomain =
           return;
         }
       }
-      domain.receives.push(buildMessagePointer(message));
+      domain.receives.push(buildMessagePointer(message, { includeTriggers: true }));
     } else {
       throw new Error(`Direction ${direction} is invalid, only 'receives' and 'sends' are supported`);
     }

--- a/packages/sdk/src/internal/utils.ts
+++ b/packages/sdk/src/internal/utils.ts
@@ -4,6 +4,7 @@ import { copy, CopyFilterAsync, CopyFilterSync } from 'fs-extra';
 import { join, dirname, normalize, sep as pathSeparator, resolve, basename, relative } from 'node:path';
 import matter from 'gray-matter';
 import { satisfies, validRange, valid } from 'semver';
+import type { MessagePointerInput } from '../types';
 
 // In-memory file index cache. Auto-built on first read, invalidated on writes.
 interface FileIndexEntry {
@@ -308,14 +309,17 @@ export const copyDir = async (catalogDir: string, source: string, target: string
   fsSync.rmSync(tmpDirectory, { recursive: true });
 };
 
-// Makes sure values in sends/recieves are unique
-export const buildMessagePointer = (message: { id: string; version: string; fields?: string[]; group?: string }) => {
-  const pointer: { id: string; version: string; fields?: string[]; group?: string } = {
+// Builds the frontmatter pointer used by sends/receives relationships.
+export const buildMessagePointer = (message: MessagePointerInput, options: { includeTriggers?: boolean } = {}) => {
+  const pointer: MessagePointerInput = {
     id: message.id,
     version: message.version,
   };
   if (message.fields) pointer.fields = message.fields;
   if (message.group) pointer.group = message.group;
+  if (options.includeTriggers && message.triggers) {
+    pointer.triggers = message.triggers.map((trigger) => ({ ...trigger }));
+  }
   return pointer;
 };
 

--- a/packages/sdk/src/messages.ts
+++ b/packages/sdk/src/messages.ts
@@ -1,14 +1,15 @@
 import { dirname, join } from 'node:path';
 import fsSync from 'node:fs';
-import type { Agent, Message, Service } from './types';
+import type { Agent, Domain, Message, Service } from './types';
 import matter from 'gray-matter';
 import { getResource, getResourcePath, isLatestVersion } from './internal/resources';
 import { findFileById, getFiles } from './internal/utils';
 import { getServices } from './services';
 import { getAgents } from './agents';
+import { getDomains } from './domains';
 import { satisfies, validRange } from 'semver';
 
-type MessageParticipant = Service | Agent;
+type MessageParticipant = Service | Agent | Domain;
 
 /**
  * Returns a message from EventCatalog by a given schema path.
@@ -61,7 +62,7 @@ export const getMessageBySchemaPath =
   };
 
 /**
- * Returns the producers and consumers (services and agents) for a given message.
+ * Returns the producers and consumers (services, agents, and domains) for a given message.
  *
  * @example
  * ```ts
@@ -69,7 +70,7 @@ export const getMessageBySchemaPath =
  *
  * const { getProducersAndConsumersForMessage } = utils('/path/to/eventcatalog');
  *
- * // Returns the producers and consumers (services and agents) for a given message
+ * // Returns the producers and consumers (services, agents, and domains) for a given message
  * const { producers, consumers } = await getProducersAndConsumersForMessage('InventoryAdjusted', '0.0.1');
  */
 export const getProducersAndConsumersForMessage =
@@ -79,9 +80,10 @@ export const getProducersAndConsumersForMessage =
     version?: string,
     options?: { latestOnly?: boolean }
   ): Promise<{ producers: MessageParticipant[]; consumers: MessageParticipant[] }> => {
-    const [services = [], agents = []] = await Promise.all([
+    const [services = [], agents = [], domains = []] = await Promise.all([
       getServices(directory)({ latestOnly: options?.latestOnly ?? true }),
       getAgents(directory)({ latestOnly: options?.latestOnly ?? true }),
+      getDomains(directory)({ latestOnly: options?.latestOnly ?? true }),
     ]);
     const message = (await getResource(directory, id, version, { type: 'message' })) as Message;
     const isMessageLatestVersion = await isLatestVersion(directory, id, version);
@@ -93,7 +95,7 @@ export const getProducersAndConsumersForMessage =
     const producers: MessageParticipant[] = [];
     const consumers: MessageParticipant[] = [];
 
-    for (const participant of [...services, ...agents]) {
+    for (const participant of [...services, ...agents, ...domains]) {
       const participantPublishesMessage = participant.sends?.some((_message) => {
         if (_message.version) {
           const isParticipantUsingSemverRange = validRange(_message.version);

--- a/packages/sdk/src/services.ts
+++ b/packages/sdk/src/services.ts
@@ -1,4 +1,4 @@
-import type { Service, Specifications } from './types';
+import type { MessagePointerInput, Service, Specifications } from './types';
 import fs from 'node:fs/promises';
 import { join, dirname, extname, relative } from 'node:path';
 import {
@@ -416,13 +416,7 @@ export const getSpecificationFilesForService = (directory: string) => async (id:
  */
 
 export const addMessageToService =
-  (directory: string) =>
-  async (
-    id: string,
-    direction: string,
-    event: { id: string; version: string; fields?: string[]; group?: string },
-    version?: string
-  ) => {
+  (directory: string) => async (id: string, direction: string, event: MessagePointerInput, version?: string) => {
     let service: Service = await getService(directory)(id, version);
     const servicePath = await getResourcePath(directory, id, version);
     const extension = extname(servicePath?.fullPath || '');
@@ -448,7 +442,7 @@ export const addMessageToService =
           return;
         }
       }
-      service.receives.push(buildMessagePointer(event));
+      service.receives.push(buildMessagePointer(event, { includeTriggers: true }));
     } else {
       throw new Error(`Direction ${direction} is invalid, only 'receives' and 'sends' are supported`);
     }

--- a/packages/sdk/src/test/agents.test.ts
+++ b/packages/sdk/src/test/agents.test.ts
@@ -477,6 +477,36 @@ describe('Agents SDK', () => {
       expect(agent.receives).toEqual([{ id: 'InvestigateOrder', version: '1.0.0' }]);
     });
 
+    it('adds messages triggered by a message the agent receives', async () => {
+      await writeAgent({
+        id: 'OrderSupportAgent',
+        name: 'Order Support Agent',
+        version: '0.0.1',
+        markdown: '# Order support agent',
+      });
+
+      await addQueryToAgent(
+        'OrderSupportAgent',
+        'receives',
+        {
+          id: 'GetOrderSummary',
+          version: '1.0.0',
+          triggers: [{ id: 'InvestigateOrder', version: '1.0.0', condition: 'When an anomaly is detected' }],
+        },
+        '0.0.1'
+      );
+
+      const agent = await getAgent('OrderSupportAgent');
+
+      expect(agent.receives).toEqual([
+        {
+          id: 'GetOrderSummary',
+          version: '1.0.0',
+          triggers: [{ id: 'InvestigateOrder', version: '1.0.0', condition: 'When an anomaly is detected' }],
+        },
+      ]);
+    });
+
     it('adds the given query to the agent sends list', async () => {
       await writeAgent({
         id: 'OrderSupportAgent',

--- a/packages/sdk/src/test/domains.test.ts
+++ b/packages/sdk/src/test/domains.test.ts
@@ -1353,6 +1353,31 @@ describe('Domain SDK', () => {
         expect(domain.receives).toEqual([{ id: 'PaymentProcessed', version: '1.0.0' }]);
       });
 
+      it('adds messages triggered by a message the domain receives', async () => {
+        await writeDomain({
+          id: 'Orders',
+          name: 'Orders Domain',
+          version: '0.0.1',
+          markdown: '# Hello world',
+        });
+
+        await addEventToDomain('Orders', 'receives', {
+          id: 'PaymentProcessed',
+          version: '1.0.0',
+          triggers: [{ id: 'GetOrderStatus', version: '1.0.0', condition: 'After payment succeeds' }],
+        });
+
+        const domain = await getDomain('Orders');
+
+        expect(domain.receives).toEqual([
+          {
+            id: 'PaymentProcessed',
+            version: '1.0.0',
+            triggers: [{ id: 'GetOrderStatus', version: '1.0.0', condition: 'After payment succeeds' }],
+          },
+        ]);
+      });
+
       it('adds a command to the receives of an existing domain', async () => {
         await writeDomain({
           id: 'Orders',

--- a/packages/sdk/src/test/messages.test.ts
+++ b/packages/sdk/src/test/messages.test.ts
@@ -15,6 +15,7 @@ const {
   getProducersAndConsumersForMessage,
   writeService,
   writeAgent,
+  writeDomain,
   addEventToService,
   addEventToAgent,
   versionEvent,
@@ -70,6 +71,29 @@ describe('Messages SDK', () => {
   });
 
   describe('getProducersAndConsumersForMessage', () => {
+    it('includes domains that send and receive the message', async () => {
+      await writeEvent({
+        id: 'InventoryAdjusted',
+        name: 'Inventory Adjusted',
+        version: '0.0.1',
+        markdown: '# Hello world',
+      });
+
+      await writeDomain({
+        id: 'Fulfilment',
+        name: 'Fulfilment',
+        version: '1.0.0',
+        markdown: '# Fulfilment',
+        sends: [{ id: 'InventoryAdjusted', version: '0.0.1' }],
+        receives: [{ id: 'InventoryAdjusted', version: '0.0.1' }],
+      });
+
+      const { producers, consumers } = await getProducersAndConsumersForMessage('InventoryAdjusted', '0.0.1');
+
+      expect(producers.map((participant) => participant.id)).toContain('Fulfilment');
+      expect(consumers.map((participant) => participant.id)).toContain('Fulfilment');
+    });
+
     it('returns the producers and consumers for a given message', async () => {
       await writeEvent({
         id: 'InventoryAdjusted',

--- a/packages/sdk/src/test/services.test.ts
+++ b/packages/sdk/src/test/services.test.ts
@@ -1238,6 +1238,42 @@ describe('Services SDK', () => {
       });
     });
 
+    it('adds messages triggered by a received message', async () => {
+      await writeService({
+        id: 'InventoryService',
+        name: 'Inventory Service',
+        version: '0.0.1',
+        markdown: '# Hello world',
+      });
+
+      await addCommandToService(
+        'InventoryService',
+        'receives',
+        {
+          id: 'ReserveInventory',
+          version: '1.0.0',
+          triggers: [
+            { id: 'InventoryReserved', version: '1.0.0', condition: 'When stock is available' },
+            { id: 'InventoryUnavailable', version: '1.0.0', condition: 'When stock is unavailable' },
+          ],
+        },
+        '0.0.1'
+      );
+
+      const service = await getService('InventoryService');
+
+      expect(service.receives).toEqual([
+        {
+          id: 'ReserveInventory',
+          version: '1.0.0',
+          triggers: [
+            { id: 'InventoryReserved', version: '1.0.0', condition: 'When stock is available' },
+            { id: 'InventoryUnavailable', version: '1.0.0', condition: 'When stock is unavailable' },
+          ],
+        },
+      ]);
+    });
+
     it('throws an error when trying to add an event to a service with an unsupported direction', async () => {
       await writeService({
         id: 'InventoryService',

--- a/packages/sdk/src/types.d.ts
+++ b/packages/sdk/src/types.d.ts
@@ -86,12 +86,27 @@ export type SendsPointer = {
   group?: string;
 };
 
+export type TriggerPointer = {
+  id: string;
+  version?: string;
+  condition?: string;
+};
+
 export type ReceivesPointer = {
   id: string;
   version?: string;
   fields?: string[];
   from?: ChannelPointer[];
   group?: string;
+  triggers?: TriggerPointer[];
+};
+
+export type MessagePointerInput = {
+  id: string;
+  version: string;
+  fields?: string[];
+  group?: string;
+  triggers?: TriggerPointer[];
 };
 
 export interface ResourceGroup {
@@ -137,6 +152,8 @@ export interface CustomDoc {
 interface MessageDetailsPanelProperty {
   producers?: DetailPanelProperty;
   consumers?: DetailPanelProperty;
+  triggers?: DetailPanelProperty;
+  triggeredBy?: DetailPanelProperty;
   channels?: DetailPanelProperty;
   versions?: DetailPanelProperty;
   repository?: DetailPanelProperty;

--- a/packages/visualiser/src/components/NodeGraph.tsx
+++ b/packages/visualiser/src/components/NodeGraph.tsx
@@ -90,6 +90,11 @@ import {
 import AnimatedMessageEdge from "../edges/AnimatedMessageEdge";
 import MultilineEdgeLabel from "../edges/MultilineEdgeLabel";
 import FlowEdge from "../edges/FlowEdge";
+import {
+  LabelledDefaultEdge,
+  LabelledSmoothStepEdge,
+  LabelledStepEdge,
+} from "../edges/LabelledEdge";
 import VisualiserSearch, { type VisualiserSearchRef } from "./VisualiserSearch";
 import StepWalkthrough from "./StepWalkthrough";
 import StudioModal from "./StudioModal";
@@ -490,6 +495,9 @@ const NodeGraphBuilder = ({
         animated: AnimatedMessageEdge,
         multiline: MultilineEdgeLabel,
         "flow-edge": FlowEdge,
+        default: LabelledDefaultEdge,
+        smoothstep: LabelledSmoothStepEdge,
+        step: LabelledStepEdge,
       }) as Record<string, any>,
     [],
   );

--- a/packages/visualiser/src/edges/AnimatedMessageEdge.tsx
+++ b/packages/visualiser/src/edges/AnimatedMessageEdge.tsx
@@ -1,6 +1,7 @@
 import { memo, useMemo } from "react";
 import { BaseEdge, getSmoothStepPath } from "@xyflow/react";
 import { EDGE_WARNING_STYLE, EDGE_DEFAULT_STYLE } from "../nodes/shared-styles";
+import EdgeLabel from "./EdgeLabel";
 
 /** Map collection type → envelope fill color (module-level, zero allocation). */
 function messageColor(collection: string): string {
@@ -15,9 +16,6 @@ function messageColor(collection: string): string {
       return "gray";
   }
 }
-
-const TSPAN_NORMAL_STYLE = { fontStyle: "normal" } as const;
-const TSPAN_ITALIC_STYLE = { fontStyle: "italic" } as const;
 
 const AnimatedMessageEdge = memo(
   ({
@@ -100,18 +98,6 @@ const AnimatedMessageEdge = memo(
       [edgePath, id, customColors.join(","), opacity, randomDelay],
     );
 
-    const lines = useMemo(() => String(label ?? "").split("\n"), [label]);
-    const longestLine = useMemo(
-      () =>
-        lines.reduce(
-          (a: string, b: string) => (a.length > b.length ? a : b),
-          "",
-        ),
-      [lines],
-    );
-    const labelWidth = Math.max(longestLine.length * 6.5 + 16, 50);
-    const firstLineDy = `${-((lines.length - 1) * 1.2) / 2}em`;
-
     return (
       <>
         <BaseEdge
@@ -122,43 +108,7 @@ const AnimatedMessageEdge = memo(
           style={warning ? EDGE_WARNING_STYLE : EDGE_DEFAULT_STYLE}
         />
         {animatedNodes}
-        <g>
-          {label && (
-            <rect
-              x={labelX - labelWidth / 2}
-              y={labelY - lines.length * 7 - 2}
-              width={labelWidth}
-              height={lines.length * 14 + 4}
-              fill="rgb(var(--ec-card-bg))"
-              fillOpacity={0.95}
-              stroke="rgb(var(--ec-page-border))"
-              strokeWidth={0.75}
-              rx={5}
-              ry={5}
-            />
-          )}
-          <text
-            x={labelX}
-            y={labelY}
-            textAnchor="middle"
-            dominantBaseline="middle"
-            fontSize="11px"
-            fontWeight={500}
-            fill="rgb(var(--ec-page-text))"
-            pointerEvents="none"
-          >
-            {lines.map((line: string, i: number) => (
-              <tspan
-                key={i}
-                x={labelX}
-                dy={i === 0 ? firstLineDy : "1.2em"}
-                style={i === 0 ? TSPAN_NORMAL_STYLE : TSPAN_ITALIC_STYLE}
-              >
-                {line}
-              </tspan>
-            ))}
-          </text>
-        </g>
+        <EdgeLabel label={label} labelX={labelX} labelY={labelY} />
       </>
     );
   },

--- a/packages/visualiser/src/edges/EdgeLabel.tsx
+++ b/packages/visualiser/src/edges/EdgeLabel.tsx
@@ -1,0 +1,45 @@
+import { EdgeLabelRenderer } from "@xyflow/react";
+import type { CSSProperties, ReactNode } from "react";
+
+interface EdgeLabelProps {
+  label: ReactNode;
+  labelX: number;
+  labelY: number;
+  style?: CSSProperties;
+}
+
+export default function EdgeLabel({
+  label,
+  labelX,
+  labelY,
+  style,
+}: EdgeLabelProps) {
+  if (label === undefined || label === null || label === "") return null;
+
+  const lines = String(label).split("\n");
+
+  return (
+    <EdgeLabelRenderer>
+      <div
+        className="nodrag nopan rounded-md border border-[rgb(var(--ec-page-border))] px-2 py-1 text-center text-[10px] font-medium leading-tight text-[rgb(var(--ec-page-text))] shadow-sm"
+        style={{
+          position: "absolute",
+          transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+          zIndex: 1000,
+          pointerEvents: "none",
+          backgroundColor: "rgb(var(--ec-card-bg))",
+          ...style,
+        }}
+      >
+        {lines.map((line, index) => (
+          <div
+            key={`${line}-${index}`}
+            className={`whitespace-nowrap ${index > 0 ? "italic" : ""}`}
+          >
+            {line}
+          </div>
+        ))}
+      </div>
+    </EdgeLabelRenderer>
+  );
+}

--- a/packages/visualiser/src/edges/LabelledEdge.tsx
+++ b/packages/visualiser/src/edges/LabelledEdge.tsx
@@ -1,0 +1,76 @@
+import {
+  BaseEdge,
+  getBezierPath,
+  getSmoothStepPath,
+  type EdgeProps,
+} from "@xyflow/react";
+import type { CSSProperties } from "react";
+import EdgeLabel from "./EdgeLabel";
+
+type PathType = "bezier" | "smoothstep" | "step";
+
+function LabelledEdge({
+  pathType,
+  ...props
+}: EdgeProps & { pathType: PathType }) {
+  const {
+    id,
+    sourceX,
+    sourceY,
+    targetX,
+    targetY,
+    sourcePosition,
+    targetPosition,
+    markerStart,
+    markerEnd,
+    style,
+    label,
+    labelStyle,
+  } = props;
+
+  const pathProps = {
+    sourceX,
+    sourceY,
+    targetX,
+    targetY,
+    sourcePosition,
+    targetPosition,
+  };
+  const [edgePath, labelX, labelY] =
+    pathType === "bezier"
+      ? getBezierPath(pathProps)
+      : getSmoothStepPath({
+          ...pathProps,
+          ...(pathType === "step" ? { borderRadius: 0 } : {}),
+        });
+
+  return (
+    <>
+      <BaseEdge
+        id={id}
+        path={edgePath}
+        markerStart={markerStart}
+        markerEnd={markerEnd}
+        style={style}
+      />
+      <EdgeLabel
+        label={label}
+        labelX={labelX}
+        labelY={labelY}
+        style={labelStyle as CSSProperties}
+      />
+    </>
+  );
+}
+
+export function LabelledDefaultEdge(props: EdgeProps) {
+  return <LabelledEdge {...props} pathType="bezier" />;
+}
+
+export function LabelledSmoothStepEdge(props: EdgeProps) {
+  return <LabelledEdge {...props} pathType="smoothstep" />;
+}
+
+export function LabelledStepEdge(props: EdgeProps) {
+  return <LabelledEdge {...props} pathType="step" />;
+}

--- a/packages/visualiser/src/edges/MultilineEdgeLabel.tsx
+++ b/packages/visualiser/src/edges/MultilineEdgeLabel.tsx
@@ -1,8 +1,6 @@
-import { memo, useMemo } from "react";
+import { memo } from "react";
 import { type EdgeProps, getSmoothStepPath } from "@xyflow/react";
-
-const TSPAN_NORMAL_STYLE = { fontStyle: "normal" } as const;
-const TSPAN_ITALIC_STYLE = { fontStyle: "italic" } as const;
+import EdgeLabel from "./EdgeLabel";
 
 export default memo(function MultilineEdgeLabel(props: EdgeProps) {
   const {
@@ -29,18 +27,6 @@ export default memo(function MultilineEdgeLabel(props: EdgeProps) {
     targetPosition,
   });
 
-  const lines = useMemo(() => String(label ?? "").split("\n"), [label]);
-  const firstLineDy = useMemo(
-    () => `${-((lines.length - 1) * 1.2) / 2}em`,
-    [lines.length],
-  );
-  const longestLine = useMemo(
-    () => lines.reduce((a, b) => (a.length > b.length ? a : b), ""),
-    [lines],
-  );
-  const labelWidth = Math.max(longestLine.length * 5.5 + 14, 44);
-  const labelHeight = lines.length * 12 + 4;
-
   return (
     <>
       <path
@@ -52,42 +38,7 @@ export default memo(function MultilineEdgeLabel(props: EdgeProps) {
         style={style as any}
       />
 
-      {label && (
-        <rect
-          x={labelX - labelWidth / 2}
-          y={labelY - labelHeight / 2}
-          width={labelWidth}
-          height={labelHeight}
-          fill="rgb(var(--ec-card-bg))"
-          fillOpacity={0.95}
-          stroke="rgb(var(--ec-page-border))"
-          strokeWidth={0.75}
-          rx={5}
-          ry={5}
-          pointerEvents="none"
-        />
-      )}
-
-      <text
-        x={labelX}
-        y={labelY}
-        textAnchor="middle"
-        dominantBaseline="middle"
-        fontSize="10px"
-        fill="rgb(var(--ec-page-text))"
-        pointerEvents="none"
-      >
-        {lines.map((line, i) => (
-          <tspan
-            key={i}
-            x={labelX}
-            dy={i === 0 ? firstLineDy : "1.2em"}
-            style={i === 0 ? TSPAN_NORMAL_STYLE : TSPAN_ITALIC_STYLE}
-          >
-            {line}
-          </tspan>
-        ))}
-      </text>
+      <EdgeLabel label={label} labelX={labelX} labelY={labelY} />
     </>
   );
 });

--- a/packages/visualiser/src/edges/index.ts
+++ b/packages/visualiser/src/edges/index.ts
@@ -6,13 +6,28 @@
 import AnimatedMessageEdge from "./AnimatedMessageEdge";
 import FlowEdge from "./FlowEdge";
 import MultilineEdgeLabel from "./MultilineEdgeLabel";
+import {
+  LabelledDefaultEdge,
+  LabelledSmoothStepEdge,
+  LabelledStepEdge,
+} from "./LabelledEdge";
 
 // Re-export
-export { AnimatedMessageEdge, FlowEdge, MultilineEdgeLabel };
+export {
+  AnimatedMessageEdge,
+  FlowEdge,
+  MultilineEdgeLabel,
+  LabelledDefaultEdge,
+  LabelledSmoothStepEdge,
+  LabelledStepEdge,
+};
 
 // Re-export for convenience
 export const edgeTypes = {
   animated: AnimatedMessageEdge,
   "flow-edge": FlowEdge,
   multiline: MultilineEdgeLabel,
+  default: LabelledDefaultEdge,
+  smoothstep: LabelledSmoothStepEdge,
+  step: LabelledStepEdge,
 };

--- a/packages/visualiser/src/nodes/Entity.tsx
+++ b/packages/visualiser/src/nodes/Entity.tsx
@@ -237,6 +237,18 @@ export default memo(function EntityNode({
               Read documentation
             </a>
           </ContextMenu.Item>
+          <ContextMenu.Item
+            asChild
+            className="text-sm text-[rgb(var(--ec-page-text))] px-2 py-1.5 outline-none cursor-pointer hover:bg-[rgb(var(--ec-accent-subtle))] rounded-sm flex items-center"
+          >
+            <a
+              href={buildUrl(
+                `/visualiser/entities/${entity.data.id}/${version}`,
+              )}
+            >
+              Focus node
+            </a>
+          </ContextMenu.Item>
         </ContextMenu.Content>
       </ContextMenu.Portal>
     </ContextMenu.Root>

--- a/packages/visualiser/src/nodes/Flow.tsx
+++ b/packages/visualiser/src/nodes/Flow.tsx
@@ -185,7 +185,7 @@ export default memo(function FlowNode({
             className="text-sm px-2 py-1.5 outline-none cursor-pointer hover:bg-orange-100 rounded-sm flex items-center"
           >
             <a href={buildUrl(`/visualiser/flows/${id}/${version}`)}>
-              View in visualiser
+              Focus node
             </a>
           </ContextMenu.Item>
           <ContextMenu.Separator className="h-[1px] bg-[rgb(var(--ec-page-border))] m-1" />

--- a/packages/visualiser/src/nodes/FocusedResourceIndicator.tsx
+++ b/packages/visualiser/src/nodes/FocusedResourceIndicator.tsx
@@ -1,0 +1,16 @@
+import { LocateFixed } from "lucide-react";
+
+export function FocusedResourceIndicator() {
+  return (
+    <>
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute -inset-1.5 z-[5] rounded-[14px] border-2 border-indigo-500/70 shadow-lg"
+      />
+      <div className="pointer-events-none absolute -bottom-2.5 right-2 z-30 inline-flex items-center gap-1 rounded-full border border-white/80 bg-indigo-600 px-2 py-0.5 text-[7px] font-bold uppercase tracking-widest text-white shadow-sm">
+        <LocateFixed className="h-2.5 w-2.5" strokeWidth={2.5} />
+        Viewing
+      </div>
+    </>
+  );
+}

--- a/packages/visualiser/src/nodes/command/CommandNode.tsx
+++ b/packages/visualiser/src/nodes/command/CommandNode.tsx
@@ -16,6 +16,7 @@ import {
   useDarkMode,
 } from "../shared-styles";
 import { TruncatedResourceName } from "../TruncatedResourceName";
+import { FocusedResourceIndicator } from "../FocusedResourceIndicator";
 
 const GlowHandle = memo(function GlowHandle({
   side,
@@ -65,6 +66,7 @@ function PostItCommand(props: CommandNode) {
         props?.selected ? "ring-2 ring-blue-400/60 ring-offset-1" : "",
       )}
     >
+      {props.data.isFocused && <FocusedResourceIndicator />}
       <Handle
         type="target"
         position={Position.Left}
@@ -226,6 +228,7 @@ function DefaultCommand(props: CommandNode) {
         boxShadow: "0 2px 12px rgba(59, 130, 246, 0.15)",
       }}
     >
+      {props.data.isFocused && <FocusedResourceIndicator />}
       <Handle
         type="target"
         position={Position.Left}

--- a/packages/visualiser/src/nodes/data/DataNode.tsx
+++ b/packages/visualiser/src/nodes/data/DataNode.tsx
@@ -16,6 +16,7 @@ import {
 } from "../shared-styles";
 import { CustomIcon, isIconPath } from "../../utils/custom-icon";
 import { TruncatedResourceName } from "../TruncatedResourceName";
+import { FocusedResourceIndicator } from "../FocusedResourceIndicator";
 
 function GlowHandle({ side }: { side: "left" | "right" }) {
   return (
@@ -91,6 +92,7 @@ function PostItData(props: DataNode) {
         props?.selected ? "ring-2 ring-indigo-400/60 ring-offset-1" : "",
       )}
     >
+      {props.data.isFocused && <FocusedResourceIndicator />}
       <Handle
         type="target"
         position={Position.Left}
@@ -258,6 +260,7 @@ function DefaultData(props: DataNode) {
         boxShadow: "0 2px 12px rgba(99, 102, 241, 0.15)",
       }}
     >
+      {props.data.isFocused && <FocusedResourceIndicator />}
       <Handle
         type="target"
         position={Position.Left}

--- a/packages/visualiser/src/nodes/event/EventNode.tsx
+++ b/packages/visualiser/src/nodes/event/EventNode.tsx
@@ -16,6 +16,7 @@ import {
 } from "../shared-styles";
 import { CustomIcon, isIconPath } from "../../utils/custom-icon";
 import { TruncatedResourceName } from "../TruncatedResourceName";
+import { FocusedResourceIndicator } from "../FocusedResourceIndicator";
 
 const GlowHandle = memo(function GlowHandle({
   side,
@@ -65,6 +66,7 @@ function PostItEvent(props: EventNode) {
         props?.selected ? "ring-2 ring-orange-400/60 ring-offset-1" : "",
       )}
     >
+      {props.data.isFocused && <FocusedResourceIndicator />}
       <Handle
         type="target"
         position={Position.Left}
@@ -231,6 +233,7 @@ function DefaultEvent(props: EventNode) {
         boxShadow: "0 2px 12px rgba(251, 146, 60, 0.15)",
       }}
     >
+      {props.data.isFocused && <FocusedResourceIndicator />}
       <Handle
         type="target"
         position={Position.Left}

--- a/packages/visualiser/src/nodes/query/QueryNode.tsx
+++ b/packages/visualiser/src/nodes/query/QueryNode.tsx
@@ -16,6 +16,7 @@ import {
   useDarkMode,
 } from "../shared-styles";
 import { TruncatedResourceName } from "../TruncatedResourceName";
+import { FocusedResourceIndicator } from "../FocusedResourceIndicator";
 
 const GlowHandle = memo(function GlowHandle({
   side,
@@ -65,6 +66,7 @@ function PostItQuery(props: QueryNode) {
         props?.selected ? "ring-2 ring-green-400/60 ring-offset-1" : "",
       )}
     >
+      {props.data.isFocused && <FocusedResourceIndicator />}
       <Handle
         type="target"
         position={Position.Left}
@@ -223,6 +225,7 @@ function DefaultQuery(props: QueryNode) {
         boxShadow: "0 2px 12px rgba(34, 197, 94, 0.15)",
       }}
     >
+      {props.data.isFocused && <FocusedResourceIndicator />}
       <Handle
         type="target"
         position={Position.Left}

--- a/packages/visualiser/src/nodes/service/ServiceNode.tsx
+++ b/packages/visualiser/src/nodes/service/ServiceNode.tsx
@@ -16,6 +16,7 @@ import {
   useDarkMode,
 } from "../shared-styles";
 import { TruncatedResourceName } from "../TruncatedResourceName";
+import { FocusedResourceIndicator } from "../FocusedResourceIndicator";
 
 const SPEC_LABELS: Record<string, string> = {
   openapi: "OpenAPI",
@@ -331,6 +332,7 @@ function PostItService(props: ServiceNode) {
         props?.selected ? p.ring : "",
       )}
     >
+      {props.data.isFocused && <FocusedResourceIndicator />}
       <Handle
         type="target"
         position={Position.Left}
@@ -490,6 +492,7 @@ function DefaultService(props: ServiceNode) {
         boxShadow: `0 2px 12px ${p.shadowColor}`,
       }}
     >
+      {props.data.isFocused && <FocusedResourceIndicator />}
       <Handle
         type="target"
         position={Position.Left}

--- a/packages/visualiser/src/types/index.ts
+++ b/packages/visualiser/src/types/index.ts
@@ -9,6 +9,8 @@ export type EventCatalogResource = {
   collection?: string;
   filePath?: string;
   id?: string;
+  /** Marks the resource represented by the current visualizer page. */
+  isFocused?: boolean;
 };
 
 /**


### PR DESCRIPTION

## What This PR Does

https://github.com/event-catalog/eventcatalog/issues/2263

Adds the ability for services, domains, and agents to document which messages they trigger when handling a received message. These trigger relationships surface in message sidebars, node graphs, and a new dedicated "Trigger paths" page per message, so teams can trace cause-and-effect chains between messages. It also improves the visualiser with a focused-resource indicator and edge labels that render above edges.

## Changes Overview

### Key Changes

- **Trigger relationships in the schema** (`content.config.ts`): `receives` pointers on services, domains, and agents now accept a `triggers` array (message id, optional version, optional condition) describing which messages are sent as a result of handling the received message.
- **New collection utility** (`utils/collections/message-triggers.ts`): resolves `triggers` / `triggeredBy` relationships from raw collection entries, plus `getMessagesWithTriggerPaths` to find only messages that participate in at least one resolved path.
- **Trigger paths page** (`pages/triggers/[type]/[id]/[version]/`): a new page per message showing one visual row per trigger path with its optional scenarios, switchable via the new `LineageScenarioSwitcher` component. Pages are only generated for messages that have at least one resolved path.
- **Message lineage graphs** (`utils/node-graphs/message-lineage.ts`): builds lineage node graphs for trigger paths.
- **Sidebar integration** (`stores/sidebar-store`): message sidebars now show both sides of trigger relationships ("triggers" and "triggered by").
- **Node graph updates**: message, service, and container node graphs include trigger edges; graph utilities updated accordingly.
- **SDK** (`@eventcatalog/sdk`): supports trigger pointers on `receives`, and now includes domains when resolving message producers and consumers.
- **Visualiser** (`@eventcatalog/visualiser`):
  - New `FocusedResourceIndicator` keeps the currently viewed resource visibly marked as the graph's focus across message, service, and data store nodes; context menus can focus another node in its own map.
  - New shared `EdgeLabel` / `LabelledEdge` components; edge labels render above graph edges so intersecting paths no longer obscure their text.
- **Example catalog**: the default example documents trigger relationships across the Reviews, Ordering, Fulfilment, and Customer domains (e.g. `ReviewModerationWorker` with conditional trigger paths).

## How It Works

Trigger metadata lives on the raw `receives` pointers of a receiver resource (service, domain, or agent). Because hydration replaces receive pointers with resolved messages (stripping trigger metadata), the new utilities operate on raw collection entries and resolve targets with `getItemsFromCollectionByIdAndSemverOrLatest`, respecting semver ranges and `latest`. Each resolved path carries the receiver and an optional `condition` label, which the trigger paths page renders per row with scenario switching. The static trigger paths pages are generated only for messages returned by `getMessagesWithTriggerPaths`, so no empty pages are built.

## Breaking Changes

None. The `triggers` field is optional; catalogs without it behave exactly as before.

## Additional Notes

- Changeset bumps `@eventcatalog/core`, `@eventcatalog/sdk`, and `@eventcatalog/visualiser` as `minor`.
- Tests added across core (sidebar, node graphs, message triggers/lineage) and the SDK (agents, domains, messages, services).