### PR TITLE
Scoped MCP servers for domains and systems

### DIFF
--- a/.changeset/calm-mcp-control.md
+++ b/.changeset/calm-mcp-control.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": minor
+---
+
+Add scoped MCP servers for domains and systems, with an `mcp.enabled` configuration option to disable the built-in server.

--- a/examples/default/eventcatalog.config.js
+++ b/examples/default/eventcatalog.config.js
@@ -18,6 +18,8 @@ export default {
     text: "Acme Inc",
   },
 
+  output: 'server',
+
   base: "/",
   trailingSlash: false,
 

--- a/packages/core/docs/development/ask-your-architecture/03-mcp-server/getting-started.md
+++ b/packages/core/docs/development/ask-your-architecture/03-mcp-server/getting-started.md
@@ -31,6 +31,18 @@ For local development:
 http://localhost:3000/docs/mcp/
 ```
 
+The MCP server is enabled by default when EventCatalog is running in server mode with a Scale license. To disable it, set
+`mcp.enabled` to `false`:
+
+```js title="eventcatalog.config.js"
+module.exports = {
+  output: 'server',
+  mcp: {
+    enabled: false,
+  },
+};
+```
+
 ### Verify the server
 
 Visit the endpoint in your browser to verify. It returns available tools and resources:
@@ -281,7 +293,6 @@ This starts the MCP Server over HTTP on port 3000 with root path `/mcp`.
 See [instructions on the GitHub repository](https://github.com/event-catalog/mcp-server/blob/main/README.Docker.md).
 
 </details>
-
 
 
 

--- a/packages/core/eventcatalog/src/components/CopyAsMarkdown.tsx
+++ b/packages/core/eventcatalog/src/components/CopyAsMarkdown.tsx
@@ -1,8 +1,11 @@
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import { Copy, FileText, Sparkles, ChevronDownIcon, ExternalLink, PenSquareIcon, RssIcon } from 'lucide-react';
-import React, { useState, isValidElement } from 'react';
+import React, { Suspense, isValidElement, lazy, useState } from 'react';
 import type { Schema } from '@utils/collections/schemas';
 import { buildUrl, toMarkdownUrl } from '@utils/url-builder';
+import McpIcon from './McpIcon';
+
+const McpConnectDialog = lazy(() => import('./McpConnectDialog'));
 
 // Type allows either a component type (like Lucide icon) or a pre-rendered element (like <img>)
 type IconInput = React.ElementType | React.ReactElement;
@@ -56,6 +59,9 @@ export function CopyPageMenu({
   preferChatAsDefault = false,
   chatButtonText = 'Ask',
   variant = 'menu',
+  mcpServerUrl,
+  resourceName,
+  mcpResourceType,
 }: {
   schemas: Schema[];
   chatQuery?: string;
@@ -66,6 +72,9 @@ export function CopyPageMenu({
   preferChatAsDefault?: boolean;
   chatButtonText?: string;
   variant?: 'menu' | 'toolbar';
+  mcpServerUrl?: string;
+  resourceName?: string;
+  mcpResourceType?: 'domain' | 'system';
 }) {
   // Define available actions
   const availableActions = {
@@ -75,6 +84,7 @@ export function CopyPageMenu({
     viewMarkdown: markdownDownloadEnabled,
     chat: chatEnabled,
     rssFeed: rssFeedEnabled,
+    mcpServer: Boolean(mcpServerUrl),
   };
 
   // Check if any actions are available
@@ -141,6 +151,13 @@ export function CopyPageMenu({
         icon: RssIcon,
       };
     }
+    if (availableActions.mcpServer) {
+      return {
+        type: 'mcpServer',
+        text: 'Connect to MCP server',
+        icon: McpIcon,
+      };
+    }
     return null;
   };
 
@@ -148,6 +165,18 @@ export function CopyPageMenu({
   const [open, setOpen] = useState(false);
   const [buttonText, setButtonText] = useState(defaultAction?.text || 'Action');
   const [copyButtonText, setCopyButtonText] = useState('Copy page as markdown');
+  const [mcpDialogOpen, setMcpDialogOpen] = useState(false);
+  const mcpDialog = mcpServerUrl && mcpDialogOpen && (
+    <Suspense fallback={null}>
+      <McpConnectDialog
+        open={mcpDialogOpen}
+        onOpenChange={setMcpDialogOpen}
+        serverUrl={mcpServerUrl}
+        resourceName={resourceName}
+        resourceType={mcpResourceType ?? 'domain'}
+      />
+    </Suspense>
+  );
 
   // Fetch the markdown from the url + .mdx
   const copyMarkdownToClipboard = async () => {
@@ -214,6 +243,9 @@ export function CopyPageMenu({
         // Dispatch custom event to open chat panel instead of navigating
         window.dispatchEvent(new CustomEvent('eventcatalog:open-chat'));
         break;
+      case 'mcpServer':
+        setMcpDialogOpen(true);
+        break;
     }
   };
 
@@ -224,6 +256,7 @@ export function CopyPageMenu({
   const actionButtonClass =
     'group inline-flex items-center gap-1.5 whitespace-nowrap text-xs font-medium text-[rgb(var(--ec-page-text-muted))] transition-colors duration-150 hover:text-[rgb(var(--ec-page-text))] focus:outline-hidden focus:ring-2 focus:ring-[rgb(var(--ec-accent))] focus:ring-offset-2 focus:ring-offset-[rgb(var(--ec-page-bg))] rounded-md';
   const actionIconClass = 'h-3.5 w-3.5 shrink-0 text-[rgb(var(--ec-icon-color))] group-hover:text-[rgb(var(--ec-page-text))]';
+  const mcpDescription = `Connect an MCP client to this ${mcpResourceType ?? 'resource'}`;
 
   const hasToolbarActions =
     availableActions.chat ||
@@ -231,12 +264,20 @@ export function CopyPageMenu({
     availableActions.viewMarkdown ||
     availableActions.copySchemas ||
     availableActions.rssFeed ||
+    availableActions.mcpServer ||
     availableActions.editPage;
 
   if (variant === 'toolbar') {
     if (!hasToolbarActions) return null;
 
-    const moreActionsAvailable = availableActions.copySchemas || availableActions.rssFeed || availableActions.editPage;
+    const showMcpToolbarAction = availableActions.mcpServer;
+    const showCopyMarkdownToolbarAction = availableActions.copyMarkdown && !showMcpToolbarAction;
+    const hasSecondaryToolbarAction = showMcpToolbarAction || showCopyMarkdownToolbarAction;
+    const moreActionsAvailable =
+      availableActions.copySchemas ||
+      availableActions.rssFeed ||
+      availableActions.editPage ||
+      (showMcpToolbarAction && availableActions.copyMarkdown);
 
     return (
       <div className="not-prose flex flex-wrap items-center gap-x-3 gap-y-1.5 text-xs text-[rgb(var(--ec-page-text-muted))]">
@@ -251,18 +292,25 @@ export function CopyPageMenu({
           </button>
         )}
 
-        {availableActions.chat && (availableActions.copyMarkdown || availableActions.viewMarkdown || moreActionsAvailable) && (
+        {availableActions.chat && (hasSecondaryToolbarAction || availableActions.viewMarkdown || moreActionsAvailable) && (
           <span className="h-4 w-px bg-[rgb(var(--ec-page-border))]" aria-hidden="true" />
         )}
 
-        {availableActions.copyMarkdown && (
+        {showMcpToolbarAction && (
+          <button type="button" onClick={() => setMcpDialogOpen(true)} className={actionButtonClass}>
+            <McpIcon className={actionIconClass} />
+            Connect to MCP server
+          </button>
+        )}
+
+        {showCopyMarkdownToolbarAction && (
           <button type="button" onClick={copyMarkdownToClipboard} className={actionButtonClass}>
             <Copy className={actionIconClass} />
             {copyButtonText}
           </button>
         )}
 
-        {availableActions.copyMarkdown && (availableActions.viewMarkdown || moreActionsAvailable) && (
+        {hasSecondaryToolbarAction && (availableActions.viewMarkdown || moreActionsAvailable) && (
           <span className="h-4 w-px bg-[rgb(var(--ec-page-border))]" aria-hidden="true" />
         )}
 
@@ -290,6 +338,15 @@ export function CopyPageMenu({
               sideOffset={10}
               align="start"
             >
+              {showMcpToolbarAction && availableActions.copyMarkdown && (
+                <DropdownMenu.Item
+                  className="cursor-pointer rounded-2xl outline-hidden transition-colors duration-150 hover:bg-[rgb(var(--ec-dropdown-hover))] data-[highlighted]:bg-[rgb(var(--ec-dropdown-hover))]"
+                  onSelect={() => copyMarkdownToClipboard()}
+                >
+                  <MenuItemContent icon={Copy} title="Copy page as markdown" description="Copy page as Markdown for LLMs" />
+                </DropdownMenu.Item>
+              )}
+
               {availableActions.copySchemas &&
                 schemas.map((schema) => {
                   const title =
@@ -348,6 +405,7 @@ export function CopyPageMenu({
             </DropdownMenu.Content>
           </DropdownMenu.Root>
         )}
+        {mcpDialog}
       </div>
     );
   }
@@ -383,6 +441,15 @@ export function CopyPageMenu({
         sideOffset={10}
         align="end"
       >
+        {availableActions.mcpServer && (
+          <DropdownMenu.Item
+            className="cursor-pointer rounded-2xl outline-hidden transition-colors duration-150 hover:bg-[rgb(var(--ec-dropdown-hover))] data-[highlighted]:bg-[rgb(var(--ec-dropdown-hover))]"
+            onSelect={() => setMcpDialogOpen(true)}
+          >
+            <MenuItemContent icon={McpIcon} title="Connect to MCP server" description={mcpDescription} />
+          </DropdownMenu.Item>
+        )}
+
         {availableActions.chat && (
           <>
             <DropdownMenu.Item
@@ -477,6 +544,7 @@ export function CopyPageMenu({
           </>
         )}
       </DropdownMenu.Content>
+      {mcpDialog}
     </DropdownMenu.Root>
   );
 }

--- a/packages/core/eventcatalog/src/components/McpConnectDialog.tsx
+++ b/packages/core/eventcatalog/src/components/McpConnectDialog.tsx
@@ -1,0 +1,98 @@
+import * as Dialog from '@radix-ui/react-dialog';
+import { Check, Copy, X } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import McpIcon from './McpIcon';
+
+type McpConnectDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  serverUrl: string;
+  resourceName?: string;
+  resourceType: 'domain' | 'system';
+};
+
+export default function McpConnectDialog({ open, onOpenChange, serverUrl, resourceName, resourceType }: McpConnectDialogProps) {
+  const [copied, setCopied] = useState(false);
+  const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const absoluteServerUrl = new URL(serverUrl, window.location.origin).href;
+
+  useEffect(
+    () => () => {
+      if (resetTimer.current) clearTimeout(resetTimer.current);
+    },
+    []
+  );
+
+  const copyServerUrl = async () => {
+    try {
+      await navigator.clipboard.writeText(absoluteServerUrl);
+      setCopied(true);
+      if (resetTimer.current) clearTimeout(resetTimer.current);
+      resetTimer.current = setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setCopied(false);
+    }
+  };
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50 data-[state=open]:animate-overlayShow" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-[100] w-[calc(100vw-2rem)] max-w-lg -translate-x-1/2 -translate-y-1/2 rounded-lg border border-[rgb(var(--ec-page-border))] bg-[rgb(var(--ec-card-bg,var(--ec-page-bg)))] p-6 shadow-xl focus:outline-hidden data-[state=open]:animate-contentShow">
+          <div className="flex items-start gap-3">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-[rgb(var(--ec-page-border))] bg-[rgb(var(--ec-content-hover))]">
+              <McpIcon className="h-5 w-5" />
+            </div>
+            <div className="min-w-0 flex-1">
+              <Dialog.Title className="text-lg font-semibold text-[rgb(var(--ec-page-text))]">Connect to MCP server</Dialog.Title>
+              <Dialog.Description className="mt-1 text-sm leading-6 text-[rgb(var(--ec-page-text-muted))]">
+                Use this URL to connect an MCP client to this {resourceType}
+                {resourceName ? `: ${resourceName}` : ''}.
+              </Dialog.Description>
+            </div>
+            <Dialog.Close asChild>
+              <button
+                type="button"
+                aria-label="Close"
+                className="rounded-md p-2 text-[rgb(var(--ec-icon-color))] transition-colors hover:bg-[rgb(var(--ec-content-hover))] hover:text-[rgb(var(--ec-page-text))] focus:outline-hidden focus:ring-2 focus:ring-[rgb(var(--ec-accent))]"
+              >
+                <X className="h-4 w-4" aria-hidden="true" />
+              </button>
+            </Dialog.Close>
+          </div>
+
+          <div className="mt-6">
+            <label htmlFor="mcp-server-url" className="text-xs font-medium text-[rgb(var(--ec-page-text-muted))]">
+              MCP server URL
+            </label>
+            <div className="mt-2 flex items-center gap-2">
+              <input
+                id="mcp-server-url"
+                type="text"
+                readOnly
+                value={absoluteServerUrl}
+                onFocus={(event) => event.currentTarget.select()}
+                className="min-w-0 flex-1 rounded-md border border-[rgb(var(--ec-page-border))] bg-[rgb(var(--ec-input-bg,var(--ec-page-bg)))] px-3 py-2.5 font-mono text-xs text-[rgb(var(--ec-page-text))] outline-hidden focus:border-[rgb(var(--ec-accent))] focus:ring-1 focus:ring-[rgb(var(--ec-accent))]"
+              />
+              <button
+                type="button"
+                onClick={copyServerUrl}
+                className="inline-flex h-10 items-center gap-2 rounded-md border border-[rgb(var(--ec-page-border))] bg-[rgb(var(--ec-card-bg,var(--ec-page-bg)))] px-3 text-sm font-medium text-[rgb(var(--ec-page-text))] transition-colors hover:bg-[rgb(var(--ec-content-hover))] focus:outline-hidden focus:ring-2 focus:ring-[rgb(var(--ec-accent))]"
+              >
+                {copied ? (
+                  <Check className="h-4 w-4 text-green-500" aria-hidden="true" />
+                ) : (
+                  <Copy className="h-4 w-4" aria-hidden="true" />
+                )}
+                {copied ? 'Copied' : 'Copy'}
+              </button>
+            </div>
+            <p className="mt-3 text-xs leading-5 text-[rgb(var(--ec-page-text-muted))]">
+              Add this remote server URL to your MCP client. Authentication may be required if it is enabled for this catalog.
+            </p>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/packages/core/eventcatalog/src/components/McpIcon.tsx
+++ b/packages/core/eventcatalog/src/components/McpIcon.tsx
@@ -1,0 +1,14 @@
+import { buildUrl } from '@utils/url-builder';
+
+export default function McpIcon({ className = 'h-4 w-4' }: { className?: string }) {
+  return (
+    <span className={`inline-flex shrink-0 ${className}`} aria-hidden="true">
+      <img src={buildUrl('/icons/protocols/mcp-light.svg', true)} alt="" className="h-full w-full object-contain dark:hidden" />
+      <img
+        src={buildUrl('/icons/protocols/mcp-dark.svg', true)}
+        alt=""
+        className="hidden h-full w-full object-contain dark:block"
+      />
+    </span>
+  );
+}

--- a/packages/core/eventcatalog/src/enterprise/__tests__/feature.spec.ts
+++ b/packages/core/eventcatalog/src/enterprise/__tests__/feature.spec.ts
@@ -1,0 +1,56 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const config = vi.hoisted(() => ({
+  output: 'server' as 'server' | 'static',
+  mcp: {} as { enabled?: boolean },
+}));
+
+vi.mock('../../../eventcatalog.config.js', () => ({ default: config }));
+
+import { isEventCatalogMCPEnabled } from '../feature';
+
+const originalScale = process.env.EVENTCATALOG_SCALE;
+
+describe('MCP feature configuration', () => {
+  beforeEach(() => {
+    process.env.EVENTCATALOG_SCALE = 'true';
+    config.output = 'server';
+    config.mcp = {};
+  });
+
+  afterAll(() => {
+    if (originalScale === undefined) {
+      delete process.env.EVENTCATALOG_SCALE;
+    } else {
+      process.env.EVENTCATALOG_SCALE = originalScale;
+    }
+  });
+
+  it('enables MCP by default in server mode with EventCatalog Scale', () => {
+    expect(isEventCatalogMCPEnabled()).toBe(true);
+  });
+
+  it('disables MCP when mcp.enabled is false', () => {
+    config.mcp.enabled = false;
+
+    expect(isEventCatalogMCPEnabled()).toBe(false);
+  });
+
+  it('enables MCP when mcp.enabled is true', () => {
+    config.mcp.enabled = true;
+
+    expect(isEventCatalogMCPEnabled()).toBe(true);
+  });
+
+  it('does not enable MCP outside server mode', () => {
+    config.output = 'static';
+
+    expect(isEventCatalogMCPEnabled()).toBe(false);
+  });
+
+  it('does not enable MCP without EventCatalog Scale', () => {
+    process.env.EVENTCATALOG_SCALE = 'false';
+
+    expect(isEventCatalogMCPEnabled()).toBe(false);
+  });
+});

--- a/packages/core/eventcatalog/src/enterprise/feature.ts
+++ b/packages/core/eventcatalog/src/enterprise/feature.ts
@@ -67,7 +67,7 @@ export const isCustomStylesEnabled = () => {
   return isEventCatalogStarterEnabled() || isEventCatalogScaleEnabled();
 };
 
-export const isEventCatalogMCPEnabled = () => isEventCatalogScaleEnabled() && isSSR();
+export const isEventCatalogMCPEnabled = () => isEventCatalogScaleEnabled() && isSSR() && (config?.mcp?.enabled ?? true);
 
 export const isEventCatalogMCPAuthEnabled = () => isEventCatalogMCPEnabled() && (config?.mcp?.auth?.enabled ?? false);
 

--- a/packages/core/eventcatalog/src/enterprise/mcp/__tests__/mcp-scope.spec.ts
+++ b/packages/core/eventcatalog/src/enterprise/mcp/__tests__/mcp-scope.spec.ts
@@ -1,0 +1,116 @@
+/**
+ * Licensed under the EventCatalog Commercial License.
+ * See /packages/core/eventcatalog/src/enterprise/LICENSE
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { MCP_SCOPE_COLLECTIONS, McpScopeNotFoundError, resolveMcpScope } from '../mcp-scope';
+
+const entry = (collection: string, id: string, version = '1.0.0', data: Record<string, any> = {}) => ({
+  id: `${id}-${version}`,
+  collection,
+  data: { id, version, name: id, ...data },
+});
+
+const collections: Record<string, any[]> = Object.fromEntries(MCP_SCOPE_COLLECTIONS.map((collection) => [collection, []]));
+
+collections.domains = [
+  entry('domains', 'payments', '1.0.0'),
+  entry('domains', 'payments', '2.0.0', {
+    domains: [{ id: 'fraud' }],
+    systems: [{ id: 'payment-system' }],
+    entities: [{ id: 'payment' }],
+  }),
+  entry('domains', 'fraud', '1.0.0', { agents: [{ id: 'fraud-agent' }] }),
+  entry('domains', 'ordering'),
+];
+collections.systems = [entry('systems', 'payment-system', '1.0.0', { services: [{ id: 'payment-service' }] })];
+collections.services = [
+  entry('services', 'payment-service', '1.0.0', {
+    sends: [{ id: 'payment-created' }],
+    writesTo: [{ id: 'payment-db' }],
+  }),
+  entry('services', 'ordering-service', '1.0.0', { receives: [{ id: 'payment-created' }] }),
+];
+collections.agents = [entry('agents', 'fraud-agent', '1.0.0', { receives: [{ id: 'payment-created' }] })];
+collections.events = [entry('events', 'payment-created', '1.0.0', { channels: [{ id: 'payments-topic' }] })];
+collections.channels = [entry('channels', 'payments-topic')];
+collections.entities = [entry('entities', 'payment')];
+collections.containers = [entry('containers', 'payment-db')];
+collections.adrs = [
+  entry('adrs', 'payments-adr', '1.0.0', { appliesTo: [{ type: 'service', id: 'payment-service' }] }),
+  entry('adrs', 'ordering-adr', '1.0.0', { appliesTo: [{ type: 'service', id: 'ordering-service' }] }),
+];
+
+const loadCollection = async (collection: (typeof MCP_SCOPE_COLLECTIONS)[number]) => collections[collection];
+
+const domainGraph = {
+  root: { type: 'domain' as const, id: 'payments', version: '2.0.0' },
+  resources: [
+    { type: 'domain' as const, id: 'payments', version: '2.0.0' },
+    { type: 'domain' as const, id: 'fraud', version: '1.0.0' },
+    { type: 'system' as const, id: 'payment-system', version: '1.0.0' },
+    { type: 'service' as const, id: 'payment-service', version: '1.0.0' },
+    { type: 'agent' as const, id: 'fraud-agent', version: '1.0.0' },
+    { type: 'event' as const, id: 'payment-created', version: '1.0.0' },
+    { type: 'channel' as const, id: 'payments-topic', version: '1.0.0' },
+    { type: 'entity' as const, id: 'payment', version: '1.0.0' },
+    { type: 'container' as const, id: 'payment-db', version: '1.0.0' },
+    { type: 'adr' as const, id: 'payments-adr', version: '1.0.0' },
+  ],
+};
+
+const systemGraph = {
+  root: { type: 'system' as const, id: 'payment-system', version: '1.0.0' },
+  resources: [
+    { type: 'system' as const, id: 'payment-system', version: '1.0.0' },
+    { type: 'service' as const, id: 'payment-service', version: '1.0.0' },
+    { type: 'event' as const, id: 'payment-created', version: '1.0.0' },
+  ],
+};
+
+const loadGraph = vi.fn(async (root: { type: string; id: string }) => {
+  if (root.id === 'missing') return undefined;
+  return root.type === 'system' ? systemGraph : domainGraph;
+});
+
+describe('resolveMcpScope', () => {
+  it('resolves the latest domain and recursively includes its contained resource graph', async () => {
+    const scope = await resolveMcpScope({ kind: 'domain', id: 'payments' }, loadCollection, loadGraph);
+
+    expect(scope.ref).toEqual({ kind: 'domain', id: 'payments', version: '2.0.0' });
+    expect(loadGraph).toHaveBeenCalledWith({ type: 'domain', id: 'payments' }, { flat: true });
+    expect(scope.has('domains', 'fraud', '1.0.0')).toBe(true);
+    expect(scope.has('systems', 'payment-system', '1.0.0')).toBe(true);
+    expect(scope.has('services', 'payment-service', '1.0.0')).toBe(true);
+    expect(scope.has('agents', 'fraud-agent', '1.0.0')).toBe(true);
+    expect(scope.has('events', 'payment-created', '1.0.0')).toBe(true);
+    expect(scope.has('channels', 'payments-topic', '1.0.0')).toBe(true);
+    expect(scope.has('containers', 'payment-db', '1.0.0')).toBe(true);
+    expect(scope.has('adrs', 'payments-adr', '1.0.0')).toBe(true);
+  });
+
+  it('does not pull in resources that are only related from outside the scope', async () => {
+    const scope = await resolveMcpScope({ kind: 'domain', id: 'payments' }, loadCollection, loadGraph);
+
+    expect(scope.has('domains', 'ordering')).toBe(false);
+    expect(scope.has('services', 'ordering-service')).toBe(false);
+    expect(scope.has('adrs', 'ordering-adr')).toBe(false);
+  });
+
+  it('supports a system as the root scope', async () => {
+    const scope = await resolveMcpScope({ kind: 'system', id: 'payment-system', version: '1.0.0' }, loadCollection, loadGraph);
+
+    expect(scope.has('systems', 'payment-system')).toBe(true);
+    expect(scope.has('services', 'payment-service')).toBe(true);
+    expect(scope.has('events', 'payment-created')).toBe(true);
+    expect(scope.has('domains', 'payments')).toBe(false);
+    expect(scope.has('agents', 'fraud-agent')).toBe(false);
+  });
+
+  it('fails cleanly when the requested scope does not exist', async () => {
+    await expect(resolveMcpScope({ kind: 'domain', id: 'missing' }, loadCollection, loadGraph)).rejects.toBeInstanceOf(
+      McpScopeNotFoundError
+    );
+  });
+});

--- a/packages/core/eventcatalog/src/enterprise/mcp/__tests__/mcp-scoped-routes.spec.ts
+++ b/packages/core/eventcatalog/src/enterprise/mcp/__tests__/mcp-scoped-routes.spec.ts
@@ -1,0 +1,168 @@
+/**
+ * Licensed under the EventCatalog Commercial License.
+ * See /packages/core/eventcatalog/src/enterprise/LICENSE
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+const domain = {
+  id: 'payments-1.0.0',
+  collection: 'domains',
+  data: { id: 'payments', version: '1.0.0', name: 'Payments', services: [{ id: 'payment-service' }] },
+};
+const system = {
+  id: 'payment-system-1.0.0',
+  collection: 'systems',
+  data: { id: 'payment-system', version: '1.0.0', name: 'Payment System', services: [{ id: 'payment-service' }] },
+};
+const service = {
+  id: 'payment-service-1.0.0',
+  collection: 'services',
+  data: { id: 'payment-service', version: '1.0.0', name: 'Payment Service' },
+};
+
+vi.mock('astro:content', () => ({
+  getCollection: vi.fn((collection: string) => {
+    if (collection === 'domains') return Promise.resolve([domain]);
+    if (collection === 'systems') return Promise.resolve([system]);
+    if (collection === 'services') return Promise.resolve([service]);
+    return Promise.resolve([]);
+  }),
+  getEntry: vi.fn(),
+}));
+
+vi.mock('@eventcatalog/sdk', () => ({
+  default: vi.fn(() => ({
+    getGraph: vi.fn((root: { type: string; id: string }) =>
+      Promise.resolve(
+        root.id === 'payments'
+          ? {
+              root: { type: 'domain', id: 'payments', version: '1.0.0' },
+              resources: [
+                { type: 'domain', id: 'payments', version: '1.0.0' },
+                { type: 'service', id: 'payment-service', version: '1.0.0' },
+              ],
+            }
+          : root.id === 'payment-system'
+            ? {
+                root: { type: 'system', id: 'payment-system', version: '1.0.0' },
+                resources: [
+                  { type: 'system', id: 'payment-system', version: '1.0.0' },
+                  { type: 'service', id: 'payment-service', version: '1.0.0' },
+                ],
+              }
+            : undefined
+      )
+    ),
+  })),
+}));
+
+vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
+  McpServer: vi.fn().mockImplementation(function () {
+    return {
+      registerTool: vi.fn(),
+      registerResource: vi.fn(),
+      connect: vi.fn(),
+    };
+  }),
+}));
+
+vi.mock('@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js', () => ({
+  WebStandardStreamableHTTPServerTransport: vi.fn().mockImplementation(function () {
+    return {
+      handleRequest: vi.fn(() => new Response(JSON.stringify({ jsonrpc: '2.0', result: {} }))),
+    };
+  }),
+}));
+
+vi.mock('../mcp-auth', () => ({
+  validateMcpRequest: vi.fn(() => Promise.resolve({ ok: true })),
+  createMcpAuthErrorResponse: vi.fn(),
+}));
+
+describe('scoped MCP routes', () => {
+  it('serves health metadata for the latest domain scope', async () => {
+    const { ALL } = await import('../mcp-server');
+    const response = await ALL({ request: new Request('http://localhost:4321/docs/mcp/domains/payments') } as any);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        name: 'EventCatalog MCP Server — Payments domain',
+        status: 'running',
+        scope: { kind: 'domain', id: 'payments', version: '1.0.0' },
+      })
+    );
+  });
+
+  it('returns 405 when an MCP client requests the unsupported SSE channel', async () => {
+    const { ALL } = await import('../mcp-server');
+    const response = await ALL({
+      request: new Request('http://localhost:4321/docs/mcp/domains/payments', {
+        headers: { Accept: 'text/event-stream' },
+      }),
+    } as any);
+
+    expect(response.status).toBe(405);
+    expect(response.headers.get('Allow')).toBe('POST');
+    await expect(response.json()).resolves.toEqual({
+      jsonrpc: '2.0',
+      error: { code: -32000, message: 'Method not allowed: this server does not provide an SSE stream.' },
+      id: null,
+    });
+  });
+
+  it('serves health metadata for the latest system scope', async () => {
+    const { ALL } = await import('../mcp-server');
+    const response = await ALL({ request: new Request('http://localhost:4321/docs/mcp/systems/payment-system') } as any);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        name: 'EventCatalog MCP Server — Payment System system',
+        status: 'running',
+        scope: { kind: 'system', id: 'payment-system', version: '1.0.0' },
+      })
+    );
+  });
+
+  it('returns 404 for an unknown domain scope', async () => {
+    const { ALL } = await import('../mcp-server');
+    const response = await ALL({ request: new Request('http://localhost:4321/docs/mcp/domains/missing') } as any);
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({ error: 'scope_not_found', message: 'Domain not found: missing (latest)' })
+    );
+  });
+
+  it('creates a scoped MCP server for protocol requests', async () => {
+    const { ALL } = await import('../mcp-server');
+    const { McpServer } = await import('@modelcontextprotocol/sdk/server/mcp.js');
+    const response = await ALL({
+      request: new Request('http://localhost:4321/docs/mcp/domains/payments/1.0.0', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} }),
+      }),
+    } as any);
+
+    expect(response.status).toBe(200);
+    expect(McpServer).toHaveBeenCalledWith({ name: 'EventCatalog MCP Server — Payments domain', version: '1.0.0' });
+  });
+
+  it('creates a system-scoped MCP server for protocol requests', async () => {
+    const { ALL } = await import('../mcp-server');
+    const { McpServer } = await import('@modelcontextprotocol/sdk/server/mcp.js');
+    const response = await ALL({
+      request: new Request('http://localhost:4321/docs/mcp/systems/payment-system/1.0.0', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} }),
+      }),
+    } as any);
+
+    expect(response.status).toBe(200);
+    expect(McpServer).toHaveBeenCalledWith({ name: 'EventCatalog MCP Server — Payment System system', version: '1.0.0' });
+  });
+});

--- a/packages/core/eventcatalog/src/enterprise/mcp/__tests__/mcp-scoped-tools.spec.ts
+++ b/packages/core/eventcatalog/src/enterprise/mcp/__tests__/mcp-scoped-tools.spec.ts
@@ -1,0 +1,75 @@
+/**
+ * Licensed under the EventCatalog Commercial License.
+ * See /packages/core/eventcatalog/src/enterprise/LICENSE
+ */
+
+import { describe, expect, it } from 'vitest';
+import { createScopedCatalogTools } from '../mcp-scoped-tools';
+import { McpScope } from '../mcp-scope';
+
+const domain = {
+  id: 'payments-1.0.0',
+  collection: 'domains',
+  data: { id: 'payments', version: '1.0.0', name: 'Payments' },
+};
+const service = {
+  id: 'payment-service-1.0.0',
+  collection: 'services',
+  data: {
+    id: 'payment-service',
+    version: '1.0.0',
+    name: 'Payment Service',
+    summary: 'Processes payments',
+    owners: ['payments-team'],
+  },
+};
+
+const createScope = () => {
+  const scope = new McpScope({ kind: 'domain', id: 'payments' }, domain);
+  scope.add(domain);
+  scope.add(service);
+  return scope;
+};
+
+describe('createScopedCatalogTools', () => {
+  it('lists only resources included in the scope', async () => {
+    const tools = createScopedCatalogTools(createScope());
+
+    await expect(tools.getResources({ collection: 'services' })).resolves.toEqual({
+      resources: [
+        {
+          id: 'payment-service',
+          version: '1.0.0',
+          name: 'Payment Service',
+          summary: 'Processes payments',
+        },
+      ],
+      nextCursor: undefined,
+      totalCount: 1,
+      scope: { kind: 'domain', id: 'payments', version: '1.0.0' },
+    });
+  });
+
+  it('fails closed before looking up a resource outside the scope', async () => {
+    const tools = createScopedCatalogTools(createScope());
+
+    await expect(tools.getResource({ collection: 'services', id: 'ordering-service', version: '1.0.0' })).resolves.toEqual({
+      error: 'Resource not found: services/ordering-service (1.0.0)',
+    });
+  });
+
+  it('searches owners only across resources in the scope', async () => {
+    const tools = createScopedCatalogTools(createScope());
+
+    const result = await tools.findResourcesByOwner({ ownerId: 'payments-team' });
+
+    expect(result.resources).toEqual([
+      {
+        collection: 'services',
+        id: 'payment-service',
+        version: '1.0.0',
+        name: 'Payment Service',
+      },
+    ]);
+  });
+});

--- a/packages/core/eventcatalog/src/enterprise/mcp/mcp-scope.ts
+++ b/packages/core/eventcatalog/src/enterprise/mcp/mcp-scope.ts
@@ -1,0 +1,159 @@
+/**
+ * Licensed under the EventCatalog Commercial License.
+ * See /packages/core/eventcatalog/src/enterprise/LICENSE
+ */
+
+import utils, { type CatalogGraphResourceType, type CatalogGraphRoot, type FlatCatalogGraph } from '@eventcatalog/sdk';
+import { getCollection } from 'astro:content';
+import { getItemsFromCollectionByIdAndSemverOrLatest } from '@utils/collections/util';
+
+export const MCP_SCOPE_COLLECTIONS = [
+  'domains',
+  'systems',
+  'services',
+  'agents',
+  'events',
+  'commands',
+  'queries',
+  'flows',
+  'channels',
+  'entities',
+  'containers',
+  'data-products',
+  'adrs',
+  'diagrams',
+] as const;
+
+export type McpScopeCollection = (typeof MCP_SCOPE_COLLECTIONS)[number];
+export type McpScopeKind = 'domain' | 'system';
+
+export type McpScopeRef = {
+  kind: McpScopeKind;
+  id: string;
+  version?: string;
+};
+
+type CatalogEntry = {
+  collection: string;
+  data: {
+    id: string;
+    version: string;
+    name?: string;
+    summary?: string;
+    hidden?: boolean;
+    [key: string]: any;
+  };
+  [key: string]: any;
+};
+
+type CollectionLoader = (collection: McpScopeCollection) => Promise<CatalogEntry[]>;
+type GraphLoader = (root: CatalogGraphRoot, options: { flat: true }) => Promise<FlatCatalogGraph | undefined>;
+
+const graphTypeToCollection: Record<CatalogGraphResourceType, McpScopeCollection> = {
+  domain: 'domains',
+  system: 'systems',
+  service: 'services',
+  agent: 'agents',
+  event: 'events',
+  command: 'commands',
+  query: 'queries',
+  flow: 'flows',
+  channel: 'channels',
+  entity: 'entities',
+  container: 'containers',
+  'data-product': 'data-products',
+  adr: 'adrs',
+};
+
+const entryKey = (id: string, version: string) => `${id}@${version}`;
+const encodeUriPart = (value: string) => encodeURIComponent(value);
+
+export class McpScopeNotFoundError extends Error {}
+
+export class McpScope {
+  readonly entries = new Map<string, Map<string, CatalogEntry>>();
+  readonly ref: Required<McpScopeRef>;
+  readonly root: CatalogEntry;
+  readonly uriPrefix: string;
+
+  constructor(ref: McpScopeRef, root: CatalogEntry) {
+    this.ref = { ...ref, version: root.data.version } as Required<McpScopeRef>;
+    this.root = root;
+    this.uriPrefix = `eventcatalog://${ref.kind}s/${encodeUriPart(root.data.id)}/${encodeUriPart(root.data.version)}`;
+  }
+
+  add(entry: CatalogEntry | undefined) {
+    if (!entry || entry.data.hidden === true) return false;
+
+    const collectionEntries = this.entries.get(entry.collection) ?? new Map<string, CatalogEntry>();
+    const key = entryKey(entry.data.id, entry.data.version);
+    if (collectionEntries.has(key)) return false;
+
+    collectionEntries.set(key, entry);
+    this.entries.set(entry.collection, collectionEntries);
+    return true;
+  }
+
+  has(collection: string, id: string, version?: string) {
+    const entries = Array.from(this.entries.get(collection)?.values() ?? []);
+    return getItemsFromCollectionByIdAndSemverOrLatest(entries, id, version).length > 0;
+  }
+
+  list(collection: string) {
+    return Array.from(this.entries.get(collection)?.values() ?? []);
+  }
+
+  listAll() {
+    return Array.from(this.entries.values()).flatMap((entries) => Array.from(entries.values()));
+  }
+
+  get name() {
+    return this.root.data.name || this.root.data.id;
+  }
+}
+
+const defaultCollectionLoader: CollectionLoader = async (collection) => getCollection(collection as any) as any;
+const catalogDirectory = process.env.PROJECT_DIR || process.cwd();
+const getCatalogGraph = utils(catalogDirectory).getGraph;
+const defaultGraphLoader: GraphLoader = (root, options) => getCatalogGraph(root, options);
+
+const scopeNotFound = (ref: McpScopeRef) =>
+  new McpScopeNotFoundError(
+    `${ref.kind === 'domain' ? 'Domain' : 'System'} not found: ${ref.id}${ref.version ? ` (${ref.version})` : ''}`
+  );
+
+export async function resolveMcpScope(
+  ref: McpScopeRef,
+  loadCollection: CollectionLoader = defaultCollectionLoader,
+  loadGraph: GraphLoader = defaultGraphLoader
+) {
+  const graph = await loadGraph({ type: ref.kind, id: ref.id, version: ref.version }, { flat: true });
+  if (!graph) throw scopeNotFound(ref);
+
+  const graphCollections = new Set(graph.resources.map((resource) => graphTypeToCollection[resource.type]));
+
+  const loadedCollections = await Promise.all(
+    Array.from(graphCollections).map(async (collection) => [collection, await loadCollection(collection)] as const)
+  );
+  const collections = new Map(
+    loadedCollections.map(([collection, entries]) => [
+      collection,
+      new Map(entries.map((entry) => [entryKey(entry.data.id, entry.data.version), entry])),
+    ])
+  );
+
+  const resolve = (collection: McpScopeCollection, id: string, version: string) =>
+    collections.get(collection)?.get(entryKey(id, version));
+
+  const rootCollection = graphTypeToCollection[graph.root.type];
+  const root = resolve(rootCollection, graph.root.id, graph.root.version);
+  if (!root || root.data.hidden === true) throw scopeNotFound(ref);
+
+  const scope = new McpScope(ref, root);
+  for (const resource of graph.resources) {
+    const collection = graphTypeToCollection[resource.type];
+    scope.add(resolve(collection, resource.id, resource.version));
+  }
+
+  return scope;
+}

