### PR TITLE
Add custom extension properties (x-*) support

### DIFF
--- a/.changeset/swift-turtles-dance.md
+++ b/.changeset/swift-turtles-dance.md
@@ -1,5 +1,6 @@
 ---
 "@eventcatalog/core": patch
+"@eventcatalog/sdk": patch
 ---
 
 Add support for custom extension properties (`x-*`) on resources, with new `<CustomProperties>` and `<CustomProperty>` MDX components to display them.

--- a/.changeset/swift-turtles-dance.md
+++ b/.changeset/swift-turtles-dance.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Add support for custom extension properties (`x-*`) on resources, with new `<CustomProperties>` and `<CustomProperty>` MDX components to display them.

--- a/examples/default/domains/Catalog/systems/product-catalog-system/adrs/adr-001-use-transactional-outbox/index.mdx
+++ b/examples/default/domains/Catalog/systems/product-catalog-system/adrs/adr-001-use-transactional-outbox/index.mdx
@@ -9,6 +9,8 @@ owners:
   - product-platform
 decisionMakers:
   - product-platform
+x-next-review-date: '2027-02-10'
+x-risk-level: medium
 appliesTo:
   - type: system
     id: product-catalog-system
@@ -28,6 +30,8 @@ badges:
 ## Context
 
 The Product Catalog System is the source of truth for products, and other systems — notably the [[system|search-system]] — depend on a reliable stream of `product-created`, `product-updated` and `product-deleted` events. Publishing to the broker directly from the [[service|product-api]] request path creates a dual-write problem: if the database commit succeeds but the broker publish fails (or vice versa), the catalog and its consumers drift out of sync. Lost or phantom events are hard to detect and expensive to reconcile.
+
+<CustomProperties title="Review metadata" />
 
 ## Decision
 

--- a/examples/default/domains/Customer/entities/customer-profile/index.mdx
+++ b/examples/default/domains/Customer/entities/customer-profile/index.mdx
@@ -7,6 +7,11 @@ aggregateRoot: true
 summary: The customer details Acme uses for commerce interactions.
 owners:
   - customer-platform
+x-contains-personal-data: true
+x-data-steward: customer-data-governance
+x-subject-access-request-fields:
+  - email
+  - displayName
 properties:
   - name: customerId
     type: UUID
@@ -29,5 +34,7 @@ properties:
 ## Overview
 
 Customer Profile is owned by [[system|customer-management-system]] and is separate from authentication credentials.
+
+<CustomProperties title="Data governance" />
 
 <EntityPropertiesTable />

--- a/examples/default/domains/Payments/index.mdx
+++ b/examples/default/domains/Payments/index.mdx
@@ -6,6 +6,10 @@ summary: |
   The Payments domain takes payment for orders and processes refunds. It orchestrates authorization and capture through an external payment processor, and screens payments for fraud.
 owners:
   - payments-platform
+x-business-criticality: mission-critical
+x-compliance-frameworks:
+  - PCI-DSS
+  - SOC2
 systems:
   - id: payment-processing-system
     version: 1.0.0
@@ -37,6 +41,8 @@ badges:
 
 The **Payments** domain is responsible for moving money. It authorizes and captures payment for orders, issues refunds, and screens payments for fraud. It owns one internal system and integrates with two external providers:
 
+<CustomProperties title="Domain metadata" />
+
 <Tiles>
   <Tile
     icon="CreditCardIcon"
@@ -67,4 +73,3 @@ The **Payment Processing System** is the internal orchestrator. When the Orderin
 The systems in this domain, how they relate, and the people who interact with them.
 
 <ContextDiagram />
-

--- a/examples/default/domains/Payments/systems/payment-processing-system/index.mdx
+++ b/examples/default/domains/Payments/systems/payment-processing-system/index.mdx
@@ -6,6 +6,12 @@ summary: |
   Internal system that orchestrates payment for orders. It authorizes payments, requests charges from the external payment processor, handles the outcome, and issues refunds.
 owners:
   - payments-platform
+x-deployment-regions:
+  - eu-west-1
+  - us-east-1
+x-recovery-objectives:
+  rto: 30m
+  rpo: 5m
 services:
   - id: payment-api
   - id: payment-worker
@@ -26,6 +32,8 @@ badges:
 ## Overview
 
 The **Payment Processing System** is the internal heart of the Payments domain. When the Ordering domain sends [[command|authorize-payment]], the [[service|payment-api]] records the intent in the [[container|payment-database]] and the [[service|payment-worker]] requests a charge from the external [[system|stripe]] via [[event|payment-requested]]. Stripe reports the outcome back as [[event|payment-succeeded]] or [[event|payment-failed]], which the worker records. The system also issues refunds via [[event|refund-requested]].
+
+<CustomProperties title="Operational metadata" />
 
 ## Context Diagram
 

--- a/examples/default/domains/Payments/systems/payment-processing-system/services/PaymentAPI/index.mdx
+++ b/examples/default/domains/Payments/systems/payment-processing-system/services/PaymentAPI/index.mdx
@@ -8,6 +8,11 @@ styles:
   icon: /icons/languages/nodejs.svg
 owners:
   - payments-platform
+x-operational-tier: 1
+x-cost-centre: payments-engineering
+x-on-call:
+  schedule: payments-primary
+  escalation-channel: '#payments-incidents'
 receives:
   - id: authorize-payment
     version: 1.0.0
@@ -25,6 +30,8 @@ import Footer from '@catalog/components/footer.astro';
 ## Overview
 
 The **Payment API** is the entry point to the Payment Processing System. It receives [[command|authorize-payment]] from the Ordering domain, records the payment intent in the [[container|payment-database]], and leaves the [[service|payment-worker]] to drive the charge against [[system|stripe]].
+
+<CustomProperties />
 
 <Tiles>
   <Tile icon="BoltIcon" href={`/visualiser/services/${frontmatter.id}/${frontmatter.version}`} title={`Receives ${frontmatter.receives.length} message`} description="The authorize-payment command from Ordering" />

--- a/examples/default/domains/Reviews/containers/review-database/index.mdx
+++ b/examples/default/domains/Reviews/containers/review-database/index.mdx
@@ -11,6 +11,10 @@ purpose: System of record for reviews, ratings and moderation decisions
 classification: internal
 retention: indefinite
 residency: eu-west-1
+x-backup-policy:
+  frequency: hourly
+  retention-days: 35
+  cross-region: true
 styles:
   icon: /icons/database/postgresql.svg
 ---
@@ -20,6 +24,8 @@ styles:
 ### What is this?
 
 The **Review Database** is the authoritative store for every review in the Reviews & Ratings domain. The [[service|review-api]] writes new reviews to it, and the [[service|review-moderation-worker]] records each moderation decision against the stored review.
+
+<CustomProperty name="x-backup-policy" label="Backup policy" />
 
 ### What does it store?
 

--- a/examples/default/domains/Reviews/flows/review-submission/index.mdx
+++ b/examples/default/domains/Reviews/flows/review-submission/index.mdx
@@ -6,6 +6,10 @@ summary: |
   How a customer's product review travels from submission, through moderation, to being published and folded into the product's aggregate rating.
 owners:
   - reviews-platform
+x-business-capability: customer-reviews
+x-success-metrics:
+  publication-target: 5m
+  moderation-pass-rate: 0.95
 steps:
   - id: customer_submits
     title: Customer submits a review
@@ -110,6 +114,8 @@ steps:
 ## Overview
 
 **Review Submission** documents the journey of a customer review from submission through moderation to publication. A review is only ever folded into a product's rating once it has been approved.
+
+<CustomProperties title="Flow metadata" />
 
 <NodeGraph />
 

--- a/examples/default/domains/Reviews/services/ReviewAPI/events/review-submitted/index.mdx
+++ b/examples/default/domains/Reviews/services/ReviewAPI/events/review-submitted/index.mdx
@@ -6,6 +6,11 @@ summary: |
   Published when a customer submits a review. The review is stored but not yet visible — it awaits moderation.
 owners:
   - reviews-platform
