### PR TITLE
Suppress Astro empty optional collection messages on preview and start

### DIFF
--- a/.changeset/quiet-optional-collections.md
+++ b/.changeset/quiet-optional-collections.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/core': patch
+---
+
+Suppress Astro's empty optional collection messages when previewing or starting EventCatalog while preserving other warnings.

--- a/packages/core/src/eventcatalog.ts
+++ b/packages/core/src/eventcatalog.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { execSync, spawn } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import { join } from 'node:path';
 import http from 'node:http';
 import fs from 'fs';
@@ -122,7 +122,10 @@ const startDevPrewarm = ({
 
 const createAstroLineFilter = () => {
   return (line: string) => {
-    return line.includes('[glob-loader]') || /The collection.*does not exist/.test(line);
+    return (
+      line.includes('[glob-loader]') ||
+      /^\s*The collection ".*" does not exist or is empty\. Please check your content config file for errors\.\s*$/.test(line)
+    );
   };
 };
 
@@ -575,7 +578,7 @@ program
     }
   });
 
-const previewCatalog = ({
+const previewCatalog = async ({
   command,
   canEmbedPages = false,
   isEventCatalogStarter = false,
@@ -586,34 +589,42 @@ const previewCatalog = ({
   isEventCatalogStarter: boolean;
   isEventCatalogScale: boolean;
 }) => {
-  execSync(
-    `cross-env PROJECT_DIR='${dir}' CATALOG_DIR='${core}' ENABLE_EMBED=${canEmbedPages} EVENTCATALOG_STARTER=${isEventCatalogStarter} EVENTCATALOG_SCALE=${isEventCatalogScale} npx astro preview ${command.args.join(' ').trim()}`,
-    {
-      cwd: core,
-      stdio: 'inherit',
-    }
-  );
+  await runCommandWithFilteredOutput({
+    command: `npx astro preview ${command.args.join(' ').trim()}`,
+    cwd: core,
+    env: {
+      PROJECT_DIR: dir,
+      CATALOG_DIR: core,
+      ENABLE_EMBED: String(canEmbedPages),
+      EVENTCATALOG_STARTER: String(isEventCatalogStarter),
+      EVENTCATALOG_SCALE: String(isEventCatalogScale),
+    },
+    shouldFilterLine: createAstroLineFilter(),
+  });
 };
 
-const startServerCatalog = ({
-  command,
+const startServerCatalog = async ({
   canEmbedPages = false,
   isEventCatalogStarter = false,
   isEventCatalogScale = false,
 }: {
-  command: Command;
   canEmbedPages: boolean;
   isEventCatalogStarter: boolean;
   isEventCatalogScale: boolean;
 }) => {
   const serverEntryPath = path.join(dir, 'dist', 'server', 'entry.mjs');
-  execSync(
-    `cross-env PROJECT_DIR='${dir}' CATALOG_DIR='${core}' ENABLE_EMBED=${canEmbedPages} EVENTCATALOG_STARTER=${isEventCatalogStarter} EVENTCATALOG_SCALE=${isEventCatalogScale} node "${serverEntryPath}"`,
-    {
-      cwd: core,
-      stdio: 'inherit',
-    }
-  );
+  await runCommandWithFilteredOutput({
+    command: `node "${serverEntryPath}"`,
+    cwd: core,
+    env: {
+      PROJECT_DIR: dir,
+      CATALOG_DIR: core,
+      ENABLE_EMBED: String(canEmbedPages),
+      EVENTCATALOG_STARTER: String(isEventCatalogStarter),
+      EVENTCATALOG_SCALE: String(isEventCatalogScale),
+    },
+    shouldFilterLine: createAstroLineFilter(),
+  });
 };
 
 program
@@ -635,7 +646,12 @@ program
     const isEventCatalogStarter = await isEventCatalogStarterEnabled();
     const isEventCatalogScale = await isEventCatalogScaleEnabled();
 
-    previewCatalog({ command, canEmbedPages: canEmbedPages || isEventCatalogScale, isEventCatalogStarter, isEventCatalogScale });
+    await previewCatalog({
+      command,
+      canEmbedPages: canEmbedPages || isEventCatalogScale,
+      isEventCatalogStarter,
+      isEventCatalogScale,
+    });
   });
 
 program
@@ -660,14 +676,13 @@ program
     const isServerOutput = await isOutputServer();
 
     if (isServerOutput) {
-      startServerCatalog({
-        command,
+      await startServerCatalog({
         canEmbedPages: canEmbedPages || isEventCatalogScale,
         isEventCatalogStarter,
         isEventCatalogScale,
       });
     } else {
-      previewCatalog({
+      await previewCatalog({
         command,
         canEmbedPages: canEmbedPages || isEventCatalogScale,
         isEventCatalogStarter,

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -96,7 +96,6 @@
 - 8f724a7: feat: add `externalSystem` flag to services for modelling third-party integrations
 
   Services can now set `externalSystem: true` in their frontmatter to be rendered as external systems. This changes their presentation without changing their capabilities — they still send and receive messages, have owners, and support specifications like any other service.
-
   - Visualiser: external services render purple with a Globe icon and an "External System" badge
   - Sidebar (root): a dedicated "External Systems" section lists externals; the regular "Services" section excludes them
   - Sidebar (domain): externals appear under a new "External Integrations" group, separate from "Services In Domain"


### PR DESCRIPTION
Closes https://github.com/event-catalog/eventcatalog/issues/2709

## What This PR Does

When previewing or starting a catalog, Astro logs noisy `The collection "..." does not exist or is empty` messages for optional content collections that a user hasn't populated. This PR routes the `preview` and `start:server` commands through the same filtered-output runner already used elsewhere, so those empty-collection messages are suppressed while all other warnings and errors are preserved.

## Changes Overview

### Key Changes
- Route `previewCatalog` and `startServerCatalog` through `runCommandWithFilteredOutput` instead of `execSync`, passing environment variables explicitly rather than via a `cross-env` command string.
- Tighten `createAstroLineFilter` to match the full, exact empty/missing-collection message instead of a loose substring, so only the intended lines are filtered.
- Make `previewCatalog` and `startServerCatalog` async and `await` them at their call sites.
- Remove the now-unused `execSync` import and the unused `command` parameter from `startServerCatalog`.

## How It Works

`runCommandWithFilteredOutput` spawns the child process and streams its output line by line, dropping any line for which `shouldFilterLine` returns true. The Astro line filter now matches `[glob-loader]` lines and the exact `The collection "..." does not exist or is empty. Please check your content config file for errors.` message, leaving everything else untouched.

## Breaking Changes

None.

## Additional Notes

No corresponding change is needed in the `eventcatalog/eventcatalog-editor` repository — this only affects the core CLI's preview/start output handling.