### PR TITLE
Add versionless URLs for the latest version of a service

### DIFF
--- a/.changeset/quiet-services-smile.md
+++ b/.changeset/quiet-services-smile.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/core': patch
+---
+
+Add stable, versionless URLs for the latest service's specifications, changelog, and attached documentation.

--- a/packages/core/docs/development/guides/98-versioning-resources.md
+++ b/packages/core/docs/development/guides/98-versioning-resources.md
@@ -10,6 +10,7 @@ description: Learn how versioning works for EventCatalog resources.
 ---
 
 import ProjectTree from '@site/src/components/MDX/ProjectTree';
+import AddedIn from '@site/src/components/MDX/AddedIn';
 
 EventCatalog resources can be versioned when you want to preserve how a resource looked at a point in time.
 
@@ -109,6 +110,20 @@ For example:
 | `Orders` service version `1.0.0` | `/docs/services/Orders/1.0.0` |
 
 This lets users compare the current resource with previous versions when they need historical context.
+
+### Stable URLs for the latest version
+
+<AddedIn version="4.3.3" />
+
+For services, the URLs for the latest version and its sub-pages (changelog, specifications, and attached documentation) stay versionless and never change as the service is versioned up.
+
+| Page | URL |
+|------|-----|
+| Overview | `/docs/services/Orders` |
+| Changelog | `/docs/services/Orders/changelog` |
+| OpenAPI spec | `/docs/services/Orders/spec/openapi` |
+
+Share these links freely. When `Orders` moves from `1.0.0` to `2.0.0`, the versionless URLs keep resolving to whatever is latest, so the link never rots. Historical versions keep their versioned URLs, for example `/docs/services/Orders/1.0.0/changelog`.
 
 ## Referencing versions
 

--- a/packages/core/docs/development/guides/resources/services/07-versioning-and-lifecycle/01-version-services.md
+++ b/packages/core/docs/development/guides/resources/services/07-versioning-and-lifecycle/01-version-services.md
@@ -8,6 +8,8 @@ title: Version services
 description: Learn how to version services
 ---
 
+import AddedIn from '@site/src/components/MDX/AddedIn';
+
 All content in EventCatalog can be versioned. This allows you to keep historic versions of content which can give context to users why things are changing.
 
 ## How to version a service

--- a/packages/core/eventcatalog/src/__tests__/latest-service-route.spec.ts
+++ b/packages/core/eventcatalog/src/__tests__/latest-service-route.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { toLatestServicePaths } from '../pages/docs/services/_latest-version-route';
+
+describe('latest service routes', () => {
+  it('creates versionless aliases for latest service paths only', () => {
+    const paths = [
+      {
+        params: { type: 'services', id: 'Orders', version: '2.0.0', filename: 'orders' },
+        props: { marker: 'latest' },
+      },
+      {
+        params: { type: 'services', id: 'Orders', version: '1.0.0', filename: 'orders' },
+        props: { marker: 'historical' },
+      },
+      {
+        params: { type: 'domains', id: 'Orders', version: '2.0.0', filename: 'orders' },
+        props: { marker: 'domain' },
+      },
+    ];
+    const latestServices = [{ data: { id: 'Orders', version: '2.0.0' } }] as any;
+
+    expect(toLatestServicePaths(paths, latestServices)).toEqual([
+      {
+        params: { id: 'Orders', filename: 'orders' },
+        props: { marker: 'latest', redirectVersion: '2.0.0' },
+      },
+    ]);
+  });
+});

--- a/packages/core/eventcatalog/src/components/LatestVersionRedirect.astro
+++ b/packages/core/eventcatalog/src/components/LatestVersionRedirect.astro
@@ -1,0 +1,26 @@
+---
+import Seo from '@components/Seo.astro';
+
+interface Props {
+  redirectUrl: string;
+  title: string;
+}
+
+const { redirectUrl, title } = Astro.props;
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <Seo title={title} />
+    <meta http-equiv="refresh" content={`0;url=${redirectUrl}`} />
+  </head>
+  <body>
+    <p>You are being redirected to <a href={redirectUrl}>{redirectUrl}</a></p>
+  </body>
+</html>
+
+<script define:vars={{ redirectUrl }}>
+  const fullRedirectUrl = redirectUrl + window.location.search + window.location.hash;
+  window.location.replace(fullRedirectUrl);
+</script>