+x-data-classification: internal
+x-retention-days: 2555
+x-downstream-uses:
+  - moderation
+  - rating-aggregation
 schemaPath: schema.json
 badges:
   - content: 'Broker:Kafka'
@@ -19,6 +24,8 @@ import Footer from '@catalog/components/footer.astro';
 ## Overview
 
 `ReviewSubmitted` is published by the [[service|review-api]] once a review has been accepted and stored. The [[service|review-moderation-worker]] consumes it to screen the review before it can be published.
+
+<CustomProperties title="Event metadata" />
 
 <SchemaViewer file="schema.json" title="JSON Schema" maxHeight="500" />
 

--- a/examples/default/domains/Reviews/services/ReviewAPI/index.mdx
+++ b/examples/default/domains/Reviews/services/ReviewAPI/index.mdx
@@ -44,6 +44,10 @@ readsFrom:
 repository:
   language: TypeScript
   url: 'https://github.com/acme/review-api'
+x-operational-tier: 1
+x-scrum-masters:
+  - David
+  - Andrew
 ---
 
 import Footer from '@catalog/components/footer.astro';
@@ -51,6 +55,8 @@ import Footer from '@catalog/components/footer.astro';
 ## Overview
 
 The **Review API** is the front door to the Reviews & Ratings domain. It validates incoming [[command|submit-review]] commands, persists reviews to the [[container|review-database]], and publishes [[event|review-submitted]]. It also serves [[query|get-product-reviews]], reading published reviews from the [[container|review-database]] and aggregate ratings from the [[container|rating-cache]].
+
+<CustomProperty name="x-scrum-masters" label="Scrum masters" />
 
 ### Responsibilities
 

--- a/examples/default/domains/Reviews/services/ReviewAPI/queries/get-product-reviews/index.mdx
+++ b/examples/default/domains/Reviews/services/ReviewAPI/queries/get-product-reviews/index.mdx
@@ -6,6 +6,8 @@ summary: |
   Query to fetch the published reviews and aggregate rating for a product.
 owners:
   - reviews-platform
+x-cacheable: true
+x-latency-slo-ms: 200
 schemaPath: schema.json
 ---
 
@@ -14,6 +16,8 @@ import Footer from '@catalog/components/footer.astro';
 ## Overview
 
 `GetProductReviews` is served by the [[service|review-api]]. It returns the published reviews for a product along with its aggregate rating, read from the [[container|review-database]] and the [[container|rating-cache]].
+
+<CustomProperties title="Query metadata" />
 
 <SchemaViewer file="schema.json" title="JSON Schema" maxHeight="500" />
 

