### PR TITLE
Resolve raw markdown endpoint file paths in SSR

### DIFF
--- a/.changeset/tidy-moons-resolve.md
+++ b/.changeset/tidy-moons-resolve.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/core': patch
+---
+
+Fix the raw Markdown resource endpoints resolving catalog files from the server working directory in SSR deployments.

--- a/packages/core/eventcatalog/src/__tests__/api/resource-markdown-api.spec.ts
+++ b/packages/core/eventcatalog/src/__tests__/api/resource-markdown-api.spec.ts
@@ -1,0 +1,52 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { GET as getMarkdown } from '../../pages/docs/[type]/[id]/[version].md';
+import { GET as getMdx } from '../../pages/docs/[type]/[id]/[version].mdx';
+
+const event = vi.hoisted(() => ({
+  data: {
+    id: 'MyEvent',
+    version: '1.0.0',
+  },
+  filePath: '../domains/mydomain/events/MyEvent/index.mdx',
+}));
+
+vi.mock('astro:content', () => ({
+  getCollection: async (collection: string) => (collection === 'events' ? [event] : []),
+}));
+
+describe('resource markdown API', () => {
+  const originalProjectDir = process.env.PROJECT_DIR;
+  const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'eventcatalog-markdown-api-'));
+  const markdown = '# My Event\n\nEvent documentation.';
+
+  beforeAll(() => {
+    process.env.PROJECT_DIR = projectDir;
+    const resourceDirectory = path.join(projectDir, 'domains', 'mydomain', 'events', 'MyEvent');
+    fs.mkdirSync(resourceDirectory, { recursive: true });
+    fs.writeFileSync(path.join(resourceDirectory, 'index.mdx'), markdown);
+  });
+
+  afterAll(() => {
+    if (originalProjectDir === undefined) {
+      delete process.env.PROJECT_DIR;
+    } else {
+      process.env.PROJECT_DIR = originalProjectDir;
+    }
+    fs.rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  it.each([
+    ['.md', getMarkdown],
+    ['.mdx', getMdx],
+  ])('reads the %s resource from PROJECT_DIR when Astro provides a relative file path', async (_extension, get) => {
+    const response = await get({
+      params: { type: 'events', id: 'MyEvent', version: '1.0.0' },
+      props: {},
+    } as any);
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe(markdown);
+  });
+});

--- a/packages/core/eventcatalog/src/__tests__/api/resource-markdown-api.spec.ts
+++ b/packages/core/eventcatalog/src/__tests__/api/resource-markdown-api.spec.ts
@@ -12,8 +12,17 @@ const event = vi.hoisted(() => ({
   filePath: '../domains/mydomain/events/MyEvent/index.mdx',
 }));
 
+const eventWithSchema = vi.hoisted(() => ({
+  data: {
+    id: 'EventWithSchema',
+    version: '1.0.0',
+    schemaPath: 'schema.json',
+  },
+  filePath: '../domains/mydomain/events/EventWithSchema/index.mdx',
+}));
+
 vi.mock('astro:content', () => ({
-  getCollection: async (collection: string) => (collection === 'events' ? [event] : []),
+  getCollection: async (collection: string) => (collection === 'events' ? [event, eventWithSchema] : []),
 }));
 
 describe('resource markdown API', () => {
@@ -26,6 +35,11 @@ describe('resource markdown API', () => {
     const resourceDirectory = path.join(projectDir, 'domains', 'mydomain', 'events', 'MyEvent');
     fs.mkdirSync(resourceDirectory, { recursive: true });
     fs.writeFileSync(path.join(resourceDirectory, 'index.mdx'), markdown);
+
+    const resourceWithSchemaDirectory = path.join(projectDir, 'domains', 'mydomain', 'events', 'EventWithSchema');
+    fs.mkdirSync(resourceWithSchemaDirectory, { recursive: true });
+    fs.writeFileSync(path.join(resourceWithSchemaDirectory, 'index.mdx'), markdown);
+    fs.writeFileSync(path.join(resourceWithSchemaDirectory, 'schema.json'), '{"type":"object"}');
   });
 
   afterAll(() => {
@@ -48,5 +62,15 @@ describe('resource markdown API', () => {
 
     expect(response.status).toBe(200);
     expect(await response.text()).toBe(markdown);
+  });
+
+  it('includes a relative schema when Astro provides a relative resource file path', async () => {
+    const response = await getMdx({
+      params: { type: 'events', id: 'EventWithSchema', version: '1.0.0' },
+      props: {},
+    } as any);
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe(`${markdown}\n\n ## Raw Schema:schema.json\n\n{"type":"object"}`);
   });
 });

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version].md.ts
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version].md.ts
@@ -9,6 +9,7 @@ import config from '@config';
 import fs from 'fs';
 import { isLLMSTxtEnabled } from '@utils/feature';
 import { filterMarkdownForAgents } from '@utils/llms';
