### PR TITLE
Resolve Astro relative file paths for changelog diffs in SSR

### DIFF
--- a/.changeset/calm-files-resolve.md
+++ b/.changeset/calm-files-resolve.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/core': patch
+---
+
+Fix changelog file diff resolution for versioned resources in SSR deployments.

--- a/packages/core/eventcatalog/src/utils/__tests__/collections/file-diffs.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/collections/file-diffs.spec.ts
@@ -110,5 +110,37 @@ describe('Diff Utilities', () => {
       expect(diffs[0]).toContain('<span class="d2h-file-name">asyncapi.yml</span>');
       expect(diffs[1]).toContain('<span class="d2h-file-name">schema.json</span>');
     });
+
+    it('resolves Astro relative file paths from PROJECT_DIR when diffing in SSR mode', async () => {
+      const originalProjectDir = process.env.PROJECT_DIR;
+      process.env.PROJECT_DIR = pathToTestCatalog;
+
+      const allEvents = [
+        {
+          data: { id: 'myevent', version: '1.0.0' },
+          filePath: '../events/OrderAmended/index.mdx',
+        },
+        {
+          data: { id: 'myevent', version: '0.9.0' },
+          filePath: '../events/OrderAmended/versioned/0.0.1/index.mdx',
+        },
+      ];
+
+      try {
+        const diffs = (await getDiffsForCurrentAndPreviousVersion(
+          '1.0.0',
+          '0.9.0',
+          'myevent',
+          // @ts-ignore
+          allEvents
+        )) as string[];
+
+        expect(diffs).toHaveLength(2);
+        expect(diffs[0]).toContain('<span class="d2h-file-name">asyncapi.yml</span>');
+        expect(diffs[1]).toContain('<span class="d2h-file-name">schema.json</span>');
+      } finally {
+        process.env.PROJECT_DIR = originalProjectDir;
+      }
+    });
   });
 });

--- a/packages/core/eventcatalog/src/utils/file-diffs.ts
+++ b/packages/core/eventcatalog/src/utils/file-diffs.ts
@@ -1,8 +1,9 @@
 import { readdir, readFile } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
+import { dirname, isAbsolute, join } from 'node:path';
 import { formatPatch, structuredPatch } from 'diff';
 import { html, parse } from 'diff2html';
 import { getItemsFromCollectionByIdAndSemverOrLatest } from './collections/util';
+import { getAbsoluteFilePathForAstroFile } from './files';
 import type { CollectionEntry } from 'astro:content';
 import type { CollectionTypes } from '@types';
 
@@ -32,7 +33,8 @@ export async function getFilesForDiffInCollection(
   const pathToFolder = collection.filePath;
   if (!pathToFolder) return [];
 
-  const dir = dirname(pathToFolder);
+  const absolutePathToFolder = isAbsolute(pathToFolder) ? pathToFolder : getAbsoluteFilePathForAstroFile(pathToFolder);
+  const dir = dirname(absolutePathToFolder);
   const allFilesInDirectory = await readdir(dir);
 
   return allFilesInDirectory


### PR DESCRIPTION
Closes #2701

## What This PR Does

Fixes changelog file diff resolution for versioned resources when running EventCatalog in SSR mode. In SSR builds, Astro provides `filePath` values as relative paths (e.g. `../events/OrderAmended/index.mdx`), which broke the directory lookup used to build version-to-version diffs. This PR resolves those relative paths to absolute paths before reading the directory.

## Changes Overview

### Key Changes
- In `getFilesForDiffInCollection`, resolve the collection's `filePath` to an absolute path when it isn't already absolute, using `getAbsoluteFilePathForAstroFile`.
- Added a test covering the SSR case where Astro relative file paths are resolved from `PROJECT_DIR`.

## How It Works

Astro content collections expose a `filePath` for each entry. During static builds this is typically absolute, but in SSR deployments it can be relative to the project directory. The diff utility previously called `dirname(pathToFolder)` directly on this value, which produced an incorrect directory when the path was relative, so `readdir` failed to find the resource's files.

The fix checks `isAbsolute(pathToFolder)`; if the path is relative it is resolved via `getAbsoluteFilePathForAstroFile`, which anchors it against `PROJECT_DIR`. The rest of the diff logic is unchanged.

## Breaking Changes

None.

## Additional Notes

No editor repository (`eventcatalog/eventcatalog-editor`) change is needed for this fix.