--- a/packages/core/eventcatalog/src/pages/docs/services/[id]/[docType]/[docId]/index.astro
+++ b/packages/core/eventcatalog/src/pages/docs/services/[id]/[docType]/[docId]/index.astro
@@ -1,0 +1,25 @@
+---
+import LatestVersionRedirect from '@components/LatestVersionRedirect.astro';
+import { isResourceDocsEnabled, isSSR } from '@utils/feature';
+import { buildUrl } from '@utils/url-builder';
+import { Page as VersionedPage } from '../../../../[type]/[id]/[version]/[docType]/[docId]/_index.data';
+import { getLatestServicePaths, getLatestServiceVersion } from '../../../_latest-version-route';
+
+export const prerender = !isSSR();
+export const getStaticPaths = async () => getLatestServicePaths(await VersionedPage.getStaticPaths());
+
+const { id, docType, docId } = Astro.params;
+const version = Astro.props.redirectVersion ?? (id ? await getLatestServiceVersion(id) : undefined);
+
+if (!isResourceDocsEnabled() || !id || !docType || !docId || !version) {
+  throw new Response(null, { status: 404, statusText: 'Resource documentation not found' });
+}
+
+const redirectUrl = buildUrl(`/docs/services/${id}/${version}/${docType}/${docId}`);
+
+if (isSSR()) {
+  return Astro.redirect(`${redirectUrl}${Astro.url.search}${Astro.url.hash}`);
+}
+---
+
+<LatestVersionRedirect title="Latest service documentation" redirectUrl={redirectUrl} />

--- a/packages/core/eventcatalog/src/pages/docs/services/[id]/asyncapi/[filename].astro
+++ b/packages/core/eventcatalog/src/pages/docs/services/[id]/asyncapi/[filename].astro
@@ -1,0 +1,25 @@
+---
+import LatestVersionRedirect from '@components/LatestVersionRedirect.astro';
+import { isSSR } from '@utils/feature';
+import { buildUrl } from '@utils/url-builder';
+import { Page as VersionedPage } from '../../../[type]/[id]/[version]/asyncapi/_[filename].data';
+import { getLatestServicePaths, getLatestServiceVersion } from '../../_latest-version-route';
+
+export const prerender = !isSSR();
+export const getStaticPaths = async () => getLatestServicePaths(await VersionedPage.getStaticPaths());
+
+const { id, filename } = Astro.params;
+const version = Astro.props.redirectVersion ?? (id ? await getLatestServiceVersion(id) : undefined);
+
+if (!id || !filename || !version) {
+  throw new Response(null, { status: 404, statusText: 'AsyncAPI specification not found' });
+}
+
+const redirectUrl = buildUrl(`/docs/services/${id}/${version}/asyncapi/${filename}`);
+
+if (isSSR()) {
+  return Astro.redirect(`${redirectUrl}${Astro.url.search}${Astro.url.hash}`);
+}
+---
+
+<LatestVersionRedirect title="Latest AsyncAPI specification" redirectUrl={redirectUrl} />

--- a/packages/core/eventcatalog/src/pages/docs/services/[id]/changelog/index.astro
+++ b/packages/core/eventcatalog/src/pages/docs/services/[id]/changelog/index.astro
@@ -1,0 +1,25 @@
+---
+import LatestVersionRedirect from '@components/LatestVersionRedirect.astro';
+import { isChangelogEnabled, isSSR } from '@utils/feature';
+import { buildUrl } from '@utils/url-builder';
+import { Page as VersionedPage } from '../../../[type]/[id]/[version]/changelog/_index.data';
+import { getLatestServicePaths, getLatestServiceVersion } from '../../_latest-version-route';
+
+export const prerender = !isSSR();
+export const getStaticPaths = async () => getLatestServicePaths(await VersionedPage.getStaticPaths());
+
+const { id } = Astro.params;
+const version = Astro.props.redirectVersion ?? (id ? await getLatestServiceVersion(id) : undefined);
+
+if (!isChangelogEnabled() || !id || !version) {
+  throw new Response(null, { status: 404, statusText: 'Changelog not found' });
+}
+
+const redirectUrl = buildUrl(`/docs/services/${id}/${version}/changelog`);
+
+if (isSSR()) {
+  return Astro.redirect(`${redirectUrl}${Astro.url.search}${Astro.url.hash}`);
+}
+---
+
+<LatestVersionRedirect title="Latest service changelog" redirectUrl={redirectUrl} />