--- a/packages/core/eventcatalog/src/enterprise/mcp/mcp-scoped-tools.ts
+++ b/packages/core/eventcatalog/src/enterprise/mcp/mcp-scoped-tools.ts
@@ -1,0 +1,197 @@
+/**
+ * Licensed under the EventCatalog Commercial License.
+ * See /packages/core/eventcatalog/src/enterprise/LICENSE
+ */
+
+import {
+  analyzeChangeImpact,
+  explainBusinessFlow,
+  explainUbiquitousLanguageTerms,
+  findMessageBySchemaId,
+  getConsumersOfMessage,
+  getMessagesProducedOrConsumedByResource,
+  getProducersOfMessage,
+  getResource,
+  getSchemaForResource,
+  paginate,
+} from '@enterprise/tools/catalog-tools';
+import type { McpScope } from './mcp-scope';
+
+const notFound = (collection: string, id: string, version?: string) => ({
+  error: `Resource not found: ${collection}/${id}${version ? ` (${version})` : ''}`,
+});
+
+const isScopedReference = (scope: McpScope, resource: any, defaultCollection?: string) => {
+  const collection = resource?.collection || defaultCollection;
+  return Boolean(collection && resource?.id && scope.has(collection, resource.id, resource.version));
+};
+
+const filterScopedReferences = (scope: McpScope, resources: any[] | undefined, defaultCollection?: string) =>
+  (resources || []).filter((resource) => isScopedReference(scope, resource, defaultCollection));
+
+export function createScopedCatalogTools(scope: McpScope) {
+  return {
+    async getResources(params: { collection: string; cursor?: string; search?: string }) {
+      let resources = scope.list(params.collection).map((resource) => ({
+        id: resource.data.id,
+        version: resource.data.version,
+        name: resource.data.name,
+        summary: resource.data.summary,
+      }));
+
+      if (params.search) {
+        const searchTerm = params.search.toLowerCase().trim();
+        resources = resources.filter(
+          (resource) =>
+            resource.id?.toLowerCase().includes(searchTerm) ||
+            resource.name?.toLowerCase().includes(searchTerm) ||
+            resource.summary?.toLowerCase().includes(searchTerm)
+        );
+      }
+
+      const result = paginate(resources, params.cursor);
+      if ('error' in result) return result;
+
+      return {
+        resources: result.items,
+        nextCursor: result.nextCursor,
+        totalCount: result.totalCount,
+        scope: scope.ref,
+      };
+    },
+
+    async getResource(params: { collection: string; id: string; version: string }) {
+      if (!scope.has(params.collection, params.id, params.version)) return notFound(params.collection, params.id, params.version);
+      return getResource(params);
+    },
+
+    async getMessagesProducedOrConsumedByResource(params: {
+      resourceId: string;
+      resourceVersion: string;
+      resourceCollection: string;
+    }) {
+      if (!scope.has(params.resourceCollection, params.resourceId, params.resourceVersion)) {
+        return notFound(params.resourceCollection, params.resourceId, params.resourceVersion);
+      }
+      return getMessagesProducedOrConsumedByResource(params);
+    },
+
+    async getSchemaForResource(params: { resourceId: string; resourceVersion: string; resourceCollection: string }) {
+      if (!scope.has(params.resourceCollection, params.resourceId, params.resourceVersion)) {
+        return notFound(params.resourceCollection, params.resourceId, params.resourceVersion);
+      }
+      return getSchemaForResource(params);
+    },
+
+    async findResourcesByOwner(params: { ownerId: string }) {
+      const resources = scope
+        .listAll()
+        .filter((resource) =>
+          (resource.data.owners || []).some((owner: string | { id: string }) =>
+            typeof owner === 'string' ? owner === params.ownerId : owner.id === params.ownerId
+          )
+        )
+        .map((resource) => ({
+          collection: resource.collection,
+          id: resource.data.id,
+          version: resource.data.version,
+          name: resource.data.name || resource.data.id,
+        }));
+
+      return { ownerId: params.ownerId, totalCount: resources.length, resources, scope: scope.ref };
+    },
+
+    async getProducersOfMessage(params: { messageId: string; messageVersion: string; messageCollection: string }) {
+      if (!scope.has(params.messageCollection, params.messageId, params.messageVersion)) {
+        return notFound(params.messageCollection, params.messageId, params.messageVersion);
+      }
+      const result = await getProducersOfMessage(params);
+      if ('error' in result) return result;
+      const producers = filterScopedReferences(scope, result.producers);
+      return { ...result, producers, count: producers.length, scope: scope.ref };
+    },
+
+    async getConsumersOfMessage(params: { messageId: string; messageVersion: string; messageCollection: string }) {
+      if (!scope.has(params.messageCollection, params.messageId, params.messageVersion)) {
+        return notFound(params.messageCollection, params.messageId, params.messageVersion);
+      }
+      const result = await getConsumersOfMessage(params);
+      if ('error' in result) return result;
+      const consumers = filterScopedReferences(scope, result.consumers);
+      return { ...result, consumers, count: consumers.length, scope: scope.ref };
+    },
+
+    async analyzeChangeImpact(params: { messageId: string; messageVersion: string; messageCollection: string }) {
+      if (!scope.has(params.messageCollection, params.messageId, params.messageVersion)) {
+        return notFound(params.messageCollection, params.messageId, params.messageVersion);
+      }
+      const result = await analyzeChangeImpact(params);
+      if ('error' in result) return result;
+
+      const producers = filterScopedReferences(scope, result.producers);
+      const consumers = filterScopedReferences(scope, result.consumers);
+      const affected = [...producers, ...consumers];
+      const affectedOwners = new Set<string>();
+      affected.forEach((resource) =>
+        (resource.owners || []).forEach((owner: string | { id: string }) =>
+          affectedOwners.add(typeof owner === 'string' ? owner : owner.id)
+        )
+      );
+
+      return {
+        ...result,
+        scope: scope.ref,
+        impact: {
+          producerCount: producers.length,
+          consumerCount: consumers.length,
+          totalResourcesAffected: new Set(affected.map((resource) => `${resource.collection}:${resource.id}`)).size,
+          totalServicesAffected: new Set(
+            affected.filter((resource) => resource.collection === 'services').map((resource) => resource.id)
+          ).size,
+          totalAgentsAffected: new Set(
+            affected.filter((resource) => resource.collection === 'agents').map((resource) => resource.id)
+          ).size,
+          teamsAffected: Array.from(affectedOwners),
+        },
+        producers,
+        consumers,
+      };
+    },
+
+    async explainBusinessFlow(params: { flowId: string; flowVersion: string }) {
+      if (!scope.has('flows', params.flowId, params.flowVersion)) return notFound('flows', params.flowId, params.flowVersion);
+      const result = await explainBusinessFlow(params);
+      if ('error' in result) return result;
+      return {
+        ...result,
+        relatedServices: filterScopedReferences(scope, result.relatedServices, 'services'),
+        relatedAgents: filterScopedReferences(scope, result.relatedAgents, 'agents'),
+        scope: scope.ref,
+      };
+    },
+
+    async findMessageBySchemaId(params: {
+      messageId: string;
+      messageVersion?: string;
+      collection?: 'events' | 'commands' | 'queries';
+    }) {
+      const result = await findMessageBySchemaId(params);
+      if ('error' in result) return result;
+      if (!scope.has(result.resource.collection, result.resource.id, result.resource.version)) {
+        return notFound(result.resource.collection, params.messageId, params.messageVersion);
+      }
+      return {
+        ...result,
+        producers: filterScopedReferences(scope, result.producers),
+        consumers: filterScopedReferences(scope, result.consumers),
+        scope: scope.ref,
+      };
+    },
+
+    async explainUbiquitousLanguageTerms(params: { domainId: string; domainVersion?: string }) {
+      if (!scope.has('domains', params.domainId, params.domainVersion))
+        return notFound('domains', params.domainId, params.domainVersion);
+      return explainUbiquitousLanguageTerms(params);
+    },
+  };
+}

