### PR TITLE
Support embedded entity properties and whole-entity relationship targets

### DIFF
--- a/.changeset/tidy-entity-relationships.md
+++ b/.changeset/tidy-entity-relationships.md
@@ -1,0 +1,8 @@
+---
+"@eventcatalog/core": patch
+"@eventcatalog/sdk": patch
+"@eventcatalog/linter": patch
+"@eventcatalog/visualiser": patch
+---
+
+Add recursive embedded entity properties and opt-in whole-entity relationship targets, render embedded properties in entity documentation and visualiser nodes, and keep generated entity maps more compact.

--- a/examples/default/domains/Ordering/entities/order/index.mdx
+++ b/examples/default/domains/Ordering/entities/order/index.mdx
@@ -12,13 +12,13 @@ properties:
     type: UUID
     required: true
     description: Unique order identifier.
-  - name: customerId
-    type: UUID
+  - name: customer
+    type: Customer
     required: true
     description: Customer who placed the order.
     references: customer-profile
     relationType: belongsTo
-    referencesIdentifier: customerId
+    referenceTarget: entity
   - name: status
     type: string
     required: true
@@ -27,6 +27,41 @@ properties:
     type: decimal
     required: true
     description: Total order value at creation.
+  - name: deliveryAddress
+    type: object
+    required: true
+    description: Delivery address captured when the order was placed.
+    properties:
+      - name: line1
+        type: string
+        required: true
+        description: First line of the delivery address.
+      - name: city
+        type: string
+        required: true
+        description: Delivery city.
+      - name: postalCode
+        type: string
+        required: true
+        description: Delivery postal code.
+      - name: countryCode
+        type: string
+        required: true
+        description: ISO 3166-1 alpha-2 delivery country code.
+  - name: adjustments
+    type: array
+    description: Discounts and credits captured as part of this order.
+    items:
+      type: object
+      properties:
+        - name: description
+          type: string
+          required: true
+          description: Reason for the adjustment.
+        - name: amount
+          type: decimal
+          required: true
+          description: Signed amount applied to the order total.
 ---
 
 ## Overview

--- a/packages/core/docs/development/guides/resources/entities/03-model-entity-relationships.md
+++ b/packages/core/docs/development/guides/resources/entities/03-model-entity-relationships.md
@@ -42,7 +42,10 @@ Use these fields on an entity property:
 
 - `references`: The id of the entity being referenced.
 - `referencesIdentifier`: The property on the referenced entity that this property matches.
+- `referenceTarget`: Set to `entity` when the relationship should point to the referenced entity as a whole.
 - `relationType`: The relationship label, such as `belongsTo`, `hasOne`, `hasMany`, or a business-specific label.
+
+`referenceTarget` is opt-in. When it is omitted, EventCatalog retains the existing behavior of targeting `referencesIdentifier`, the referenced entity's `identifier`, or its first property.
 
 ## Example relationship
 