--- a/packages/core/eventcatalog/src/pages/docs/services/[id]/graphql/[filename].astro
+++ b/packages/core/eventcatalog/src/pages/docs/services/[id]/graphql/[filename].astro
@@ -1,0 +1,25 @@
+---
+import LatestVersionRedirect from '@components/LatestVersionRedirect.astro';
+import { isSSR } from '@utils/feature';
+import { buildUrl } from '@utils/url-builder';
+import { Page as VersionedPage } from '../../../[type]/[id]/[version]/graphql/_[filename].data';
+import { getLatestServicePaths, getLatestServiceVersion } from '../../_latest-version-route';
+
+export const prerender = !isSSR();
+export const getStaticPaths = async () => getLatestServicePaths(await VersionedPage.getStaticPaths());
+
+const { id, filename } = Astro.params;
+const version = Astro.props.redirectVersion ?? (id ? await getLatestServiceVersion(id) : undefined);
+
+if (!id || !filename || !version) {
+  throw new Response(null, { status: 404, statusText: 'GraphQL specification not found' });
+}
+
+const redirectUrl = buildUrl(`/docs/services/${id}/${version}/graphql/${filename}`);
+
+if (isSSR()) {
+  return Astro.redirect(`${redirectUrl}${Astro.url.search}${Astro.url.hash}`);
+}
+---
+
+<LatestVersionRedirect title="Latest GraphQL specification" redirectUrl={redirectUrl} />

--- a/packages/core/eventcatalog/src/pages/docs/services/[id]/spec/[filename].astro
+++ b/packages/core/eventcatalog/src/pages/docs/services/[id]/spec/[filename].astro
@@ -1,0 +1,25 @@
+---
+import LatestVersionRedirect from '@components/LatestVersionRedirect.astro';
+import { isSSR } from '@utils/feature';
+import { buildUrl } from '@utils/url-builder';
+import { Page as VersionedPage } from '../../../[type]/[id]/[version]/spec/_[filename].data';
+import { getLatestServicePaths, getLatestServiceVersion } from '../../_latest-version-route';
+
+export const prerender = !isSSR();
+export const getStaticPaths = async () => getLatestServicePaths(await VersionedPage.getStaticPaths());
+
+const { id, filename } = Astro.params;
+const version = Astro.props.redirectVersion ?? (id ? await getLatestServiceVersion(id) : undefined);
+
+if (!id || !filename || !version) {
+  throw new Response(null, { status: 404, statusText: 'OpenAPI specification not found' });
+}
+
+const redirectUrl = buildUrl(`/docs/services/${id}/${version}/spec/${filename}`);
+
+if (isSSR()) {
+  return Astro.redirect(`${redirectUrl}${Astro.url.search}${Astro.url.hash}`);
+}
+---
+
+<LatestVersionRedirect title="Latest OpenAPI specification" redirectUrl={redirectUrl} />

--- a/packages/core/eventcatalog/src/pages/docs/services/_latest-version-route.ts
+++ b/packages/core/eventcatalog/src/pages/docs/services/_latest-version-route.ts
@@ -1,0 +1,42 @@
+import type { CollectionEntry } from 'astro:content';
+
+type StaticPath = {
+  params: Record<string, string | undefined>;
+  props?: Record<string, unknown>;
+};
+
+type LatestService = CollectionEntry<'services'>;
+
+export const toLatestServicePaths = (paths: StaticPath[], latestServices: LatestService[]): StaticPath[] => {
+  const latestVersions = new Map(latestServices.map((service) => [service.data.id, service.data.version]));
+
+  return paths.flatMap(({ params, props = {} }) => {
+    const { type, version, ...aliasParams } = params;
+
+    if (type !== 'services' || !params.id || latestVersions.get(params.id) !== version) {
+      return [];
+    }
+
+    return [
+      {
+        params: aliasParams,
+        props: {
+          ...props,
+          redirectVersion: version,
+        },
+      },
+    ];
+  });
+};
+
+export const getLatestServicePaths = async (paths: StaticPath[]): Promise<StaticPath[]> => {
+  const { getServices } = await import('@utils/collections/services');
+  const latestServices = await getServices({ getAllVersions: false });
+  return toLatestServicePaths(paths, latestServices);
+};
+
+export const getLatestServiceVersion = async (id: string): Promise<string | undefined> => {
+  const { getServices } = await import('@utils/collections/services');
+  const latestServices = await getServices({ getAllVersions: false });
+  return latestServices.find((service) => service.data.id === id)?.data.version;
+};

