### PR TITLE
Fix sidebar collapse state for ADR status groups

### DIFF
--- a/.changeset/brave-otters-listen.md
+++ b/.changeset/brave-otters-listen.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix(sidebar): use stable collapse keys for ADR status groups so collapse state persists correctly

--- a/examples/default/eventcatalog.config.js
+++ b/examples/default/eventcatalog.config.js
@@ -18,8 +18,6 @@ export default {
     text: "Acme Inc",
   },
 
-  output: 'server',
-
   base: "/",
   trailingSlash: false,
 

--- a/packages/core/eventcatalog/src/components/SideNav/NestedSideBar/index.tsx
+++ b/packages/core/eventcatalog/src/components/SideNav/NestedSideBar/index.tsx
@@ -13,7 +13,7 @@ import {
   removeFavorite as removeFavoriteAction,
   type FavoriteItem,
 } from '@stores/favorites-store';
-import { getBadgeClasses } from './utils';
+import { getBadgeClasses, isGroupCollapsed } from './utils';
 import { resolveIconUrl } from '@utils/icon';
 
 const cn = (...classes: (string | false | undefined)[]) => classes.filter(Boolean).join(' ');
@@ -754,9 +754,9 @@ export default function NestedSideBar() {
         return child && isVisible(child);
       }) ?? [];
 
-    const groupId = groupKey || `group-${index}`;
+    const groupId = groupKey || group.collapseKey || `group-${index}`;
     const canCollapse = visibleChildren.length > 3;
-    const isCollapsed = collapsedSections.has(groupId);
+    const isCollapsed = isGroupCollapsed(canCollapse, groupId, collapsedSections);
 
     // When a group's children are subtle subgroups (e.g. Resources > Services/Flows/Data Stores),
     // they render flush under the parent icon instead of inside the indented border guide.

--- a/packages/core/eventcatalog/src/components/SideNav/NestedSideBar/utils.spec.ts
+++ b/packages/core/eventcatalog/src/components/SideNav/NestedSideBar/utils.spec.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { isGroupCollapsed } from './utils';
+
+describe('isGroupCollapsed', () => {
+  it('ignores persisted collapse state when the group cannot be expanded', () => {
+    expect(isGroupCollapsed(false, 'group-1', new Set(['group-1']))).toBe(false);
+  });
+
+  it('uses persisted collapse state when the group can be expanded', () => {
+    expect(isGroupCollapsed(true, 'adrs:status:superseded', new Set(['adrs:status:superseded']))).toBe(true);
+  });
+});

--- a/packages/core/eventcatalog/src/components/SideNav/NestedSideBar/utils.ts
+++ b/packages/core/eventcatalog/src/components/SideNav/NestedSideBar/utils.ts
@@ -1,5 +1,8 @@
 // Shared utilities for NestedSideBar components
 