--- a/packages/core/eventcatalog/src/enterprise/mcp/mcp-server.ts
+++ b/packages/core/eventcatalog/src/enterprise/mcp/mcp-server.ts
@@ -10,33 +10,11 @@ import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/
 import { z } from 'zod';
 import { join } from 'node:path';
 import { isEventCatalogScaleEnabled } from '@utils/feature';
-import {
-  getResources,
-  getResource,
-  getMessagesProducedOrConsumedByResource,
-  getSchemaForResource,
-  findResourcesByOwner,
-  getProducersOfMessage,
-  getConsumersOfMessage,
-  analyzeChangeImpact,
-  explainBusinessFlow,
-  getTeams,
-  getTeam,
-  getUsers,
-  getUser,
-  findMessageBySchemaId,
-  explainUbiquitousLanguageTerms,
-  getCustomDocs,
-  searchCustomDocs,
-  getCustomDoc,
-  collectionSchema,
-  resourceCollectionSchema,
-  messageCollectionSchema,
-  toolDescriptions,
-  getC4Diagram,
-} from '@enterprise/tools/catalog-tools';
+import * as catalogTools from '@enterprise/tools/catalog-tools';
 import { getCollection } from 'astro:content';
 import { createMcpAuthErrorResponse, validateMcpRequest } from './mcp-auth';