--- a/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/sidebar-builder.spec.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/sidebar-builder.spec.ts
@@ -1899,7 +1899,7 @@ describe('getNestedSideBarData', () => {
         expect(serviceNode).toHaveNavigationLink({
           type: 'item',
           title: 'Overview',
-          href: '/docs/services/ShippingService/0.0.1',
+          href: '/docs/services/ShippingService',
         });
       });
 
@@ -1917,7 +1917,7 @@ describe('getNestedSideBarData', () => {
         expect(serviceNode).toHaveNavigationLink({
           type: 'item',
           title: 'Changelog',
-          href: '/docs/services/ShippingService/0.0.1/changelog',
+          href: '/docs/services/ShippingService/changelog',
         });
         config.changelog = { enabled: false };
       });
@@ -1936,7 +1936,7 @@ describe('getNestedSideBarData', () => {
         expect(serviceNode).not.toHaveNavigationLink({
           type: 'item',
           title: 'Changelog',
-          href: '/docs/services/ShippingService/0.0.1/changelog',
+          href: '/docs/services/ShippingService/changelog',
         });
       });
 
@@ -1959,7 +1959,7 @@ describe('getNestedSideBarData', () => {
         expect(serviceNode).not.toHaveNavigationLink({
           type: 'item',
           title: 'Changelog',
-          href: '/docs/services/ShippingService/0.0.1/changelog',
+          href: '/docs/services/ShippingService/changelog',
         });
         config.changelog = { enabled: false };
       });
@@ -2109,21 +2109,59 @@ describe('getNestedSideBarData', () => {
             type: 'item',
             title: 'OpenAPI',
             leftIcon: '/icons/openapi-black.svg',
-            href: '/docs/services/ShippingService/0.0.1/spec/openapi',
+            href: '/docs/services/ShippingService/spec/openapi',
           },
           {
             type: 'item',
             title: 'AsyncAPI',
             leftIcon: '/icons/asyncapi-black.svg',
-            href: '/docs/services/ShippingService/0.0.1/asyncapi/asyncapi',
+            href: '/docs/services/ShippingService/asyncapi/asyncapi',
           },
           {
             type: 'item',
             title: 'GraphQL',
             leftIcon: '/icons/graphql-black.svg',
-            href: '/docs/services/ShippingService/0.0.1/graphql/graphql',
+            href: '/docs/services/ShippingService/graphql/graphql',
           },
         ]);
+      });
+
+      it('keeps specification links versioned for historical service versions', async () => {
+        const { writeService } = utils(CATALOG_FOLDER);
+        const specifications = [{ type: 'asyncapi' as const, path: 'asyncapi.yaml', name: 'AsyncAPI' }];
+
+        await writeService({
+          id: 'ShippingService',
+          name: 'ShippingService',
+          version: '1.0.0',
+          markdown: 'ShippingService',
+          specifications,
+        });
+        await writeService(
+          {
+            id: 'ShippingService',
+            name: 'ShippingService',
+            version: '2.0.0',
+            markdown: 'ShippingService',
+            specifications,
+          },
+          { versionExistingContent: true }
+        );
+
+        const navigationData = await getNestedSideBarData();
+        const historicalServiceNode = getNavigationConfigurationByKey('service:ShippingService:1.0.0', navigationData);
+        const latestServiceNode = getNavigationConfigurationByKey('service:ShippingService:2.0.0', navigationData);
+
+        expect(historicalServiceNode).toHaveNavigationLink({
+          type: 'item',
+          title: 'AsyncAPI',
+          href: '/docs/services/ShippingService/1.0.0/asyncapi/asyncapi',
+        });
+        expect(latestServiceNode).toHaveNavigationLink({
+          type: 'item',
+          title: 'AsyncAPI',
+          href: '/docs/services/ShippingService/asyncapi/asyncapi',
+        });
       });
     });
 