--- a/packages/core/eventcatalog/src/components/MDX/CustomProperties/CustomProperties.astro
+++ b/packages/core/eventcatalog/src/components/MDX/CustomProperties/CustomProperties.astro
@@ -1,0 +1,39 @@
+---
+import CustomPropertyRow from './CustomPropertyRow.astro';
+import { getCustomProperties } from './custom-properties';
+
+interface Props {
+  title?: string;
+  data?: Record<string, unknown>;
+}
+
+const { title = 'Custom properties', data } = Astro.props;
+const properties = getCustomProperties(data);
+---
+
+{
+  properties.length > 0 && (
+    <section class="not-prose my-8">
+      {title && <h3 class="mb-4 text-xl font-semibold text-[rgb(var(--ec-page-text))]">{title}</h3>}
+      <div class="overflow-x-auto">
+        <table class="w-full border-collapse text-left text-sm text-[rgb(var(--ec-page-text-muted))]">
+          <thead>
+            <tr class="border-b border-[rgb(var(--ec-page-border))] text-[rgb(var(--ec-page-text))]">
+              <th scope="col" class="py-3 pr-6 font-semibold">
+                Property
+              </th>
+              <th scope="col" class="py-3 font-semibold">
+                Value
+              </th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-[rgb(var(--ec-page-border))]">
+            {properties.map((property) => (
+              <CustomPropertyRow property={property} />
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  )
+}

--- a/packages/core/eventcatalog/src/components/MDX/CustomProperties/CustomProperty.astro
+++ b/packages/core/eventcatalog/src/components/MDX/CustomProperties/CustomProperty.astro
@@ -1,0 +1,37 @@
+---
+import CustomPropertyRow from './CustomPropertyRow.astro';
+import { getCustomProperty } from './custom-properties';
+
+interface Props {
+  name: string;
+  label?: string;
+  data?: Record<string, unknown>;
+}
+
+const { name, label, data } = Astro.props;
+const property = getCustomProperty(data, name);
+
+if (property && label) property.label = label;
+---
+
+{
+  property && (
+    <div class="not-prose my-6 overflow-x-auto">
+      <table class="w-full border-collapse text-left text-sm text-[rgb(var(--ec-page-text-muted))]">
+        <thead>
+          <tr class="border-b border-[rgb(var(--ec-page-border))] text-[rgb(var(--ec-page-text))]">
+            <th scope="col" class="py-3 pr-6 font-semibold">
+              Property
+            </th>
+            <th scope="col" class="py-3 font-semibold">
+              Value
+            </th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-[rgb(var(--ec-page-border))]">
+          <CustomPropertyRow property={property} />
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/packages/core/eventcatalog/src/components/MDX/CustomProperties/CustomPropertyRow.astro
+++ b/packages/core/eventcatalog/src/components/MDX/CustomProperties/CustomPropertyRow.astro
@@ -1,0 +1,37 @@
+---
+import CustomPropertyValue from './CustomPropertyValue.astro';
+import type { CustomProperty } from './custom-properties';
+import { InformationCircleIcon } from '@heroicons/react/24/outline';
+
+interface Props {
+  property: CustomProperty;
+}
+
+const { property } = Astro.props;
+---
+
+<tr class="hover:bg-[rgb(var(--ec-content-hover))]">
+  <td class="w-1/3 min-w-48 py-4 pr-6 align-top font-medium text-[rgb(var(--ec-page-text))]">
+    <span class="inline-flex items-center gap-1.5">
+      {property.label}
+      <span class="group relative inline-flex">
+        <button
+          type="button"
+          class="inline-flex cursor-help text-[rgb(var(--ec-page-text-muted))] hover:text-[rgb(var(--ec-page-text))] focus:outline-hidden focus:ring-2 focus:ring-[rgb(var(--ec-accent))] focus:ring-offset-2"
+          aria-label={`Frontmatter property: ${property.name}`}
+        >
+          <InformationCircleIcon className="h-4 w-4" aria-hidden="true" />
+        </button>
+        <span
+          role="tooltip"
+          class="pointer-events-none absolute left-full top-1/2 z-20 ml-2 -translate-y-1/2 whitespace-nowrap rounded-md bg-[rgb(var(--ec-page-text))] px-2.5 py-1.5 text-xs font-medium text-[rgb(var(--ec-page-bg))] opacity-0 shadow-lg transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
+        >
+          {property.name}
+        </span>
+      </span>
+    </span>
+  </td>
+  <td class="min-w-0 py-4 align-top text-sm">
+    <CustomPropertyValue value={property.value} />
+  </td>
+</tr>

--- a/packages/core/eventcatalog/src/components/MDX/CustomProperties/CustomPropertyValue.astro
+++ b/packages/core/eventcatalog/src/components/MDX/CustomProperties/CustomPropertyValue.astro
@@ -1,0 +1,51 @@
+---
+import { formatCustomPropertyLabel } from './custom-properties';
+
+interface Props {
+  value: unknown;
+}
+
+const { value } = Astro.props;
+const isArray = Array.isArray(value);
+const isDate = value instanceof Date;
+const isObject = value !== null && typeof value === 'object' && !isArray && !isDate;
+const entries = isObject ? Object.entries(value as Record<string, unknown>) : [];
+const scalarValue = value === null || value === undefined ? '—' : isDate ? value.toISOString() : String(value);
+---
+
+{
+  isArray ? (
+    value.length > 0 ? (
+      <ul class="m-0 list-disc space-y-1 pl-5 text-[rgb(var(--ec-page-text))]">
+        {value.map((item) => (
+          <li>
+            <Astro.self value={item} />
+          </li>
+        ))}
+      </ul>
+    ) : (
+      <span class="text-[rgb(var(--ec-page-text-muted))]">—</span>
+    )
+  ) : isObject ? (
+    entries.length > 0 ? (
+      <dl class="m-0 space-y-2">
+        {entries.map(([name, nestedValue]) => (
+          <div class="grid gap-1 sm:grid-cols-[minmax(0,10rem)_minmax(0,1fr)]">
+            <dt class="font-medium text-[rgb(var(--ec-page-text-muted))]">{formatCustomPropertyLabel(name)}</dt>
+            <dd class="m-0 min-w-0 text-[rgb(var(--ec-page-text))]">
+              <Astro.self value={nestedValue} />
+            </dd>
+          </div>
+        ))}
+      </dl>
+    ) : (
+      <span class="text-[rgb(var(--ec-page-text-muted))]">—</span>
+    )
+  ) : typeof value === 'boolean' ? (
+    <span class="inline-flex rounded-full bg-[rgb(var(--ec-content-hover))] px-2 py-0.5 text-xs font-medium text-[rgb(var(--ec-page-text))]">
+      {scalarValue}
+    </span>
+  ) : (
+    <span class="break-words text-[rgb(var(--ec-page-text))]">{scalarValue}</span>
+  )
+}

--- a/packages/core/eventcatalog/src/components/MDX/CustomProperties/custom-properties.spec.ts
+++ b/packages/core/eventcatalog/src/components/MDX/CustomProperties/custom-properties.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { formatCustomPropertyLabel, getCustomProperties, getCustomProperty, isCustomPropertyName } from './custom-properties';
+
+describe('custom properties MDX components', () => {
+  it('recognizes extension property names', () => {
+    expect(isCustomPropertyName('x-owner')).toBe(true);
+    expect(isCustomPropertyName('x-')).toBe(false);
+    expect(isCustomPropertyName('owner')).toBe(false);
+  });
+
+  it('creates a readable label without changing uppercase text', () => {
+    expect(formatCustomPropertyLabel('x-operational-tier')).toBe('Operational Tier');
+    expect(formatCustomPropertyLabel('x-PII_classification')).toBe('PII Classification');
+  });
+
+  it('extracts only custom properties and preserves their values', () => {
+    const properties = getCustomProperties({
+      id: 'payment-api',
+      'x-operational-tier': 1,
+      'x-on-call': { schedule: 'payments-primary' },
+    });
+
+    expect(properties).toEqual([
+      { name: 'x-operational-tier', label: 'Operational Tier', value: 1 },
+      { name: 'x-on-call', label: 'On Call', value: { schedule: 'payments-primary' } },
+    ]);
+  });
+
+  it('gets a named custom property', () => {
+    expect(getCustomProperty({ 'x-owner': 'payments' }, 'x-owner')).toEqual({
+      name: 'x-owner',
+      label: 'Owner',
+      value: 'payments',
+    });
+    expect(getCustomProperty({ owner: 'payments' }, 'owner')).toBeUndefined();
+    expect(getCustomProperty({ 'x-owner': 'payments' }, 'x-missing')).toBeUndefined();
+  });
+});

--- a/packages/core/eventcatalog/src/components/MDX/CustomProperties/custom-properties.ts
+++ b/packages/core/eventcatalog/src/components/MDX/CustomProperties/custom-properties.ts
@@ -1,0 +1,39 @@
+export type CustomProperty = {
+  name: string;
+  label: string;
+  value: unknown;
+};
+
+export const isCustomPropertyName = (name: string) => name.startsWith('x-') && name.length > 2;
+
+export const formatCustomPropertyLabel = (name: string) => {
+  const propertyName = isCustomPropertyName(name) ? name.slice(2) : name;
+
+  return propertyName
+    .split(/[-_.\s]+/)
+    .filter(Boolean)
+    .map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
+    .join(' ');
+};
+
+export const getCustomProperties = (data?: Record<string, unknown>): CustomProperty[] => {
+  if (!data) return [];
+
+  return Object.entries(data)
+    .filter(([name]) => isCustomPropertyName(name))
+    .map(([name, value]) => ({
+      name,
+      label: formatCustomPropertyLabel(name),
+      value,
+    }));
+};
+
+export const getCustomProperty = (data: Record<string, unknown> | undefined, name: string): CustomProperty | undefined => {
+  if (!data || !isCustomPropertyName(name) || !Object.prototype.hasOwnProperty.call(data, name)) return undefined;
+
+  return {
+    name,
+    label: formatCustomPropertyLabel(name),
+    value: data[name],
+  };
+};

--- a/packages/core/eventcatalog/src/components/MDX/components.tsx
+++ b/packages/core/eventcatalog/src/components/MDX/components.tsx
@@ -41,6 +41,8 @@ import SchemaViewerPortal from '@components/MDX/SchemaViewer/SchemaViewerPortal'
 import { jsx } from 'astro/jsx-runtime';
 import RemoteSchema from '@components/MDX/RemoteSchema.astro';
 import Visibility from '@components/MDX/Visibility';
+import CustomProperties from '@components/MDX/CustomProperties/CustomProperties.astro';
+import CustomProperty from '@components/MDX/CustomProperties/CustomProperty.astro';
 
 const getEntityMapCollection = (props: any, mdxProp: any) => {
   const collection = mdxProp.collection ?? props.collection;
@@ -50,6 +52,8 @@ const getEntityMapCollection = (props: any, mdxProp: any) => {
 const components = (props: any) => {
   return {
     Attachments: (mdxProp: any) => jsx(Attachments, { ...props, ...mdxProp }),
+    CustomProperties: (mdxProp: any) => jsx(CustomProperties, { ...props, ...mdxProp }),
+    CustomProperty: (mdxProp: any) => jsx(CustomProperty, { ...props, ...mdxProp }),
     Accordion,
     AccordionGroup,
     Admonition,

--- a/packages/core/eventcatalog/src/content.config.ts
+++ b/packages/core/eventcatalog/src/content.config.ts
@@ -10,6 +10,7 @@ import { userTeamDirectoryLoader } from './enterprise/directory/user-team-direct
 import config from '@config';
 import { schemaLoader } from './utils/collections/schema-loader';
 import { globWithSafeWatcher, withIgnoredBuildArtifacts } from './utils/collections/glob-loader';
+import { withExtensionProperties } from './utils/collections/extension-properties';
 
 // Enterprise Collections
 import { customPagesSchema, resourceDocsSchema, resourceDocCategoriesSchema } from './enterprise/collections';
@@ -270,85 +271,87 @@ const flows = defineCollection({
       return `${data.id}-${data.version}`;
     },
   }),
-  schema: z
-    .object({
-      detailsPanel: z
-        .object({
-          owners: detailPanelPropertySchema.optional(),
-          versions: detailPanelPropertySchema.optional(),
-          changelog: detailPanelPropertySchema.optional(),
-        })
-        .optional(),
-      steps: z.array(
-        z
+  schema: withExtensionProperties(
+    z
+      .object({
+        detailsPanel: z
           .object({
-            id: z.union([z.string(), z.number()]),
-            type: z.enum(['node', 'message', 'agent', 'user', 'actor']).optional(),
-            title: z.string(),
-            summary: z.string().optional(),
-            message: pointer.optional(),
-            agent: pointer.optional(),
-            service: pointer.optional(),
-            flow: pointer.optional(),
-            container: pointer.optional(),
-            dataProduct: pointer.optional(),
-
-            actor: z
-              .object({
-                name: z.string(),
-                summary: z.string().optional(),
-              })
-              .optional(),
-            custom: z
-              .object({
-                title: z.string(),
-                icon: z.string().optional(),
-                type: z.string().optional(),
-                summary: z.string().optional(),
-                url: z.string().url().optional(),
-                color: z.string().optional(),
-                properties: z.record(z.string(), z.union([z.string(), z.number()])).optional(),
-                height: z.number().optional(),
-                menu: z
-                  .array(
-                    z.object({
-                      label: z.string(),
-                      url: z.string().url().optional(),
-                    })
-                  )
-                  .optional(),
-              })
-              .optional(),
-            externalSystem: z
-              .object({
-                name: z.string(),
-                summary: z.string().optional(),
-                url: z.string().url().optional(),
-              })
-              .optional(),
-            next_step: flowStep,
-            next_steps: z.array(flowStep).optional(),
+            owners: detailPanelPropertySchema.optional(),
+            versions: detailPanelPropertySchema.optional(),
+            changelog: detailPanelPropertySchema.optional(),
           })
-          .refine((data) => {
-            // Cant have both next_steps and next_steps
-            if (data.next_step && data.next_steps) return false;
+          .optional(),
+        steps: z.array(
+          z
+            .object({
+              id: z.union([z.string(), z.number()]),
+              type: z.enum(['node', 'message', 'agent', 'user', 'actor']).optional(),
+              title: z.string(),
+              summary: z.string().optional(),
+              message: pointer.optional(),
+              agent: pointer.optional(),
+              service: pointer.optional(),
+              flow: pointer.optional(),
+              container: pointer.optional(),
+              dataProduct: pointer.optional(),
 
-            // Either one or non types can be present
-            const typesUsed = [
-              data.message,
-              data.agent,
-              data.service,
-              data.flow,
-              data.container,
-              data.dataProduct,
-              data.actor,
-              data.custom,
-            ].filter((v) => v).length;
-            return typesUsed === 0 || typesUsed === 1;
-          })
-      ),
-    })
-    .extend(baseSchema.shape),
+              actor: z
+                .object({
+                  name: z.string(),
+                  summary: z.string().optional(),
+                })
+                .optional(),
+              custom: z
+                .object({
+                  title: z.string(),
+                  icon: z.string().optional(),
+                  type: z.string().optional(),
+                  summary: z.string().optional(),
+                  url: z.string().url().optional(),
+                  color: z.string().optional(),
+                  properties: z.record(z.string(), z.union([z.string(), z.number()])).optional(),
+                  height: z.number().optional(),
+                  menu: z
+                    .array(
+                      z.object({
+                        label: z.string(),
+                        url: z.string().url().optional(),
+                      })
+                    )
+                    .optional(),
+                })
+                .optional(),
+              externalSystem: z
+                .object({
+                  name: z.string(),
+                  summary: z.string().optional(),
+                  url: z.string().url().optional(),
+                })
+                .optional(),
+              next_step: flowStep,
+              next_steps: z.array(flowStep).optional(),
+            })
+            .refine((data) => {
+              // Cant have both next_steps and next_steps
+              if (data.next_step && data.next_steps) return false;
+
+              // Either one or non types can be present
+              const typesUsed = [
+                data.message,
+                data.agent,
+                data.service,
+                data.flow,
+                data.container,
+                data.dataProduct,
+                data.actor,
+                data.custom,
+              ].filter((v) => v).length;
+              return typesUsed === 0 || typesUsed === 1;
+            })
+        ),
+      })
+      .extend(baseSchema.shape)
+  ),
 });
 
 const operationSchema = z
@@ -380,19 +383,21 @@ const events = defineCollection({
       return `${data.id}-${data.version}`;
     },
   }),
-  schema: z
-    .object({
-      // Used by users
-      operation: operationSchema,
-      // Used by eventcatalog
-      producers: z.array(reference('services')).optional(),
-      consumers: z.array(reference('services')).optional(),
-      channels: z.array(channelPointer).optional(),
-      schemas: z.array(schemaPointer).optional(),
-      messageChannels: z.array(reference('channels')).optional(),
-      detailsPanel: messageDetailsPanelPropertySchema.optional(),
-    })
-    .extend(baseSchema.shape),
+  schema: withExtensionProperties(
+    z
+      .object({
+        // Used by users
+        operation: operationSchema,
+        // Used by eventcatalog
+        producers: z.array(reference('services')).optional(),
+        consumers: z.array(reference('services')).optional(),
+        channels: z.array(channelPointer).optional(),
+        schemas: z.array(schemaPointer).optional(),
+        messageChannels: z.array(reference('channels')).optional(),
+        detailsPanel: messageDetailsPanelPropertySchema.optional(),
+      })
+      .extend(baseSchema.shape)
+  ),
 });
 
 const commands = defineCollection({
@@ -403,19 +408,21 @@ const commands = defineCollection({
       return `${data.id}-${data.version}`;
     },
   }),
-  schema: z
-    .object({
-      // Used by users
-      operation: operationSchema,
-      // Used by eventcatalog
-      producers: z.array(reference('services')).optional(),
-      consumers: z.array(reference('services')).optional(),
-      channels: z.array(channelPointer).optional(),
-      schemas: z.array(schemaPointer).optional(),
-      detailsPanel: messageDetailsPanelPropertySchema.optional(),
-      messageChannels: z.array(reference('channels')).optional(),
-    })
-    .extend(baseSchema.shape),
+  schema: withExtensionProperties(
+    z
+      .object({
+        // Used by users
+        operation: operationSchema,
+        // Used by eventcatalog
+        producers: z.array(reference('services')).optional(),
+        consumers: z.array(reference('services')).optional(),
+        channels: z.array(channelPointer).optional(),
+        schemas: z.array(schemaPointer).optional(),
+        detailsPanel: messageDetailsPanelPropertySchema.optional(),
+        messageChannels: z.array(reference('channels')).optional(),
+      })
+      .extend(baseSchema.shape)
+  ),
 });
 
 const queries = defineCollection({
@@ -426,19 +433,21 @@ const queries = defineCollection({
       return `${data.id}-${data.version}`;
     },
   }),
-  schema: z
-    .object({
-      // Used by users
-      operation: operationSchema,
-      // Used by eventcatalog
-      producers: z.array(reference('services')).optional(),
-      consumers: z.array(reference('services')).optional(),
-      channels: z.array(channelPointer).optional(),
-      schemas: z.array(schemaPointer).optional(),
-      detailsPanel: messageDetailsPanelPropertySchema.optional(),
-      messageChannels: z.array(reference('channels')).optional(),
-    })
-    .extend(baseSchema.shape),
+  schema: withExtensionProperties(
+    z
+      .object({
+        // Used by users
+        operation: operationSchema,
+        // Used by eventcatalog
+        producers: z.array(reference('services')).optional(),
+        consumers: z.array(reference('services')).optional(),
+        channels: z.array(channelPointer).optional(),
+        schemas: z.array(schemaPointer).optional(),
+        detailsPanel: messageDetailsPanelPropertySchema.optional(),
+        messageChannels: z.array(reference('channels')).optional(),
+      })
+      .extend(baseSchema.shape)
+  ),
 });
 
 const dataProductOutputPointer = z.object({
@@ -461,24 +470,26 @@ const dataProducts = defineCollection({
       return `${data.id}-${data.version}`;
     },
   }),
-  schema: z
-    .object({
-      inputs: z.array(pointer).optional(),
-      outputs: z.array(dataProductOutputPointer).optional(),
-      detailsPanel: z
-        .object({
-          domains: detailPanelPropertySchema.optional(),
-          inputs: detailPanelPropertySchema.optional(),
-          outputs: detailPanelPropertySchema.optional(),
-          versions: detailPanelPropertySchema.optional(),
-          repository: detailPanelPropertySchema.optional(),
-          owners: detailPanelPropertySchema.optional(),
-          changelog: detailPanelPropertySchema.optional(),
-          flows: detailPanelPropertySchema.optional(),
-        })
-        .optional(),
-    })
-    .extend(baseSchema.shape),
+  schema: withExtensionProperties(
+    z
+      .object({
+        inputs: z.array(pointer).optional(),
+        outputs: z.array(dataProductOutputPointer).optional(),
+        detailsPanel: z
+          .object({
+            domains: detailPanelPropertySchema.optional(),
+            inputs: detailPanelPropertySchema.optional(),
+            outputs: detailPanelPropertySchema.optional(),
+            versions: detailPanelPropertySchema.optional(),
+            repository: detailPanelPropertySchema.optional(),
+            owners: detailPanelPropertySchema.optional(),
+            changelog: detailPanelPropertySchema.optional(),
+            flows: detailPanelPropertySchema.optional(),
+          })
+          .optional(),
+      })
+      .extend(baseSchema.shape)
+  ),
 });
 
 const services = defineCollection({
@@ -506,30 +517,32 @@ const services = defineCollection({
       return `${data.id}-${data.version}`;
     },
   }),
-  schema: z
-    .object({
-      sends: z.array(sendsPointer).optional(),
-      receives: z.array(receivesPointer).optional(),
-      entities: z.array(pointer).optional(),
-      writesTo: z.array(pointer).optional(),
-      readsFrom: z.array(pointer).optional(),
-      flows: z.array(pointer).optional(),
-      externalSystem: z.boolean().optional(),
-      detailsPanel: z
-        .object({
-          domains: detailPanelPropertySchema.optional(),
-          messages: detailPanelPropertySchema.optional(),
-          versions: detailPanelPropertySchema.optional(),
-          specifications: detailPanelPropertySchema.optional(),
-          entities: detailPanelPropertySchema.optional(),
-          repository: detailPanelPropertySchema.optional(),
-          owners: detailPanelPropertySchema.optional(),
-          changelog: detailPanelPropertySchema.optional(),
-          containers: detailPanelPropertySchema.optional(),
-        })
-        .optional(),
-    })
-    .extend(baseSchema.shape),
+  schema: withExtensionProperties(
+    z
+      .object({
+        sends: z.array(sendsPointer).optional(),
+        receives: z.array(receivesPointer).optional(),
+        entities: z.array(pointer).optional(),
+        writesTo: z.array(pointer).optional(),
+        readsFrom: z.array(pointer).optional(),
+        flows: z.array(pointer).optional(),
+        externalSystem: z.boolean().optional(),
+        detailsPanel: z
+          .object({
+            domains: detailPanelPropertySchema.optional(),
+            messages: detailPanelPropertySchema.optional(),
+            versions: detailPanelPropertySchema.optional(),
+            specifications: detailPanelPropertySchema.optional(),
+            entities: detailPanelPropertySchema.optional(),
+            repository: detailPanelPropertySchema.optional(),
+            owners: detailPanelPropertySchema.optional(),
+            changelog: detailPanelPropertySchema.optional(),
+            containers: detailPanelPropertySchema.optional(),
+          })
+          .optional(),
+      })
+      .extend(baseSchema.shape)
+  ),
 });
 
 const agentTool = z.object({
@@ -554,31 +567,33 @@ const agents = defineCollection({
       return `${data.id}-${data.version}`;
     },
   }),
-  schema: z
-    .object({
-      sends: z.array(sendsPointer).optional(),
-      receives: z.array(receivesPointer).optional(),
-      writesTo: z.array(pointer).optional(),
-      readsFrom: z.array(pointer).optional(),
-      flows: z.array(pointer).optional(),
-      model: agentModel.optional(),
-      tools: z.array(agentTool).optional(),
-      specifications: z.undefined().optional(),
-      detailsPanel: z
-        .object({
-          domains: detailPanelPropertySchema.optional(),
-          messages: detailPanelPropertySchema.optional(),
-          versions: detailPanelPropertySchema.optional(),
-          repository: detailPanelPropertySchema.optional(),
-          owners: detailPanelPropertySchema.optional(),
-          changelog: detailPanelPropertySchema.optional(),
-          containers: detailPanelPropertySchema.optional(),
-          tools: detailPanelPropertySchema.optional(),
-          model: detailPanelPropertySchema.optional(),
-        })
-        .optional(),
-    })
-    .extend(baseSchema.shape),
+  schema: withExtensionProperties(
+    z
+      .object({
+        sends: z.array(sendsPointer).optional(),
+        receives: z.array(receivesPointer).optional(),
+        writesTo: z.array(pointer).optional(),
+        readsFrom: z.array(pointer).optional(),
+        flows: z.array(pointer).optional(),
+        model: agentModel.optional(),
+        tools: z.array(agentTool).optional(),
+        specifications: z.undefined().optional(),
+        detailsPanel: z
+          .object({
+            domains: detailPanelPropertySchema.optional(),
+            messages: detailPanelPropertySchema.optional(),
+            versions: detailPanelPropertySchema.optional(),
+            repository: detailPanelPropertySchema.optional(),
+            owners: detailPanelPropertySchema.optional(),
+            changelog: detailPanelPropertySchema.optional(),
+            containers: detailPanelPropertySchema.optional(),
+            tools: detailPanelPropertySchema.optional(),
+            model: detailPanelPropertySchema.optional(),
+          })
+          .optional(),
+      })
+      .extend(baseSchema.shape)
+  ),
 });
 
 const adrStatus = z.enum(ADR_STATUS_VALUES);