+import { createScopedCatalogTools } from './mcp-scoped-tools';
+import { McpScopeNotFoundError, resolveMcpScope, type McpScope, type McpScopeKind } from './mcp-scope';
 
 const catalogDirectory = process.env.PROJECT_DIR || process.cwd();
 
@@ -81,196 +59,202 @@ try {
 }
 
 // Create MCP Server with tools that access Astro collections
-function createMcpServer() {
+function createMcpServer(scope?: McpScope) {
   const server = new McpServer({
-    name: 'EventCatalog MCP Server',
+    name: scope ? `EventCatalog MCP Server — ${scope.name} ${scope.ref.kind}` : 'EventCatalog MCP Server',
     version: '1.0.0',
   });
+
+  const tools = scope ? createScopedCatalogTools(scope) : catalogTools;
 
   // Register all built-in tools using the helper
   server.registerTool(
     'getResources',
     {
-      description: toolDescriptions.getResources,
+      description: catalogTools.toolDescriptions.getResources,
       inputSchema: z.object({
-        collection: collectionSchema.describe('The collection to get the resources from'),
+        collection: catalogTools.collectionSchema.describe('The collection to get the resources from'),
         cursor: z.string().optional().describe('Pagination cursor from previous response'),
         search: z.string().optional().describe('Search term to filter resources by name, id, or summary (case-insensitive)'),
       }),
     },
-    createToolHandler(getResources, 'Failed to get resources')
+    createToolHandler(tools.getResources, 'Failed to get resources')
   );
 
   server.registerTool(
     'getResource',
     {
-      description: toolDescriptions.getResource,
+      description: catalogTools.toolDescriptions.getResource,
       inputSchema: z.object({
-        collection: collectionSchema.describe('The collection to get the resource from'),
+        collection: catalogTools.collectionSchema.describe('The collection to get the resource from'),
         id: z.string().describe('The id of the resource to get'),
         version: z.string().describe('The version of the resource to get'),
       }),
     },
-    createToolHandler(getResource, 'Failed to get resource')
+    createToolHandler(tools.getResource, 'Failed to get resource')
   );
 
   server.registerTool(
     'getMessagesProducedOrConsumedByResource',
     {
-      description: toolDescriptions.getMessagesProducedOrConsumedByResource,
+      description: catalogTools.toolDescriptions.getMessagesProducedOrConsumedByResource,
       inputSchema: z.object({
         resourceId: z.string().describe('The id of the resource to get the messages produced or consumed for'),
         resourceVersion: z.string().describe('The version of the resource to get the messages produced or consumed for'),
-        resourceCollection: resourceCollectionSchema
+        resourceCollection: catalogTools.resourceCollectionSchema
           .describe('The collection of the resource to get the messages produced or consumed for')
           .default('services'),
       }),
     },
-    createToolHandler(getMessagesProducedOrConsumedByResource, 'Failed to get messages')
+    createToolHandler(tools.getMessagesProducedOrConsumedByResource, 'Failed to get messages')
   );
 
   server.registerTool(
     'getSchemaForResource',
     {
-      description: toolDescriptions.getSchemaForResource,
+      description: catalogTools.toolDescriptions.getSchemaForResource,
       inputSchema: z.object({
         resourceId: z.string().describe('The id of the resource to get the schema for'),
         resourceVersion: z.string().describe('The version of the resource to get the schema for'),
-        resourceCollection: resourceCollectionSchema
+        resourceCollection: catalogTools.resourceCollectionSchema
           .describe('The collection of the resource to get the schema for')
           .default('services'),
       }),
     },
-    createToolHandler(getSchemaForResource, 'Failed to get schema')
+    createToolHandler(tools.getSchemaForResource, 'Failed to get schema')
   );
 
   server.registerTool(
     'findResourcesByOwner',
     {
-      description: toolDescriptions.findResourcesByOwner,
+      description: catalogTools.toolDescriptions.findResourcesByOwner,
       inputSchema: z.object({
         ownerId: z.string().describe('The id of the owner (team or user) to find resources for'),
       }),
     },
-    createToolHandler(findResourcesByOwner, 'Failed to find resources')
+    createToolHandler(tools.findResourcesByOwner, 'Failed to find resources')
   );
 
   server.registerTool(
     'getProducersOfMessage',
     {
-      description: toolDescriptions.getProducersOfMessage,
+      description: catalogTools.toolDescriptions.getProducersOfMessage,
       inputSchema: z.object({
         messageId: z.string().describe('The id of the message to find producers for'),
         messageVersion: z.string().describe('The version of the message'),
-        messageCollection: messageCollectionSchema
+        messageCollection: catalogTools.messageCollectionSchema
           .describe('The collection type of the message (events, commands, or queries)')
           .default('events'),
       }),
     },
-    createToolHandler(getProducersOfMessage, 'Failed to get producers')
+    createToolHandler(tools.getProducersOfMessage, 'Failed to get producers')
   );
 
   server.registerTool(
     'getConsumersOfMessage',
     {
-      description: toolDescriptions.getConsumersOfMessage,
+      description: catalogTools.toolDescriptions.getConsumersOfMessage,
       inputSchema: z.object({
         messageId: z.string().describe('The id of the message to find consumers for'),
         messageVersion: z.string().describe('The version of the message'),
-        messageCollection: messageCollectionSchema
+        messageCollection: catalogTools.messageCollectionSchema
           .describe('The collection type of the message (events, commands, or queries)')
           .default('events'),
       }),
     },
-    createToolHandler(getConsumersOfMessage, 'Failed to get consumers')
+    createToolHandler(tools.getConsumersOfMessage, 'Failed to get consumers')
   );
 
-  server.registerTool(
-    'getC4Diagram',
-    {
-      description: toolDescriptions.getC4Diagram,
-      inputSchema: z.object({
-        viewId: z.string().describe('The id of the LikeC4 view to return source files for').optional(),
-      }),
-    },
-    createToolHandler(getC4Diagram, 'Failed to get c4 diagram')
-  );
+  if (!scope) {
+    server.registerTool(
+      'getC4Diagram',
+      {
+        description: catalogTools.toolDescriptions.getC4Diagram,
+        inputSchema: z.object({
+          viewId: z.string().describe('The id of the LikeC4 view to return source files for').optional(),
+        }),
+      },
+      createToolHandler(catalogTools.getC4Diagram, 'Failed to get c4 diagram')
+    );
+  }
 
   server.registerTool(
     'analyzeChangeImpact',
     {
-      description: toolDescriptions.analyzeChangeImpact,
+      description: catalogTools.toolDescriptions.analyzeChangeImpact,
       inputSchema: z.object({
         messageId: z.string().describe('The id of the message to analyze impact for'),
         messageVersion: z.string().describe('The version of the message'),
-        messageCollection: messageCollectionSchema
+        messageCollection: catalogTools.messageCollectionSchema
           .describe('The collection type of the message (events, commands, or queries)')
           .default('events'),
       }),
     },
-    createToolHandler(analyzeChangeImpact, 'Failed to analyze impact')
+    createToolHandler(tools.analyzeChangeImpact, 'Failed to analyze impact')
   );
 
   server.registerTool(
     'explainBusinessFlow',
     {
-      description: toolDescriptions.explainBusinessFlow,
+      description: catalogTools.toolDescriptions.explainBusinessFlow,
       inputSchema: z.object({
         flowId: z.string().describe('The id of the flow to explain'),
         flowVersion: z.string().describe('The version of the flow'),
       }),
     },
-    createToolHandler(explainBusinessFlow, 'Failed to explain flow')
+    createToolHandler(tools.explainBusinessFlow, 'Failed to explain flow')
   );
 
-  server.registerTool(
-    'getTeams',
-    {
-      description: toolDescriptions.getTeams,
-      inputSchema: z.object({
-        cursor: z.string().optional().describe('Pagination cursor from previous response'),
-      }),
-    },
-    createToolHandler(getTeams, 'Failed to get teams')
-  );
+  if (!scope) {
+    server.registerTool(
+      'getTeams',
+      {
+        description: catalogTools.toolDescriptions.getTeams,
+        inputSchema: z.object({
+          cursor: z.string().optional().describe('Pagination cursor from previous response'),
+        }),
+      },
+      createToolHandler(catalogTools.getTeams, 'Failed to get teams')
+    );
 
-  server.registerTool(
-    'getTeam',
-    {
-      description: toolDescriptions.getTeam,
-      inputSchema: z.object({
-        id: z.string().describe('The id of the team to get'),
-      }),
-    },
-    createToolHandler(getTeam, 'Failed to get team')
-  );
+    server.registerTool(
+      'getTeam',
+      {
+        description: catalogTools.toolDescriptions.getTeam,
+        inputSchema: z.object({
+          id: z.string().describe('The id of the team to get'),
+        }),
+      },
+      createToolHandler(catalogTools.getTeam, 'Failed to get team')
+    );
 
-  server.registerTool(
-    'getUsers',
-    {
-      description: toolDescriptions.getUsers,
-      inputSchema: z.object({
-        cursor: z.string().optional().describe('Pagination cursor from previous response'),
-      }),
-    },
-    createToolHandler(getUsers, 'Failed to get users')
-  );
+    server.registerTool(
+      'getUsers',
+      {
+        description: catalogTools.toolDescriptions.getUsers,
+        inputSchema: z.object({
+          cursor: z.string().optional().describe('Pagination cursor from previous response'),
+        }),
+      },
+      createToolHandler(catalogTools.getUsers, 'Failed to get users')
+    );
 
-  server.registerTool(
-    'getUser',
-    {
-      description: toolDescriptions.getUser,
-      inputSchema: z.object({
-        id: z.string().describe('The id of the user to get'),
-      }),
-    },
-    createToolHandler(getUser, 'Failed to get user')
-  );
+    server.registerTool(
+      'getUser',
+      {
+        description: catalogTools.toolDescriptions.getUser,
+        inputSchema: z.object({
+          id: z.string().describe('The id of the user to get'),
+        }),
+      },
+      createToolHandler(catalogTools.getUser, 'Failed to get user')
+    );
+  }
 
   server.registerTool(
     'findMessageBySchemaId',
     {
-      description: toolDescriptions.findMessageBySchemaId,
+      description: catalogTools.toolDescriptions.findMessageBySchemaId,
       inputSchema: z.object({
         messageId: z.string().describe('The message id (from x-eventcatalog-id in the schema)'),
         messageVersion: z
@@ -279,64 +263,68 @@ function createMcpServer() {
           .describe(
             'The message version (from x-eventcatalog-version in the schema). If not provided, returns the latest version.'
           ),
-        collection: messageCollectionSchema
+        collection: catalogTools.messageCollectionSchema
           .optional()
           .describe('Optional hint for which collection to search (events, commands, or queries)'),
       }),
     },
-    createToolHandler(findMessageBySchemaId, 'Failed to find message')
+    createToolHandler(tools.findMessageBySchemaId, 'Failed to find message')
   );
 
-  server.registerTool(
-    'explainUbiquitousLanguageTerms',
-    {
-      description: toolDescriptions.explainUbiquitousLanguageTerms,
-      inputSchema: z.object({
-        domainId: z.string().describe('The id of the domain to get ubiquitous language terms for'),
-        domainVersion: z.string().optional().describe('The version of the domain. If not provided, uses the latest version.'),
-      }),
-    },
-    createToolHandler(explainUbiquitousLanguageTerms, 'Failed to get ubiquitous language terms')
-  );
+  if (!scope || scope.ref.kind === 'domain') {
+    server.registerTool(
+      'explainUbiquitousLanguageTerms',
+      {
+        description: catalogTools.toolDescriptions.explainUbiquitousLanguageTerms,
+        inputSchema: z.object({
+          domainId: z.string().describe('The id of the domain to get ubiquitous language terms for'),
+          domainVersion: z.string().optional().describe('The version of the domain. If not provided, uses the latest version.'),
+        }),
+      },
+      createToolHandler(tools.explainUbiquitousLanguageTerms, 'Failed to get ubiquitous language terms')
+    );
+  }
 
-  server.registerTool(
-    'getCustomDocs',
-    {
-      description: toolDescriptions.getCustomDocs,
-      inputSchema: z.object({
-        cursor: z.string().optional().describe('Pagination cursor from previous response'),
-        search: z.string().optional().describe('Search term to filter docs by title, id, or summary (case-insensitive)'),
-      }),
-    },
-    createToolHandler(getCustomDocs, 'Failed to get custom documentation pages')
-  );
+  if (!scope) {
+    server.registerTool(
+      'getCustomDocs',
+      {
+        description: catalogTools.toolDescriptions.getCustomDocs,
+        inputSchema: z.object({
+          cursor: z.string().optional().describe('Pagination cursor from previous response'),
+          search: z.string().optional().describe('Search term to filter docs by title, id, or summary (case-insensitive)'),
+        }),
+      },
+      createToolHandler(catalogTools.getCustomDocs, 'Failed to get custom documentation pages')
+    );
 
-  server.registerTool(
-    'searchCustomDocs',
-    {
-      description: toolDescriptions.searchCustomDocs,
-      inputSchema: z.object({
-        query: z.string().describe('Full-text search query, e.g. keywords describing the topic to find'),
-        limit: z.number().optional().describe('Maximum number of results to return (default 10)'),
-      }),
-    },
-    createToolHandler(searchCustomDocs, 'Failed to search custom documentation')
-  );
+    server.registerTool(
+      'searchCustomDocs',
+      {
+        description: catalogTools.toolDescriptions.searchCustomDocs,
+        inputSchema: z.object({
+          query: z.string().describe('Full-text search query, e.g. keywords describing the topic to find'),
+          limit: z.number().optional().describe('Maximum number of results to return (default 10)'),
+        }),
+      },
+      createToolHandler(catalogTools.searchCustomDocs, 'Failed to search custom documentation')
+    );
 
-  server.registerTool(
-    'getCustomDoc',
-    {
-      description: toolDescriptions.getCustomDoc,
-      inputSchema: z.object({
-        id: z.string().describe('The id or slug of the custom documentation page'),
-        section: z.string().optional().describe('Optional section heading to return only that section of the page'),
-      }),
-    },
-    createToolHandler(getCustomDoc, 'Failed to get custom documentation page')
-  );
+    server.registerTool(
+      'getCustomDoc',
+      {
+        description: catalogTools.toolDescriptions.getCustomDoc,
+        inputSchema: z.object({
+          id: z.string().describe('The id or slug of the custom documentation page'),
+          section: z.string().optional().describe('Optional section heading to return only that section of the page'),
+        }),
+      },
+      createToolHandler(catalogTools.getCustomDoc, 'Failed to get custom documentation page')
+    );
+  }
 
   // Register extended tools from user configuration
-  for (const [toolName, toolConfig] of Object.entries(extendedTools)) {
+  for (const [toolName, toolConfig] of Object.entries(scope ? {} : extendedTools)) {
     if (!toolConfig || typeof toolConfig !== 'object') continue;
 
     // Extract tool properties (Vercel AI SDK format)
@@ -386,9 +374,13 @@ function createMcpServer() {
         'agents',
         'services',
         'domains',
+        'systems',
         'flows',
         'channels',
         'entities',
+        'containers',
+        'diagrams',
+        'data-products',
         'adrs',
       ] as const,
     },
@@ -415,6 +407,12 @@ function createMcpServer() {
       uri: 'eventcatalog://services',
       description: 'All services in EventCatalog',
       collections: ['services'] as const,
+    },
+    {
+      name: 'All Systems in EventCatalog',
+      uri: 'eventcatalog://systems',
+      description: 'All systems in EventCatalog',
+      collections: ['systems'] as const,
     },
     {
       name: 'All Agents in EventCatalog',
@@ -465,6 +463,12 @@ function createMcpServer() {
       collections: ['flows'] as const,
     },
     {
+      name: 'All Data Products in EventCatalog',
+      uri: 'eventcatalog://data-products',
+      description: 'All data products in EventCatalog',
+      collections: ['data-products'] as const,
+    },
+    {
       name: 'All Teams in EventCatalog',
       uri: 'eventcatalog://teams',
       description: 'All teams in EventCatalog',
@@ -479,16 +483,26 @@ function createMcpServer() {
   ];
 
   for (const resource of resourceDefinitions) {
+    if (scope && resource.collections.every((collection) => collection === 'teams' || collection === 'users')) continue;
+
+    const resourceUri = scope
+      ? `${scope.uriPrefix}/resources${resource.uri === 'eventcatalog://all' ? '' : `/${resource.uri.replace('eventcatalog://', '')}`}`
+      : resource.uri;
+    const resourceName = scope ? resource.name.replace('in EventCatalog', `in ${scope.name} ${scope.ref.kind}`) : resource.name;
+    const resourceDescription = scope
+      ? resource.description.replace('in EventCatalog', `in ${scope.name} ${scope.ref.kind}`)
+      : resource.description;
+
     server.registerResource(
-      resource.name,
-      resource.uri,
-      { description: resource.description, mimeType: 'application/json' },
+      resourceName,
+      resourceUri,
+      { description: resourceDescription, mimeType: 'application/json' },
       async (uri: URL) => {
         const allResources: any[] = [];
 
         for (const collectionName of resource.collections) {
           try {
-            const items = await getCollection(collectionName as any);
+            const items = scope ? scope.list(collectionName) : await getCollection(collectionName as any);
             for (const item of items) {
               allResources.push({
                 type: collectionName,
@@ -507,7 +521,7 @@ function createMcpServer() {
           contents: [
             {
               uri: uri.href,
-              text: JSON.stringify({ resources: allResources }, null, 2),
+              text: JSON.stringify({ ...(scope && { scope: scope.ref }), resources: allResources }, null, 2),
               mimeType: 'application/json',
             },
           ],
@@ -525,8 +539,39 @@ function createMcpServer() {
 // Create Hono app for MCP routes
 const app = new Hono().basePath('/docs/mcp');
 
-// Built-in tool names derived from toolDescriptions
-const builtInTools = Object.keys(toolDescriptions);
+const globalBuiltInTools = [
+  'getResources',
+  'getResource',
+  'getMessagesProducedOrConsumedByResource',
+  'getSchemaForResource',
+  'findResourcesByOwner',
+  'getProducersOfMessage',
+  'getConsumersOfMessage',
+  'getC4Diagram',
+  'analyzeChangeImpact',
+  'explainBusinessFlow',
+  'getTeams',
+  'getTeam',
+  'getUsers',
+  'getUser',
+  'findMessageBySchemaId',
+  'explainUbiquitousLanguageTerms',
+  'getCustomDocs',
+  'searchCustomDocs',
+  'getCustomDoc',
+];
+
+const scopedBuiltInTools = globalBuiltInTools.filter(
+  (tool) =>
+    !['getC4Diagram', 'getTeams', 'getTeam', 'getUsers', 'getUser', 'getCustomDocs', 'searchCustomDocs', 'getCustomDoc'].includes(
+      tool
+    )
+);
+
+const getScopedBuiltInTools = (scope: McpScope) =>
+  scope.ref.kind === 'system'
+    ? scopedBuiltInTools.filter((tool) => tool !== 'explainUbiquitousLanguageTerms')
+    : scopedBuiltInTools;
 
 // MCP Resource URIs
 const mcpResources = [
@@ -538,32 +583,85 @@ const mcpResources = [
   'eventcatalog://adrs',
   'eventcatalog://services',
   'eventcatalog://domains',
+  'eventcatalog://systems',
+  'eventcatalog://channels',
   'eventcatalog://entities',
+  'eventcatalog://containers',
+  'eventcatalog://diagrams',
+  'eventcatalog://data-products',
   'eventcatalog://flows',
   'eventcatalog://teams',
   'eventcatalog://users',
 ];
 
-// Health check endpoint
-app.get('/', async (c: Context) => {
+const getMcpResourceUris = (scope?: McpScope) =>
+  scope
+    ? mcpResources
+        .filter((uri) => uri !== 'eventcatalog://teams' && uri !== 'eventcatalog://users')
+        .map(
+          (uri) => `${scope.uriPrefix}/resources${uri === 'eventcatalog://all' ? '' : `/${uri.replace('eventcatalog://', '')}`}`
+        )
+    : mcpResources;
+
+const getScopeRef = (c: Context, kind: McpScopeKind) => ({
+  kind,
+  id: c.req.param('id'),
+  version: c.req.param('version') || 'latest',
+});
+
+const resolveRequestScope = async (c: Context, kind?: McpScopeKind) => (kind ? resolveMcpScope(getScopeRef(c, kind)) : undefined);
+
+const createScopeNotFoundResponse = (error: McpScopeNotFoundError) =>
+  new Response(JSON.stringify({ error: 'scope_not_found', message: error.message }), {
+    status: 404,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+const acceptsEventStream = (request: Request) =>
+  request.headers.get('accept')?.toLowerCase().includes('text/event-stream') ?? false;
+
+const createSseNotSupportedResponse = () =>
+  new Response(
+    JSON.stringify({
+      jsonrpc: '2.0',
+      error: { code: -32000, message: 'Method not allowed: this server does not provide an SSE stream.' },
+      id: null,
+    }),
+    {
+      status: 405,
+      headers: { Allow: 'POST', 'Content-Type': 'application/json' },
+    }
+  );
+
+const handleGetRequest = async (c: Context, kind?: McpScopeKind) => {
   const auth = await validateMcpRequest(c.req.raw);
 
   if (!auth.ok) {
     return createMcpAuthErrorResponse(auth);
   }
 
-  return c.json({
-    name: 'EventCatalog MCP Server',
-    version: '1.1.0',
-    status: 'running',
-    tools: [...builtInTools, ...extendedToolNames],
-    extendedTools: extendedToolNames.length > 0 ? extendedToolNames : undefined,
-    resources: mcpResources,
-  });
-});
+  // Streamable HTTP clients may open an optional GET SSE channel for server-initiated messages.
+  // This endpoint is stateless and does not support that channel, so the MCP specification requires a 405.
+  if (acceptsEventStream(c.req.raw)) return createSseNotSupportedResponse();
 
-// MCP protocol endpoint - handles POST requests for MCP protocol
-app.post('/', async (c: Context) => {
+  try {
+    const scope = await resolveRequestScope(c, kind);
+    return c.json({
+      name: scope ? `EventCatalog MCP Server — ${scope.name} ${scope.ref.kind}` : 'EventCatalog MCP Server',
+      version: '1.2.0',
+      status: 'running',
+      ...(scope && { scope: scope.ref }),
+      tools: scope ? getScopedBuiltInTools(scope) : [...globalBuiltInTools, ...extendedToolNames],
+      extendedTools: !scope && extendedToolNames.length > 0 ? extendedToolNames : undefined,
+      resources: getMcpResourceUris(scope),
+    });
+  } catch (error) {
+    if (error instanceof McpScopeNotFoundError) return createScopeNotFoundResponse(error);
+    throw error;
+  }
+};
+
+const handleMcpRequest = async (c: Context, kind?: McpScopeKind) => {
   try {
     const auth = await validateMcpRequest(c.req.raw);
 
@@ -571,17 +669,16 @@ app.post('/', async (c: Context) => {
       return createMcpAuthErrorResponse(auth);
     }
 
-    // Create fresh server and transport per request — the MCP SDK's
-    // WebStandardStreamableHTTPServerTransport is single-use in stateless
-    // mode: it sets _hasHandledRequest=true after the first call and throws
-    // on any subsequent request. McpServer equally rejects reconnection.
-    const server = createMcpServer();
+    const scope = await resolveRequestScope(c, kind);
+    const server = createMcpServer(scope);
     const transport = new WebStandardStreamableHTTPServerTransport({
       sessionIdGenerator: undefined,
     });
     await server.connect(transport);
     return await transport.handleRequest(c.req.raw);
   } catch (error) {
+    if (error instanceof McpScopeNotFoundError) return createScopeNotFoundResponse(error);
+
     console.error('MCP request error:', error);
     return c.json(
       {
@@ -595,7 +692,21 @@ app.post('/', async (c: Context) => {
       500
     );
   }
-});
+};
+
+// Browser GETs return health metadata; MCP SSE negotiation is rejected with 405 because this server is stateless.
+app.get('/', (c: Context) => handleGetRequest(c));
+
+for (const kind of ['domain', 'system'] as const) {
+  const path = `${kind}s`;
+  app.get(`/${path}/:id`, (c: Context) => handleGetRequest(c, kind));
+  app.get(`/${path}/:id/:version`, (c: Context) => handleGetRequest(c, kind));
+  app.post(`/${path}/:id`, (c: Context) => handleMcpRequest(c, kind));
+  app.post(`/${path}/:id/:version`, (c: Context) => handleMcpRequest(c, kind));
+}
+
+// MCP protocol endpoint - handles POST requests for MCP protocol
+app.post('/', (c: Context) => handleMcpRequest(c));
 
 // Astro API route handler - delegates all requests to Hono
 // Note: SSR and Scale plan checks are handled at build time by the integration

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/index.astro
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/index.astro
@@ -64,6 +64,7 @@ import {
   isMarkdownDownloadEnabled,
   isVisualiserEnabled,
   isRSSEnabled,
+  isEventCatalogMCPEnabled,
 } from '@utils/feature';
 import { getMDXComponentsByName, parseMdxBooleanProp } from '@utils/markdown';
 
@@ -89,6 +90,15 @@ const pageTitle = `${props.collection} | ${props.data.name}`.replace(/^\w/, (c) 
 const contentBadges = props.data.badges || [];
 const editUrl =
   props.data.editUrl || (config.editUrl && props?.filePath ? buildEditUrlForResource(config.editUrl, props?.filePath) : '');
+const isLatestVersion = props.data.latestVersion === props.data.version;
+const mcpResourceType = props.collection === 'domains' ? 'domain' : props.collection === 'systems' ? 'system' : undefined;
+const mcpServerUrl =
+  mcpResourceType && isEventCatalogMCPEnabled()
+    ? buildUrl(
+        `/docs/mcp/${mcpResourceType}s/${encodeURIComponent(props.data.id)}${isLatestVersion ? '' : `/${encodeURIComponent(props.data.version)}`}`,
+        true
+      )
+    : undefined;
 
 const headerIconSrc = isIconPath(props.data.styles?.icon) ? resolveIconUrl(props.data.styles!.icon!) : null;
 
@@ -458,6 +468,9 @@ if (!isAdrPage && !hasCurrentFlowEmbed && !hasCurrentPageNodeGraph) {
                 rssFeedEnabled={isRSSEnabled()}
                 editUrl={editUrl}
                 preferChatAsDefault={isEventCatalogChatEnabled()}
+                mcpServerUrl={mcpServerUrl}
+                resourceName={props.data.name}
+                mcpResourceType={mcpResourceType}
               />
             </div>
             {

--- a/packages/core/eventcatalog/src/types/mcp-modules.d.ts
+++ b/packages/core/eventcatalog/src/types/mcp-modules.d.ts
@@ -7,6 +7,7 @@ declare module 'hono' {
   export interface Context {
     req: {
       raw: Request;
+      param: (name: string) => string;
     };
     json: (data: unknown, status?: number) => Response;
   }

--- a/packages/core/src/eventcatalog.config.ts
+++ b/packages/core/src/eventcatalog.config.ts
@@ -186,6 +186,11 @@ type McpAuthConfig = {
 };
 
 type McpConfig = {
+  /**
+   * Enables the built-in MCP server when EventCatalog is running in server mode with a Scale license.
+   * @default true
+   */
+  enabled?: boolean;
   auth?: McpAuthConfig;
 };
 

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -108,7 +108,6 @@
 - 8f724a7: feat: add `externalSystem` flag to services for modelling third-party integrations
 
   Services can now set `externalSystem: true` in their frontmatter to be rendered as external systems. This changes their presentation without changing their capabilities — they still send and receive messages, have owners, and support specifications like any other service.
-
   - Visualiser: external services render purple with a Globe icon and an "External System" badge
   - Sidebar (root): a dedicated "External Systems" section lists externals; the regular "Services" section excludes them
   - Sidebar (domain): externals appear under a new "External Integrations" group, separate from "Services In Domain"


### PR DESCRIPTION
## What This PR Does

Adds scoped MCP servers so an MCP client can connect to a single domain or system rather than the whole catalog. Each scope exposes the same tool surface as the global server, but every tool only sees the resources reachable from that domain or system in the catalog graph.

Also adds an `mcp.enabled` config option so teams can turn the built-in MCP server off, and surfaces a "Connect to MCP server" action on domain and system documentation pages.

## Changes Overview

### Key Changes

- **Scoped MCP routes** — `/docs/mcp/domains/:id` and `/docs/mcp/systems/:id`, with optional `/:version` for non-latest versions.
- **Scope resolution** (`mcp-scope.ts`) — resolves a domain or system reference into the set of resources inside that scope, using the SDK's flat catalog graph.
- **Scoped tools** (`mcp-scoped-tools.ts`) — wraps the shared catalog tools so results are filtered to the resolved scope. `mcp-server.ts` now takes an optional scope and swaps in the scoped tool set.
- **`mcp.enabled` config** — defaults to `true`; `isEventCatalogMCPEnabled()` respects it alongside the existing Scale-license and SSR checks.
- **UI** — new `McpConnectDialog` and `McpIcon`, wired into `CopyAsMarkdown` and rendered on domain/system doc pages. The dialog is lazy-loaded so it doesn't add to the initial bundle.
- **Tests** — new specs covering scope resolution, scoped routes, scoped tools, and the feature flag.

## How It Works

`resolveMcpScope()` takes a domain or system reference and walks the catalog graph from that root, collecting every reachable resource keyed by collection. `createScopedCatalogTools()` then wraps each shared tool from `@enterprise/tools/catalog-tools`, filtering its output against that set so out-of-scope resources are never returned.

`createMcpServer(scope?)` registers the same tools either way — tool descriptions and input schemas stay identical, only the implementations change. Without a scope it uses the shared tools directly, so global-server behaviour is unchanged.

On the docs page, `mcpServerUrl` is built only for domains and systems when MCP is enabled, and version is appended to the URL only when viewing a non-latest version.

## Breaking Changes

None. The global MCP server behaves as before, and `mcp.enabled` defaults to `true`.

## Additional Notes

- `examples/default/eventcatalog.config.js` now sets `output: 'server'` so the example catalog can exercise the MCP routes locally.
- Reviewer note: worth a look at the toolbar-variant logic in `CopyAsMarkdown.tsx` — the MCP action takes the primary secondary-slot and pushes "copy as markdown" into the overflow menu when both are available.