+export const isGroupCollapsed = (canCollapse: boolean, groupId: string, collapsedSections: Set<string>): boolean =>
+  canCollapse && collapsedSections.has(groupId);
+
 /**
  * Returns Tailwind classes for badge styling based on badge type.
  * Uses CSS variables from theme.css for proper theming support.

--- a/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/sidebar-builder.spec.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/sidebar-builder.spec.ts
@@ -113,6 +113,10 @@ vi.mock('astro:content', async (importOriginal) => {
           const { getDataProducts } = utils(CATALOG_FOLDER);
           const dataProducts = (await getDataProducts()) ?? [];
           return Promise.resolve(dataProducts.map((dataProduct) => toAstroCollection(dataProduct, 'data-products')));
+        case 'adrs':
+          const { getAdrs } = utils(CATALOG_FOLDER);
+          const adrs = (await getAdrs()) ?? [];
+          return Promise.resolve(adrs.map((adr) => toAstroCollection(adr, 'adrs')));
         case 'ubiquitousLanguages':
           return Promise.resolve(
             mockUbiquitousLanguages.map((ubiquitousLanguage) => toAstroCollection(ubiquitousLanguage, 'ubiquitousLanguages'))
@@ -197,6 +201,43 @@ describe('getNestedSideBarData', () => {
   });
 
   describe('root navigation items (default navigation config)', () => {
+    it('uses stable collapse keys for ADR status groups', async () => {
+      const { writeAdr } = utils(CATALOG_FOLDER);
+
+      await writeAdr({
+        id: 'accepted-decision',
+        name: 'Accepted decision',
+        version: '1.0.0',
+        status: 'accepted',
+        date: '2026-07-21',
+        markdown: '# Accepted decision',
+      });
+      await writeAdr({
+        id: 'superseded-decision',
+        name: 'Superseded decision',
+        version: '1.0.0',
+        status: 'superseded',
+        date: '2026-07-20',
+        markdown: '# Superseded decision',
+      });
+
+      const navigationData = await getNestedSideBarData();
+      const adrsNode = getNavigationConfigurationByKey('list:adrs', navigationData);
+
+      expect(adrsNode.pages).toEqual([
+        expect.objectContaining({
+          title: 'Accepted (1)',
+          collapseKey: 'adrs:status:accepted',
+          pages: ['adr:accepted-decision:1.0.0'],
+        }),
+        expect.objectContaining({
+          title: 'Superseded (1)',
+          collapseKey: 'adrs:status:superseded',
+          pages: ['adr:superseded-decision:1.0.0'],
+        }),
+      ]);
+    });
+
     it('renders a list of domains (that are not in a subdomain) as a root navigation item', async () => {
       const { writeDomain, getDomain } = utils(CATALOG_FOLDER);
 

--- a/packages/core/eventcatalog/src/stores/sidebar-store/builders/shared.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/builders/shared.ts
@@ -23,6 +23,7 @@ export type ChildRef = string | NavNode;
 export type NavNode = {
   type: 'group' | 'item';
   title: string;
+  collapseKey?: string; // Stable key used to persist collapse state for inline groups
   icon?: string; // Lucide icon name
   subtle?: boolean; // Render lightweight styling for nested subgroup headers
   leftIcon?: string; // Path to SVG icon shown on the left of the label

--- a/packages/core/eventcatalog/src/stores/sidebar-store/state.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/state.ts
@@ -69,6 +69,7 @@ const groupAdrsByStatus = (adrs: Adr[]): NavNode[] =>
     groups.push({
       type: 'group',
       title: `${formatAdrStatus(status)} (${adrsForStatus.length})`,
+      collapseKey: `adrs:status:${status}`,
       subtle: true,
       pages: [...adrsForStatus].sort(byResourceName).map(getAdrNodeKey),
     });


### PR DESCRIPTION
Fixes https://github.com/event-catalog/eventcatalog/issues/2728

## What This PR Does

Fixes the sidebar collapse behavior for ADR status groups (Accepted, Superseded, etc.). These groups previously used index-based ids (`group-0`, `group-1`) to persist collapse state, so the persisted state could apply to the wrong group when the sidebar contents changed. Groups now carry a stable `collapseKey` (e.g. `adrs:status:accepted`) that survives reordering.

It also stops small groups (3 or fewer visible children, which render without a collapse toggle) from being treated as collapsed by stale persisted state, which could hide their contents with no way to expand them.

## Changes Overview

### Key Changes
- Add optional `collapseKey` to the `NavNode` type in the sidebar store, used to persist collapse state for inline groups
- Set `collapseKey: 'adrs:status:<status>'` when building ADR status groups in the sidebar state
- `NestedSideBar` now prefers `collapseKey` over the index-based fallback id when resolving a group's collapse state
- New `isGroupCollapsed` utility: a group only reads persisted collapse state when it is actually collapsible (more than 3 visible children)
- Tests for `isGroupCollapsed` and for the stable collapse keys on ADR status groups
- Remove `output: 'server'` from the default example catalog config

## How It Works

The sidebar persists collapsed section ids in a `Set`. Group ids resolve in order: explicit group key, then the new `collapseKey`, then the `group-<index>` fallback. ADR status groups are generated dynamically from ADR frontmatter, so they now embed the status in their key, making the persisted state independent of group order. The `isGroupCollapsed` helper gates the persisted state on `canCollapse`, so non-collapsible groups always render expanded.

## Breaking Changes

None

## Additional Notes

No corresponding change is needed in the eventcatalog-editor repository — this is internal sidebar rendering/state logic in core.