@@ -614,31 +629,33 @@ const adrs = defineCollection({
     base: projectDirBase,
     generateId: ({ data }) => `${data.id}-${data.version}`,
   }),
-  schema: z
-    .object({
-      status: adrStatus,
-      date: z.coerce.date(),
-      decisionMakers: z.array(ownerReference).optional(),
-      appliesTo: z.array(adrResourcePointer).optional(),
-      supersedes: z.array(adrPointer).optional(),
-      supersededBy: z.array(adrPointer).optional(),
-      amends: z.array(adrPointer).optional(),
-      amendedBy: z.array(adrPointer).optional(),
-      related: z.array(adrPointer).optional(),
-      detailsPanel: z
-        .object({
-          status: detailPanelPropertySchema.optional(),
-          date: detailPanelPropertySchema.optional(),
-          decisionMakers: detailPanelPropertySchema.optional(),
-          appliesTo: detailPanelPropertySchema.optional(),
-          relationships: detailPanelPropertySchema.optional(),
-          owners: detailPanelPropertySchema.optional(),
-          repository: detailPanelPropertySchema.optional(),
-          changelog: detailPanelPropertySchema.optional(),
-        })
-        .optional(),
-    })
-    .extend(baseSchema.shape),
+  schema: withExtensionProperties(
+    z
+      .object({
+        status: adrStatus,
+        date: z.coerce.date(),
+        decisionMakers: z.array(ownerReference).optional(),
+        appliesTo: z.array(adrResourcePointer).optional(),
+        supersedes: z.array(adrPointer).optional(),
+        supersededBy: z.array(adrPointer).optional(),
+        amends: z.array(adrPointer).optional(),
+        amendedBy: z.array(adrPointer).optional(),
+        related: z.array(adrPointer).optional(),
+        detailsPanel: z
+          .object({
+            status: detailPanelPropertySchema.optional(),
+            date: detailPanelPropertySchema.optional(),
+            decisionMakers: detailPanelPropertySchema.optional(),
+            appliesTo: detailPanelPropertySchema.optional(),
+            relationships: detailPanelPropertySchema.optional(),
+            owners: detailPanelPropertySchema.optional(),
+            repository: detailPanelPropertySchema.optional(),
+            changelog: detailPanelPropertySchema.optional(),
+          })
+          .optional(),
+      })
+      .extend(baseSchema.shape)
+  ),
 });
 
 // 1) Put this near your other enums/utilities