@@ -4642,7 +4680,7 @@ describe('getNestedSideBarData', () => {
           {
             type: 'item',
             title: 'Service Boundary ADR',
-            href: '/docs/services/ShippingService/0.0.1/adrs/service-boundary',
+            href: '/docs/services/ShippingService/adrs/service-boundary',
           },
         ]);
 

--- a/packages/core/eventcatalog/src/stores/sidebar-store/builders/service.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/builders/service.ts
@@ -58,12 +58,15 @@ export const buildServiceNode = (
   const renderEntities = serviceEntities.length > 0 && shouldRenderSideBarSection(service, 'entities');
   const renderOwners = owners.length > 0 && shouldRenderSideBarSection(service, 'owners');
   const renderRepository = service.data.repository && shouldRenderSideBarSection(service, 'repository');
+  const isLatestVersion = service.data.version === service.data.latestVersion;
+  const docsBasePath = `/docs/services/${service.data.id}${isLatestVersion ? '' : `/${service.data.version}`}`;
   const docsSection = buildResourceDocsSection(
     'services',
     service.data.id,
     service.data.version,
     context.resourceDocs,
-    context.resourceDocCategories
+    context.resourceDocCategories,
+    { includeVersionInUrl: !isLatestVersion }
   );
 
   // Diagrams
@@ -82,11 +85,11 @@ export const buildServiceNode = (
     pages: [
       buildQuickReferenceSection(
         [
-          { title: 'Overview', href: buildUrl(`/docs/services/${service.data.id}/${service.data.version}`) },
+          { title: 'Overview', href: buildUrl(docsBasePath) },
           isChangelogEnabled() &&
             shouldRenderSideBarSection(service, 'changelog') && {
               title: 'Changelog',
-              href: buildUrl(`/docs/services/${service.data.id}/${service.data.version}/changelog`),
+              href: buildUrl(`${docsBasePath}/changelog`),
             },
         ].filter(Boolean) as { title: string; href: string }[]
       ),
@@ -135,25 +138,19 @@ export const buildServiceNode = (
             type: 'item',
             title: `${specification.name}`,
             leftIcon: '/icons/openapi-black.svg',
-            href: buildUrl(
-              `/docs/services/${service.data.id}/${service.data.version}/spec/${specification.filenameWithoutExtension}`
-            ),
+            href: buildUrl(`${docsBasePath}/spec/${specification.filenameWithoutExtension}`),
           })),
           ...asyncAPISpecifications.map((specification) => ({
             type: 'item',
             title: `${specification.name}`,
             leftIcon: '/icons/asyncapi-black.svg',
-            href: buildUrl(
-              `/docs/services/${service.data.id}/${service.data.version}/asyncapi/${specification.filenameWithoutExtension}`
-            ),
+            href: buildUrl(`${docsBasePath}/asyncapi/${specification.filenameWithoutExtension}`),
           })),
           ...graphQLSpecifications.map((specification) => ({
             type: 'item',
             title: `${specification.name}`,
             leftIcon: '/icons/graphql-black.svg',
-            href: buildUrl(
-              `/docs/services/${service.data.id}/${service.data.version}/graphql/${specification.filenameWithoutExtension}`
-            ),
+            href: buildUrl(`${docsBasePath}/graphql/${specification.filenameWithoutExtension}`),
           })),
         ],
       },

