### PR TITLE
Add getGraph API to the SDK

### DIFF
--- a/.changeset/brave-otters-explore.md
+++ b/.changeset/brave-otters-explore.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/sdk': patch
+---
+
+Add `getGraph` API to the SDK for traversing resources reachable from a catalog resource (domains, services, messages, channels, entities, flows, ADRs and more), with support for traversal depth and flat or nested output

--- a/packages/sdk/src/graph.ts
+++ b/packages/sdk/src/graph.ts
@@ -1,0 +1,473 @@
+import { maxSatisfying, validRange } from 'semver';
+import { getAdrs } from './adrs';
+import { getAgents } from './agents';
+import { getChannels } from './channels';
+import { getCommands } from './commands';
+import { getDataProducts } from './data-products';
+import { getDataStores } from './data-stores';
+import { getDomains } from './domains';
+import { getEntities } from './entities';
+import { getEvents } from './events';
+import { getFlows } from './flows';
+import { getQueries } from './queries';
+import { getServices } from './services';
+import { getSystems } from './systems';
+import type {
+  BaseSchema,
+  CatalogGraph,
+  CatalogGraphNode,
+  CatalogGraphOptions,
+  CatalogGraphResource,
+  CatalogGraphResourceType,
+  CatalogGraphRoot,
+  GetCatalogGraph,
+  ResourcePointer,
+} from './types';
+
+type CatalogResource = BaseSchema & {
+  hidden?: boolean;
+  [key: string]: any;
+};
+
+type ResourceCollectionLoader = (options?: { latestOnly?: boolean }) => Promise<CatalogResource[] | undefined>;
+
+type ResourceIndex = {
+  byId: Map<string, CatalogResource[]>;
+  byVersion: Map<string, CatalogResource>;
+};
+
+type ResolvedResource = {
+  type: CatalogGraphResourceType;
+  resource: CatalogResource;
+};
+
+type AncestorPath = {
+  key: string;
+  parent?: AncestorPath;
+};
+
+type AdrTarget = {
+  pointer: ResourcePointer;
+  resource: CatalogResource;
+};
+
+const DEFAULT_DEPTH = Number.POSITIVE_INFINITY;
+
+const RESOURCE_TYPE_ORDER: CatalogGraphResourceType[] = [
+  'domain',
+  'system',
+  'service',
+  'agent',
+  'event',
+  'command',
+  'query',
+  'channel',
+  'entity',
+  'container',
+  'data-product',
+  'flow',
+  'adr',
+];
+
+const typeOrder = new Map(RESOURCE_TYPE_ORDER.map((type, index) => [type, index]));
+const NON_ADR_RESOURCE_TYPES = RESOURCE_TYPE_ORDER.filter((type) => type !== 'adr');
+const NESTED_TRAVERSAL_CONCURRENCY = 16;
+
+const RESOURCE_TYPE_ALIASES: Record<string, CatalogGraphResourceType> = {
+  domains: 'domain',
+  systems: 'system',
+  services: 'service',
+  agents: 'agent',
+  events: 'event',
+  commands: 'command',
+  queries: 'query',
+  channels: 'channel',
+  entities: 'entity',
+  containers: 'container',
+  'data-products': 'data-product',
+  flows: 'flow',
+  adrs: 'adr',
+};
+
+const resourceKey = (resource: CatalogGraphResource) => `${resource.type}:${resource.id}:${resource.version}`;
+
+const toGraphResource = (type: CatalogGraphResourceType, resource: CatalogResource): CatalogGraphResource => ({
+  type,
+  id: resource.id,
+  version: resource.version,
+});
+
+const sortResources = (left: CatalogGraphResource, right: CatalogGraphResource) => {
+  const typeComparison = (typeOrder.get(left.type) || 0) - (typeOrder.get(right.type) || 0);
+  if (typeComparison !== 0) return typeComparison;
+
+  const idComparison = left.id.localeCompare(right.id);
+  return idComparison !== 0 ? idComparison : left.version.localeCompare(right.version);
+};
+
+const normalizeResourceType = (type: string | undefined): CatalogGraphResourceType | undefined => {
+  if (!type) return undefined;
+  if (RESOURCE_TYPE_ORDER.includes(type as CatalogGraphResourceType)) return type as CatalogGraphResourceType;
+  return RESOURCE_TYPE_ALIASES[type];
+};
+
+const indexResources = (resources: CatalogResource[]): ResourceIndex => {
+  const byId = new Map<string, CatalogResource[]>();
+  const byVersion = new Map<string, CatalogResource>();
+
+  for (const resource of resources) {
+    const versions = byId.get(resource.id);
+    if (versions) versions.push(resource);
+    else byId.set(resource.id, [resource]);
+    byVersion.set(`${resource.id}:${resource.version}`, resource);
+  }
+
+  return { byId, byVersion };
+};
+
+const pathIncludes = (path: AncestorPath, key: string) => {
+  let current: AncestorPath | undefined = path;
+  while (current) {
+    if (current.key === key) return true;
+    current = current.parent;
+  }
+  return false;
+};
+
+const mapWithConcurrency = async <Input, Output>(
+  items: Input[],
+  concurrency: number,
+  transform: (item: Input) => Promise<Output>
+) => {
+  const results = new Array<Output>(items.length);
+  let nextIndex = 0;
+
+  const worker = async () => {
+    while (nextIndex < items.length) {
+      const index = nextIndex++;
+      results[index] = await transform(items[index]);
+    }
+  };
+
+  const workers = Array.from({ length: Math.min(concurrency, items.length) }, worker);
+  await Promise.all(workers);
+  return results;
+};
+
+const validateDepth = (depth: number) => {
+  if (!Number.isInteger(depth) || depth < 0) {
+    throw new Error('Graph depth must be a non-negative integer');
+  }
+};
+
+/**
+ * Returns the resources reachable from a catalog resource.
+ *
+ * Depth zero returns only the root, depth one includes its direct children,
+ * and each additional level traverses the relationships of those children.
+ * When depth is omitted, every reachable relationship is traversed. Nested
+ * output is returned by default. Pass `flat: true` to return one deduplicated
+ * resource list instead.
+ */
+export const getGraph = (directory: string): GetCatalogGraph => {
+  const graph = async (root: CatalogGraphRoot, options: CatalogGraphOptions = {}): Promise<CatalogGraph | undefined> => {
+    const depth = options.depth ?? DEFAULT_DEPTH;
+    if (options.depth !== undefined) validateDepth(depth);
+
+    const collectionLoaders: Record<CatalogGraphResourceType, ResourceCollectionLoader> = {
+      domain: getDomains(directory),
+      system: getSystems(directory),
+      service: getServices(directory),
+      agent: getAgents(directory),
+      event: getEvents(directory),
+      command: getCommands(directory),
+      query: getQueries(directory),
+      flow: getFlows(directory),
+      channel: getChannels(directory),
+      entity: getEntities(directory),
+      container: getDataStores(directory),
+      'data-product': getDataProducts(directory),
+      adr: getAdrs(directory),
+    };
+
+    const latestIndexCache = new Map<CatalogGraphResourceType, Promise<ResourceIndex>>();
+    const allVersionsIndexCache = new Map<CatalogGraphResourceType, Promise<ResourceIndex>>();
+    const adjacencyCache = new Map<string, Promise<ResolvedResource[]>>();
+
+    const loadLatestIndex = (type: CatalogGraphResourceType) => {
+      const cachedIndex = latestIndexCache.get(type);
+      if (cachedIndex) return cachedIndex;
+
+      const index = collectionLoaders[type]({ latestOnly: true }).then((resources) => indexResources(resources || []));
+      latestIndexCache.set(type, index);
+      return index;
+    };
+
+    const loadAllVersionsIndex = (type: CatalogGraphResourceType) => {
+      const cachedIndex = allVersionsIndexCache.get(type);
+      if (cachedIndex) return cachedIndex;
+
+      const latestIndex = latestIndexCache.get(type);
+      const index = Promise.all([collectionLoaders[type](), latestIndex]).then(([resources, loadedLatestIndex]) => {
+        const allVersionsIndex = indexResources(resources || []);
+
+        // Reuse latest resource objects when the all-versions query contains
+        // the same id and version, avoiding duplicate retained markdown data.
+        for (const [id, latestResources] of loadedLatestIndex?.byId || []) {
+          const latestResource = latestResources[0];
+          if (!latestResource) continue;
+
+          const key = `${id}:${latestResource.version}`;
+          if (!allVersionsIndex.byVersion.has(key)) continue;
+
+          allVersionsIndex.byVersion.set(key, latestResource);
+          const versions = allVersionsIndex.byId.get(id);
+          const matchingVersion = versions?.findIndex((resource) => resource.version === latestResource.version) ?? -1;
+          if (versions && matchingVersion !== -1) versions[matchingVersion] = latestResource;
+        }
+
+        return allVersionsIndex;
+      });
+      allVersionsIndexCache.set(type, index);
+      return index;
+    };
+
+    const read = async (type: CatalogGraphResourceType, pointer: ResourcePointer) => {
+      const latestIndex = await loadLatestIndex(type);
+      const latestResource = latestIndex.byId.get(pointer.id)?.[0];
+
+      if (!pointer.version || pointer.version === 'latest') {
+        return latestResource;
+      }
+
+      if (latestResource?.version === pointer.version) return latestResource;
+
+      const allVersionsIndex = await loadAllVersionsIndex(type);
+      const exactMatch = allVersionsIndex.byVersion.get(`${pointer.id}:${pointer.version}`);
+      if (exactMatch) return exactMatch;
+
+      const range = validRange(pointer.version);
+      if (!range) return undefined;
+
+      const candidates = allVersionsIndex.byId.get(pointer.id) || [];
+      const version = maxSatisfying(
+        candidates.map((resource) => resource.version),
+        range
+      );
+      return candidates.find((resource) => resource.version === version);
+    };
+
+    const resolvePointer = async (pointer: ResourcePointer, candidateTypes: CatalogGraphResourceType[]) => {
+      const explicitType = normalizeResourceType(pointer.type);
+      if (pointer.type && !explicitType) return [];
+
+      const types = explicitType ? [explicitType] : candidateTypes;
+      const resolved = await Promise.all(
+        types.map(async (type) => {
+          const resource = await read(type, pointer);
+          return resource && resource.hidden !== true ? { type, resource } : undefined;
+        })
+      );
+
+      return resolved.filter((resource): resource is ResolvedResource => resource !== undefined);
+    };
+
+    const resolvePointers = async (pointers: ResourcePointer[], candidateTypes: CatalogGraphResourceType[]) => {
+      const resolved = await Promise.all(pointers.map((pointer) => resolvePointer(pointer, candidateTypes)));
+      return resolved.flat();
+    };
+
+    let adrTargetIndex: Promise<Map<string, AdrTarget[]>> | undefined;
+    const loadAdrTargetIndex = () => {
+      if (adrTargetIndex) return adrTargetIndex;
+
+      adrTargetIndex = loadAllVersionsIndex('adr').then((adrIndex) => {
+        const targets = new Map<string, AdrTarget[]>();
+
+        for (const adr of adrIndex.byVersion.values()) {
+          if (adr.hidden === true) continue;
+
+          for (const pointer of adr.appliesTo || []) {
+            const type = normalizeResourceType(pointer.type);
+            if (!type || type === 'adr') continue;
+
+            const key = `${type}:${pointer.id}`;
+            const entries = targets.get(key);
+            const target = { pointer, resource: adr };
+            if (entries) entries.push(target);
+            else targets.set(key, [target]);
+          }
+        }
+
+        return targets;
+      });
+      return adrTargetIndex;
+    };
+
+    const pointerMatchesVersion = (pointer: ResourcePointer, version: string) => {
+      if (!pointer.version || pointer.version === 'latest') return true;
+      if (pointer.version === version) return true;
+
+      const range = validRange(pointer.version);
+      return range ? maxSatisfying([version], range) === version : false;
+    };
+
+    const getAdrsForResource = async (type: CatalogGraphResourceType, resource: CatalogResource) => {
+      if (type === 'adr') return [];
+
+      const targets = (await loadAdrTargetIndex()).get(`${type}:${resource.id}`) || [];
+      return targets
+        .filter(({ pointer }) => pointerMatchesVersion(pointer, resource.version))
+        .map(({ resource }) => ({ type: 'adr' as const, resource }));
+    };
+
+    const resolveChildren = async (type: CatalogGraphResourceType, resource: CatalogResource): Promise<ResolvedResource[]> => {
+      const children: ResolvedResource[] = [];
+      const addPointers = async (pointers: ResourcePointer[], candidateTypes: CatalogGraphResourceType[]) => {
+        children.push(...(await resolvePointers(pointers, candidateTypes)));
+      };
+
+      if (type === 'domain') {
+        await addPointers(resource.domains || [], ['domain']);
+        await addPointers(resource.systems || [], ['system']);
+        await addPointers(resource.services || [], ['service']);
+        await addPointers(resource.agents || [], ['agent']);
+        await addPointers(resource.entities || [], ['entity']);
+        await addPointers(resource.flows || [], ['flow']);
+        await addPointers([...(resource.dataProducts || []), ...(resource['data-products'] || [])], ['data-product']);
+        await addPointers([...(resource.sends || []), ...(resource.receives || [])], ['event', 'command', 'query']);
+      } else if (type === 'system') {
+        await addPointers(resource.relationships || [], ['system']);
+        await addPointers(resource.services || [], ['service']);
+        await addPointers(resource.flows || [], ['flow']);
+        await addPointers(resource.entities || [], ['entity']);
+        await addPointers(resource.containers || [], ['container']);
+      } else if (type === 'service' || type === 'agent') {
+        await addPointers([...(resource.sends || []), ...(resource.receives || [])], ['event', 'command', 'query']);
+        await addPointers(resource.entities || [], ['entity']);
+        await addPointers(resource.flows || [], ['flow']);
+        await addPointers([...(resource.writesTo || []), ...(resource.readsFrom || [])], ['container']);
+      } else if (type === 'event' || type === 'command' || type === 'query') {
+        await addPointers([...(resource.channels || []), ...(resource.messageChannels || [])], ['channel']);
+      } else if (type === 'channel') {
+        await addPointers(resource.routes || [], ['channel']);
+      } else if (type === 'data-product') {
+        await addPointers(
+          [...(resource.inputs || []), ...(resource.outputs || [])],
+          ['event', 'command', 'query', 'channel', 'container', 'service']
+        );
+      } else if (type === 'flow') {
+        for (const step of resource.steps || []) {
+          if (step.message) await addPointers([step.message], ['event', 'command', 'query']);
+          if (step.agent) await addPointers([step.agent], ['agent']);
+          if (step.service) await addPointers([step.service], ['service']);
+          if (step.flow) await addPointers([step.flow], ['flow']);
+          if (step.container) await addPointers([step.container], ['container']);
+          if (step.dataProduct) await addPointers([step.dataProduct], ['data-product']);
+        }
+      } else if (type === 'adr') {
+        await addPointers(resource.appliesTo || [], NON_ADR_RESOURCE_TYPES);
+        await addPointers(
+          [
+            ...(resource.supersedes || []),
+            ...(resource.supersededBy || []),
+            ...(resource.amends || []),
+            ...(resource.amendedBy || []),
+            ...(resource.related || []),
+          ],
+          ['adr']
+        );
+      }
+
+      children.push(...(await getAdrsForResource(type, resource)));
+
+      const uniqueChildren = new Map<string, ResolvedResource>();
+      for (const child of children) {
+        const graphResource = toGraphResource(child.type, child.resource);
+        uniqueChildren.set(resourceKey(graphResource), child);
+      }
+
+      return Array.from(uniqueChildren.values()).sort((left, right) =>
+        sortResources(toGraphResource(left.type, left.resource), toGraphResource(right.type, right.resource))
+      );
+    };
+
+    const getChildren = (type: CatalogGraphResourceType, resource: CatalogResource) => {
+      const key = resourceKey(toGraphResource(type, resource));
+      const cachedChildren = adjacencyCache.get(key);
+      if (cachedChildren) return cachedChildren;
+
+      const children = resolveChildren(type, resource);
+      adjacencyCache.set(key, children);
+      return children;
+    };
+
+    const buildNode = async (
+      type: CatalogGraphResourceType,
+      resource: CatalogResource,
+      remainingDepth: number,
+      ancestors?: AncestorPath
+    ): Promise<CatalogGraphNode> => {
+      const graphResource = toGraphResource(type, resource);
+      const key = resourceKey(graphResource);
+      if (remainingDepth === 0) return { ...graphResource, children: [] };
+
+      const nextAncestors = { key, parent: ancestors };
+      const resolvedChildren = await getChildren(type, resource);
+      const children = await mapWithConcurrency(
+        resolvedChildren,
+        NESTED_TRAVERSAL_CONCURRENCY,
+        ({ type: childType, resource: childResource }) => {
+          const child = toGraphResource(childType, childResource);
+          if (pathIncludes(nextAncestors, resourceKey(child))) return Promise.resolve({ ...child, children: [] });
+          return buildNode(childType, childResource, remainingDepth - 1, nextAncestors);
+        }
+      );
+
+      return { ...graphResource, children };
+    };
+
+    const rootResource = await read(root.type, root);
+    if (!rootResource || rootResource.hidden === true) return undefined;
+
+    const flatRoot = toGraphResource(root.type, rootResource);
+    if (!options.flat) {
+      const nestedRoot = await buildNode(root.type, rootResource, depth);
+      return { root: nestedRoot };
+    }
+
+    const flatRootKey = resourceKey(flatRoot);
+    const resources = new Map<string, CatalogGraphResource>([[flatRootKey, flatRoot]]);
+    const visited = new Set<string>([flatRootKey]);
+    const queue: Array<ResolvedResource & { remainingDepth: number }> = [
+      { type: root.type, resource: rootResource, remainingDepth: depth },
+    ];
+
+    for (let index = 0; index < queue.length; index++) {
+      const current = queue[index];
+      if (current.remainingDepth === 0) continue;
+
+      const children = await getChildren(current.type, current.resource);
+      for (const child of children) {
+        const graphResource = toGraphResource(child.type, child.resource);
+        const key = resourceKey(graphResource);
+        if (visited.has(key)) continue;
+
+        visited.add(key);
+        resources.set(key, graphResource);
+        queue.push({ ...child, remainingDepth: current.remainingDepth - 1 });
+      }
+    }
+
+    const relatedResources = Array.from(resources.values())
+      .filter((resource) => resourceKey(resource) !== flatRootKey)
+      .sort(sortResources);
+
+    return {
+      root: flatRoot,
+      resources: [flatRoot, ...relatedResources],
+    };
+  };
+
+  return graph as GetCatalogGraph;
+};

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -151,6 +151,7 @@ import { writeTeam, getTeam, getTeams, rmTeamById, getOwnersForResource } from '
 
 import { writeUser, getUser, getUsers, rmUserById } from './users';
 import { dumpCatalog, getEventCatalogConfigurationFile } from './eventcatalog';