@@ -666,35 +683,38 @@ const containers = defineCollection({
       return `${data.id}-${data.version}`;
     },
   }),
-  schema: z
-    .object({
-      container_type: containerTypeEnum, // <— the important discriminator inside DataContainer
-      technology: z.string().optional(), // e.g. "postgres@14", "kafka", "s3"
-      authoritative: z.boolean().optional().default(false),
-      access_mode: accessModeEnum.optional(), // read/write/readWrite/appendOnly
-      classification: dataClassificationEnum.optional(),
-      residency: z.string().optional(),
-      retention: z.string().optional(),
-      // details panel toggles (aligns with your pattern)
-      detailsPanel: z
-        .object({
-          versions: detailPanelPropertySchema.optional(),
-          repository: detailPanelPropertySchema.optional(),
-          owners: detailPanelPropertySchema.optional(),
-          changelog: detailPanelPropertySchema.optional(),
-          attachments: detailPanelPropertySchema.optional(),
-          services: detailPanelPropertySchema.optional(),
-          flows: detailPanelPropertySchema.optional(),
-        })
-        .optional(),
-      services: z.array(reference('services')).optional(),
+  schema: withExtensionProperties(
+    z
+      .object({
+        container_type: containerTypeEnum, // <— the important discriminator inside DataContainer
+        technology: z.string().optional(), // e.g. "postgres@14", "kafka", "s3"
+        purpose: z.string().optional(),
+        authoritative: z.boolean().optional().default(false),
+        access_mode: accessModeEnum.optional(), // read/write/readWrite/appendOnly
+        classification: dataClassificationEnum.optional(),
+        residency: z.string().optional(),
+        retention: z.string().optional(),
+        // details panel toggles (aligns with your pattern)
+        detailsPanel: z
+          .object({
+            versions: detailPanelPropertySchema.optional(),
+            repository: detailPanelPropertySchema.optional(),
+            owners: detailPanelPropertySchema.optional(),
+            changelog: detailPanelPropertySchema.optional(),
+            attachments: detailPanelPropertySchema.optional(),
+            services: detailPanelPropertySchema.optional(),
+            flows: detailPanelPropertySchema.optional(),
+          })
+          .optional(),
+        services: z.array(reference('services')).optional(),
 
-      servicesThatWriteToContainer: z.array(reference('services')).optional(),
-      servicesThatReadFromContainer: z.array(reference('services')).optional(),
-      dataProductsThatWriteToContainer: z.array(reference('data-products')).optional(),
-      dataProductsThatReadFromContainer: z.array(reference('data-products')).optional(),
-    })
-    .extend(baseSchema.shape),
+        servicesThatWriteToContainer: z.array(reference('services')).optional(),
+        servicesThatReadFromContainer: z.array(reference('services')).optional(),
+        dataProductsThatWriteToContainer: z.array(reference('data-products')).optional(),
+        dataProductsThatReadFromContainer: z.array(reference('data-products')).optional(),
+      })
+      .extend(baseSchema.shape)
+  ),
 });
 
 const customPages = defineCollection({
@@ -756,35 +776,37 @@ const domains = defineCollection({
       return `${data.id}-${data.version}`;
     },
   }),
-  schema: z
-    .object({
-      services: z.array(pointer).optional(),
-      agents: z.array(pointer).optional(),
-      domains: z.array(pointer).optional(),
-      systems: z.array(pointer).optional(),
-      entities: z.array(pointer).optional(),
-      'data-products': z.array(pointer).optional(),
-      flows: z.array(pointer).optional(),
-      sends: z.array(sendsPointer).optional(),
-      receives: z.array(receivesPointer).optional(),
-      detailsPanel: z
-        .object({
-          parentDomains: detailPanelPropertySchema.optional(),
-          subdomains: detailPanelPropertySchema.optional(),
-          systems: detailPanelPropertySchema.optional(),
-          services: detailPanelPropertySchema.optional(),
-          entities: detailPanelPropertySchema.optional(),
-          messages: detailPanelPropertySchema.optional(),
-          ubiquitousLanguage: detailPanelPropertySchema.optional(),
-          repository: detailPanelPropertySchema.optional(),
-          versions: detailPanelPropertySchema.optional(),
-          owners: detailPanelPropertySchema.optional(),
-          changelog: detailPanelPropertySchema.optional(),
-          attachments: detailPanelPropertySchema.optional(),
-        })
-        .optional(),
-    })
-    .extend(baseSchema.shape),
+  schema: withExtensionProperties(
+    z
+      .object({
+        services: z.array(pointer).optional(),
+        agents: z.array(pointer).optional(),
+        domains: z.array(pointer).optional(),
+        systems: z.array(pointer).optional(),
+        entities: z.array(pointer).optional(),
+        'data-products': z.array(pointer).optional(),
+        flows: z.array(pointer).optional(),
+        sends: z.array(sendsPointer).optional(),
+        receives: z.array(receivesPointer).optional(),
+        detailsPanel: z
+          .object({
+            parentDomains: detailPanelPropertySchema.optional(),
+            subdomains: detailPanelPropertySchema.optional(),
+            systems: detailPanelPropertySchema.optional(),
+            services: detailPanelPropertySchema.optional(),
+            entities: detailPanelPropertySchema.optional(),
+            messages: detailPanelPropertySchema.optional(),
+            ubiquitousLanguage: detailPanelPropertySchema.optional(),
+            repository: detailPanelPropertySchema.optional(),
+            versions: detailPanelPropertySchema.optional(),
+            owners: detailPanelPropertySchema.optional(),
+            changelog: detailPanelPropertySchema.optional(),
+            attachments: detailPanelPropertySchema.optional(),
+          })
+          .optional(),
+      })
+      .extend(baseSchema.shape)
+  ),
 });
 
 // A relationship from one system to another, used by the System Diagram.