--- a/packages/core/eventcatalog/src/stores/sidebar-store/builders/shared.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/builders/shared.ts
@@ -189,8 +189,10 @@ export const buildResourceDocsSection = (
   id: string,
   version: string,
   resourceDocs: ResourceDocEntry[],
-  resourceDocCategories: ResourceDocCategoryEntry[]
+  resourceDocCategories: ResourceDocCategoryEntry[],
+  options: { includeVersionInUrl?: boolean } = {}
 ): NavNode | null => {
+  const { includeVersionInUrl = true } = options;
   const docsForResource = resourceDocs.filter(
     (doc) => doc.data.resourceCollection === collection && doc.data.resourceId === id && doc.data.resourceVersion === version
   );
@@ -249,7 +251,7 @@ export const buildResourceDocsSection = (
         type: 'item',
         title: doc.data.title || doc.data.id,
         href: buildUrl(
-          `/docs/${collection}/${id}/${version}/${encodeURIComponent(doc.data.type)}/${encodeURIComponent(doc.data.id)}`
+          `/docs/${collection}/${id}${includeVersionInUrl ? `/${version}` : ''}/${encodeURIComponent(doc.data.type)}/${encodeURIComponent(doc.data.id)}`
         ),
       })),
     })),


### PR DESCRIPTION
Closes https://github.com/event-catalog/eventcatalog/issues/2737

## What This PR Does

Service sub-pages previously always embedded the version number in the URL, which meant any link you shared (an OpenAPI spec, a changelog, an ADR) broke as soon as the service was versioned up. This PR adds stable, versionless URLs that always resolve to the latest version of a service.

Historical versions keep their existing versioned URLs, so nothing that already exists changes meaning. The new versionless routes sit alongside them as permanent aliases.

## Changes Overview

### Key Changes

- New alias routes under `/docs/services/[id]/...` covering the OpenAPI spec, AsyncAPI, GraphQL, changelog, and attached resource documentation pages.
- New `_latest-version-route.ts` helper that derives the versionless static paths from the existing versioned route definitions, emitting an alias only for the latest version of each service.
- New `LatestVersionRedirect.astro` component handling the redirect in static builds.
- Sidebar navigation now emits versionless URLs for the latest version of a service, and keeps versioned URLs for historical versions.
- `buildResourceDocsSection` gained an `includeVersionInUrl` option so attached docs follow the same rule.

Before and after, for the latest version of a service:

| Before | After |
| --- | --- |
| `/docs/services/ShippingService/0.0.1` | `/docs/services/ShippingService` |
| `/docs/services/ShippingService/0.0.1/changelog` | `/docs/services/ShippingService/changelog` |
| `/docs/services/ShippingService/0.0.1/spec/openapi` | `/docs/services/ShippingService/spec/openapi` |
| `/docs/services/ShippingService/0.0.1/asyncapi/asyncapi` | `/docs/services/ShippingService/asyncapi/asyncapi` |
| `/docs/services/ShippingService/0.0.1/graphql/graphql` | `/docs/services/ShippingService/graphql/graphql` |
| `/docs/services/ShippingService/0.0.1/adrs/service-boundary` | `/docs/services/ShippingService/adrs/service-boundary` |

## How It Works

Each alias route reuses the `getStaticPaths` of its existing versioned counterpart and filters it down through `toLatestServicePaths`, which drops the `version` param and keeps only entries whose version matches the service's latest. This means the alias routes stay automatically in sync with the versioned routes rather than duplicating their path logic.

Resolution then differs by build mode:

- **SSR** — the route issues a real `Astro.redirect` to the canonical versioned URL.
- **Static** — `LatestVersionRedirect.astro` renders a `meta http-equiv="refresh"` alongside a `window.location.replace` script, with a visible link as the no-JS fallback.

Query strings and hash fragments are carried across the redirect in both modes, so deep links into a spec page keep working.

Feature flags are respected: the changelog alias 404s when the changelog is disabled, and the resource-docs alias 404s when resource docs are disabled.

## Breaking Changes

None. Existing versioned URLs continue to resolve exactly as before; the versionless routes are purely additive. The only user-visible difference is that sidebar links for the latest version of a service now point at the versionless URL.

## Additional Notes

- Docs were updated automatically by the pre-commit docs hook (`versioning-resources` and `version-services` guides) and are included in this commit.
- Tests: added `latest-service-route.spec.ts` covering the alias path filtering, plus a sidebar test asserting historical versions keep versioned specification links. Full sidebar suite (178 tests) passes.
- Note for reviewers: `pnpm --filter @eventcatalog/core run check` currently fails on `main` for an unrelated reason — a stale git-ignored build artifact in `examples/default/dist/generated/` carries a `tags` property that no longer satisfies the events schema. This is pre-existing and not introduced here; it clears with a fresh `generate`.