@@ -82,6 +85,49 @@ properties:
 ```
 
 This tells EventCatalog that `order.customerId` references the `customer.customerId` identifier.
+
+## Reference a whole entity
+
+Use `referenceTarget: entity` when the relationship is to the entity rather than one of its properties.
+
+```yaml
+properties:
+  - name: customer
+    type: object
+    references: customer
+    referenceTarget: entity
+    relationType: placedBy
+```
+
+This renders the relationship against the `Customer` entity header. Existing relationships that omit `referenceTarget` continue to use property-level targeting.
+
+## Model embedded objects
+
+Use nested `properties` for a value object that only exists as part of its parent entity. Embedded objects have no entity id and cannot be referenced independently from elsewhere in the catalog.
+
+```yaml
+properties:
+  - name: deliveryAddress
+    type: object
+    properties:
+      - name: line1
+        type: string
+        required: true
+      - name: city
+        type: string
+        required: true
+  - name: adjustments
+    type: array
+    items:
+      type: object
+      properties:
+        - name: reason
+          type: string
+        - name: amount
+          type: decimal
+```
+
+Embedded properties appear inside their parent entity rather than as separate nodes in entity maps.
 
 ## Relationship direction
 

--- a/packages/core/docs/development/guides/resources/entities/06-reference.md
+++ b/packages/core/docs/development/guides/resources/entities/06-reference.md
@@ -258,9 +258,13 @@ attachments:
 | `description` | `string` | Description of the property. |
 | `references` | `string` | Entity id referenced by this property. |
 | `referencesIdentifier` | `string` | Identifier property on the referenced entity. |
+| `referenceTarget` | `entity` | Targets the referenced entity as a whole instead of one of its properties. |
 | `relationType` | `string` | Relationship label shown in entity maps. |
 | `enum` | `array` | Allowed string values. |
-| `items` | `object` | Item type for array properties. |
+| `properties` | `array` | Nested properties for an embedded object. |
+| `items` | `object` | Item type and optional nested properties for array properties. |
+
+Property definitions are recursive, so embedded objects and arrays of embedded objects can contain their own `properties`. Embedded objects are owned by their parent entity and are not independently referenceable catalog resources.
 
 ## EntityPropertiesTable component
 

--- a/packages/core/eventcatalog/src/components/MDX/EntityPropertiesTable/EntityPropertiesTable.astro
+++ b/packages/core/eventcatalog/src/components/MDX/EntityPropertiesTable/EntityPropertiesTable.astro
@@ -8,11 +8,30 @@ type EntityProperty = {
   type: string;
   required?: boolean;
   description?: string;
+  references?: string;
+  referencesIdentifier?: string;
+  referenceTarget?: 'entity';
   enum?: string[];
+  properties?: EntityProperty[];
   items?: {
     type: string;
+    properties?: EntityProperty[];
   };
 };
+
+type EntityPropertyRow = {
+  property: EntityProperty;
+  depth: number;
+};
+
+const getNestedProperties = (property: EntityProperty) =>
+  property.properties || (property.type === 'array' ? property.items?.properties : undefined) || [];
+
+const flattenProperties = (entityProperties: EntityProperty[], depth = 0): EntityPropertyRow[] =>
+  entityProperties.flatMap((property) => [{ property, depth }, ...flattenProperties(getNestedProperties(property), depth + 1)]);
+
+const getPropertyTypeLabel = (property: EntityProperty) =>
+  property.type === 'array' && property.items ? `${property.items.type}[]` : property.type;
 
 // Expects a CollectionEntry for 'entities'.
 // The actual properties structure might differ slightly from the base type,
@@ -22,6 +41,7 @@ export interface Props extends CollectionEntry<'entities'> {}
 const { data, collection } = Astro.props;
 // Cast the properties to our expected type for use in the template
 const properties = data?.properties as EntityProperty[] | undefined;
+const propertyRows = flattenProperties(properties || []);
 const isComponentEnabled = collection === 'entities';
 ---
 
@@ -56,23 +76,23 @@ const isComponentEnabled = collection === 'entities';
             <th scope="col" class="py-3 px-6 min-w-[250px]">
               Description
             </th>
+            <th scope="col" class="py-3 px-6 min-w-[180px]">
+              Reference
+            </th>
           </tr>
         </thead>
         <tbody>
-          {properties.map((prop) => (
+          {propertyRows.map(({ property: prop, depth }) => (
             <tr class="bg-[rgb(var(--ec-card-bg,var(--ec-page-bg)))] border-b border-[rgb(var(--ec-page-border))] hover:bg-[rgb(var(--ec-content-hover))] align-top">
-              <td class="py-4 px-6 font-medium text-[rgb(var(--ec-page-text))] whitespace-nowrap">
+              <td
+                class="py-4 pr-6 font-medium text-[rgb(var(--ec-page-text))] whitespace-nowrap"
+                style={`padding-left: ${24 + depth * 20}px`}
+              >
+                {depth > 0 && <span class="mr-1 text-[rgb(var(--ec-icon-color))]">↳</span>}
                 <code class="text-sm bg-[rgb(var(--ec-content-hover))] rounded px-1 py-0.5">{prop.name}</code>
               </td>
               <td class="py-4 px-6 text-[rgb(var(--ec-page-text-muted))]">
-                {prop.type === 'array' && prop.items ? (
-                  <span>
-                    array&lt;<code class="text-sm bg-[rgb(var(--ec-content-hover))] rounded px-1 py-0.5">{prop.items.type}</code>
-                    &gt;
-                  </span>
-                ) : (
-                  <code class="text-sm bg-[rgb(var(--ec-content-hover))] rounded px-1 py-0.5">{prop.type}</code>
-                )}
+                <code class="text-sm bg-[rgb(var(--ec-content-hover))] rounded px-1 py-0.5">{getPropertyTypeLabel(prop)}</code>
                 {prop.enum && (
                   <div class="text-xs text-[rgb(var(--ec-page-text-muted))] mt-2">
                     <span class="font-semibold block mb-1">Enum:</span>
@@ -99,6 +119,22 @@ const isComponentEnabled = collection === 'entities';
               </td>
               <td class="py-4 px-6 text-[rgb(var(--ec-page-text-muted))]">
                 {prop.description || <span class="text-[rgb(var(--ec-icon-color))] italic">No description provided.</span>}
+              </td>
+              <td class="py-4 px-6 text-[rgb(var(--ec-page-text-muted))]">
+                {prop.references ? (
+                  <div class="flex flex-col gap-1">
+                    <code class="text-sm bg-[rgb(var(--ec-content-hover))] rounded px-1 py-0.5 w-fit">{prop.references}</code>
+                    <span class="text-xs">
+                      {prop.referenceTarget === 'entity'
+                        ? 'Whole entity'
+                        : prop.referencesIdentifier
+                          ? `Property: ${prop.referencesIdentifier}`
+                          : 'Identifier or first property'}
+                    </span>
+                  </div>
+                ) : (
+                  <span class="text-[rgb(var(--ec-icon-color))]">—</span>
+                )}
               </td>
             </tr>
           ))}

--- a/packages/core/eventcatalog/src/content.config.ts
+++ b/packages/core/eventcatalog/src/content.config.ts
@@ -963,6 +963,44 @@ const ubiquitousLanguages = defineCollection({
   }),
 });
 
+interface EntityPropertySchema {
+  name: string;
+  type: string;
+  required?: boolean;
+  description?: string;
+  references?: string;
+  referencesIdentifier?: string;
+  referenceTarget?: 'entity';
+  relationType?: string;
+  enum?: string[];
+  properties?: EntityPropertySchema[];
+  items?: {
+    type: string;
+    properties?: EntityPropertySchema[];
+  };
+}
+
+const entityPropertySchema: z.ZodType<EntityPropertySchema> = z.lazy(() =>
+  z.object({
+    name: z.string(),
+    type: z.string(),
+    required: z.boolean().optional(),
+    description: z.string().optional(),
+    references: z.string().optional(),
+    referencesIdentifier: z.string().optional(),
+    referenceTarget: z.literal('entity').optional(),
+    relationType: z.string().optional(),
+    enum: z.array(z.string()).optional(),
+    properties: z.array(entityPropertySchema).optional(),
+    items: z
+      .object({
+        type: z.string(),
+        properties: z.array(entityPropertySchema).optional(),
+      })
+      .optional(),
+  })
+);
+
 const entities = defineCollection({
   loader: globWithSafeWatcher({
     pattern: withIgnoredBuildArtifacts(['**/entities/*/index.(md|mdx)', '**/entities/*/versioned/*/index.(md|mdx)']),
@@ -976,25 +1014,7 @@ const entities = defineCollection({
       .object({
         aggregateRoot: z.boolean().optional(),
         identifier: z.string().optional(),
-        properties: z
-          .array(
-            z.object({
-              name: z.string(),
-              type: z.string(),
-              required: z.boolean().optional(),
-              description: z.string().optional(),
-              references: z.string().optional(),
-              referencesIdentifier: z.string().optional(),
-              relationType: z.string().optional(),
-              enum: z.array(z.string()).optional(),
-              items: z
-                .object({
-                  type: z.string(),
-                })
-                .optional(),
-            })
-          )
-          .optional(),
+        properties: z.array(entityPropertySchema).optional(),
         services: z.array(reference('services')).optional(),
         domains: z.array(reference('domains')).optional(),
         detailsPanel: z

--- a/packages/core/eventcatalog/src/utils/__tests__/domains/domain-entity-map.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/domains/domain-entity-map.spec.ts
@@ -1,5 +1,5 @@
 import { MarkerType } from '@xyflow/react';
-import { getNodesAndEdges } from '../../node-graphs/domain-entity-map';
+import { ENTITY_TARGET_HANDLE_ID, getNodesAndEdges } from '../../node-graphs/domain-entity-map';
 import { expect, describe, it, vi, beforeEach } from 'vitest';
 import { getCollection, getEntry } from 'astro:content';
 import type { CollectionKey } from 'astro:content';
@@ -48,6 +48,31 @@ const mockEntities = [
           required: false,
           references: 'Payment',
           relationType: 'hasOne',
+        },
+        {
+          name: 'payment',
+          type: 'object',
+          required: false,
+          references: 'Payment',
+          referenceTarget: 'entity',
+          relationType: 'paidWith',
+        },
+        {
+          name: 'deliveryAddress',
+          type: 'object',
+          required: true,
+          properties: [
+            {
+              name: 'line1',
+              type: 'string',
+              required: true,
+            },
+            {
+              name: 'countryCode',
+              type: 'string',
+              required: true,
+            },
+          ],
         },
       ],
     },
@@ -410,7 +435,7 @@ describe('Domain Entity Map NodeGraph', () => {
       });
 
       // Check edges
-      expect(edges).toHaveLength(3); // Order -> Customer, Order -> OrderItem, Order -> Payment
+      expect(edges).toHaveLength(4); // Order -> Customer, OrderItem, and Payment twice
 
       // Check Order -> Customer edge
       const orderToCustomerEdge = edges.find((e: any) => e.source === 'Order-1.0.0' && e.target === 'Customer-1.0.0');
@@ -529,6 +554,20 @@ describe('Domain Entity Map NodeGraph', () => {
       });
     });
 
+    it('targets the entity header when referenceTarget is entity without changing the default fallback', async () => {
+      const { edges } = await getNodesAndEdges({ id: 'Orders', version: '1.0.0' });
+
+      const orderToPaymentEntityEdge = edges.find(
+        (edge: any) => edge.source === 'Order-1.0.0' && edge.sourceHandle === 'payment-source'
+      );
+
+      expect(orderToPaymentEntityEdge).toMatchObject({
+        target: 'Payment-1.0.0',
+        targetHandle: ENTITY_TARGET_HANDLE_ID,
+        label: 'paidWith',
+      });
+    });
+
     it('creates a hasMany edge for array item entity types without explicit references', async () => {
       const { nodes, edges } = await getNodesAndEdges({ id: 'Warehousing', version: '1.0.0' });
 
@@ -537,6 +576,7 @@ describe('Domain Entity Map NodeGraph', () => {
       const warehouseToBinEdge = edges.find((e: any) => e.source === 'Warehouse-1.0.0' && e.target === 'Bin-1.0.0');
 
       expect(warehouseNode).toBeDefined();
+      expect(warehouseNode.data.referencePropertyNames).toEqual(['bins']);
       expect(binNode).toMatchObject({
         id: 'Bin-1.0.0',
         type: 'entities',
@@ -560,6 +600,7 @@ describe('Domain Entity Map NodeGraph', () => {
       const productEdges = edges.filter((e: any) => e.source === 'Product-1.0.0' || e.target === 'Product-1.0.0');
 
       expect(productNode).toBeDefined();
+      expect(productNode.data.referencePropertyNames).toEqual([]);
       expect(stringNode).toBeUndefined();
       expect(productEdges).toHaveLength(0);
     });
@@ -618,7 +659,7 @@ describe('Domain Entity Map NodeGraph', () => {
       expect(orderNode.data.entity.data.version).toBe('1.0.0');
     });
 
-    it('should properly position nodes using dagre layout', async () => {
+    it('should properly position nodes using ELK layout', async () => {
       const { nodes } = await getNodesAndEdges({ id: 'Orders', version: '1.0.0' });
 
       // All nodes should have valid positions
@@ -643,6 +684,15 @@ describe('Domain Entity Map NodeGraph', () => {
       // Shipment should be positioned to the right of connected entities
       const maxConnectedX = Math.max(...connectedNodes.map((n: any) => n.position.x));
       expect(shipmentNode.position.x).toBeGreaterThan(maxConnectedX);
+    });
+
+    it('keeps the generated entity map compact', async () => {
+      const { nodes } = await getNodesAndEdges({ id: 'Orders', version: '1.0.0' });
+      const xPositions = nodes.map((node: any) => node.position.x);
+      const yPositions = nodes.map((node: any) => node.position.y);
+
+      expect(Math.max(...xPositions) - Math.min(...xPositions)).toBeLessThan(1200);
+      expect(Math.max(...yPositions) - Math.min(...yPositions)).toBeLessThan(900);
     });
 
     it('should handle entity with no identifier property', async () => {

--- a/packages/core/eventcatalog/src/utils/node-graphs/domain-entity-map.ts
+++ b/packages/core/eventcatalog/src/utils/node-graphs/domain-entity-map.ts
@@ -10,11 +10,18 @@ import { getServices, type Service } from '@utils/collections/services';
 
 const elk = new ELK();
 
+export const ENTITY_TARGET_HANDLE_ID = '__eventcatalog-entity-target';
+
 const getReferencedEntityId = (property: any, entityMap: Map<string, Entity[]>) => {
   if (property.references) return property.references;
   if (property.type === 'array' && property.items?.type && entityMap.has(property.items.type)) return property.items.type;
   return undefined;
 };
+
+const getReferencePropertyNames = (entity: Entity, entityMap: Map<string, Entity[]>) =>
+  entity.data.properties
+    ?.filter((property: any) => getReferencedEntityId(property, entityMap))
+    .map((property: any) => property.name) ?? [];
 
 const getRelationType = (property: any) => {
   if (property.relationType) return property.relationType;
@@ -64,7 +71,14 @@ export const getNodesAndEdges = async ({ id, version, entities, type = 'domains'
       id: nodeId,
       type: 'entities',
       position: { x: 0, y: 0 },
-      data: { label: entity.data.name, entity, domainName: resource?.data.name, domainId: resource?.data.id },
+      data: {
+        label: entity.data.name,
+        entity,
+        domainName: resource?.data.name,
+        domainId: resource?.data.id,
+        entityTargetHandle: ENTITY_TARGET_HANDLE_ID,
+        referencePropertyNames: getReferencePropertyNames(entity, entityMap),
+      },
     });
   }
 
@@ -116,6 +130,8 @@ export const getNodesAndEdges = async ({ id, version, entities, type = 'domains'
             externalToDomain: true,
             domainName: domainName,
             domainId: domainId,
+            entityTargetHandle: ENTITY_TARGET_HANDLE_ID,
+            referencePropertyNames: getReferencePropertyNames(externalEntity, entityMap),
           },
         });
         addedExternalEntities.push(externalEntity);
@@ -151,9 +167,12 @@ export const getNodesAndEdges = async ({ id, version, entities, type = 'domains'
         // Use the property name as the source handle
         const sourceHandle = `${referenceProperty.name}-source`;
 
-        // Use referencesIdentifier if provided, otherwise use identifier or first property
+        // Whole-entity targeting is explicit so existing catalogs retain their
+        // identifier/first-property fallback behavior.
         let targetHandle = '';
-        if (referenceProperty.referencesIdentifier) {
+        if (referenceProperty.referenceTarget === 'entity') {
+          targetHandle = ENTITY_TARGET_HANDLE_ID;
+        } else if (referenceProperty.referencesIdentifier) {
           targetHandle = `${referenceProperty.referencesIdentifier}-target`;
         } else if (referencedEntity.data.identifier) {
           targetHandle = `${referencedEntity.data.identifier}-target`;
@@ -211,8 +230,8 @@ export const getNodesAndEdges = async ({ id, version, entities, type = 'domains'
   // Prepare ELK graph structure
   const elkNodes = nodes.map((node: any) => ({
     id: node.id,
-    width: 280,
-    height: 200,
+    width: 220,
+    height: Math.max(120, 72 + (node.data.entity.data.properties?.length ?? 0) * 40),
   }));
 
   const elkEdges = edges.map((edge: any) => ({
@@ -225,12 +244,10 @@ export const getNodesAndEdges = async ({ id, version, entities, type = 'domains'
     id: 'root',
     layoutOptions: {
       'elk.algorithm': 'force',
-      'elk.force.repulsivePower': '2.0',
-      'elk.force.iterations': '500',
-      'elk.spacing.nodeNode': '150',
-      'elk.spacing.edgeNode': '75',
-      'elk.spacing.edgeEdge': '30',
-      'elk.padding': '[top=50,left=50,bottom=50,right=50]',
+      'elk.force.iterations': '300',
+      'elk.spacing.nodeNode': '45',
+      'elk.spacing.componentComponent': '50',
+      'elk.padding': '[top=30,left=30,bottom=30,right=30]',
       'elk.separateConnectedComponents': 'true',
     },
     children: elkNodes,

--- a/packages/linter/src/schemas/entity.ts
+++ b/packages/linter/src/schemas/entity.ts
@@ -1,21 +1,43 @@
 import { z } from 'zod';
 import { baseSchema, detailPanelPropertySchema } from './common';
 
-const propertySchema = z.object({
-  name: z.string(),
-  type: z.string(),
-  required: z.boolean().optional(),
-  description: z.string().optional(),
-  references: z.string().optional(),
-  referencesIdentifier: z.string().optional(),
-  relationType: z.string().optional(),
-  enum: z.array(z.string()).optional(),
-  items: z
-    .object({
-      type: z.string(),
-    })
-    .optional(),
-});
+export interface EntityPropertySchema {
+  name: string;
+  type: string;
+  required?: boolean;
+  description?: string;
+  references?: string;
+  referencesIdentifier?: string;
+  referenceTarget?: 'entity';
+  relationType?: string;
+  enum?: string[];
+  properties?: EntityPropertySchema[];
+  items?: {
+    type: string;
+    properties?: EntityPropertySchema[];
+  };
+}
+
+const propertySchema: z.ZodType<EntityPropertySchema> = z.lazy(() =>
+  z.object({
+    name: z.string(),
+    type: z.string(),
+    required: z.boolean().optional(),
+    description: z.string().optional(),
+    references: z.string().optional(),
+    referencesIdentifier: z.string().optional(),
+    referenceTarget: z.literal('entity').optional(),
+    relationType: z.string().optional(),
+    enum: z.array(z.string()).optional(),
+    properties: z.array(propertySchema).optional(),
+    items: z
+      .object({
+        type: z.string(),
+        properties: z.array(propertySchema).optional(),
+      })
+      .optional(),
+  })
+);
 
 export const entitySchema = z
   .object({

--- a/packages/linter/src/types/index.ts
+++ b/packages/linter/src/types/index.ts
@@ -70,7 +70,14 @@ export interface EntityProperty {
   description?: string;
   references?: string;
   referencesIdentifier?: string;
-  relationType?: 'one-to-one' | 'one-to-many';
+  referenceTarget?: 'entity';
+  relationType?: string;
+  enum?: string[];
+  properties?: EntityProperty[];
+  items?: {
+    type: string;
+    properties?: EntityProperty[];
+  };
 }
 
 export interface ValidationError {

--- a/packages/linter/tests/schema-validator.test.ts
+++ b/packages/linter/tests/schema-validator.test.ts
@@ -190,7 +190,28 @@ describe('validateSchema', () => {
             name: 'orders',
             type: 'Order[]',
             references: 'order',
+            referenceTarget: 'entity',
             relationType: 'one-to-many',
+          },
+          {
+            name: 'profile',
+            type: 'object',
+            properties: [
+              {
+                name: 'displayName',
+                type: 'string',
+              },
+              {
+                name: 'preferences',
+                type: 'object',
+                properties: [
+                  {
+                    name: 'locale',
+                    type: 'string',
+                  },
+                ],
+              },
+            ],
           },
         ],
       });

--- a/packages/sdk/src/types.d.ts
+++ b/packages/sdk/src/types.d.ts
@@ -453,18 +453,27 @@ interface DetailPanelProperty {
   visible: boolean;
 }
 
+export interface EntityProperty {
+  name: string;
+  type: string;
+  required?: boolean;
+  description?: string;
+  references?: string;
+  referencesIdentifier?: string;
+  referenceTarget?: 'entity';
+  relationType?: string;
+  enum?: string[];
+  properties?: EntityProperty[];
+  items?: {
+    type: string;
+    properties?: EntityProperty[];
+  };
+}
+
 export interface Entity extends BaseSchema {
   aggregateRoot?: boolean;
   identifier?: string;
-  properties?: {
-    name: string;
-    type: string;
-    required?: boolean;
-    description?: string;
-    references?: string;
-    referencesIdentifier?: string;
-    relationType?: string;
-  }[];
+  properties?: EntityProperty[];
   detailsPanel?: {
     domains?: DetailPanelProperty;
     services?: DetailPanelProperty;

--- a/packages/visualiser/src/components/NodeGraph.tsx
+++ b/packages/visualiser/src/components/NodeGraph.tsx
@@ -129,6 +129,7 @@ const LARGE_GRAPH_NODE_THRESHOLD = 30;
 
 // Static props for ReactFlow - defined outside component to avoid new references on every render
 const NODE_ORIGIN: [number, number] = [0.1, 0.1];
+const INITIAL_FIT_VIEW_OPTIONS = { padding: 0.2, duration: 0 } as const;
 const MINIMAP_STYLE = {
   backgroundColor: "rgb(var(--ec-page-bg))",
   border: "1px solid rgb(var(--ec-page-border))",
@@ -506,9 +507,28 @@ const NodeGraphBuilder = ({
   const { fitView, getNodes, getIntersectingNodes, getZoom, setCenter } =
     useReactFlow();
   const storeApi = useStoreApi();
+  const previousGraphInputRef = useRef({
+    nodes: initialNodes,
+    edges: initialEdges,
+  });
 
   // Sync when parent passes new nodes/edges (e.g. playground re-parse)
   useEffect(() => {
+    const previousGraphInput = previousGraphInputRef.current;
+    previousGraphInputRef.current = {
+      nodes: initialNodes,
+      edges: initialEdges,
+    };
+
+    // React Flow's fitView prop handles the initial viewport after measuring
+    // the nodes. Avoid scheduling a second animated fit on mount.
+    if (
+      previousGraphInput.nodes === initialNodes &&
+      previousGraphInput.edges === initialEdges
+    ) {
+      return;
+    }
+
     setNodes(initialNodes);
     setEdges(initialEdges);
     // fitView after React Flow processes the new nodes
@@ -2371,6 +2391,7 @@ const NodeGraphBuilder = ({
             nodes={nodes}
             edges={edges}
             fitView
+            fitViewOptions={INITIAL_FIT_VIEW_OPTIONS}
             onNodesChange={handleNodesChange}
             onEdgesChange={onEdgesChange}
             onEdgeMouseEnter={handleEdgeMouseEnter}

--- a/packages/visualiser/src/nodes/Entity.component.test.tsx
+++ b/packages/visualiser/src/nodes/Entity.component.test.tsx
@@ -1,0 +1,152 @@
+// @vitest-environment jsdom
+
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import EntityNode, { ENTITY_TARGET_HANDLE_ID } from "./Entity";
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const { updateNodeInternals } = vi.hoisted(() => ({
+  updateNodeInternals: vi.fn(),
+}));
+
+vi.mock("@xyflow/react", () => ({
+  Handle: ({ id, type }: { id?: string; type: string }) => (
+    <div
+      className="react-flow__handle"
+      data-handle-id={id}
+      data-handle-type={type}
+    />
+  ),
+  Position: {
+    Left: "left",
+    Right: "right",
+  },
+  useUpdateNodeInternals: () => updateNodeInternals,
+}));
+
+vi.mock("@radix-ui/react-context-menu", () => ({
+  Root: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  Trigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  Portal: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  Content: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  Item: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("../utils/badges", () => ({
+  getIcon: () => () => <span data-testid="entity-icon" />,
+}));
+
+vi.mock("../context/PortalContainerContext", () => ({
+  usePortalContainer: () => undefined,
+}));
+
+describe("EntityNode", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    updateNodeInternals.mockClear();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("renders the whole-entity target and expands embedded properties from the whole row", () => {
+    act(() => {
+      root.render(
+        <EntityNode
+          id="Order-1.0.0"
+          data={{
+            mode: "full",
+            entityTargetHandle: ENTITY_TARGET_HANDLE_ID,
+            referencePropertyNames: ["orderLines"],
+            entity: {
+              data: {
+                id: "Order",
+                name: "Order",
+                version: "1.0.0",
+                properties: [
+                  {
+                    name: "customerId",
+                    type: "UUID",
+                    references: "Customer",
+                  },
+                  {
+                    name: "orderLines",
+                    type: "array",
+                    items: { type: "OrderLine" },
+                  },
+                  {
+                    name: "adjustments",
+                    type: "array",
+                    items: {
+                      type: "object",
+                      properties: [{ name: "amount", type: "decimal" }],
+                    },
+                  },
+                  {
+                    name: "deliveryAddress",
+                    type: "object",
+                    properties: [{ name: "city", type: "string" }],
+                  },
+                ],
+              },
+            },
+          }}
+        />,
+      );
+    });
+
+    expect(
+      container.querySelector(`[data-handle-id="${ENTITY_TARGET_HANDLE_ID}"]`),
+    ).not.toBeNull();
+    expect(
+      container.querySelector('[title="References Customer"]'),
+    ).not.toBeNull();
+    expect(
+      container.querySelector('[title="References OrderLine"]'),
+    ).not.toBeNull();
+    expect(container.querySelector('[title="References object"]')).toBeNull();
+    expect(container.textContent).not.toContain("city");
+    expect(updateNodeInternals).not.toHaveBeenCalled();
+
+    const row = container.querySelector<HTMLElement>(
+      '[role="button"][aria-label="Expand deliveryAddress"]',
+    );
+    expect(row).not.toBeNull();
+
+    act(() => {
+      row?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(container.textContent).toContain("city");
+    expect(
+      container.querySelector(
+        '[role="button"][aria-label="Collapse deliveryAddress"]',
+      ),
+    ).not.toBeNull();
+    expect(updateNodeInternals).toHaveBeenCalledTimes(1);
+    expect(updateNodeInternals).toHaveBeenCalledWith("Order-1.0.0");
+
+    const expandedRow = container.querySelector<HTMLElement>(
+      '[role="button"][aria-label="Collapse deliveryAddress"]',
+    );
+    act(() => {
+      expandedRow?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(container.textContent).not.toContain("city");
+    expect(updateNodeInternals).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/visualiser/src/nodes/Entity.test.ts
+++ b/packages/visualiser/src/nodes/Entity.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getPropertyTypeLabel } from "./Entity";
+import { getNestedEntityProperties, getPropertyTypeLabel } from "./Entity";
 
 describe("getPropertyTypeLabel", () => {
   it("shows the item type for array properties", () => {
@@ -15,5 +15,28 @@ describe("getPropertyTypeLabel", () => {
 
   it("falls back to the property type for scalar properties", () => {
     expect(getPropertyTypeLabel({ type: "string" })).toBe("string");
+  });
+
+  it("returns properties nested directly in an object", () => {
+    expect(
+      getNestedEntityProperties({
+        name: "address",
+        type: "object",
+        properties: [{ name: "city", type: "string" }],
+      }),
+    ).toEqual([{ name: "city", type: "string" }]);
+  });
+
+  it("returns properties nested in array items", () => {
+    expect(
+      getNestedEntityProperties({
+        name: "lines",
+        type: "array",
+        items: {
+          type: "object",
+          properties: [{ name: "quantity", type: "number" }],
+        },
+      }),
+    ).toEqual([{ name: "quantity", type: "number" }]);
   });
 });

--- a/packages/visualiser/src/nodes/Entity.tsx
+++ b/packages/visualiser/src/nodes/Entity.tsx
@@ -1,8 +1,9 @@
-import { Handle, Position } from "@xyflow/react";
+import { Handle, Position, useUpdateNodeInternals } from "@xyflow/react";
 import { getIcon } from "../utils/badges";
 import * as ContextMenu from "@radix-ui/react-context-menu";
 import { buildUrl } from "../utils/url-builder";
-import { memo, useState, useMemo } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ChevronDownIcon, ChevronRightIcon } from "@heroicons/react/20/solid";
 import { usePortalContainer } from "../context/PortalContainerContext";
 import {
   HANDLE_LEFT_OFFSET_STYLE,
@@ -11,11 +12,30 @@ import {
 } from "./shared-styles";
 import { TruncatedResourceName } from "./TruncatedResourceName";
 
+export const ENTITY_TARGET_HANDLE_ID = "__eventcatalog-entity-target";
+
+export interface EntityProperty {
+  name: string;
+  type: string;
+  required?: boolean;
+  description?: string;
+  references?: string;
+  referencesIdentifier?: string;
+  referenceTarget?: "entity";
+  relationType?: string;
+  enum?: string[];
+  properties?: EntityProperty[];
+  items?: {
+    type: string;
+    properties?: EntityProperty[];
+  };
+}
+
 interface EntityData {
   id: string;
   name: string;
   version: string;
-  properties?: any[];
+  properties?: EntityProperty[];
   aggregateRoot?: boolean;
   sidebar?: any;
   styles?: {
@@ -43,6 +63,8 @@ interface Data {
   externalToDomain?: boolean;
   domainName?: string;
   domainId?: string;
+  entityTargetHandle?: string;
+  referencePropertyNames?: string[];
   group?: {
     type: string;
     value: string;
@@ -61,12 +83,30 @@ export const getPropertyTypeLabel = (property: any) => {
   return property.type;
 };
 
+export const getNestedEntityProperties = (
+  property: EntityProperty,
+): EntityProperty[] => {
+  if (property.properties?.length) return property.properties;
+  if (property.type === "array" && property.items?.properties?.length) {
+    return property.items.properties;
+  }
+  return [];
+};
+
 export default memo(function EntityNode({
+  id,
   data,
   sourcePosition,
   targetPosition,
 }: any) {
-  const { mode, entity, externalToDomain, domainName } = data as Data;
+  const {
+    mode,
+    entity,
+    externalToDomain,
+    domainName,
+    entityTargetHandle = ENTITY_TARGET_HANDLE_ID,
+    referencePropertyNames = EMPTY_ARRAY,
+  } = data as Data;
   const {
     name,
     version,
@@ -84,7 +124,161 @@ export default memo(function EntityNode({
   const Icon = useMemo(() => getIcon(icon), [icon]);
 
   const [hoveredProperty, setHoveredProperty] = useState<string | null>(null);
+  const [expandedProperties, setExpandedProperties] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const previousExpandedProperties = useRef(expandedProperties);
+  const updateNodeInternals = useUpdateNodeInternals();
   const portalContainer = usePortalContainer();
+  const referenceProperties = useMemo(
+    () => new Set(referencePropertyNames),
+    [referencePropertyNames],
+  );
+
+  const toggleProperty = useCallback((propertyPath: string) => {
+    setExpandedProperties((current) => {
+      const next = new Set(current);
+      if (next.has(propertyPath)) {
+        next.delete(propertyPath);
+      } else {
+        next.add(propertyPath);
+      }
+      return next;
+    });
+  }, []);
+
+  useEffect(() => {
+    if (previousExpandedProperties.current === expandedProperties) return;
+    previousExpandedProperties.current = expandedProperties;
+    updateNodeInternals(id);
+  }, [expandedProperties, id, updateNodeInternals]);
+
+  const renderPropertyRows = (
+    entityProperties: EntityProperty[],
+    depth = 0,
+    parentPath = "",
+  ): React.ReactNode =>
+    entityProperties.map((property, index) => {
+      const propertyPath = parentPath
+        ? `${parentPath}.${property.name}`
+        : property.name;
+      const propertyKey = `${propertyPath}-${index}`;
+      const isHovered = hoveredProperty === propertyKey;
+      const nestedProperties = getNestedEntityProperties(property);
+      const isExpandable = nestedProperties.length > 0;
+      const isExpanded = expandedProperties.has(propertyPath);
+      const isTopLevel = depth === 0;
+      const referencedEntityId =
+        property.references ||
+        (isTopLevel && referenceProperties.has(property.name)
+          ? property.items?.type
+          : undefined);
+
+      return (
+        <div key={propertyKey}>
+          <div
+            className={classNames(
+              "relative flex items-center justify-between py-2 pr-4 hover:bg-[rgb(var(--ec-page-border)/0.2)]",
+              isExpandable && "nodrag nopan cursor-pointer",
+            )}
+            style={{ paddingLeft: `${16 + depth * 16}px` }}
+            role={isExpandable ? "button" : undefined}
+            tabIndex={isExpandable ? 0 : undefined}
+            aria-label={
+              isExpandable
+                ? `${isExpanded ? "Collapse" : "Expand"} ${property.name}`
+                : undefined
+            }
+            aria-expanded={isExpandable ? isExpanded : undefined}
+            onClick={(event) => {
+              if (!isExpandable) return;
+              const target = event.target as HTMLElement;
+              if (target.closest(".react-flow__handle")) return;
+              toggleProperty(propertyPath);
+            }}
+            onKeyDown={(event) => {
+              if (!isExpandable || (event.key !== "Enter" && event.key !== " "))
+                return;
+              event.preventDefault();
+              toggleProperty(propertyPath);
+            }}
+            onMouseEnter={() =>
+              property.description && setHoveredProperty(propertyKey)
+            }
+            onMouseLeave={() => setHoveredProperty(null)}
+          >
+            {isTopLevel && (
+              <>
+                <Handle
+                  type="target"
+                  position={Position.Left}
+                  id={`${property.name}-target`}
+                  className="!w-3 !h-3 !bg-[rgb(var(--ec-card-bg))] !border-2 !border-[rgb(var(--ec-page-border))] !rounded-full !left-[-0px]"
+                  style={HANDLE_LEFT_OFFSET_STYLE}
+                />
+                <Handle
+                  type="source"
+                  position={Position.Right}
+                  id={`${property.name}-source`}
+                  className="!w-3 !h-3 !bg-[rgb(var(--ec-card-bg))] !border-2 !border-[rgb(var(--ec-page-border))] !rounded-full !right-[-0px]"
+                  style={HANDLE_RIGHT_OFFSET_STYLE}
+                />
+              </>
+            )}
+
+            <div className="flex-1 flex items-center justify-between gap-3 min-w-0">
+              <div className="flex items-center gap-1 min-w-0">
+                {isExpandable && (
+                  <span
+                    className="shrink-0 text-[rgb(var(--ec-page-text-muted))]"
+                    aria-hidden="true"
+                  >
+                    {isExpanded ? (
+                      <ChevronDownIcon className="h-3.5 w-3.5" />
+                    ) : (
+                      <ChevronRightIcon className="h-3.5 w-3.5" />
+                    )}
+                  </span>
+                )}
+                <span className="text-sm font-medium text-[rgb(var(--ec-page-text))] truncate">
+                  {property.name}
+                </span>
+                {property.required && (
+                  <span className="text-red-500 text-xs">*</span>
+                )}
+              </div>
+              <span className="text-sm text-[rgb(var(--ec-page-text-muted))] font-mono shrink-0">
+                {getPropertyTypeLabel(property)}
+              </span>
+            </div>
+
+            {referencedEntityId && (
+              <div className="absolute right-2 top-1/2 transform -translate-y-1/2">
+                <div
+                  className="w-2 h-2 bg-blue-500 rounded-full"
+                  title={`References ${referencedEntityId}`}
+                ></div>
+              </div>
+            )}
+
+            {isHovered && property.description && (
+              <div className="absolute left-full ml-2 top-1/2 transform -translate-y-1/2 z-[9999] w-[200px] bg-gray-900 text-white text-xs rounded-lg py-2 px-3 pointer-events-none shadow-xl max-w-xl opacity-100">
+                <div className="text-gray-200 whitespace-normal break-words">
+                  {property.description}
+                </div>
+                <div className="absolute right-full top-1/2 transform -translate-y-1/2 border-4 border-transparent border-r-gray-900"></div>
+              </div>
+            )}
+          </div>
+
+          {isExpandable && isExpanded && (
+            <div className="divide-y divide-[rgb(var(--ec-page-border))] border-t border-[rgb(var(--ec-page-border))] bg-[rgb(var(--ec-content-hover)/0.18)]">
+              {renderPropertyRows(nestedProperties, depth + 1, propertyPath)}
+            </div>
+          )}
+        </div>
+      );
+    });
 
   return (
     <ContextMenu.Root>
@@ -98,10 +292,17 @@ export default memo(function EntityNode({
           {/* Table Header */}
           <div
             className={classNames(
-              "px-4 py-2 rounded-t-lg border-b border-[rgb(var(--ec-page-border))]",
+              "relative px-4 py-2 rounded-t-lg border-b border-[rgb(var(--ec-page-border))]",
               externalToDomain ? "bg-amber-500/20" : "bg-blue-500/15",
             )}
           >
+            <Handle
+              type="target"
+              position={Position.Left}
+              id={entityTargetHandle}
+              className="!w-3 !h-3 !bg-[rgb(var(--ec-card-bg))] !border-2 !border-[rgb(var(--ec-page-border))] !rounded-full !left-[-0px]"
+              style={HANDLE_LEFT_OFFSET_STYLE}
+            />
             <div className="flex items-center gap-2 min-w-0">
               {Icon && (
                 <Icon className="w-4 h-4 text-[rgb(var(--ec-page-text-muted))]" />
@@ -134,76 +335,7 @@ export default memo(function EntityNode({
           {/* Properties Table */}
           {properties.length > 0 ? (
             <div className="divide-y divide-[rgb(var(--ec-page-border))] relative">
-              {properties.map((property: any, index: number) => {
-                const propertyKey = `${property.name}-${index}`;
-                const isHovered = hoveredProperty === propertyKey;
-                return (
-                  <div
-                    key={propertyKey}
-                    className="relative flex items-center justify-between px-4 py-2 hover:bg-[rgb(var(--ec-page-border)/0.2)]"
-                    onMouseEnter={() =>
-                      property.description && setHoveredProperty(propertyKey)
-                    }
-                    onMouseLeave={() => setHoveredProperty(null)}
-                  >
-                    {/* Target handle */}
-                    <Handle
-                      type="target"
-                      position={Position.Left}
-                      id={`${property.name}-target`}
-                      className="!w-3 !h-3 !bg-[rgb(var(--ec-card-bg))] !border-2 !border-[rgb(var(--ec-page-border))] !rounded-full !left-[-0px]"
-                      style={HANDLE_LEFT_OFFSET_STYLE}
-                    />
-
-                    {/* Source handle */}
-                    <Handle
-                      type="source"
-                      position={Position.Right}
-                      id={`${property.name}-source`}
-                      className="!w-3 !h-3 !bg-[rgb(var(--ec-card-bg))] !border-2 !border-[rgb(var(--ec-page-border))] !rounded-full !right-[-0px]"
-                      style={HANDLE_RIGHT_OFFSET_STYLE}
-                    />
-
-                    {/* Property content */}
-                    <div className="flex-1 flex items-center justify-between">
-                      <div className="flex items-center gap-1">
-                        <span className="text-sm font-medium text-[rgb(var(--ec-page-text))]">
-                          {property.name}
-                        </span>
-                        {property.required && (
-                          <span className="text-red-500 text-xs">*</span>
-                        )}
-                      </div>
-                      <span className="text-sm text-[rgb(var(--ec-page-text-muted))] font-mono">
-                        {getPropertyTypeLabel(property)}
-                      </span>
-                    </div>
-
-                    {/* Reference indicator */}
-                    {(property.references ||
-                      (property.type === "array" && property.items?.type)) && (
-                      <div className="absolute right-2 top-1/2 transform -translate-y-1/2">
-                        <div
-                          className="w-2 h-2 bg-blue-500 rounded-full"
-                          title={`References ${
-                            property.references || property.items.type
-                          }`}
-                        ></div>
-                      </div>
-                    )}
-
-                    {/* Property Tooltip */}
-                    {isHovered && property.description && (
-                      <div className="absolute left-full ml-2 top-1/2 transform -translate-y-1/2 z-[9999] w-[200px] bg-gray-900 text-white text-xs rounded-lg py-2 px-3 pointer-events-none shadow-xl max-w-xl opacity-100">
-                        <div className="text-gray-200 whitespace-normal break-words">
-                          {property.description}
-                        </div>
-                        <div className="absolute right-full top-1/2 transform -translate-y-1/2 border-4 border-transparent border-r-gray-900"></div>
-                      </div>
-                    )}
-                  </div>
-                );
-              })}
+              {renderPropertyRows(properties)}
             </div>
           ) : (
             <div className="px-4 py-3 text-sm text-[rgb(var(--ec-page-text-muted))] text-center">

--- a/packages/visualiser/src/nodes/index.ts
+++ b/packages/visualiser/src/nodes/index.ts
@@ -56,6 +56,12 @@ export type { FieldNodeType } from "./field";
 // Shared components
 export { NotesIndicator } from "./NotesIndicator";
 export { OwnerIndicator, normalizeOwners } from "./OwnerIndicator";
+export {
+  ENTITY_TARGET_HANDLE_ID,
+  getNestedEntityProperties,
+  getPropertyTypeLabel,
+} from "./Entity";
+export type { EntityProperty } from "./Entity";
 
 // Core nodes (single files) - import then re-export for nodeComponents
 import CustomNode from "./Custom";


### PR DESCRIPTION
Closes https://github.com/event-catalog/eventcatalog/issues/2590
Closes https://github.com/event-catalog/eventcatalog/issues/2588

## What This PR Does

Entities can now model complex objects: properties can declare nested `properties` (recursively, including inside `items` for arrays), so value objects like an address or a money amount can live inside an entity instead of being forced into their own entity. Entities can also be referenced as a whole via the new `referenceTarget: entity` option, so a relationship edge points at the entity node itself rather than a specific property handle.

## Changes Overview

### Key Changes

- **Schema (`content.config.ts`, linter `entity.ts`, SDK `types.d.ts`)**: entity property schemas are now recursive via `z.lazy()` — a property can contain `properties`, and `items` can contain `properties`. Adds `referenceTarget: 'entity'` to target a whole entity in a relationship.
- **Visualiser (`Entity.tsx`)**: entity nodes render nested properties as expandable rows (chevron toggle, keyboard accessible), with a dedicated whole-entity target handle. Node internals update when rows expand/collapse so edges stay attached.
- **Node graph (`domain-entity-map.ts`)**: edges route to the new entity-level target handle when `referenceTarget: 'entity'` is set, falling back to the existing identifier/first-property behavior otherwise. Layout is tightened (smaller nodes, property-count-based heights, reduced spacing) for more compact entity maps.
- **Docs table (`EntityPropertiesTable.astro`)**: renders embedded properties in entity documentation pages.
- **Docs and example catalog**: entity guides updated with embedded properties and whole-entity relationship examples; the default example's `Order` entity demonstrates both.

## How It Works

The property schema is defined once as a recursive Zod type (`z.lazy()`) and mirrored in the linter and SDK types, so nested objects validate at any depth. In the visualiser, each expandable property row tracks its dot-delimited path in a `Set` of expanded paths; toggling a row triggers `updateNodeInternals` so React Flow recalculates handle positions. When building the domain entity map, a property with `referenceTarget: 'entity'` gets its edge target set to a shared `__eventcatalog-entity-target` handle rendered on the entity node header, instead of a per-property handle.

## Breaking Changes

None. `referenceTarget` is opt-in and existing catalogs keep the identifier/first-property fallback behavior. Nested `properties` are additive to the schema.

## Additional Notes

- Includes a changeset (`patch`) for `@eventcatalog/core`, `@eventcatalog/sdk`, `@eventcatalog/linter`, and `@eventcatalog/visualiser`.
- New component test file `Entity.component.test.tsx` covers the expandable nested-property rendering.