+import { getGraph } from './graph';
 import { createSnapshot, diffSnapshots, listSnapshots } from './snapshots';
 import { writeChangelog, appendChangelog, getChangelog, rmChangelog } from './changelogs';
 import {
@@ -1169,6 +1170,14 @@ export default (path: string) => {
      * @returns A JSON file with the catalog
      */
     dumpCatalog: dumpCatalog(join(path)),
+
+    /**
+     * Returns the resources reachable from a catalog resource.
+     * @param root - Resource to use as the root of the graph
+     * @param options - Traversal depth and whether to return a flat resource list
+     * @returns The resolved graph, or undefined when the root does not exist
+     */
+    getGraph: getGraph(join(path)),
 
     /**
      * Returns the event catalog configuration file.

--- a/packages/sdk/src/test/graph-data-flow-adrs.test.ts
+++ b/packages/sdk/src/test/graph-data-flow-adrs.test.ts
@@ -1,0 +1,411 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import utils from '../index';
+import type { CatalogGraphNode } from '../types';
+
+const CATALOG_PATH = path.join(__dirname, 'catalog-graph-data-flow-adrs');
+
+const {
+  getGraph,
+  writeAdr,
+  writeAgent,
+  writeChannel,
+  writeCommand,
+  writeDataProduct,
+  writeDataStore,
+  writeDomain,
+  writeEntity,
+  writeEvent,
+  writeFlow,
+  writeQuery,
+  writeService,
+  writeSystem,
+} = utils(CATALOG_PATH);
+
+beforeEach(() => {
+  fs.rmSync(CATALOG_PATH, { recursive: true, force: true });
+  fs.mkdirSync(CATALOG_PATH, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(CATALOG_PATH, { recursive: true, force: true });
+});
+
+const expectEntityChildren = async (relationships: Partial<Parameters<typeof writeEntity>[0]>, children: CatalogGraphNode[]) => {
+  await writeEntity({
+    id: 'root-entity',
+    name: 'Root Entity',
+    version: '1.0.0',
+    markdown: '# Root Entity',
+    ...relationships,
+  });
+
+  const graph = await getGraph({ type: 'entity', id: 'root-entity' }, { depth: 1 });
+  expect(graph).toEqual({ root: { type: 'entity', id: 'root-entity', version: '1.0.0', children } });
+};
+
+const expectContainerChildren = async (
+  relationships: Partial<Parameters<typeof writeDataStore>[0]>,
+  children: CatalogGraphNode[]
+) => {
+  await writeDataStore({
+    id: 'root-container',
+    name: 'Root Container',
+    version: '1.0.0',
+    markdown: '# Root Container',
+    container_type: 'database',
+    ...relationships,
+  });
+
+  const graph = await getGraph({ type: 'container', id: 'root-container' }, { depth: 1 });
+  expect(graph).toEqual({ root: { type: 'container', id: 'root-container', version: '1.0.0', children } });
+};
+
+const expectDataProductChildren = async (
+  relationships: Partial<Parameters<typeof writeDataProduct>[0]>,
+  children: CatalogGraphNode[]
+) => {
+  await writeDataProduct({
+    id: 'root-data-product',
+    name: 'Root Data Product',
+    version: '1.0.0',
+    markdown: '# Root Data Product',
+    ...relationships,
+  });
+
+  const graph = await getGraph({ type: 'data-product', id: 'root-data-product' }, { depth: 1 });
+  expect(graph).toEqual({ root: { type: 'data-product', id: 'root-data-product', version: '1.0.0', children } });
+};
+
+const expectFlowChildren = async (relationships: Partial<Parameters<typeof writeFlow>[0]>, children: CatalogGraphNode[]) => {
+  await writeFlow({
+    id: 'root-flow',
+    name: 'Root Flow',
+    version: '1.0.0',
+    markdown: '# Root Flow',
+    steps: [],
+    ...relationships,
+  });
+
+  const graph = await getGraph({ type: 'flow', id: 'root-flow' }, { depth: 1 });
+  expect(graph).toEqual({ root: { type: 'flow', id: 'root-flow', version: '1.0.0', children } });
+};
+
+const expectAdrChildren = async (relationships: Partial<Parameters<typeof writeAdr>[0]>, children: CatalogGraphNode[]) => {
+  await writeAdr({
+    id: 'root-adr',
+    name: 'Root ADR',
+    version: '1.0.0',
+    markdown: '# Root ADR',
+    status: 'accepted',
+    date: '2026-07-20',
+    ...relationships,
+  });
+
+  const graph = await getGraph({ type: 'adr', id: 'root-adr' }, { depth: 1 });
+  expect(graph).toEqual({ root: { type: 'adr', id: 'root-adr', version: '1.0.0', children } });
+};
+
+describe('Entity graphs', () => {
+  it('includes ADRs that apply to the entity', async () => {
+    await writeAdr({
+      id: 'entity-adr',
+      name: 'Entity ADR',
+      version: '1.0.0',
+      markdown: '# Entity ADR',
+      status: 'accepted',
+      date: '2026-07-20',
+      appliesTo: [{ type: 'entity', id: 'root-entity' }],
+    });
+
+    await expectEntityChildren({}, [{ type: 'adr', id: 'entity-adr', version: '1.0.0', children: [] }]);
+  });
+
+  it('does not create children for entity property metadata', async () => {
+    await expectEntityChildren(
+      {
+        aggregateRoot: true,
+        identifier: 'id',
+        properties: [{ name: 'id', type: 'string', required: true }],
+      },
+      []
+    );
+  });
+});
+
+describe('Container graphs', () => {
+  it('includes ADRs that apply to the container', async () => {
+    await writeAdr({
+      id: 'container-adr',
+      name: 'Container ADR',
+      version: '1.0.0',
+      markdown: '# Container ADR',
+      status: 'accepted',
+      date: '2026-07-20',
+      appliesTo: [{ type: 'container', id: 'root-container' }],
+    });
+
+    await expectContainerChildren({}, [{ type: 'adr', id: 'container-adr', version: '1.0.0', children: [] }]);
+  });
+
+  it('does not create children for storage metadata', async () => {
+    await expectContainerChildren(
+      {
+        technology: 'PostgreSQL',
+        authoritative: true,
+        access_mode: 'read-write',
+      },
+      []
+    );
+  });
+});
+
+describe('Data product graphs', () => {
+  it('includes supported resource types from inputs and outputs', async () => {
+    await writeService({ id: 'input-service', name: 'Input Service', version: '1.0.0', markdown: '# Input Service' });
+    await writeEvent({ id: 'input-event', name: 'Input Event', version: '1.0.0', markdown: '# Input Event' });
+    await writeCommand({ id: 'input-command', name: 'Input Command', version: '1.0.0', markdown: '# Input Command' });
+    await writeQuery({ id: 'input-query', name: 'Input Query', version: '1.0.0', markdown: '# Input Query' });
+    await writeChannel({ id: 'input-channel', name: 'Input Channel', version: '1.0.0', markdown: '# Input Channel' });
+    await writeDataStore({
+      id: 'output-container',
+      name: 'Output Container',
+      version: '1.0.0',
+      markdown: '# Output Container',
+      container_type: 'database',
+    });
+
+    await expectDataProductChildren(
+      {
+        inputs: [
+          { id: 'input-service' },
+          { id: 'input-event' },
+          { id: 'input-command' },
+          { id: 'input-query' },
+          { id: 'input-channel' },
+        ],
+        outputs: [{ id: 'output-container' }],
+      },
+      [
+        { type: 'service', id: 'input-service', version: '1.0.0', children: [] },
+        { type: 'event', id: 'input-event', version: '1.0.0', children: [] },
+        { type: 'command', id: 'input-command', version: '1.0.0', children: [] },
+        { type: 'query', id: 'input-query', version: '1.0.0', children: [] },
+        { type: 'channel', id: 'input-channel', version: '1.0.0', children: [] },
+        { type: 'container', id: 'output-container', version: '1.0.0', children: [] },
+      ]
+    );
+  });
+
+  it('uses an explicit pointer type when resource ids collide', async () => {
+    await writeEvent({ id: 'shared-id', name: 'Shared Event', version: '1.0.0', markdown: '# Shared Event' });
+    await writeService({ id: 'shared-id', name: 'Shared Service', version: '1.0.0', markdown: '# Shared Service' });
+
+    await expectDataProductChildren({ inputs: [{ type: 'event', id: 'shared-id' }] }, [
+      { type: 'event', id: 'shared-id', version: '1.0.0', children: [] },
+    ]);
+  });
+
+  it('includes ADRs that apply to the data product', async () => {
+    await writeAdr({
+      id: 'data-product-adr',
+      name: 'Data Product ADR',
+      version: '1.0.0',
+      markdown: '# Data Product ADR',
+      status: 'accepted',
+      date: '2026-07-20',
+      appliesTo: [{ type: 'data-product', id: 'root-data-product' }],
+    });
+
+    await expectDataProductChildren({}, [{ type: 'adr', id: 'data-product-adr', version: '1.0.0', children: [] }]);
+  });
+});
+
+describe('Flow graphs', () => {
+  it('includes every catalog resource referenced by flow steps', async () => {
+    await writeService({ id: 'flow-service', name: 'Flow Service', version: '1.0.0', markdown: '# Flow Service' });
+    await writeAgent({ id: 'flow-agent', name: 'Flow Agent', version: '1.0.0', markdown: '# Flow Agent' });
+    await writeEvent({ id: 'flow-event', name: 'Flow Event', version: '1.0.0', markdown: '# Flow Event' });
+    await writeCommand({ id: 'flow-command', name: 'Flow Command', version: '1.0.0', markdown: '# Flow Command' });
+    await writeQuery({ id: 'flow-query', name: 'Flow Query', version: '1.0.0', markdown: '# Flow Query' });
+    await writeDataStore({
+      id: 'flow-container',
+      name: 'Flow Container',
+      version: '1.0.0',
+      markdown: '# Flow Container',
+      container_type: 'database',
+    });
+    await writeDataProduct({
+      id: 'flow-data-product',
+      name: 'Flow Data Product',
+      version: '1.0.0',
+      markdown: '# Flow Data Product',
+    });
+    await writeFlow({ id: 'child-flow', name: 'Child Flow', version: '1.0.0', markdown: '# Child Flow', steps: [] });
+
+    await expectFlowChildren(
+      {
+        steps: [
+          { id: 1, title: 'Service', service: { id: 'flow-service' } },
+          { id: 2, title: 'Agent', agent: { id: 'flow-agent' } },
+          { id: 3, title: 'Event', message: { id: 'flow-event' } },
+          { id: 4, title: 'Command', message: { id: 'flow-command' } },
+          { id: 5, title: 'Query', message: { id: 'flow-query' } },
+          { id: 6, title: 'Container', container: { id: 'flow-container' } },
+          { id: 7, title: 'Data Product', dataProduct: { id: 'flow-data-product' } },
+          { id: 8, title: 'Flow', flow: { id: 'child-flow' } },
+        ],
+      },
+      [
+        { type: 'service', id: 'flow-service', version: '1.0.0', children: [] },
+        { type: 'agent', id: 'flow-agent', version: '1.0.0', children: [] },
+        { type: 'event', id: 'flow-event', version: '1.0.0', children: [] },
+        { type: 'command', id: 'flow-command', version: '1.0.0', children: [] },
+        { type: 'query', id: 'flow-query', version: '1.0.0', children: [] },
+        { type: 'container', id: 'flow-container', version: '1.0.0', children: [] },
+        { type: 'data-product', id: 'flow-data-product', version: '1.0.0', children: [] },
+        { type: 'flow', id: 'child-flow', version: '1.0.0', children: [] },
+      ]
+    );
+  });
+
+  it('does not include actor, custom, or external-system steps because they are not catalog resources', async () => {
+    await expectFlowChildren(
+      {
+        steps: [
+          { id: 1, title: 'Actor', actor: { name: 'Customer' } },
+          { id: 2, title: 'Custom', custom: { title: 'Custom Node' } },
+          { id: 3, title: 'External', externalSystem: { name: 'External System' } },
+        ],
+      },
+      []
+    );
+  });
+
+  it('includes ADRs that apply to the flow', async () => {
+    await writeAdr({
+      id: 'flow-adr',
+      name: 'Flow ADR',
+      version: '1.0.0',
+      markdown: '# Flow ADR',
+      status: 'accepted',
+      date: '2026-07-20',
+      appliesTo: [{ type: 'flow', id: 'root-flow' }],
+    });
+
+    await expectFlowChildren({}, [{ type: 'adr', id: 'flow-adr', version: '1.0.0', children: [] }]);
+  });
+});
+
+describe('ADR graphs', () => {
+  it('includes every supported resource type from appliesTo', async () => {
+    await writeDomain({ id: 'adr-domain', name: 'ADR Domain', version: '1.0.0', markdown: '# ADR Domain' });
+    await writeSystem({ id: 'adr-system', name: 'ADR System', version: '1.0.0', markdown: '# ADR System' });
+    await writeService({ id: 'adr-service', name: 'ADR Service', version: '1.0.0', markdown: '# ADR Service' });
+    await writeAgent({ id: 'adr-agent', name: 'ADR Agent', version: '1.0.0', markdown: '# ADR Agent' });
+    await writeEvent({ id: 'adr-event', name: 'ADR Event', version: '1.0.0', markdown: '# ADR Event' });
+    await writeCommand({ id: 'adr-command', name: 'ADR Command', version: '1.0.0', markdown: '# ADR Command' });
+    await writeQuery({ id: 'adr-query', name: 'ADR Query', version: '1.0.0', markdown: '# ADR Query' });
+    await writeChannel({ id: 'adr-channel', name: 'ADR Channel', version: '1.0.0', markdown: '# ADR Channel' });
+    await writeEntity({ id: 'adr-entity', name: 'ADR Entity', version: '1.0.0', markdown: '# ADR Entity' });
+    await writeDataStore({
+      id: 'adr-container',
+      name: 'ADR Container',
+      version: '1.0.0',
+      markdown: '# ADR Container',
+      container_type: 'database',
+    });
+    await writeDataProduct({
+      id: 'adr-data-product',
+      name: 'ADR Data Product',
+      version: '1.0.0',
+      markdown: '# ADR Data Product',
+    });
+    await writeFlow({ id: 'adr-flow', name: 'ADR Flow', version: '1.0.0', markdown: '# ADR Flow', steps: [] });
+
+    await expectAdrChildren(
+      {
+        appliesTo: [
+          { type: 'domain', id: 'adr-domain' },
+          { type: 'system', id: 'adr-system' },
+          { type: 'service', id: 'adr-service' },
+          { type: 'agent', id: 'adr-agent' },
+          { type: 'event', id: 'adr-event' },
+          { type: 'command', id: 'adr-command' },
+          { type: 'query', id: 'adr-query' },
+          { type: 'channel', id: 'adr-channel' },
+          { type: 'entity', id: 'adr-entity' },
+          { type: 'container', id: 'adr-container' },
+          { type: 'data-product', id: 'adr-data-product' },
+          { type: 'flow', id: 'adr-flow' },
+        ],
+      },
+      [
+        { type: 'domain', id: 'adr-domain', version: '1.0.0', children: [] },
+        { type: 'system', id: 'adr-system', version: '1.0.0', children: [] },
+        { type: 'service', id: 'adr-service', version: '1.0.0', children: [] },
+        { type: 'agent', id: 'adr-agent', version: '1.0.0', children: [] },
+        { type: 'event', id: 'adr-event', version: '1.0.0', children: [] },
+        { type: 'command', id: 'adr-command', version: '1.0.0', children: [] },
+        { type: 'query', id: 'adr-query', version: '1.0.0', children: [] },
+        { type: 'channel', id: 'adr-channel', version: '1.0.0', children: [] },
+        { type: 'entity', id: 'adr-entity', version: '1.0.0', children: [] },
+        { type: 'container', id: 'adr-container', version: '1.0.0', children: [] },
+        { type: 'data-product', id: 'adr-data-product', version: '1.0.0', children: [] },
+        { type: 'flow', id: 'adr-flow', version: '1.0.0', children: [] },
+      ]
+    );
+  });
+
+  it('includes supersedes, supersededBy, amends, amendedBy, and related ADRs', async () => {
+    const relatedAdrs = [
+      ['supersedes-adr', 'Supersedes ADR'],
+      ['superseded-by-adr', 'Superseded By ADR'],
+      ['amends-adr', 'Amends ADR'],
+      ['amended-by-adr', 'Amended By ADR'],
+      ['related-adr', 'Related ADR'],
+    ] as const;
+
+    for (const [id, name] of relatedAdrs) {
+      await writeAdr({ id, name, version: '1.0.0', markdown: `# ${name}`, status: 'accepted', date: '2026-07-20' });
+    }
+
+    await expectAdrChildren(
+      {
+        supersedes: [{ id: 'supersedes-adr' }],
+        supersededBy: [{ id: 'superseded-by-adr' }],
+        amends: [{ id: 'amends-adr' }],
+        amendedBy: [{ id: 'amended-by-adr' }],
+        related: [{ id: 'related-adr' }],
+      },
+      [
+        { type: 'adr', id: 'amended-by-adr', version: '1.0.0', children: [] },
+        { type: 'adr', id: 'amends-adr', version: '1.0.0', children: [] },
+        { type: 'adr', id: 'related-adr', version: '1.0.0', children: [] },
+        { type: 'adr', id: 'superseded-by-adr', version: '1.0.0', children: [] },
+        { type: 'adr', id: 'supersedes-adr', version: '1.0.0', children: [] },
+      ]
+    );
+  });
+
+  it('does not include appliesTo targets outside the supported graph resource types', async () => {
+    await writeEvent({
+      id: 'adr-user',
+      name: 'Resource With User Id',
+      version: '1.0.0',
+      markdown: '# Resource With User Id',
+    });
+
+    await expectAdrChildren(
+      {
+        appliesTo: [
+          { type: 'user', id: 'adr-user' },
+          { type: 'team', id: 'adr-team' },
+          { type: 'diagram', id: 'adr-diagram' },
+        ],
+      },
+      []
+    );
+  });
+});

--- a/packages/sdk/src/test/graph-messages-channels.test.ts
+++ b/packages/sdk/src/test/graph-messages-channels.test.ts
@@ -1,0 +1,239 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import utils from '../index';
+import type { CatalogGraphNode } from '../types';
+
+const CATALOG_PATH = path.join(__dirname, 'catalog-graph-messages-channels');
+
+const { getGraph, writeAdr, writeChannel, writeCommand, writeEvent, writeQuery } = utils(CATALOG_PATH);
+
+beforeEach(() => {
+  fs.rmSync(CATALOG_PATH, { recursive: true, force: true });
+  fs.mkdirSync(CATALOG_PATH, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(CATALOG_PATH, { recursive: true, force: true });
+});
+
+const expectEventChildren = async (relationships: Partial<Parameters<typeof writeEvent>[0]>, children: CatalogGraphNode[]) => {
+  await writeEvent({
+    id: 'root-event',
+    name: 'Root Event',
+    version: '1.0.0',
+    markdown: '# Root Event',
+    ...relationships,
+  });
+
+  const graph = await getGraph({ type: 'event', id: 'root-event' }, { depth: 1 });
+  expect(graph).toEqual({
+    root: { type: 'event', id: 'root-event', version: '1.0.0', children },
+  });
+};
+
+const expectCommandChildren = async (
+  relationships: Partial<Parameters<typeof writeCommand>[0]>,
+  children: CatalogGraphNode[]
+) => {
+  await writeCommand({
+    id: 'root-command',
+    name: 'Root Command',
+    version: '1.0.0',
+    markdown: '# Root Command',
+    ...relationships,
+  });
+
+  const graph = await getGraph({ type: 'command', id: 'root-command' }, { depth: 1 });
+  expect(graph).toEqual({
+    root: { type: 'command', id: 'root-command', version: '1.0.0', children },
+  });
+};
+
+const expectQueryChildren = async (relationships: Partial<Parameters<typeof writeQuery>[0]>, children: CatalogGraphNode[]) => {
+  await writeQuery({
+    id: 'root-query',
+    name: 'Root Query',
+    version: '1.0.0',
+    markdown: '# Root Query',
+    ...relationships,
+  });
+
+  const graph = await getGraph({ type: 'query', id: 'root-query' }, { depth: 1 });
+  expect(graph).toEqual({
+    root: { type: 'query', id: 'root-query', version: '1.0.0', children },
+  });
+};
+
+const expectChannelChildren = async (
+  relationships: Partial<Parameters<typeof writeChannel>[0]>,
+  children: CatalogGraphNode[]
+) => {
+  await writeChannel({
+    id: 'root-channel',
+    name: 'Root Channel',
+    version: '1.0.0',
+    markdown: '# Root Channel',
+    ...relationships,
+  });
+
+  const graph = await getGraph({ type: 'channel', id: 'root-channel' }, { depth: 1 });
+  expect(graph).toEqual({
+    root: { type: 'channel', id: 'root-channel', version: '1.0.0', children },
+  });
+};
+
+describe('Event graphs', () => {
+  it('includes channels', async () => {
+    await writeChannel({ id: 'event-channel', name: 'Event Channel', version: '1.0.0', markdown: '# Event Channel' });
+
+    await expectEventChildren({ channels: [{ id: 'event-channel' }] }, [
+      { type: 'channel', id: 'event-channel', version: '1.0.0', children: [] },
+    ]);
+  });
+
+  it('includes ADRs that apply to the event', async () => {
+    await writeAdr({
+      id: 'event-adr',
+      name: 'Event ADR',
+      version: '1.0.0',
+      markdown: '# Event ADR',
+      status: 'accepted',
+      date: '2026-07-20',
+      appliesTo: [{ type: 'event', id: 'root-event' }],
+    });
+
+    await expectEventChildren({}, [{ type: 'adr', id: 'event-adr', version: '1.0.0', children: [] }]);
+  });
+
+  it('traverses channel routes when depth is omitted', async () => {
+    await writeChannel({ id: 'routed-channel', name: 'Routed Channel', version: '1.0.0', markdown: '# Routed Channel' });
+    await writeChannel({
+      id: 'event-channel',
+      name: 'Event Channel',
+      version: '1.0.0',
+      markdown: '# Event Channel',
+      routes: [{ id: 'routed-channel' }],
+    });
+    await writeEvent({
+      id: 'root-event',
+      name: 'Root Event',
+      version: '1.0.0',
+      markdown: '# Root Event',
+      channels: [{ id: 'event-channel' }],
+    });
+
+    const graph = await getGraph({ type: 'event', id: 'root-event' });
+
+    expect(graph).toEqual({
+      root: {
+        type: 'event',
+        id: 'root-event',
+        version: '1.0.0',
+        children: [
+          {
+            type: 'channel',
+            id: 'event-channel',
+            version: '1.0.0',
+            children: [{ type: 'channel', id: 'routed-channel', version: '1.0.0', children: [] }],
+          },
+        ],
+      },
+    });
+  });
+
+  it('does not create children for operation metadata', async () => {
+    await expectEventChildren({ operation: { method: 'POST', path: '/orders' } }, []);
+  });
+});
+
+describe('Command graphs', () => {
+  it('includes channels', async () => {
+    await writeChannel({ id: 'command-channel', name: 'Command Channel', version: '1.0.0', markdown: '# Command Channel' });
+
+    await expectCommandChildren({ channels: [{ id: 'command-channel' }] }, [
+      { type: 'channel', id: 'command-channel', version: '1.0.0', children: [] },
+    ]);
+  });
+
+  it('includes ADRs that apply to the command', async () => {
+    await writeAdr({
+      id: 'command-adr',
+      name: 'Command ADR',
+      version: '1.0.0',
+      markdown: '# Command ADR',
+      status: 'accepted',
+      date: '2026-07-20',
+      appliesTo: [{ type: 'command', id: 'root-command' }],
+    });
+
+    await expectCommandChildren({}, [{ type: 'adr', id: 'command-adr', version: '1.0.0', children: [] }]);
+  });
+
+  it('does not create children for operation metadata', async () => {
+    await expectCommandChildren({ operation: { method: 'POST', path: '/orders' } }, []);
+  });
+});
+
+describe('Query graphs', () => {
+  it('includes channels', async () => {
+    await writeChannel({ id: 'query-channel', name: 'Query Channel', version: '1.0.0', markdown: '# Query Channel' });
+
+    await expectQueryChildren({ channels: [{ id: 'query-channel' }] }, [
+      { type: 'channel', id: 'query-channel', version: '1.0.0', children: [] },
+    ]);
+  });
+
+  it('includes ADRs that apply to the query', async () => {
+    await writeAdr({
+      id: 'query-adr',
+      name: 'Query ADR',
+      version: '1.0.0',
+      markdown: '# Query ADR',
+      status: 'accepted',
+      date: '2026-07-20',
+      appliesTo: [{ type: 'query', id: 'root-query' }],
+    });
+
+    await expectQueryChildren({}, [{ type: 'adr', id: 'query-adr', version: '1.0.0', children: [] }]);
+  });
+
+  it('does not create children for operation metadata', async () => {
+    await expectQueryChildren({ operation: { method: 'GET', path: '/orders' } }, []);
+  });
+});
+
+describe('Channel graphs', () => {
+  it('includes routed channels', async () => {
+    await writeChannel({ id: 'routed-channel', name: 'Routed Channel', version: '1.0.0', markdown: '# Routed Channel' });
+
+    await expectChannelChildren({ routes: [{ id: 'routed-channel' }] }, [
+      { type: 'channel', id: 'routed-channel', version: '1.0.0', children: [] },
+    ]);
+  });
+
+  it('includes ADRs that apply to the channel', async () => {
+    await writeAdr({
+      id: 'channel-adr',
+      name: 'Channel ADR',
+      version: '1.0.0',
+      markdown: '# Channel ADR',
+      status: 'accepted',
+      date: '2026-07-20',
+      appliesTo: [{ type: 'channel', id: 'root-channel' }],
+    });
+
+    await expectChannelChildren({}, [{ type: 'adr', id: 'channel-adr', version: '1.0.0', children: [] }]);
+  });
+
+  it('does not create children for protocol and delivery metadata', async () => {
+    await expectChannelChildren(
+      {
+        address: 'orders',
+        protocols: ['kafka'],
+        deliveryGuarantee: 'at-least-once',
+      },
+      []
+    );
+  });
+});

--- a/packages/sdk/src/test/graph-services-agents.test.ts
+++ b/packages/sdk/src/test/graph-services-agents.test.ts
@@ -1,0 +1,279 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import utils from '../index';
+import type { CatalogGraphNode } from '../types';
+
+const CATALOG_PATH = path.join(__dirname, 'catalog-graph-services-agents');
+
+const {
+  getGraph,
+  writeAdr,
+  writeAgent,
+  writeCommand,
+  writeDataStore,
+  writeEntity,
+  writeEvent,
+  writeFlow,
+  writeQuery,
+  writeService,
+} = utils(CATALOG_PATH);
+
+beforeEach(() => {
+  fs.rmSync(CATALOG_PATH, { recursive: true, force: true });
+  fs.mkdirSync(CATALOG_PATH, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(CATALOG_PATH, { recursive: true, force: true });
+});
+
+const expectServiceChildren = async (
+  relationships: Partial<Parameters<typeof writeService>[0]>,
+  children: CatalogGraphNode[]
+) => {
+  await writeService({
+    id: 'root-service',
+    name: 'Root Service',
+    version: '1.0.0',
+    markdown: '# Root Service',
+    ...relationships,
+  });
+
+  const graph = await getGraph({ type: 'service', id: 'root-service' }, { depth: 1 });
+
+  expect(graph).toEqual({
+    root: {
+      type: 'service',
+      id: 'root-service',
+      version: '1.0.0',
+      children,
+    },
+  });
+};
+
+const expectAgentChildren = async (relationships: Partial<Parameters<typeof writeAgent>[0]>, children: CatalogGraphNode[]) => {
+  await writeAgent({
+    id: 'root-agent',
+    name: 'Root Agent',
+    version: '1.0.0',
+    markdown: '# Root Agent',
+    ...relationships,
+  });
+
+  const graph = await getGraph({ type: 'agent', id: 'root-agent' }, { depth: 1 });
+
+  expect(graph).toEqual({
+    root: {
+      type: 'agent',
+      id: 'root-agent',
+      version: '1.0.0',
+      children,
+    },
+  });
+};
+
+describe('Service graphs', () => {
+  it('includes events, commands, and queries from sends and receives', async () => {
+    await writeEvent({ id: 'service-event', name: 'Service Event', version: '1.0.0', markdown: '# Service Event' });
+    await writeCommand({ id: 'service-command', name: 'Service Command', version: '1.0.0', markdown: '# Service Command' });
+    await writeQuery({ id: 'service-query', name: 'Service Query', version: '1.0.0', markdown: '# Service Query' });
+
+    await expectServiceChildren(
+      {
+        sends: [{ id: 'service-event' }, { id: 'service-query' }],
+        receives: [{ id: 'service-command' }],
+      },
+      [
+        { type: 'event', id: 'service-event', version: '1.0.0', children: [] },
+        { type: 'command', id: 'service-command', version: '1.0.0', children: [] },
+        { type: 'query', id: 'service-query', version: '1.0.0', children: [] },
+      ]
+    );
+  });
+
+  it('includes entities', async () => {
+    await writeEntity({ id: 'service-entity', name: 'Service Entity', version: '1.0.0', markdown: '# Service Entity' });
+
+    await expectServiceChildren({ entities: [{ id: 'service-entity' }] }, [
+      { type: 'entity', id: 'service-entity', version: '1.0.0', children: [] },
+    ]);
+  });
+
+  it('includes flows', async () => {
+    await writeFlow({ id: 'service-flow', name: 'Service Flow', version: '1.0.0', markdown: '# Service Flow', steps: [] });
+
+    await expectServiceChildren({ flows: [{ id: 'service-flow' }] }, [
+      { type: 'flow', id: 'service-flow', version: '1.0.0', children: [] },
+    ]);
+  });
+
+  it('includes containers from writesTo and readsFrom', async () => {
+    await writeDataStore({
+      id: 'service-read-db',
+      name: 'Service Read Database',
+      version: '1.0.0',
+      markdown: '# Service Read Database',
+      container_type: 'database',
+    });
+    await writeDataStore({
+      id: 'service-write-db',
+      name: 'Service Write Database',
+      version: '1.0.0',
+      markdown: '# Service Write Database',
+      container_type: 'database',
+    });
+
+    await expectServiceChildren(
+      {
+        readsFrom: [{ id: 'service-read-db' }],
+        writesTo: [{ id: 'service-write-db' }],
+      },
+      [
+        { type: 'container', id: 'service-read-db', version: '1.0.0', children: [] },
+        { type: 'container', id: 'service-write-db', version: '1.0.0', children: [] },
+      ]
+    );
+  });
+
+  it('includes ADRs that apply to the service', async () => {
+    await writeAdr({
+      id: 'service-adr',
+      name: 'Service ADR',
+      version: '1.0.0',
+      markdown: '# Service ADR',
+      status: 'accepted',
+      date: '2026-07-20',
+      appliesTo: [{ type: 'service', id: 'root-service' }],
+    });
+
+    await expectServiceChildren({}, [{ type: 'adr', id: 'service-adr', version: '1.0.0', children: [] }]);
+  });
+
+  it('traverses all service descendants when depth is omitted', async () => {
+    const { writeChannel } = utils(CATALOG_PATH);
+    await writeChannel({ id: 'service-channel', name: 'Service Channel', version: '1.0.0', markdown: '# Service Channel' });
+    await writeEvent({
+      id: 'service-event',
+      name: 'Service Event',
+      version: '1.0.0',
+      markdown: '# Service Event',
+      channels: [{ id: 'service-channel' }],
+    });
+    await writeService({
+      id: 'root-service',
+      name: 'Root Service',
+      version: '1.0.0',
+      markdown: '# Root Service',
+      sends: [{ id: 'service-event' }],
+    });
+
+    const graph = await getGraph({ type: 'service', id: 'root-service' });
+
+    expect(graph).toEqual({
+      root: {
+        type: 'service',
+        id: 'root-service',
+        version: '1.0.0',
+        children: [
+          {
+            type: 'event',
+            id: 'service-event',
+            version: '1.0.0',
+            children: [{ type: 'channel', id: 'service-channel', version: '1.0.0', children: [] }],
+          },
+        ],
+      },
+    });
+  });
+
+  it('does not create children for service metadata', async () => {
+    await expectServiceChildren(
+      {
+        externalSystem: true,
+        specifications: [{ type: 'openapi', path: 'openapi.yml' }],
+      },
+      []
+    );
+  });
+});
+
+describe('Agent graphs', () => {
+  it('includes events, commands, and queries from sends and receives', async () => {
+    await writeEvent({ id: 'agent-event', name: 'Agent Event', version: '1.0.0', markdown: '# Agent Event' });
+    await writeCommand({ id: 'agent-command', name: 'Agent Command', version: '1.0.0', markdown: '# Agent Command' });
+    await writeQuery({ id: 'agent-query', name: 'Agent Query', version: '1.0.0', markdown: '# Agent Query' });
+
+    await expectAgentChildren(
+      {
+        sends: [{ id: 'agent-event' }, { id: 'agent-query' }],
+        receives: [{ id: 'agent-command' }],
+      },
+      [
+        { type: 'event', id: 'agent-event', version: '1.0.0', children: [] },
+        { type: 'command', id: 'agent-command', version: '1.0.0', children: [] },
+        { type: 'query', id: 'agent-query', version: '1.0.0', children: [] },
+      ]
+    );
+  });
+
+  it('includes flows', async () => {
+    await writeFlow({ id: 'agent-flow', name: 'Agent Flow', version: '1.0.0', markdown: '# Agent Flow', steps: [] });
+
+    await expectAgentChildren({ flows: [{ id: 'agent-flow' }] }, [
+      { type: 'flow', id: 'agent-flow', version: '1.0.0', children: [] },
+    ]);
+  });
+
+  it('includes containers from writesTo and readsFrom', async () => {
+    await writeDataStore({
+      id: 'agent-read-db',
+      name: 'Agent Read Database',
+      version: '1.0.0',
+      markdown: '# Agent Read Database',
+      container_type: 'database',
+    });
+    await writeDataStore({
+      id: 'agent-write-db',
+      name: 'Agent Write Database',
+      version: '1.0.0',
+      markdown: '# Agent Write Database',
+      container_type: 'database',
+    });
+
+    await expectAgentChildren(
+      {
+        readsFrom: [{ id: 'agent-read-db' }],
+        writesTo: [{ id: 'agent-write-db' }],
+      },
+      [
+        { type: 'container', id: 'agent-read-db', version: '1.0.0', children: [] },
+        { type: 'container', id: 'agent-write-db', version: '1.0.0', children: [] },
+      ]
+    );
+  });
+
+  it('includes ADRs that apply to the agent', async () => {
+    await writeAdr({
+      id: 'agent-adr',
+      name: 'Agent ADR',
+      version: '1.0.0',
+      markdown: '# Agent ADR',
+      status: 'accepted',
+      date: '2026-07-20',
+      appliesTo: [{ type: 'agent', id: 'root-agent' }],
+    });
+
+    await expectAgentChildren({}, [{ type: 'adr', id: 'agent-adr', version: '1.0.0', children: [] }]);
+  });
+
+  it('does not create children for model and tool metadata', async () => {
+    await expectAgentChildren(
+      {
+        model: { provider: 'openai', name: 'gpt' },
+        tools: [{ name: 'search', type: 'mcp' }],
+      },
+      []
+    );
+  });
+});

--- a/packages/sdk/src/test/graph.test.ts
+++ b/packages/sdk/src/test/graph.test.ts
@@ -1,0 +1,904 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import utils from '../index';
+import type { CatalogGraphNode } from '../types';
+
+const CATALOG_PATH = path.join(__dirname, 'catalog-graph');
+
+const {
+  getGraph,
+  versionDomain,
+  writeAdr,
+  writeAgent,
+  writeChannel,
+  writeCommand,
+  writeDataProduct,
+  writeDataStore,
+  writeDomain,
+  writeEntity,
+  writeEvent,
+  writeFlow,
+  writeQuery,
+  writeService,
+  writeSystem,
+} = utils(CATALOG_PATH);
+
+beforeEach(() => {
+  fs.rmSync(CATALOG_PATH, { recursive: true, force: true });
+  fs.mkdirSync(CATALOG_PATH, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(CATALOG_PATH, { recursive: true, force: true });
+});
+
+const writeCatalog = async () => {
+  await writeDomain({
+    id: 'payments',
+    name: 'Payments',
+    version: '1.0.0',
+    markdown: '# Payments v1',
+  });
+  await versionDomain('payments');
+  await writeDomain({
+    id: 'payments',
+    name: 'Payments',
+    version: '2.0.0',
+    markdown: '# Payments v2',
+    domains: [{ id: 'fraud' }],
+    systems: [{ id: 'payment-system' }],
+    entities: [{ id: 'payment' }],
+    flows: [{ id: 'payment-flow' }],
+    dataProducts: [{ id: 'payment-data-product' }],
+  });
+  await writeDomain({
+    id: 'fraud',
+    name: 'Fraud',
+    version: '1.0.0',
+    markdown: '# Fraud',
+    agents: [{ id: 'fraud-agent' }],
+  });
+  await writeSystem({
+    id: 'payment-system',
+    name: 'Payment System',
+    version: '1.0.0',
+    markdown: '# Payment System',
+    services: [{ id: 'payment-service' }],
+    flows: [{ id: 'payment-flow' }],
+    entities: [{ id: 'payment' }],
+    containers: [{ id: 'payment-db' }],
+  });
+  await writeService({
+    id: 'payment-service',
+    name: 'Payment Service',
+    version: '1.0.0',
+    markdown: '# Payment Service',
+    sends: [{ id: 'payment-created', version: '1.0.0' }],
+    receives: [{ id: 'request-payment', version: '1.0.0' }],
+    writesTo: [{ id: 'payment-db' }],
+  });
+  await writeAgent({
+    id: 'fraud-agent',
+    name: 'Fraud Agent',
+    version: '1.0.0',
+    markdown: '# Fraud Agent',
+    receives: [{ id: 'payment-created', version: '1.0.0' }],
+    sends: [{ id: 'get-risk', version: '1.0.0' }],
+  });
+  await writeEvent({
+    id: 'payment-created',
+    name: 'Payment Created',
+    version: '1.0.0',
+    markdown: '# Payment Created',
+    channels: [{ id: 'payments-topic' }],
+  });
+  await writeCommand({
+    id: 'request-payment',
+    name: 'Request Payment',
+    version: '1.0.0',
+    markdown: '# Request Payment',
+  });
+  await writeQuery({
+    id: 'get-risk',
+    name: 'Get Risk',
+    version: '1.0.0',
+    markdown: '# Get Risk',
+  });
+  await writeChannel({
+    id: 'payments-topic',
+    name: 'Payments Topic',
+    version: '1.0.0',
+    markdown: '# Payments Topic',
+  });
+  await writeEntity({
+    id: 'payment',
+    name: 'Payment',
+    version: '1.0.0',
+    markdown: '# Payment',
+  });
+  await writeDataStore({
+    id: 'payment-db',
+    name: 'Payment Database',
+    version: '1.0.0',
+    markdown: '# Payment Database',
+    container_type: 'database',
+  });
+  await writeFlow({
+    id: 'payment-flow',
+    name: 'Payment Flow',
+    version: '1.0.0',
+    markdown: '# Payment Flow',
+    steps: [],
+  });
+  await writeDataProduct({
+    id: 'payment-data-product',
+    name: 'Payment Data Product',
+    version: '1.0.0',
+    markdown: '# Payment Data Product',
+    inputs: [{ id: 'payment-created' }],
+    outputs: [{ id: 'payment-db' }],
+  });
+  await writeAdr({
+    id: 'payments-adr',
+    name: 'Payments ADR',
+    version: '1.0.0',
+    markdown: '# Payments ADR',
+    status: 'accepted',
+    date: '2026-07-15',
+    appliesTo: [{ type: 'service', id: 'payment-service' }],
+  });
+
+  await writeDomain({
+    id: 'ordering',
+    name: 'Ordering',
+    version: '1.0.0',
+    markdown: '# Ordering',
+    services: [{ id: 'ordering-service' }],
+  });
+  await writeService({
+    id: 'ordering-service',
+    name: 'Ordering Service',
+    version: '1.0.0',
+    markdown: '# Ordering Service',
+    receives: [{ id: 'payment-created' }],
+  });
+  await writeAdr({
+    id: 'ordering-adr',
+    name: 'Ordering ADR',
+    version: '1.0.0',
+    markdown: '# Ordering ADR',
+    status: 'accepted',
+    date: '2026-07-15',
+    appliesTo: [{ type: 'service', id: 'ordering-service' }],
+  });
+};
+
+const expectDomainChildren = async (relationships: Partial<Parameters<typeof writeDomain>[0]>, children: CatalogGraphNode[]) => {
+  await writeDomain({
+    id: 'root-domain',
+    name: 'Root Domain',
+    version: '1.0.0',
+    markdown: '# Root Domain',
+    ...relationships,
+  });
+
+  const graph = await getGraph({ type: 'domain', id: 'root-domain' }, { depth: 1 });
+
+  expect(graph).toEqual({
+    root: {
+      type: 'domain',
+      id: 'root-domain',
+      version: '1.0.0',
+      children,
+    },
+  });
+};
+
+const expectSystemChildren = async (relationships: Partial<Parameters<typeof writeSystem>[0]>, children: CatalogGraphNode[]) => {
+  await writeSystem({
+    id: 'root-system',
+    name: 'Root System',
+    version: '1.0.0',
+    markdown: '# Root System',
+    ...relationships,
+  });
+
+  const graph = await getGraph({ type: 'system', id: 'root-system' }, { depth: 1 });
+
+  expect(graph).toEqual({
+    root: {
+      type: 'system',
+      id: 'root-system',
+      version: '1.0.0',
+      children,
+    },
+  });
+};
+
+describe('Graph SDK', () => {
+  describe('Domain graphs', () => {
+    it('includes subdomains', async () => {
+      await writeDomain({
+        id: 'child-domain',
+        name: 'Child Domain',
+        version: '1.0.0',
+        markdown: '# Child Domain',
+      });
+
+      await expectDomainChildren({ domains: [{ id: 'child-domain' }] }, [
+        { type: 'domain', id: 'child-domain', version: '1.0.0', children: [] },
+      ]);
+    });
+
+    it('includes systems', async () => {
+      await writeSystem({
+        id: 'domain-system',
+        name: 'Domain System',
+        version: '1.0.0',
+        markdown: '# Domain System',
+      });
+
+      await expectDomainChildren({ systems: [{ id: 'domain-system' }] }, [
+        { type: 'system', id: 'domain-system', version: '1.0.0', children: [] },
+      ]);
+    });
+
+    it('includes services', async () => {
+      await writeService({
+        id: 'domain-service',
+        name: 'Domain Service',
+        version: '1.0.0',
+        markdown: '# Domain Service',
+      });
+
+      await expectDomainChildren({ services: [{ id: 'domain-service' }] }, [
+        { type: 'service', id: 'domain-service', version: '1.0.0', children: [] },
+      ]);
+    });
+
+    it('includes agents', async () => {
+      await writeAgent({
+        id: 'domain-agent',
+        name: 'Domain Agent',
+        version: '1.0.0',
+        markdown: '# Domain Agent',
+      });
+
+      await expectDomainChildren({ agents: [{ id: 'domain-agent' }] }, [
+        { type: 'agent', id: 'domain-agent', version: '1.0.0', children: [] },
+      ]);
+    });
+
+    it('includes entities', async () => {
+      await writeEntity({
+        id: 'domain-entity',
+        name: 'Domain Entity',
+        version: '1.0.0',
+        markdown: '# Domain Entity',
+      });
+
+      await expectDomainChildren({ entities: [{ id: 'domain-entity' }] }, [
+        { type: 'entity', id: 'domain-entity', version: '1.0.0', children: [] },
+      ]);
+    });
+
+    it('includes data products', async () => {
+      await writeDataProduct({
+        id: 'domain-data-product',
+        name: 'Domain Data Product',
+        version: '1.0.0',
+        markdown: '# Domain Data Product',
+      });
+
+      await expectDomainChildren({ dataProducts: [{ id: 'domain-data-product' }] }, [
+        { type: 'data-product', id: 'domain-data-product', version: '1.0.0', children: [] },
+      ]);
+    });
+
+    it('includes flows', async () => {
+      await writeFlow({
+        id: 'domain-flow',
+        name: 'Domain Flow',
+        version: '1.0.0',
+        markdown: '# Domain Flow',
+        steps: [],
+      });
+
+      await expectDomainChildren({ flows: [{ id: 'domain-flow' }] }, [
+        { type: 'flow', id: 'domain-flow', version: '1.0.0', children: [] },
+      ]);
+    });
+
+    it('includes events, commands, and queries from sends and receives', async () => {
+      await writeEvent({
+        id: 'domain-event',
+        name: 'Domain Event',
+        version: '1.0.0',
+        markdown: '# Domain Event',
+      });
+      await writeCommand({
+        id: 'domain-command',
+        name: 'Domain Command',
+        version: '1.0.0',
+        markdown: '# Domain Command',
+      });
+      await writeQuery({
+        id: 'domain-query',
+        name: 'Domain Query',
+        version: '1.0.0',
+        markdown: '# Domain Query',
+      });
+
+      await expectDomainChildren(
+        {
+          sends: [{ id: 'domain-event' }, { id: 'domain-query' }],
+          receives: [{ id: 'domain-command' }],
+        },
+        [
+          { type: 'event', id: 'domain-event', version: '1.0.0', children: [] },
+          { type: 'command', id: 'domain-command', version: '1.0.0', children: [] },
+          { type: 'query', id: 'domain-query', version: '1.0.0', children: [] },
+        ]
+      );
+    });
+
+    it('includes ADRs that apply to the domain', async () => {
+      await writeAdr({
+        id: 'domain-adr',
+        name: 'Domain ADR',
+        version: '1.0.0',
+        markdown: '# Domain ADR',
+        status: 'accepted',
+        date: '2026-07-20',
+        appliesTo: [{ type: 'domain', id: 'root-domain' }],
+      });
+
+      await expectDomainChildren({}, [{ type: 'adr', id: 'domain-adr', version: '1.0.0', children: [] }]);
+    });
+
+    it('traverses the complete reachable domain graph when depth is omitted', async () => {
+      await writeDomain({
+        id: 'level-three',
+        name: 'Level Three',
+        version: '1.0.0',
+        markdown: '# Level Three',
+      });
+      await writeDomain({
+        id: 'level-two',
+        name: 'Level Two',
+        version: '1.0.0',
+        markdown: '# Level Two',
+        domains: [{ id: 'level-three' }],
+      });
+      await writeDomain({
+        id: 'level-one',
+        name: 'Level One',
+        version: '1.0.0',
+        markdown: '# Level One',
+        domains: [{ id: 'level-two' }],
+      });
+
+      const graph = await getGraph({ type: 'domain', id: 'level-one' });
+
+      expect(graph).toEqual({
+        root: {
+          type: 'domain',
+          id: 'level-one',
+          version: '1.0.0',
+          children: [
+            {
+              type: 'domain',
+              id: 'level-two',
+              version: '1.0.0',
+              children: [{ type: 'domain', id: 'level-three', version: '1.0.0', children: [] }],
+            },
+          ],
+        },
+      });
+    });
+
+    it('stops after one relationship level when depth is one', async () => {
+      await writeDomain({
+        id: 'level-two',
+        name: 'Level Two',
+        version: '1.0.0',
+        markdown: '# Level Two',
+      });
+      await writeDomain({
+        id: 'level-one',
+        name: 'Level One',
+        version: '1.0.0',
+        markdown: '# Level One',
+        domains: [{ id: 'level-two' }],
+      });
+
+      const graph = await getGraph({ type: 'domain', id: 'level-one' }, { depth: 1 });
+
+      expect(graph).toEqual({
+        root: {
+          type: 'domain',
+          id: 'level-one',
+          version: '1.0.0',
+          children: [{ type: 'domain', id: 'level-two', version: '1.0.0', children: [] }],
+        },
+      });
+    });
+
+    it('stops after two relationship levels when depth is two', async () => {
+      await writeDomain({
+        id: 'level-three',
+        name: 'Level Three',
+        version: '1.0.0',
+        markdown: '# Level Three',
+      });
+      await writeDomain({
+        id: 'level-two',
+        name: 'Level Two',
+        version: '1.0.0',
+        markdown: '# Level Two',
+        domains: [{ id: 'level-three' }],
+      });
+      await writeDomain({
+        id: 'level-one',
+        name: 'Level One',
+        version: '1.0.0',
+        markdown: '# Level One',
+        domains: [{ id: 'level-two' }],
+      });
+
+      const graph = await getGraph({ type: 'domain', id: 'level-one' }, { depth: 2 });
+
+      expect(graph).toEqual({
+        root: {
+          type: 'domain',
+          id: 'level-one',
+          version: '1.0.0',
+          children: [
+            {
+              type: 'domain',
+              id: 'level-two',
+              version: '1.0.0',
+              children: [{ type: 'domain', id: 'level-three', version: '1.0.0', children: [] }],
+            },
+          ],
+        },
+      });
+    });
+  });
+
+  describe('System graphs', () => {
+    it('includes related systems', async () => {
+      await writeSystem({
+        id: 'related-system',
+        name: 'Related System',
+        version: '1.0.0',
+        markdown: '# Related System',
+      });
+
+      await expectSystemChildren({ relationships: [{ id: 'related-system' }] }, [
+        { type: 'system', id: 'related-system', version: '1.0.0', children: [] },
+      ]);
+    });
+
+    it('includes services', async () => {
+      await writeService({
+        id: 'system-service',
+        name: 'System Service',
+        version: '1.0.0',
+        markdown: '# System Service',
+      });
+
+      await expectSystemChildren({ services: [{ id: 'system-service' }] }, [
+        { type: 'service', id: 'system-service', version: '1.0.0', children: [] },
+      ]);
+    });
+
+    it('includes flows', async () => {
+      await writeFlow({
+        id: 'system-flow',
+        name: 'System Flow',
+        version: '1.0.0',
+        markdown: '# System Flow',
+        steps: [],
+      });
+
+      await expectSystemChildren({ flows: [{ id: 'system-flow' }] }, [
+        { type: 'flow', id: 'system-flow', version: '1.0.0', children: [] },
+      ]);
+    });
+
+    it('includes entities', async () => {
+      await writeEntity({
+        id: 'system-entity',
+        name: 'System Entity',
+        version: '1.0.0',
+        markdown: '# System Entity',
+      });
+
+      await expectSystemChildren({ entities: [{ id: 'system-entity' }] }, [
+        { type: 'entity', id: 'system-entity', version: '1.0.0', children: [] },
+      ]);
+    });
+
+    it('includes containers', async () => {
+      await writeDataStore({
+        id: 'system-container',
+        name: 'System Container',
+        version: '1.0.0',
+        markdown: '# System Container',
+        container_type: 'database',
+      });
+
+      await expectSystemChildren({ containers: [{ id: 'system-container' }] }, [
+        { type: 'container', id: 'system-container', version: '1.0.0', children: [] },
+      ]);
+    });
+
+    it('includes ADRs that apply to the system', async () => {
+      await writeAdr({
+        id: 'system-adr',
+        name: 'System ADR',
+        version: '1.0.0',
+        markdown: '# System ADR',
+        status: 'accepted',
+        date: '2026-07-20',
+        appliesTo: [{ type: 'system', id: 'root-system' }],
+      });
+
+      await expectSystemChildren({}, [{ type: 'adr', id: 'system-adr', version: '1.0.0', children: [] }]);
+    });
+
+    it('does not include actors because they are not catalog resources', async () => {
+      await expectSystemChildren(
+        {
+          actors: [{ id: 'customer', name: 'Customer', direction: 'inbound' }],
+        },
+        []
+      );
+    });
+
+    it('traverses the complete reachable system graph when depth is omitted', async () => {
+      await writeChannel({
+        id: 'system-channel',
+        name: 'System Channel',
+        version: '1.0.0',
+        markdown: '# System Channel',
+      });
+      await writeEvent({
+        id: 'system-event',
+        name: 'System Event',
+        version: '1.0.0',
+        markdown: '# System Event',
+        channels: [{ id: 'system-channel' }],
+      });
+      await writeService({
+        id: 'system-service',
+        name: 'System Service',
+        version: '1.0.0',
+        markdown: '# System Service',
+        sends: [{ id: 'system-event' }],
+      });
+      await writeSystem({
+        id: 'root-system',
+        name: 'Root System',
+        version: '1.0.0',
+        markdown: '# Root System',
+        services: [{ id: 'system-service' }],
+      });
+
+      const graph = await getGraph({ type: 'system', id: 'root-system' });
+
+      expect(graph).toEqual({
+        root: {
+          type: 'system',
+          id: 'root-system',
+          version: '1.0.0',
+          children: [
+            {
+              type: 'service',
+              id: 'system-service',
+              version: '1.0.0',
+              children: [
+                {
+                  type: 'event',
+                  id: 'system-event',
+                  version: '1.0.0',
+                  children: [{ type: 'channel', id: 'system-channel', version: '1.0.0', children: [] }],
+                },
+              ],
+            },
+          ],
+        },
+      });
+    });
+
+    it('stops after one relationship level when depth is one', async () => {
+      await writeEvent({
+        id: 'system-event',
+        name: 'System Event',
+        version: '1.0.0',
+        markdown: '# System Event',
+      });
+      await writeService({
+        id: 'system-service',
+        name: 'System Service',
+        version: '1.0.0',
+        markdown: '# System Service',
+        sends: [{ id: 'system-event' }],
+      });
+      await writeSystem({
+        id: 'root-system',
+        name: 'Root System',
+        version: '1.0.0',
+        markdown: '# Root System',
+        services: [{ id: 'system-service' }],
+      });
+
+      const graph = await getGraph({ type: 'system', id: 'root-system' }, { depth: 1 });
+
+      expect(graph).toEqual({
+        root: {
+          type: 'system',
+          id: 'root-system',
+          version: '1.0.0',
+          children: [{ type: 'service', id: 'system-service', version: '1.0.0', children: [] }],
+        },
+      });
+    });
+
+    it('stops after two relationship levels when depth is two', async () => {
+      await writeChannel({
+        id: 'system-channel',
+        name: 'System Channel',
+        version: '1.0.0',
+        markdown: '# System Channel',
+      });
+      await writeEvent({
+        id: 'system-event',
+        name: 'System Event',
+        version: '1.0.0',
+        markdown: '# System Event',
+        channels: [{ id: 'system-channel' }],
+      });
+      await writeService({
+        id: 'system-service',
+        name: 'System Service',
+        version: '1.0.0',
+        markdown: '# System Service',
+        sends: [{ id: 'system-event' }],
+      });
+      await writeSystem({
+        id: 'root-system',
+        name: 'Root System',
+        version: '1.0.0',
+        markdown: '# Root System',
+        services: [{ id: 'system-service' }],
+      });
+
+      const graph = await getGraph({ type: 'system', id: 'root-system' }, { depth: 2 });
+
+      expect(graph).toEqual({
+        root: {
+          type: 'system',
+          id: 'root-system',
+          version: '1.0.0',
+          children: [
+            {
+              type: 'service',
+              id: 'system-service',
+              version: '1.0.0',
+              children: [{ type: 'event', id: 'system-event', version: '1.0.0', children: [] }],
+            },
+          ],
+        },
+      });
+    });
+  });
+
+  it('when depth is one, the latest resource and one level of children are returned as a nested graph', async () => {
+    await writeCatalog();
+
+    const graph = await getGraph({ type: 'domain', id: 'payments' }, { depth: 1 });
+
+    expect(graph).toEqual({
+      root: {
+        type: 'domain',
+        id: 'payments',
+        version: '2.0.0',
+        children: [
+          { type: 'domain', id: 'fraud', version: '1.0.0', children: [] },
+          { type: 'system', id: 'payment-system', version: '1.0.0', children: [] },
+          { type: 'entity', id: 'payment', version: '1.0.0', children: [] },
+          { type: 'data-product', id: 'payment-data-product', version: '1.0.0', children: [] },
+          { type: 'flow', id: 'payment-flow', version: '1.0.0', children: [] },
+        ],
+      },
+    });
+  });
+
+  it('when depth is increased, the children of children are traversed', async () => {
+    await writeCatalog();
+
+    const graph = await getGraph({ type: 'domain', id: 'payments' }, { depth: 2 });
+
+    expect(graph).toEqual({
+      root: {
+        type: 'domain',
+        id: 'payments',
+        version: '2.0.0',
+        children: [
+          {
+            type: 'domain',
+            id: 'fraud',
+            version: '1.0.0',
+            children: [{ type: 'agent', id: 'fraud-agent', version: '1.0.0', children: [] }],
+          },
+          {
+            type: 'system',
+            id: 'payment-system',
+            version: '1.0.0',
+            children: [
+              { type: 'service', id: 'payment-service', version: '1.0.0', children: [] },
+              { type: 'entity', id: 'payment', version: '1.0.0', children: [] },
+              { type: 'container', id: 'payment-db', version: '1.0.0', children: [] },
+              { type: 'flow', id: 'payment-flow', version: '1.0.0', children: [] },
+            ],
+          },
+          { type: 'entity', id: 'payment', version: '1.0.0', children: [] },
+          {
+            type: 'data-product',
+            id: 'payment-data-product',
+            version: '1.0.0',
+            children: [
+              { type: 'event', id: 'payment-created', version: '1.0.0', children: [] },
+              { type: 'container', id: 'payment-db', version: '1.0.0', children: [] },
+            ],
+          },
+          { type: 'flow', id: 'payment-flow', version: '1.0.0', children: [] },
+        ],
+      },
+    });
+  });
+
+  it('when flat is true, all resources within the requested depth are returned once', async () => {
+    await writeCatalog();
+
+    const graph = await getGraph({ type: 'domain', id: 'payments' }, { depth: 3, flat: true });
+
+    expect(graph).toEqual({
+      root: { type: 'domain', id: 'payments', version: '2.0.0' },
+      resources: [
+        { type: 'domain', id: 'payments', version: '2.0.0' },
+        { type: 'domain', id: 'fraud', version: '1.0.0' },
+        { type: 'system', id: 'payment-system', version: '1.0.0' },
+        { type: 'service', id: 'payment-service', version: '1.0.0' },
+        { type: 'agent', id: 'fraud-agent', version: '1.0.0' },
+        { type: 'event', id: 'payment-created', version: '1.0.0' },
+        { type: 'command', id: 'request-payment', version: '1.0.0' },
+        { type: 'query', id: 'get-risk', version: '1.0.0' },
+        { type: 'channel', id: 'payments-topic', version: '1.0.0' },
+        { type: 'entity', id: 'payment', version: '1.0.0' },
+        { type: 'container', id: 'payment-db', version: '1.0.0' },
+        { type: 'data-product', id: 'payment-data-product', version: '1.0.0' },
+        { type: 'flow', id: 'payment-flow', version: '1.0.0' },
+        { type: 'adr', id: 'payments-adr', version: '1.0.0' },
+      ],
+    });
+  });
+
+  it('when a flat graph has many converging paths, each reachable resource is expanded once', async () => {
+    const layerCount = 14;
+
+    for (let layer = layerCount; layer >= 1; layer--) {
+      const children = layer === layerCount ? [] : [{ id: `domain-${layer + 1}-a` }, { id: `domain-${layer + 1}-b` }];
+
+      await writeDomain({
+        id: `domain-${layer}-a`,
+        name: `Domain ${layer} A`,
+        version: '1.0.0',
+        markdown: `# Domain ${layer} A`,
+        domains: children,
+      });
+      await writeDomain({
+        id: `domain-${layer}-b`,
+        name: `Domain ${layer} B`,
+        version: '1.0.0',
+        markdown: `# Domain ${layer} B`,
+        domains: children,
+      });
+    }
+
+    await writeDomain({
+      id: 'root-domain',
+      name: 'Root Domain',
+      version: '1.0.0',
+      markdown: '# Root Domain',
+      domains: [{ id: 'domain-1-a' }, { id: 'domain-1-b' }],
+    });
+
+    const graph = await getGraph({ type: 'domain', id: 'root-domain' }, { flat: true });
+
+    expect(graph?.resources).toHaveLength(1 + layerCount * 2);
+    expect(new Set(graph?.resources.map((resource) => `${resource.type}:${resource.id}:${resource.version}`)).size).toBe(
+      1 + layerCount * 2
+    );
+  });
+
+  it('when depth is zero, only the requested version of the root is returned', async () => {
+    await writeCatalog();
+
+    const graph = await getGraph({ type: 'domain', id: 'payments', version: '1.0.0' }, { depth: 0 });
+
+    expect(graph).toEqual({
+      root: { type: 'domain', id: 'payments', version: '1.0.0', children: [] },
+    });
+  });
+
+  it('when a non-domain resource is the root, its relationships are traversed', async () => {
+    await writeCatalog();
+
+    const graph = await getGraph({ type: 'service', id: 'payment-service' }, { depth: 1 });
+
+    expect(graph).toEqual({
+      root: {
+        type: 'service',
+        id: 'payment-service',
+        version: '1.0.0',
+        children: [
+          { type: 'event', id: 'payment-created', version: '1.0.0', children: [] },
+          { type: 'command', id: 'request-payment', version: '1.0.0', children: [] },
+          { type: 'container', id: 'payment-db', version: '1.0.0', children: [] },
+          { type: 'adr', id: 'payments-adr', version: '1.0.0', children: [] },
+        ],
+      },
+    });
+  });
+
+  it('when resources contain circular references, traversal stops at the cycle', async () => {
+    await writeDomain({
+      id: 'domain-a',
+      name: 'Domain A',
+      version: '1.0.0',
+      markdown: '# Domain A',
+      domains: [{ id: 'domain-b' }],
+    });
+    await writeDomain({
+      id: 'domain-b',
+      name: 'Domain B',
+      version: '1.0.0',
+      markdown: '# Domain B',
+      domains: [{ id: 'domain-a' }],
+    });
+
+    const graph = await getGraph({ type: 'domain', id: 'domain-a' }, { depth: 3 });
+
+    expect(graph).toEqual({
+      root: {
+        type: 'domain',
+        id: 'domain-a',
+        version: '1.0.0',
+        children: [
+          {
+            type: 'domain',
+            id: 'domain-b',
+            version: '1.0.0',
+            children: [{ type: 'domain', id: 'domain-a', version: '1.0.0', children: [] }],
+          },
+        ],
+      },
+    });
+  });
+
+  it('when depth is invalid, an error is thrown', async () => {
+    await expect(getGraph({ type: 'domain', id: 'payments' }, { depth: -1 })).rejects.toThrowError(
+      'Graph depth must be a non-negative integer'
+    );
+  });
+
+  it('when the requested graph root does not exist, undefined is returned', async () => {
+    const graph = await getGraph({ type: 'domain', id: 'missing-domain' });
+
+    expect(graph).toEqual(undefined);
+  });
+});

--- a/packages/sdk/src/types.d.ts
+++ b/packages/sdk/src/types.d.ts
@@ -52,6 +52,61 @@ export type ResourcePointer = {
   type?: string;
 };
 
+export type CatalogGraphResourceType =
+  | 'domain'
+  | 'system'
+  | 'service'
+  | 'agent'
+  | 'event'
+  | 'command'
+  | 'query'
+  | 'flow'
+  | 'channel'
+  | 'entity'
+  | 'container'
+  | 'data-product'
+  | 'adr';
+
+export type CatalogGraphRoot = {
+  type: CatalogGraphResourceType;
+  id: string;
+  version?: string;
+};
+
+export type CatalogGraphOptions = {
+  /** Number of relationship levels to traverse. Defaults to the complete reachable graph. */
+  depth?: number;
+  /** Return one deduplicated resource list instead of nested children. */
+  flat?: boolean;
+};
+
+export type CatalogGraphResource = {
+  type: CatalogGraphResourceType;
+  id: string;
+  version: string;
+};
+
+export type CatalogGraphNode = CatalogGraphResource & {
+  children: CatalogGraphNode[];
+};
+
+export type NestedCatalogGraph = {
+  root: CatalogGraphNode;
+};
+
+export type FlatCatalogGraph = {
+  root: CatalogGraphResource;
+  resources: CatalogGraphResource[];
+};
+
+export type CatalogGraph = NestedCatalogGraph | FlatCatalogGraph;
+
+export interface GetCatalogGraph {
+  (root: CatalogGraphRoot, options: CatalogGraphOptions & { flat: true }): Promise<FlatCatalogGraph | undefined>;
+  (root: CatalogGraphRoot, options?: CatalogGraphOptions & { flat?: false }): Promise<NestedCatalogGraph | undefined>;
+  (root: CatalogGraphRoot, options: CatalogGraphOptions): Promise<CatalogGraph | undefined>;
+}
+
 export type SystemScope = 'internal' | 'external';
 
 export type SystemRelationshipPointer = {


### PR DESCRIPTION
## What This PR Does

Adds a new `getGraph` API to `@eventcatalog/sdk` that returns the resources reachable from any catalog resource. Given a root (a domain, service, event, flow, etc.), it traverses the catalog's relationships and returns either a nested tree of children or a flat, deduplicated resource list. This gives consumers a single call to answer "what does this resource connect to?" across the whole catalog.

## Changes Overview

### Key Changes
- New `packages/sdk/src/graph.ts` implementing the traversal engine (473 lines)
- `getGraph` exposed on the SDK's default export in `packages/sdk/src/index.ts`
- New graph types in `packages/sdk/src/types.d.ts`: `CatalogGraphRoot`, `CatalogGraphOptions`, `CatalogGraphNode`, `NestedCatalogGraph`, `FlatCatalogGraph`, and the `GetCatalogGraph` overloaded signature
- 1,833 lines of tests across four new test files covering core traversal, services/agents, messages/channels, and data products/flows/ADRs
- Changeset for a patch release of `@eventcatalog/sdk`

## How It Works

- **Supported resource types**: domains, systems, services, agents, events, commands, queries, flows, channels, entities, containers (data stores), data products, and ADRs. Plural aliases (e.g. `services`) are normalized to their singular form.
- **Version resolution**: a root or pointer version can be exact, a semver range (resolved with `maxSatisfying`), `latest`, or omitted (defaults to latest).
- **Options**: `depth` limits how many relationship levels are traversed (depth 0 is just the root; omitted means the full reachable graph). `flat: true` returns `{ root, resources }` with one deduplicated, stably sorted list instead of a nested tree. TypeScript overloads narrow the return type based on the `flat` option.
- **Performance**: collection reads are cached per type (with separate latest-only and all-versions indexes that share resource objects to avoid retaining duplicate markdown data), adjacency lookups are memoized, and nested traversal runs with a concurrency limit of 16. Cycles are handled via ancestor-path tracking so recursive relationships terminate.
- Returns `undefined` when the root resource does not exist.

## Breaking Changes

None. This is a purely additive API.

## Additional Notes

- The changeset is a `patch` bump per the release hint.
- No changes are needed in the editor repository (`eventcatalog/eventcatalog-editor`) — this is an additive SDK API with no editor-facing surface.