@@ -835,34 +857,36 @@ const systems = defineCollection({
       return `${data.id}-${data.version}`;
     },
   }),
-  schema: z
-    .object({
-      // Whether the system belongs to your organisation (`internal`) or is a
-      // third-party/SaaS system you integrate with (`external`, e.g. "Resend",
-      // "Stripe"). External systems are shaded in the node-graph. Defaults to internal.
-      scope: z.enum(['internal', 'external']).optional().default('internal'),
-      services: z.array(pointer).optional(),
-      flows: z.array(pointer).optional(),
-      entities: z.array(pointer).optional(),
-      containers: z.array(pointer).optional(),
-      relationships: z.array(systemRelationshipPointer).optional(),
-      actors: z.array(systemActorRelationship).optional(),
-      detailsPanel: z
-        .object({
-          versions: detailPanelPropertySchema.optional(),
-          repository: detailPanelPropertySchema.optional(),
-          owners: detailPanelPropertySchema.optional(),
-          changelog: detailPanelPropertySchema.optional(),
-          attachments: detailPanelPropertySchema.optional(),
-          services: detailPanelPropertySchema.optional(),
-          flows: detailPanelPropertySchema.optional(),
-          entities: detailPanelPropertySchema.optional(),
-          containers: detailPanelPropertySchema.optional(),
-          diagrams: detailPanelPropertySchema.optional(),
-        })
-        .optional(),
-    })
-    .extend(baseSchema.shape),
+  schema: withExtensionProperties(
+    z
+      .object({
+        // Whether the system belongs to your organisation (`internal`) or is a
+        // third-party/SaaS system you integrate with (`external`, e.g. "Resend",
+        // "Stripe"). External systems are shaded in the node-graph. Defaults to internal.
+        scope: z.enum(['internal', 'external']).optional().default('internal'),
+        services: z.array(pointer).optional(),
+        flows: z.array(pointer).optional(),
+        entities: z.array(pointer).optional(),
+        containers: z.array(pointer).optional(),
+        relationships: z.array(systemRelationshipPointer).optional(),
+        actors: z.array(systemActorRelationship).optional(),
+        detailsPanel: z
+          .object({
+            versions: detailPanelPropertySchema.optional(),
+            repository: detailPanelPropertySchema.optional(),
+            owners: detailPanelPropertySchema.optional(),
+            changelog: detailPanelPropertySchema.optional(),
+            attachments: detailPanelPropertySchema.optional(),
+            services: detailPanelPropertySchema.optional(),
+            flows: detailPanelPropertySchema.optional(),
+            entities: detailPanelPropertySchema.optional(),
+            containers: detailPanelPropertySchema.optional(),
+            diagrams: detailPanelPropertySchema.optional(),
+          })
+          .optional(),
+      })
+      .extend(baseSchema.shape)
+  ),
 });
 
 const channels = defineCollection({
@@ -873,41 +897,43 @@ const channels = defineCollection({
       return `${data.id}-${data.version}`;
     },
   }),
-  schema: z
-    .object({
-      channels: z.array(channelPointer).optional(),
-      address: z.string().optional(),
-      protocols: z.array(z.string()).optional(),
-      deliveryGuarantee: z.enum(['at-most-once', 'at-least-once', 'exactly-once']).optional(),
-      routes: z.array(channelPointer).optional(),
-      parameters: z
-        .record(
-          z.string(),
-          z.object({
-            enum: z.array(z.string()).optional(),
-            default: z.string().optional(),
-            examples: z.array(z.string()).optional(),
-            description: z.string().optional(),
+  schema: withExtensionProperties(
+    z
+      .object({
+        channels: z.array(channelPointer).optional(),
+        address: z.string().optional(),
+        protocols: z.array(z.string()).optional(),
+        deliveryGuarantee: z.enum(['at-most-once', 'at-least-once', 'exactly-once']).optional(),
+        routes: z.array(channelPointer).optional(),
+        parameters: z
+          .record(
+            z.string(),
+            z.object({
+              enum: z.array(z.string()).optional(),
+              default: z.string().optional(),
+              examples: z.array(z.string()).optional(),
+              description: z.string().optional(),
+            })
+          )
+          .optional(),
+        messages: z.array(z.object({ collection: z.string(), name: z.string(), ...pointer.shape })).optional(),
+        detailsPanel: z
+          .object({
+            producers: detailPanelPropertySchema.optional(),
+            consumers: detailPanelPropertySchema.optional(),
+            messages: detailPanelPropertySchema.optional(),
+            protocols: detailPanelPropertySchema.optional(),
+            parameters: detailPanelPropertySchema.optional(),
+            versions: detailPanelPropertySchema.optional(),
+            repository: detailPanelPropertySchema.optional(),
+            owners: detailPanelPropertySchema.optional(),
+            changelog: detailPanelPropertySchema.optional(),
+            attachments: detailPanelPropertySchema.optional(),
           })
-        )
-        .optional(),
-      messages: z.array(z.object({ collection: z.string(), name: z.string(), ...pointer.shape })).optional(),
-      detailsPanel: z
-        .object({
-          producers: detailPanelPropertySchema.optional(),
-          consumers: detailPanelPropertySchema.optional(),
-          messages: detailPanelPropertySchema.optional(),
-          protocols: detailPanelPropertySchema.optional(),
-          parameters: detailPanelPropertySchema.optional(),
-          versions: detailPanelPropertySchema.optional(),
-          repository: detailPanelPropertySchema.optional(),
-          owners: detailPanelPropertySchema.optional(),
-          changelog: detailPanelPropertySchema.optional(),
-          attachments: detailPanelPropertySchema.optional(),
-        })
-        .optional(),
-    })
-    .extend(baseSchema.shape),
+          .optional(),
+      })
+      .extend(baseSchema.shape)
+  ),
 });
 
 const ubiquitousLanguages = defineCollection({
@@ -945,45 +971,46 @@ const entities = defineCollection({
       return `${data.id}-${data.version}`;
     },
   }),
-  schema: z
-    .object({
-      aggregateRoot: z.boolean().optional(),
-      identifier: z.string().optional(),
-      properties: z
-        .array(
-          z.object({
-            name: z.string(),
-            type: z.string(),
-            required: z.boolean().optional(),
-            description: z.string().optional(),
-            references: z.string().optional(),
-            referencesIdentifier: z.string().optional(),
-            relationType: z.string().optional(),
-            enum: z.array(z.string()).optional(),
-            items: z
-              .object({
-                type: z.string(),
-              })
-              .optional(),
+  schema: withExtensionProperties(
+    z
+      .object({
+        aggregateRoot: z.boolean().optional(),
+        identifier: z.string().optional(),
+        properties: z
+          .array(
+            z.object({
+              name: z.string(),
+              type: z.string(),
+              required: z.boolean().optional(),
+              description: z.string().optional(),
+              references: z.string().optional(),
+              referencesIdentifier: z.string().optional(),
+              relationType: z.string().optional(),
+              enum: z.array(z.string()).optional(),
+              items: z
+                .object({
+                  type: z.string(),
+                })
+                .optional(),
+            })
+          )
+          .optional(),
+        services: z.array(reference('services')).optional(),
+        domains: z.array(reference('domains')).optional(),
+        detailsPanel: z
+          .object({
+            domains: detailPanelPropertySchema.optional(),
+            services: detailPanelPropertySchema.optional(),
+            messages: detailPanelPropertySchema.optional(),
+            versions: detailPanelPropertySchema.optional(),
+            owners: detailPanelPropertySchema.optional(),
+            changelog: detailPanelPropertySchema.optional(),
+            attachments: detailPanelPropertySchema.optional(),
           })
-        )
-        .optional(),
-      services: z.array(reference('services')).optional(),
-      domains: z.array(reference('domains')).optional(),
-      detailsPanel: z
-        .object({
-          domains: detailPanelPropertySchema.optional(),
-          services: detailPanelPropertySchema.optional(),
-          messages: detailPanelPropertySchema.optional(),
-          versions: detailPanelPropertySchema.optional(),
-          owners: detailPanelPropertySchema.optional(),
-          changelog: detailPanelPropertySchema.optional(),
-          attachments: detailPanelPropertySchema.optional(),
-        })
-        .optional(),
-    })
-
-    .extend(baseSchema.shape),
+          .optional(),
+      })
+      .extend(baseSchema.shape)
+  ),
 });
 
 const users = defineCollection({
@@ -1084,14 +1111,16 @@ const diagrams = defineCollection({
     base: projectDirBase,
     generateId: ({ data }) => `${data.id}-${data.version}`,
   }),
-  schema: z
-    .object({
-      id: z.string(),
-      name: z.string(),
-      version: z.string(),
-      summary: z.string().optional(),
-    })
-    .extend(baseSchema.shape),
+  schema: withExtensionProperties(
+    z
+      .object({
+        id: z.string(),
+        name: z.string(),
+        version: z.string(),
+        summary: z.string().optional(),
+      })
+      .extend(baseSchema.shape)
+  ),
 });
 
 const schemas = defineCollection({

--- a/packages/core/eventcatalog/src/utils/__tests__/collections/extension-properties.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/collections/extension-properties.spec.ts
@@ -1,0 +1,82 @@
+import { z } from 'astro/zod';
+import { describe, expect, it } from 'vitest';
+import { withExtensionProperties } from '@utils/collections/extension-properties';
+
+const resourceSchema = withExtensionProperties(
+  z.object({
+    id: z.string(),
+    name: z.string(),
+    version: z.string(),
+  })
+);
+
+describe('resource extension properties', () => {
+  it('preserves x- properties and their values', () => {
+    const resource = {
+      id: 'PaymentService',
+      name: 'Payment Service',
+      version: '1.0.0',
+      'x-operational-tier': 1,
+      'x-scrum-masters': ['David', 'Andrew'],
+      'x-metadata': {
+        costCentre: 'payments',
+        criticality: 'high',
+      },
+    };
+
+    expect(resourceSchema.parse(resource)).toEqual(resource);
+  });
+
+  it('rejects undeclared properties that do not use the x- prefix', () => {
+    const result = resourceSchema.safeParse({
+      id: 'PaymentService',
+      name: 'Payment Service',
+      version: '1.0.0',
+      operationalTier: 1,
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+
+    expect(result.error.issues).toEqual([
+      expect.objectContaining({
+        code: 'custom',
+        path: ['operationalTier'],
+        message: 'Unknown property "operationalTier". Custom properties must start with "x-".',
+      }),
+    ]);
+  });
+
+  it('rejects the prefix without a property name', () => {
+    const result = resourceSchema.safeParse({
+      id: 'PaymentService',
+      name: 'Payment Service',
+      version: '1.0.0',
+      'x-': true,
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+
+    expect(result.error.issues[0]).toEqual(
+      expect.objectContaining({
+        path: ['x-'],
+        message: 'Unknown property "x-". Custom properties must start with "x-".',
+      })
+    );
+  });
+
+  it('continues to validate declared properties', () => {
+    const result = resourceSchema.safeParse({
+      id: 123,
+      name: 'Payment Service',
+      version: '1.0.0',
+      'x-operational-tier': 1,
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+
+    expect(result.error.issues[0]).toEqual(expect.objectContaining({ path: ['id'] }));
+  });
+});

--- a/packages/core/eventcatalog/src/utils/collections/extension-properties.ts
+++ b/packages/core/eventcatalog/src/utils/collections/extension-properties.ts
@@ -1,0 +1,25 @@
+import { z } from 'astro/zod';
+
+export const EXTENSION_PROPERTY_PREFIX = 'x-';
+
+export const withExtensionProperties = <Shape extends z.core.$ZodShape, Config extends z.core.$ZodObjectConfig>(
+  schema: z.ZodObject<Shape, Config>
+) => {
+  const knownProperties = new Set(Object.keys(schema.shape));
+
+  return schema.catchall(z.unknown()).superRefine((data, context) => {
+    for (const property of Object.keys(data)) {
+      const isKnownProperty = knownProperties.has(property);
+      const isExtensionProperty =
+        property.startsWith(EXTENSION_PROPERTY_PREFIX) && property.length > EXTENSION_PROPERTY_PREFIX.length;
+
+      if (!isKnownProperty && !isExtensionProperty) {
+        context.addIssue({
+          code: 'custom',
+          path: [property],
+          message: `Unknown property "${property}". Custom properties must start with "${EXTENSION_PROPERTY_PREFIX}".`,
+        });
+      }
+    }
+  });
+};

--- a/packages/sdk/src/test/extension-properties.types.ts
+++ b/packages/sdk/src/test/extension-properties.types.ts
@@ -1,0 +1,27 @@
+import type { Event } from '../types';
+
+const event: Event = {
+  id: 'OrderPlaced',
+  name: 'Order Placed',
+  version: '1.0.0',
+  markdown: '',
+  'x-operational-tier': 1,
+  'x-scrum-masters': ['David', 'Andrew'],
+  'x-on-call': {
+    schedule: 'orders-primary',
+  },
+};
+
+const extensionValue: unknown = event['x-operational-tier'];
+
+const eventWithInvalidProperty: Event = {
+  id: 'OrderPlaced',
+  name: 'Order Placed',
+  version: '1.0.0',
+  markdown: '',
+  // @ts-expect-error Custom properties must use the x-* namespace.
+  operationalTier: 1,
+};
+
+void extensionValue;
+void eventWithInvalidProperty;

--- a/packages/sdk/src/test/resources.test.ts
+++ b/packages/sdk/src/test/resources.test.ts
@@ -1,12 +1,13 @@
 // users.test.js
-import { expect, it, describe, beforeEach, afterEach } from 'vitest';
+import { expect, it, describe, beforeEach, afterEach, expectTypeOf } from 'vitest';
 import utils from '../index';
+import type { Event } from '../types';
 import path from 'node:path';
 import fs from 'node:fs';
 
 const CATALOG_PATH = path.join(__dirname, 'catalog-resources');
 
-const { writeEvent, getResourceFolderName } = utils(CATALOG_PATH);
+const { writeEvent, getEvent, getResourceFolderName } = utils(CATALOG_PATH);
 
 // clean the catalog before each test
 beforeEach(() => {
@@ -19,6 +20,36 @@ afterEach(() => {
 });
 
 describe('Resources SDK', () => {
+  describe('extension properties', () => {
+    it('writes and reads x-* properties on resources', async () => {
+      const event: Event = {
+        id: 'OrderPlaced',
+        version: '1.0.0',
+        name: 'Order Placed',
+        markdown: '',
+        'x-operational-tier': 1,
+        'x-scrum-masters': ['David', 'Andrew'],
+        'x-on-call': {
+          schedule: 'orders-primary',
+        },
+      };
+
+      expectTypeOf(event['x-operational-tier']).toEqualTypeOf<unknown>();
+
+      await writeEvent(event);
+
+      const resource = await getEvent('OrderPlaced');
+
+      expect(resource).toMatchObject({
+        'x-operational-tier': 1,
+        'x-scrum-masters': ['David', 'Andrew'],
+        'x-on-call': {
+          schedule: 'orders-primary',
+        },
+      });
+    });
+  });
+
   describe('getResourceFolderName', () => {
     it('returns the folder name of a given resource,', async () => {
       await writeEvent({

--- a/packages/sdk/src/types.d.ts
+++ b/packages/sdk/src/types.d.ts
@@ -1,5 +1,9 @@
+export interface ExtensionProperties {
+  [key: `x-${string}`]: unknown;
+}
+
 // Base type for all resources (domains, services and messages)
-export interface BaseSchema {
+export interface BaseSchema extends ExtensionProperties {
   id: string;
   name: string;
   summary?: string;


### PR DESCRIPTION
## What This PR Does

Adds first-class support for custom extension properties on EventCatalog resources. Any frontmatter key prefixed with `x-` (for example `x-business-criticality` or `x-on-call`) is now preserved through the content collection schemas and typed in the SDK. Two new MDX components — `<CustomProperties>` and `<CustomProperty>` — let authors surface these properties in resource documentation.

## Changes Overview

### Key Changes

- **SDK types**: New `ExtensionProperties` interface (`[key: \`x-${string}\`]: unknown`) that `BaseSchema` extends, so all resources accept arbitrary `x-*` keys.
- **Content collections**: New `withExtensionProperties` helper applied across the schemas in `content.config.ts` so `x-*` frontmatter passes validation instead of being stripped.
- **MDX components**: New `CustomProperties` directory (`CustomProperties.astro`, `CustomProperty.astro`, `CustomPropertyRow.astro`, `CustomPropertyValue.astro`) plus helper `custom-properties.ts`, registered in `components.tsx`.
- **Tests**: Unit specs for the extension-properties helper and the MDX components, SDK type tests, and a round-trip write/read test in `resources.test.ts`.
- **Example catalog**: Adds `x-*` metadata and `<CustomProperties>` usage across several `examples/default` resources.

## How It Works

`withExtensionProperties` wraps a Zod object schema so keys matching `x-*` are retained rather than dropped during content validation. The `CustomProperties` component reads a resource's props, filters to the `x-` prefixed keys, and renders them as rows; `CustomProperty` renders a single named property. On the SDK side, `BaseSchema extends ExtensionProperties` makes the same properties available (typed as `unknown`) when reading and writing resources.

## Breaking Changes

None. Extension properties are additive and optional.

## Additional Notes

- Verified against the editor repo (`eventcatalog/eventcatalog-editor`): no corresponding change is required there for this addition.