### PR TITLE
Suppress Astro getStaticPaths dynamic-page warning during build

### DIFF
--- a/.changeset/quiet-otters-filter.md
+++ b/.changeset/quiet-otters-filter.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Suppress the Astro `getStaticPaths() ignored in dynamic page` router warning during builds and extract the Astro output filters into a dedicated, tested module

--- a/packages/core/src/__tests__/astro-output.spec.ts
+++ b/packages/core/src/__tests__/astro-output.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { createAstroDevLineFilter, createAstroLineFilter } from '../astro-output';
+
+describe('Astro output filters', () => {
+  describe('build output', () => {
+    const shouldFilterLine = createAstroLineFilter();
+
+    it('filters getStaticPaths warnings for dynamic pages', () => {
+      expect(
+        shouldFilterLine(
+          '11:09:22 [WARN] [router] getStaticPaths() ignored in dynamic page /src/pages/docs/[type]/[id]/index.astro. Add `export const prerender = true;` to prerender the page as static HTML during the build process.'
+        )
+      ).toBe(true);
+    });
+
+    it('does not filter other router warnings', () => {
+      expect(shouldFilterLine('11:09:22 [WARN] [router] A different routing warning')).toBe(false);
+    });
+
+    it('does not filter matching text from a different logger', () => {
+      expect(shouldFilterLine('11:09:22 [WARN] [build] getStaticPaths() ignored in dynamic page example.astro')).toBe(false);
+    });
+
+    it('continues to filter expected content loader noise', () => {
+      expect(shouldFilterLine('11:09:22 [WARN] [glob-loader] No files found')).toBe(true);
+      expect(
+        shouldFilterLine('The collection "events" does not exist or is empty. Please check your content config file for errors.')
+      ).toBe(true);
+    });
+  });
+
+  describe('development output', () => {
+    it('continues to filter all router messages', () => {
+      const shouldFilterLine = createAstroDevLineFilter();
+
+      expect(shouldFilterLine('11:09:22 [WARN] [router] A different routing warning')).toBe(true);
+    });
+  });
+});

--- a/packages/core/src/astro-output.ts
+++ b/packages/core/src/astro-output.ts
@@ -1,0 +1,19 @@
+export const createAstroLineFilter = () => {
+  return (line: string) => {
+    const isIgnoredGetStaticPathsWarning = line.includes('[router]') && line.includes('getStaticPaths() ignored in dynamic page');
+
+    return (
+      line.includes('[glob-loader]') ||
+      isIgnoredGetStaticPathsWarning ||
+      /^\s*The collection ".*" does not exist or is empty\. Please check your content config file for errors\.\s*$/.test(line)
+    );
+  };
+};
+
+export const createAstroDevLineFilter = () => {
+  const shouldFilterAstroLine = createAstroLineFilter();
+
+  return (line: string) => {
+    return shouldFilterAstroLine(line) || line.includes('[router]');
+  };
+};

--- a/packages/core/src/eventcatalog.ts
+++ b/packages/core/src/eventcatalog.ts
@@ -21,6 +21,7 @@ import { logger } from './utils/cli-logger';
 import { buildFieldsIndex } from '../eventcatalog/src/enterprise/fields/field-indexer';
 import { buildSearchIndex } from './search-indexer';
 import { linkCoreNodeModules, resolveInstalledCoreNodeModules } from './core-node-modules';
+import { createAstroDevLineFilter, createAstroLineFilter } from './astro-output';
 const currentDir = path.dirname(fileURLToPath(import.meta.url));
 const program = new Command().version(VERSION);
 
@@ -118,23 +119,6 @@ const startDevPrewarm = ({
   };
 
   setTimeout(tick, initialDelayMs);
-};
-
-const createAstroLineFilter = () => {
-  return (line: string) => {
-    return (
-      line.includes('[glob-loader]') ||
-      /^\s*The collection ".*" does not exist or is empty\. Please check your content config file for errors\.\s*$/.test(line)
-    );
-  };
-};
-
-const createAstroDevLineFilter = () => {
-  const shouldFilterAstroLine = createAstroLineFilter();
-
-  return (line: string) => {
-    return shouldFilterAstroLine(line) || line.includes('[router]');
-  };
 };
 
 const buildDevSearchIndex = async ({ config }: { config: Awaited<ReturnType<typeof getEventCatalogConfigFile>> }) => {


### PR DESCRIPTION
## What This PR Does

Filters out the noisy Astro `[router] getStaticPaths() ignored in dynamic page` warning that appears during builds, so the CLI output stays clean. It also extracts the Astro output line-filtering logic out of `eventcatalog.ts` into a dedicated `astro-output.ts` module and adds unit tests to cover the filtering behaviour.

## Changes Overview

### Key Changes
- Add a new filter rule that suppresses the `[router] getStaticPaths() ignored in dynamic page` warning in build output.
- Move `createAstroLineFilter` and `createAstroDevLineFilter` from `eventcatalog.ts` into a new `astro-output.ts` module.
- Add `astro-output.spec.ts` with tests for build and dev filters, including guards against over-filtering (e.g. other `[router]` warnings and matching text from a different logger).

## How It Works

`createAstroLineFilter` now returns `true` (i.e. filter/suppress the line) for lines that both include `[router]` and contain `getStaticPaths() ignored in dynamic page`, in addition to the existing `[glob-loader]` and empty-collection noise. The dev filter (`createAstroDevLineFilter`) continues to suppress all `[router]` lines, preserving previous development-mode behaviour. `eventcatalog.ts` imports these filters from the extracted module instead of defining them inline.

## Breaking Changes

None.

## Additional Notes

- The build-mode filter is intentionally narrow — only the specific `getStaticPaths() ignored in dynamic page` router warning is suppressed, so genuine routing warnings still surface.
- No corresponding change is needed in the `eventcatalog/eventcatalog-editor` repository; this only affects CLI build/dev output filtering in core.