+import { getAbsoluteFilePathForAstroFile } from '@utils/files';
 
 const events = await getCollection('events');
 const agents = await getCollection('agents');
@@ -67,7 +68,8 @@ export const GET: APIRoute = async ({ params, props }) => {
 
   const content = props?.content ?? findContent(params);
   if (content?.filePath) {
-    const file = filterMarkdownForAgents(fs.readFileSync(content.filePath, 'utf8'));
+    const absoluteFilePath = getAbsoluteFilePathForAstroFile(content.filePath);
+    const file = filterMarkdownForAgents(fs.readFileSync(absoluteFilePath, 'utf8'));
     return new Response(file, { status: 200 });
   }
 

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version].mdx.ts
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version].mdx.ts
@@ -72,7 +72,7 @@ export const GET: APIRoute = async ({ params, props }) => {
     let file = fs.readFileSync(absoluteFilePath, 'utf8');
 
     try {
-      file = addSchemaToMarkdown(content, file);
+      file = addSchemaToMarkdown({ ...content, filePath: absoluteFilePath }, file);
     } catch (error) {
       console.log('Warning: Cant find the schema for', content.data.id, content.data.version);
     }

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version].mdx.ts
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version].mdx.ts
@@ -8,6 +8,7 @@ import config from '@config';
 import fs from 'fs';
 import { addSchemaToMarkdown, filterMarkdownForAgents } from '@utils/llms';
 import { isLLMSTxtEnabled, isSSR } from '@utils/feature';
+import { getAbsoluteFilePathForAstroFile } from '@utils/files';
 const events = await getCollection('events');
 const agents = await getCollection('agents');
 const commands = await getCollection('commands');
@@ -67,7 +68,8 @@ export const GET: APIRoute = async ({ params, props }) => {
 
   const content = props?.content ?? findContent(params);
   if (content?.filePath) {
-    let file = fs.readFileSync(content.filePath, 'utf8');
+    const absoluteFilePath = getAbsoluteFilePathForAstroFile(content.filePath);
+    let file = fs.readFileSync(absoluteFilePath, 'utf8');
 
     try {
       file = addSchemaToMarkdown(content, file);

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -96,7 +96,6 @@
 - 8f724a7: feat: add `externalSystem` flag to services for modelling third-party integrations
 
   Services can now set `externalSystem: true` in their frontmatter to be rendered as external systems. This changes their presentation without changing their capabilities — they still send and receive messages, have owners, and support specifications like any other service.
-
   - Visualiser: external services render purple with a Globe icon and an "External System" badge
   - Sidebar (root): a dedicated "External Systems" section lists externals; the regular "Services" section excludes them
   - Sidebar (domain): externals appear under a new "External Integrations" group, separate from "Services In Domain"


### PR DESCRIPTION
Closes #2702

## What This PR Does

The raw Markdown resource endpoints (`/docs/[type]/[id]/[version].md` and `.mdx`) read catalog files directly from the `filePath` that Astro provides, which is relative to the catalog directory. In SSR deployments this relative path was resolved against the server's working directory, causing the file read to fail. This PR resolves the path to an absolute location before reading so the endpoints work correctly in SSR.

## Changes Overview

### Key Changes
- Use `getAbsoluteFilePathForAstroFile` to resolve the content `filePath` before `fs.readFileSync` in both the `.md` and `.mdx` resource endpoints.
- Add tests covering both endpoints reading the resource from `PROJECT_DIR` when Astro provides a relative file path.

## How It Works

Astro content collections expose `filePath` as a path relative to the catalog root. The existing `getAbsoluteFilePathForAstroFile` utility joins that relative path against `PROJECT_DIR`, producing an absolute path that is stable regardless of the server's current working directory. Both endpoints now run the `filePath` through this helper before reading from disk.

## Breaking Changes

None.

## Additional Notes

No editor repository (`eventcatalog/eventcatalog-editor`) change is needed — this is a core SSR file-resolution fix.