### PR TITLE
Improve sidebar group collapsing, persistence, and resizing

### DIFF
--- a/.changeset/tame-plums-relax.md
+++ b/.changeset/tame-plums-relax.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Improve sidebar navigation group collapsing, persistence, and layout scrolling

--- a/examples/default/domains/Ordering/systems/order-management-system/services/OrderService/asyncapi.yml
+++ b/examples/default/domains/Ordering/systems/order-management-system/services/OrderService/asyncapi.yml
@@ -7,7 +7,8 @@ info:
     The event-driven interface of the Order Service — the system of record for orders.
 
     The service consumes commands to create and cancel orders, and publishes events as
-    orders move through their lifecycle (created, completed, cancelled). Query access
+    orders move through their lifecycle, including confirmation, amendments, operational
+    holds, fulfilment, completion, cancellation, and archival. Query access
     (`GetOrder`) is served over the REST API and is not part of this AsyncAPI document.
   contact:
     name: Ordering Platform
@@ -39,6 +40,22 @@ channels:
     messages:
       OrderCreated:
         $ref: '#/components/messages/OrderCreated'
+      OrderConfirmed:
+        $ref: '#/components/messages/OrderConfirmed'
+      OrderAmended:
+        $ref: '#/components/messages/OrderAmended'
+      OrderPlacedOnHold:
+        $ref: '#/components/messages/OrderPlacedOnHold'
+      OrderHoldReleased:
+        $ref: '#/components/messages/OrderHoldReleased'
+      OrderFulfilmentStarted:
+        $ref: '#/components/messages/OrderFulfilmentStarted'
+      OrderStatusChanged:
+        $ref: '#/components/messages/OrderStatusChanged'
+      OrderDeliveryAddressChanged:
+        $ref: '#/components/messages/OrderDeliveryAddressChanged'
+      OrderArchived:
+        $ref: '#/components/messages/OrderArchived'
       OrderCompleted:
         $ref: '#/components/messages/OrderCompleted'
       OrderCancelled:
@@ -71,6 +88,78 @@ operations:
       $ref: '#/channels/orderEvents'
     messages:
       - $ref: '#/channels/orderEvents/messages/OrderCreated'
+
+  publishOrderConfirmed:
+    action: send
+    title: Order Confirmed
+    summary: Published when an order is confirmed and ready for fulfilment.
+    channel:
+      $ref: '#/channels/orderEvents'
+    messages:
+      - $ref: '#/channels/orderEvents/messages/OrderConfirmed'
+
+  publishOrderAmended:
+    action: send
+    title: Order Amended
+    summary: Published when an accepted order is changed before fulfilment.
+    channel:
+      $ref: '#/channels/orderEvents'
+    messages:
+      - $ref: '#/channels/orderEvents/messages/OrderAmended'
+
+  publishOrderPlacedOnHold:
+    action: send
+    title: Order Placed On Hold
+    summary: Published when order progression is paused for review.
+    channel:
+      $ref: '#/channels/orderEvents'
+    messages:
+      - $ref: '#/channels/orderEvents/messages/OrderPlacedOnHold'
+
+  publishOrderHoldReleased:
+    action: send
+    title: Order Hold Released
+    summary: Published when an operational hold is resolved.
+    channel:
+      $ref: '#/channels/orderEvents'
+    messages:
+      - $ref: '#/channels/orderEvents/messages/OrderHoldReleased'
+
+  publishOrderFulfilmentStarted:
+    action: send
+    title: Order Fulfilment Started
+    summary: Published when an order is released for picking and packing.
+    channel:
+      $ref: '#/channels/orderEvents'
+    messages:
+      - $ref: '#/channels/orderEvents/messages/OrderFulfilmentStarted'
+
+  publishOrderStatusChanged:
+    action: send
+    title: Order Status Changed
+    summary: Published for every accepted order lifecycle transition.
+    channel:
+      $ref: '#/channels/orderEvents'
+    messages:
+      - $ref: '#/channels/orderEvents/messages/OrderStatusChanged'
+
+  publishOrderDeliveryAddressChanged:
+    action: send
+    title: Order Delivery Address Changed
+    summary: Published when the validated delivery address changes before dispatch.
+    channel:
+      $ref: '#/channels/orderEvents'
+    messages:
+      - $ref: '#/channels/orderEvents/messages/OrderDeliveryAddressChanged'
+
+  publishOrderArchived:
+    action: send
+    title: Order Archived
+    summary: Published when a terminal order is moved to long-term storage.
+    channel:
+      $ref: '#/channels/orderEvents'
+    messages:
+      - $ref: '#/channels/orderEvents/messages/OrderArchived'
 
   publishOrderCompleted:
     action: send
@@ -110,6 +199,54 @@ components:
       summary: Published when a new order has been created.
       payload:
         $ref: '#/components/schemas/OrderCreated'
+    OrderConfirmed:
+      name: OrderConfirmed
+      title: Order Confirmed
+      summary: Published when an order is confirmed and ready for fulfilment.
+      payload:
+        $ref: '#/components/schemas/OrderConfirmed'
+    OrderAmended:
+      name: OrderAmended
+      title: Order Amended
+      summary: Published when an accepted order is changed before fulfilment.
+      payload:
+        $ref: '#/components/schemas/OrderAmended'
+    OrderPlacedOnHold:
+      name: OrderPlacedOnHold
+      title: Order Placed On Hold
+      summary: Published when order progression is paused for review.
+      payload:
+        $ref: '#/components/schemas/OrderPlacedOnHold'
+    OrderHoldReleased:
+      name: OrderHoldReleased
+      title: Order Hold Released
+      summary: Published when an operational hold is resolved.
+      payload:
+        $ref: '#/components/schemas/OrderHoldReleased'
+    OrderFulfilmentStarted:
+      name: OrderFulfilmentStarted
+      title: Order Fulfilment Started
+      summary: Published when an order is released for picking and packing.
+      payload:
+        $ref: '#/components/schemas/OrderFulfilmentStarted'
+    OrderStatusChanged:
+      name: OrderStatusChanged
+      title: Order Status Changed
+      summary: Published for every accepted order lifecycle transition.
+      payload:
+        $ref: '#/components/schemas/OrderStatusChanged'
+    OrderDeliveryAddressChanged:
+      name: OrderDeliveryAddressChanged
+      title: Order Delivery Address Changed
+      summary: Published when the validated delivery address changes before dispatch.
+      payload:
+        $ref: '#/components/schemas/OrderDeliveryAddressChanged'
+    OrderArchived:
+      name: OrderArchived
+      title: Order Archived
+      summary: Published when a terminal order is moved to long-term storage.
+      payload:
+        $ref: '#/components/schemas/OrderArchived'
     OrderCompleted:
       name: OrderCompleted
       title: Order Completed
@@ -197,6 +334,240 @@ components:
           type: string
           pattern: '^[A-Z]{3}$'
         createdAt:
+          type: string
+          format: date-time
+
+    OrderConfirmed:
+      type: object
+      description: Published when an order is confirmed and ready for fulfilment.
+      required: [orderId, customerId, confirmationNumber, total, currency, confirmedAt]
+      properties:
+        orderId:
+          type: string
+          format: uuid
+        customerId:
+          type: string
+          format: uuid
+        confirmationNumber:
+          type: string
+          pattern: '^ORD-[0-9]{8}$'
+        paymentAuthorizationId:
+          type: string
+        inventoryReservationId:
+          type: string
+        total:
+          type: integer
+          minimum: 0
+        currency:
+          type: string
+          pattern: '^[A-Z]{3}$'
+        confirmedAt:
+          type: string
+          format: date-time
+
+    OrderAmended:
+      type: object
+      description: Published when an accepted order is amended.
+      required: [orderId, revision, changedFields, previousTotal, newTotal, currency, amendedBy, amendedAt]
+      properties:
+        orderId:
+          type: string
+          format: uuid
+        revision:
+          type: integer
+          minimum: 2
+        changedFields:
+          type: array
+          minItems: 1
+          uniqueItems: true
+          items:
+            type: string
+            enum: [items, deliveryAddress, deliveryMethod, promotionCode]
+        previousTotal:
+          type: integer
+          minimum: 0
+        newTotal:
+          type: integer
+          minimum: 0
+        currency:
+          type: string
+          pattern: '^[A-Z]{3}$'
+        amendedBy:
+          type: string
+        reason:
+          type: string
+          maxLength: 250
+        amendedAt:
+          type: string
+          format: date-time
+
+    OrderPlacedOnHold:
+      type: object
+      description: Published when an order is paused for operational review.
+      required: [orderId, holdId, reason, ownerTeam, reviewBy, placedAt]
+      properties:
+        orderId:
+          type: string
+          format: uuid
+        holdId:
+          type: string
+          format: uuid
+        reason:
+          type: string
+          enum: [PAYMENT_REVIEW, FRAUD_REVIEW, ADDRESS_VERIFICATION, INVENTORY_RECHECK]
+        ownerTeam:
+          type: string
+        customerMessage:
+          type: string
+          maxLength: 280
+        reviewBy:
+          type: string
+          format: date-time
+        placedAt:
+          type: string
+          format: date-time
+
+    OrderHoldReleased:
+      type: object
+      description: Published when an operational hold is released.
+      required: [orderId, holdId, previousReason, resolution, releasedBy, nextStatus, releasedAt]
+      properties:
+        orderId:
+          type: string
+          format: uuid
+        holdId:
+          type: string
+          format: uuid
+        previousReason:
+          type: string
+          enum: [PAYMENT_REVIEW, FRAUD_REVIEW, ADDRESS_VERIFICATION, INVENTORY_RECHECK]
+        resolution:
+          type: string
+          maxLength: 250
+        releasedBy:
+          type: string
+        nextStatus:
+          type: string
+          enum: [CONFIRMED, AWAITING_FULFILMENT]
+        releasedAt:
+          type: string
+          format: date-time
+
+    OrderFulfilmentStarted:
+      type: object
+      description: Published when an order is released for picking and packing.
+      required: [orderId, fulfilmentId, warehouseId, itemCount, priority, deliveryMethod, startedAt]
+      properties:
+        orderId:
+          type: string
+          format: uuid
+        fulfilmentId:
+          type: string
+          format: uuid
+        warehouseId:
+          type: string
+        itemCount:
+          type: integer
+          minimum: 1
+        priority:
+          type: string
+          enum: [STANDARD, EXPEDITED, SAME_DAY]
+        deliveryMethod:
+          type: string
+          enum: [HOME_DELIVERY, CLICK_AND_COLLECT]
+        estimatedDispatchAt:
+          type: string
+          format: date-time
+        startedAt:
+          type: string
+          format: date-time
+
+    OrderStatusChanged:
+      type: object
+      description: Published for every accepted order lifecycle transition.
+      required: [orderId, previousStatus, newStatus, sequence, changedAt]
+      properties:
+        orderId:
+          type: string
+          format: uuid
+        previousStatus:
+          type: string
+          enum: [CREATED, CONFIRMED, ON_HOLD, AWAITING_FULFILMENT, FULFILLING, COMPLETED, CANCELLED]
+        newStatus:
+          type: string
+          enum: [CONFIRMED, ON_HOLD, AWAITING_FULFILMENT, FULFILLING, COMPLETED, CANCELLED, ARCHIVED]
+        sequence:
+          type: integer
+          minimum: 1
+        changeReason:
+          type: string
+          maxLength: 250
+        correlationId:
+          type: string
+          format: uuid
+        changedAt:
+          type: string
+          format: date-time
+
+    OrderDeliveryAddressChanged:
+      type: object
+      description: Published when the validated delivery address changes before dispatch.
+      required: [orderId, addressRevision, previousPostalCode, deliveryAddress, changedBy, changedAt]
+      properties:
+        orderId:
+          type: string
+          format: uuid
+        addressRevision:
+          type: integer
+          minimum: 2
+        previousPostalCode:
+          type: string
+        deliveryAddress:
+          type: object
+          required: [recipientName, line1, city, postalCode, countryCode]
+          properties:
+            recipientName:
+              type: string
+            line1:
+              type: string
+            line2:
+              type: string
+            city:
+              type: string
+            postalCode:
+              type: string
+            countryCode:
+              type: string
+              pattern: '^[A-Z]{2}$'
+        changedBy:
+          type: string
+        changedAt:
+          type: string
+          format: date-time
+
+    OrderArchived:
+      type: object
+      description: Published when a terminal order is moved to long-term storage.
+      required: [orderId, terminalStatus, retentionCategory, archiveReference, recordChecksum, terminalAt, archivedAt]
+      properties:
+        orderId:
+          type: string
+          format: uuid
+        terminalStatus:
+          type: string
+          enum: [COMPLETED, CANCELLED]
+        retentionCategory:
+          type: string
+          enum: [STANDARD, FINANCIAL_RECORD, LEGAL_HOLD]
+        archiveReference:
+          type: string
+        recordChecksum:
+          type: string
+          pattern: '^[a-f0-9]{64}$'
+        terminalAt:
+          type: string
+          format: date-time
+        archivedAt:
           type: string
           format: date-time
 

--- a/examples/default/domains/Ordering/systems/order-management-system/services/OrderService/events/OrderAmended/index.mdx
+++ b/examples/default/domains/Ordering/systems/order-management-system/services/OrderService/events/OrderAmended/index.mdx
@@ -1,0 +1,29 @@
+---
+id: order-amended
+name: Order Amended
+version: 1.0.0
+summary: |
+  Published when an accepted order is changed before fulfilment begins.
+owners:
+  - ordering-platform
+badges:
+  - content: 'Broker:Kafka'
+    backgroundColor: blue
+    textColor: blue
+    icon: BoltIcon
+schemaPath: schema.json
+---
+
+import Footer from '@catalog/components/footer.astro';
+
+## Overview
+
+`OrderAmended` records an approved change to an order, such as a quantity adjustment, delivery method change, or promotional correction. Consumers use the revision and changed fields to update projections without rebuilding the full order history.
+
+<SchemaViewer file="schema.json" title="JSON Schema" maxHeight="500" />
+
+## Architecture diagram
+
+<NodeGraph />
+
+<Footer />

--- a/examples/default/domains/Ordering/systems/order-management-system/services/OrderService/events/OrderAmended/schema.json
+++ b/examples/default/domains/Ordering/systems/order-management-system/services/OrderService/events/OrderAmended/schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "OrderAmended",
+  "description": "Published when an accepted order is amended",
+  "type": "object",
+  "properties": {
+    "orderId": { "type": "string", "format": "uuid" },
+    "revision": { "type": "integer", "minimum": 2 },
+    "changedFields": {
+      "type": "array",
+      "items": { "type": "string", "enum": ["items", "deliveryAddress", "deliveryMethod", "promotionCode"] },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "previousTotal": { "type": "integer", "minimum": 0 },
+    "newTotal": { "type": "integer", "minimum": 0 },
+    "currency": { "type": "string", "pattern": "^[A-Z]{3}$" },
+    "amendedBy": { "type": "string", "description": "Customer, support agent, or automated policy identifier" },
+    "reason": { "type": "string", "maxLength": 250 },
+    "amendedAt": { "type": "string", "format": "date-time" }
+  },
+  "required": ["orderId", "revision", "changedFields", "previousTotal", "newTotal", "currency", "amendedBy", "amendedAt"],
+  "examples": [
+    {
+      "orderId": "7e86e1d8-cd5f-4d6f-ae8e-bdc5ed3a0d13",
+      "revision": 2,
+      "changedFields": ["items", "promotionCode"],
+      "previousTotal": 12999,
+      "newTotal": 11999,
+      "currency": "GBP",
+      "amendedBy": "support-agent:maya.chen",
+      "reason": "Removed duplicate accessory and applied verified welcome offer",
+      "amendedAt": "2026-07-29T09:48:03Z"
+    }
+  ]
+}

--- a/examples/default/domains/Ordering/systems/order-management-system/services/OrderService/events/OrderArchived/index.mdx
+++ b/examples/default/domains/Ordering/systems/order-management-system/services/OrderService/events/OrderArchived/index.mdx
@@ -1,0 +1,29 @@
+---
+id: order-archived
+name: Order Archived
+version: 1.0.0
+summary: |
+  Published when a terminal order is moved from operational storage to the long-term archive.
+owners:
+  - ordering-platform
+badges:
+  - content: 'Broker:Kafka'
+    backgroundColor: blue
+    textColor: blue
+    icon: BoltIcon
+schemaPath: schema.json
+---
+
+import Footer from '@catalog/components/footer.astro';
+
+## Overview
+
+`OrderArchived` marks the end of the operational retention period for a completed or cancelled order. Reporting, compliance, and support systems use the archive reference to locate historical data after it leaves the primary order database.
+
+<SchemaViewer file="schema.json" title="JSON Schema" maxHeight="500" />
+
+## Architecture diagram
+
+<NodeGraph />
+
+<Footer />

--- a/examples/default/domains/Ordering/systems/order-management-system/services/OrderService/events/OrderArchived/schema.json
+++ b/examples/default/domains/Ordering/systems/order-management-system/services/OrderService/events/OrderArchived/schema.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "OrderArchived",
+  "description": "Published when a terminal order is moved to long-term storage",
+  "type": "object",
+  "properties": {
+    "orderId": { "type": "string", "format": "uuid" },
+    "terminalStatus": { "type": "string", "enum": ["COMPLETED", "CANCELLED"] },
+    "retentionCategory": { "type": "string", "enum": ["STANDARD", "FINANCIAL_RECORD", "LEGAL_HOLD"] },
+    "archiveReference": { "type": "string" },
+    "recordChecksum": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+    "terminalAt": { "type": "string", "format": "date-time" },
+    "archivedAt": { "type": "string", "format": "date-time" }
+  },
+  "required": [
+    "orderId",
+    "terminalStatus",
+    "retentionCategory",
+    "archiveReference",
+    "recordChecksum",
+    "terminalAt",
+    "archivedAt"
+  ],
+  "examples": [
+    {
+      "orderId": "7e86e1d8-cd5f-4d6f-ae8e-bdc5ed3a0d13",
+      "terminalStatus": "COMPLETED",
+      "retentionCategory": "FINANCIAL_RECORD",
+      "archiveReference": "orders/2026/07/7e86e1d8-cd5f-4d6f-ae8e-bdc5ed3a0d13.json",
+      "recordChecksum": "a948904f2f0f479b8f8197694b30184b0d2ed1c1cd2a1ec0fb85d299a192a447",
+      "terminalAt": "2026-08-01T14:22:09Z",
+      "archivedAt": "2033-08-01T02:15:00Z"
+    }
+  ]
+}

--- a/examples/default/domains/Ordering/systems/order-management-system/services/OrderService/events/OrderConfirmed/index.mdx
+++ b/examples/default/domains/Ordering/systems/order-management-system/services/OrderService/events/OrderConfirmed/index.mdx
@@ -1,0 +1,29 @@
+---
+id: order-confirmed
+name: Order Confirmed
+version: 1.0.0
+summary: |
+  Published when payment, inventory, and order validation have succeeded and the order is ready for fulfilment.
+owners:
+  - ordering-platform
+badges:
+  - content: 'Broker:Kafka'
+    backgroundColor: blue
+    textColor: blue
+    icon: BoltIcon
+schemaPath: schema.json
+---
+
+import Footer from '@catalog/components/footer.astro';
+
+## Overview
+
+`OrderConfirmed` is published by the [[service|order-service]] once an order has passed validation and its payment and inventory reservations are secured. Fulfilment, customer notification, and analytics consumers use this as the reliable signal that the order can progress.
+
+<SchemaViewer file="schema.json" title="JSON Schema" maxHeight="500" />
+
+## Architecture diagram
+
+<NodeGraph />
+
+<Footer />

--- a/examples/default/domains/Ordering/systems/order-management-system/services/OrderService/events/OrderConfirmed/schema.json
+++ b/examples/default/domains/Ordering/systems/order-management-system/services/OrderService/events/OrderConfirmed/schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "OrderConfirmed",
+  "description": "Published when an order is confirmed and ready for fulfilment",
+  "type": "object",
+  "properties": {
+    "orderId": { "type": "string", "format": "uuid" },
+    "customerId": { "type": "string", "format": "uuid" },
+    "confirmationNumber": { "type": "string", "pattern": "^ORD-[0-9]{8}$" },
+    "paymentAuthorizationId": { "type": "string" },
+    "inventoryReservationId": { "type": "string" },
+    "total": { "type": "integer", "minimum": 0, "description": "Confirmed total in minor units" },
+    "currency": { "type": "string", "pattern": "^[A-Z]{3}$" },
+    "confirmedAt": { "type": "string", "format": "date-time" }
+  },
+  "required": ["orderId", "customerId", "confirmationNumber", "total", "currency", "confirmedAt"],
+  "examples": [
+    {
+      "orderId": "7e86e1d8-cd5f-4d6f-ae8e-bdc5ed3a0d13",
+      "customerId": "5d1db561-4ce3-4f92-956a-b787c2f55342",
+      "confirmationNumber": "ORD-10428371",
+      "paymentAuthorizationId": "pa_9f38c0f0",
+      "inventoryReservationId": "res_48721",
+      "total": 12999,
+      "currency": "GBP",
+      "confirmedAt": "2026-07-29T09:42:18Z"
+    }
+  ]
+}

--- a/examples/default/domains/Ordering/systems/order-management-system/services/OrderService/events/OrderDeliveryAddressChanged/index.mdx
+++ b/examples/default/domains/Ordering/systems/order-management-system/services/OrderService/events/OrderDeliveryAddressChanged/index.mdx
@@ -1,0 +1,29 @@
+---
+id: order-delivery-address-changed
+name: Order Delivery Address Changed
+version: 1.0.0
+summary: |
+  Published when the validated delivery address changes before dispatch.
+owners:
+  - ordering-platform
+badges:
+  - content: 'Broker:Kafka'
+    backgroundColor: blue
+    textColor: blue
+    icon: BoltIcon
+schemaPath: schema.json
+---
+
+import Footer from '@catalog/components/footer.astro';
+
+## Overview
+
+`OrderDeliveryAddressChanged` provides fulfilment and carrier integrations with the latest validated delivery destination. The previous postal code and revision make stale updates detectable without exposing unnecessary customer details.
+
+<SchemaViewer file="schema.json" title="JSON Schema" maxHeight="500" />
+
+## Architecture diagram
+
+<NodeGraph />
+
+<Footer />

--- a/examples/default/domains/Ordering/systems/order-management-system/services/OrderService/events/OrderDeliveryAddressChanged/schema.json
+++ b/examples/default/domains/Ordering/systems/order-management-system/services/OrderService/events/OrderDeliveryAddressChanged/schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "OrderDeliveryAddressChanged",
+  "description": "Published when the validated delivery address for an order changes",
+  "type": "object",
+  "properties": {
+    "orderId": { "type": "string", "format": "uuid" },
+    "addressRevision": { "type": "integer", "minimum": 2 },
+    "previousPostalCode": { "type": "string" },
+    "deliveryAddress": {
+      "type": "object",
+      "properties": {
+        "recipientName": { "type": "string" },
+        "line1": { "type": "string" },
+        "line2": { "type": "string" },
+        "city": { "type": "string" },
+        "postalCode": { "type": "string" },
+        "countryCode": { "type": "string", "pattern": "^[A-Z]{2}$" }
+      },
+      "required": ["recipientName", "line1", "city", "postalCode", "countryCode"]
+    },
+    "changedBy": { "type": "string" },
+    "changedAt": { "type": "string", "format": "date-time" }
+  },
+  "required": ["orderId", "addressRevision", "previousPostalCode", "deliveryAddress", "changedBy", "changedAt"],
+  "examples": [
+    {
+      "orderId": "7e86e1d8-cd5f-4d6f-ae8e-bdc5ed3a0d13",
+      "addressRevision": 2,
+      "previousPostalCode": "SW1A 1AA",
+      "deliveryAddress": {
+        "recipientName": "Alex Morgan",
+        "line1": "18 Market Street",
+        "line2": "Apartment 4B",
+        "city": "London",
+        "postalCode": "E1 6AN",
+        "countryCode": "GB"
+      },
+      "changedBy": "customer:5d1db561-4ce3-4f92-956a-b787c2f55342",
+      "changedAt": "2026-07-29T09:46:41Z"
+    }
+  ]
+}

--- a/examples/default/domains/Ordering/systems/order-management-system/services/OrderService/events/OrderFulfilmentStarted/index.mdx
+++ b/examples/default/domains/Ordering/systems/order-management-system/services/OrderService/events/OrderFulfilmentStarted/index.mdx
@@ -1,0 +1,29 @@
+---
+id: order-fulfilment-started
+name: Order Fulfilment Started
+version: 1.0.0
+summary: |
+  Published when an order is released to a fulfilment location for picking and packing.
+owners:
+  - ordering-platform
+badges:
+  - content: 'Broker:Kafka'
+    backgroundColor: blue
+    textColor: blue
+    icon: BoltIcon
+schemaPath: schema.json
+---
+
+import Footer from '@catalog/components/footer.astro';
+
+## Overview
+
+`OrderFulfilmentStarted` marks the handoff from order management to warehouse execution. Customer communications use it to update delivery expectations, while analytics consumers measure the time from confirmation to operational fulfilment.
+
+<SchemaViewer file="schema.json" title="JSON Schema" maxHeight="500" />
+
+## Architecture diagram
+
+<NodeGraph />
+
+<Footer />

--- a/examples/default/domains/Ordering/systems/order-management-system/services/OrderService/events/OrderFulfilmentStarted/schema.json
+++ b/examples/default/domains/Ordering/systems/order-management-system/services/OrderService/events/OrderFulfilmentStarted/schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "OrderFulfilmentStarted",
+  "description": "Published when an order is released for picking and packing",
+  "type": "object",
+  "properties": {
+    "orderId": { "type": "string", "format": "uuid" },
+    "fulfilmentId": { "type": "string", "format": "uuid" },
+    "warehouseId": { "type": "string" },
+    "itemCount": { "type": "integer", "minimum": 1 },
+    "priority": { "type": "string", "enum": ["STANDARD", "EXPEDITED", "SAME_DAY"] },
+    "deliveryMethod": { "type": "string", "enum": ["HOME_DELIVERY", "CLICK_AND_COLLECT"] },
+    "estimatedDispatchAt": { "type": "string", "format": "date-time" },
+    "startedAt": { "type": "string", "format": "date-time" }
+  },
+  "required": ["orderId", "fulfilmentId", "warehouseId", "itemCount", "priority", "deliveryMethod", "startedAt"],
+  "examples": [
+    {
+      "orderId": "7e86e1d8-cd5f-4d6f-ae8e-bdc5ed3a0d13",
+      "fulfilmentId": "65c36d91-fe6c-4ea1-bc4c-95e73afece2b",
+      "warehouseId": "wh-london-02",
+      "itemCount": 3,
+      "priority": "EXPEDITED",
+      "deliveryMethod": "HOME_DELIVERY",
+      "estimatedDispatchAt": "2026-07-29T16:30:00Z",
+      "startedAt": "2026-07-29T10:06:12Z"
+    }
+  ]
+}

--- a/examples/default/domains/Ordering/systems/order-management-system/services/OrderService/events/OrderHoldReleased/index.mdx
+++ b/examples/default/domains/Ordering/systems/order-management-system/services/OrderService/events/OrderHoldReleased/index.mdx
@@ -1,0 +1,29 @@
+---
+id: order-hold-released
+name: Order Hold Released
+version: 1.0.0
+summary: |
+  Published when an operational hold is resolved and the order can continue.
+owners:
+  - ordering-platform
+badges:
+  - content: 'Broker:Kafka'
+    backgroundColor: blue
+    textColor: blue
+    icon: BoltIcon
+schemaPath: schema.json
+---
+
+import Footer from '@catalog/components/footer.astro';
+
+## Overview
+
+`OrderHoldReleased` resumes processing after the concern represented by an order hold has been resolved. The event correlates to the original hold and records the resolution for support, audit, and fulfilment consumers.
+
+<SchemaViewer file="schema.json" title="JSON Schema" maxHeight="500" />
+
+## Architecture diagram
+
+<NodeGraph />
+
+<Footer />

--- a/examples/default/domains/Ordering/systems/order-management-system/services/OrderService/events/OrderHoldReleased/schema.json
+++ b/examples/default/domains/Ordering/systems/order-management-system/services/OrderService/events/OrderHoldReleased/schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "OrderHoldReleased",
+  "description": "Published when an operational hold on an order is released",
+  "type": "object",
+  "properties": {
+    "orderId": { "type": "string", "format": "uuid" },
+    "holdId": { "type": "string", "format": "uuid" },
+    "previousReason": {
+      "type": "string",
+      "enum": ["PAYMENT_REVIEW", "FRAUD_REVIEW", "ADDRESS_VERIFICATION", "INVENTORY_RECHECK"]
+    },
+    "resolution": { "type": "string", "maxLength": 250 },
+    "releasedBy": { "type": "string" },
+    "nextStatus": { "type": "string", "enum": ["CONFIRMED", "AWAITING_FULFILMENT"] },
+    "releasedAt": { "type": "string", "format": "date-time" }
+  },
+  "required": ["orderId", "holdId", "previousReason", "resolution", "releasedBy", "nextStatus", "releasedAt"],
+  "examples": [
+    {
+      "orderId": "7e86e1d8-cd5f-4d6f-ae8e-bdc5ed3a0d13",
+      "holdId": "49c81188-c99a-4af4-97c9-2e9516bba8f7",
+      "previousReason": "ADDRESS_VERIFICATION",
+      "resolution": "Postal address matched the carrier validation service",
+      "releasedBy": "address-verification-policy:v3",
+      "nextStatus": "AWAITING_FULFILMENT",
+      "releasedAt": "2026-07-29T10:04:51Z"
+    }
+  ]
+}

--- a/examples/default/domains/Ordering/systems/order-management-system/services/OrderService/events/OrderPlacedOnHold/index.mdx
+++ b/examples/default/domains/Ordering/systems/order-management-system/services/OrderService/events/OrderPlacedOnHold/index.mdx
@@ -1,0 +1,29 @@
+---
+id: order-placed-on-hold
+name: Order Placed On Hold
+version: 1.0.0
+summary: |
+  Published when order progression is paused for a review or dependency check.
+owners:
+  - ordering-platform
+badges:
+  - content: 'Broker:Kafka'
+    backgroundColor: blue
+    textColor: blue
+    icon: BoltIcon
+schemaPath: schema.json
+---
+
+import Footer from '@catalog/components/footer.astro';
+
+## Overview
+
+`OrderPlacedOnHold` tells fulfilment and customer-facing systems to pause work while a payment, fraud, address, or inventory concern is reviewed. It includes the owning team and review deadline so operational tooling can route and escalate the hold.
+
+<SchemaViewer file="schema.json" title="JSON Schema" maxHeight="500" />
+
+## Architecture diagram
+
+<NodeGraph />
+
+<Footer />

--- a/examples/default/domains/Ordering/systems/order-management-system/services/OrderService/events/OrderPlacedOnHold/schema.json
+++ b/examples/default/domains/Ordering/systems/order-management-system/services/OrderService/events/OrderPlacedOnHold/schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "OrderPlacedOnHold",
+  "description": "Published when an order is paused for operational review",
+  "type": "object",
+  "properties": {
+    "orderId": { "type": "string", "format": "uuid" },
+    "holdId": { "type": "string", "format": "uuid" },
+    "reason": {
+      "type": "string",
+      "enum": ["PAYMENT_REVIEW", "FRAUD_REVIEW", "ADDRESS_VERIFICATION", "INVENTORY_RECHECK"]
+    },
+    "ownerTeam": { "type": "string" },
+    "customerMessage": { "type": "string", "maxLength": 280 },
+    "reviewBy": { "type": "string", "format": "date-time" },
+    "placedAt": { "type": "string", "format": "date-time" }
+  },
+  "required": ["orderId", "holdId", "reason", "ownerTeam", "reviewBy", "placedAt"],
+  "examples": [
+    {
+      "orderId": "7e86e1d8-cd5f-4d6f-ae8e-bdc5ed3a0d13",
+      "holdId": "49c81188-c99a-4af4-97c9-2e9516bba8f7",
+      "reason": "ADDRESS_VERIFICATION",
+      "ownerTeam": "ordering-operations",
+      "customerMessage": "We are confirming one detail of your delivery address. No action is required yet.",
+      "reviewBy": "2026-07-29T11:00:00Z",
+      "placedAt": "2026-07-29T09:51:26Z"
+    }
+  ]
+}

--- a/examples/default/domains/Ordering/systems/order-management-system/services/OrderService/events/OrderStatusChanged/index.mdx
+++ b/examples/default/domains/Ordering/systems/order-management-system/services/OrderService/events/OrderStatusChanged/index.mdx
@@ -1,0 +1,29 @@
+---
+id: order-status-changed
+name: Order Status Changed
+version: 1.0.0
+summary: |
+  Published for every accepted transition in the order lifecycle state machine.
+owners:
+  - ordering-platform
+badges:
+  - content: 'Broker:Kafka'
+    backgroundColor: blue
+    textColor: blue
+    icon: BoltIcon
+schemaPath: schema.json
+---
+
+import Footer from '@catalog/components/footer.astro';
+
+## Overview
+
+`OrderStatusChanged` is the canonical state-transition event for projections and operational timelines. More specific business events remain the preferred integration points, while this event supports generic history, search, support, and analytics use cases.
+
+<SchemaViewer file="schema.json" title="JSON Schema" maxHeight="500" />
+
+## Architecture diagram
+
+<NodeGraph />
+
+<Footer />

--- a/examples/default/domains/Ordering/systems/order-management-system/services/OrderService/events/OrderStatusChanged/schema.json
+++ b/examples/default/domains/Ordering/systems/order-management-system/services/OrderService/events/OrderStatusChanged/schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "OrderStatusChanged",
+  "description": "Published for every accepted order lifecycle transition",
+  "type": "object",
+  "properties": {
+    "orderId": { "type": "string", "format": "uuid" },
+    "previousStatus": {
+      "type": "string",
+      "enum": ["CREATED", "CONFIRMED", "ON_HOLD", "AWAITING_FULFILMENT", "FULFILLING", "COMPLETED", "CANCELLED"]
+    },
+    "newStatus": {
+      "type": "string",
+      "enum": ["CONFIRMED", "ON_HOLD", "AWAITING_FULFILMENT", "FULFILLING", "COMPLETED", "CANCELLED", "ARCHIVED"]
+    },
+    "sequence": { "type": "integer", "minimum": 1, "description": "Monotonic transition number for the order" },
+    "changeReason": { "type": "string", "maxLength": 250 },
+    "correlationId": { "type": "string", "format": "uuid" },
+    "changedAt": { "type": "string", "format": "date-time" }
+  },
+  "required": ["orderId", "previousStatus", "newStatus", "sequence", "changedAt"],
+  "examples": [
+    {
+      "orderId": "7e86e1d8-cd5f-4d6f-ae8e-bdc5ed3a0d13",
+      "previousStatus": "AWAITING_FULFILMENT",
+      "newStatus": "FULFILLING",
+      "sequence": 5,
+      "changeReason": "Released to warehouse wh-london-02",
+      "correlationId": "896f860b-aea5-4b98-91c5-ef4d188778dd",
+      "changedAt": "2026-07-29T10:06:12Z"
+    }
+  ]
+}

--- a/examples/default/domains/Ordering/systems/order-management-system/services/OrderService/index.mdx
+++ b/examples/default/domains/Ordering/systems/order-management-system/services/OrderService/index.mdx
@@ -26,6 +26,22 @@ receives:
 sends:
   - id: order-created
     version: 1.0.0
+  - id: order-confirmed
+    version: 1.0.0
+  - id: order-amended
+    version: 1.0.0
+  - id: order-placed-on-hold
+    version: 1.0.0
+  - id: order-hold-released
+    version: 1.0.0
+  - id: order-fulfilment-started
+    version: 1.0.0
+  - id: order-status-changed
+    version: 1.0.0
+  - id: order-delivery-address-changed
+    version: 1.0.0
+  - id: order-archived
+    version: 1.0.0
   - id: order-completed
     version: 1.0.0
   - id: order-cancelled
@@ -47,26 +63,36 @@ import Footer from '@catalog/components/footer.astro';
 
 ## Overview
 
-The **Order Service** is the heart of the Order Management System. It receives [[command|create-order]] from the [[system|checkout-system]], persists orders to the [[container|order-database]], and serves order lookups via [[query|get-order]]. It also handles [[command|cancel-order]]. As orders move through their lifecycle it publishes [[event|order-created]], [[event|order-completed]] and [[event|order-cancelled]] events.
+The **Order Service** is the heart of the Order Management System. It receives [[command|create-order]] from the [[system|checkout-system]], persists orders to the [[container|order-database]], and serves order lookups via [[query|get-order]]. It also handles [[command|cancel-order]]. As orders move through their lifecycle it publishes detailed events covering creation, confirmation, amendments, operational holds, fulfilment, completion, cancellation, and archival.
 
 <Tiles>
-  <Tile icon="BoltIcon" href={`/visualiser/services/${frontmatter.id}/${frontmatter.version}`} title={`Sends ${frontmatter.sends.length} messages`} description="Order lifecycle events" />
-  <Tile icon="BoltIcon" href={`/visualiser/services/${frontmatter.id}/${frontmatter.version}`} title={`Receives ${frontmatter.receives.length} messages`} description="Order commands and queries" />
+  <Tile
+    icon="BoltIcon"
+    href={`/visualiser/services/${frontmatter.id}/${frontmatter.version}`}
+    title={`Sends ${frontmatter.sends.length} messages`}
+    description="Order lifecycle events"
+  />
+  <Tile
+    icon="BoltIcon"
+    href={`/visualiser/services/${frontmatter.id}/${frontmatter.version}`}
+    title={`Receives ${frontmatter.receives.length} messages`}
+    description="Order commands and queries"
+  />
 </Tiles>
 
 ### Responsibilities
 
-| Area | Description |
-|------|-------------|
-| Order creation | Handles [[command\|create-order]] from the Checkout System and persists the order. |
-| Order cancellation | Handles [[command\|cancel-order]] and compensates downstream where needed. |
-| Order lookups | Serves [[query\|get-order]] from the [[container\|order-database]]. |
-| Event publishing | Emits [[event\|order-created]], [[event\|order-completed]] and [[event\|order-cancelled]]. |
+| Area               | Description                                                                                                        |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| Order creation     | Handles [[command\|create-order]] from the Checkout System and persists the order.                                 |
+| Order cancellation | Handles [[command\|cancel-order]] and compensates downstream where needed.                                         |
+| Order lookups      | Serves [[query\|get-order]] from the [[container\|order-database]].                                                |
+| Event publishing   | Emits a complete order lifecycle stream for fulfilment, customer communications, support, and analytics consumers. |
 
 ## Architecture diagram
 
 <NodeGraph />
 
-<MessageTable format="all" limit={8} />
+<MessageTable format="all" limit={12} />
 
 <Footer />

--- a/examples/default/domains/Shopping/systems/cart-system/services/CartAPI/openapi-2.yml
+++ b/examples/default/domains/Shopping/systems/cart-system/services/CartAPI/openapi-2.yml
@@ -1,0 +1,200 @@
+openapi: 3.0.3
+info:
+  title: Cart API
+  version: 1.0.0
+  description: |
+    Public-facing API for the Cart System. Customers use it to build a cart —
+    adding and removing items — and to check out. At checkout the cart is priced
+    (including discounts from the Promotion System) and a `CartCheckedOut` event
+    is published.
+  contact:
+    name: Shopping Platform
+    email: shopping-platform@acme.test
+servers:
+  - url: https://api.acme.test
+    description: Production
+tags:
+  - name: Cart
+    description: Build and check out a shopping cart.
+paths:
+  /carts/{cartId}/items:
+    parameters:
+      - $ref: '#/components/parameters/CartId'
+    post:
+      operationId: addItemToCart
+      summary: Add an item to the cart
+      tags:
+        - Cart
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AddItemRequest'
+      responses:
+        '200':
+          description: The item was added; the updated cart is returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Cart'
+        '400':
+          description: The request was invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: The cart was not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /carts/{cartId}/items/{productId}:
+    parameters:
+      - $ref: '#/components/parameters/CartId'
+      - name: productId
+        in: path
+        required: true
+        description: Identifier of the product to remove.
+        schema:
+          type: string
+          format: uuid
+    delete:
+      operationId: removeItemFromCart
+      summary: Remove an item from the cart
+      tags:
+        - Cart
+      responses:
+        '200':
+          description: The item was removed; the updated cart is returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Cart'
+        '404':
+          description: The cart or item was not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /carts/{cartId}/checkout:
+    parameters:
+      - $ref: '#/components/parameters/CartId'
+    post:
+      operationId: checkoutCart
+      summary: Check out the cart
+      description: Prices the cart (including discounts) and, on success, publishes a `CartCheckedOut` event.
+      tags:
+        - Cart
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CheckoutRequest'
+      responses:
+        '200':
+          description: The cart was checked out.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Cart'
+        '400':
+          description: The request was invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: The cart was not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '409':
+          description: The cart is empty or already checked out.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+components:
+  parameters:
+    CartId:
+      name: cartId
+      in: path
+      required: true
+      description: Unique identifier of the cart.
+      schema:
+        type: string
+        format: uuid
+  schemas:
+    Cart:
+      type: object
+      required: [cartId, status, items, currency]
+      properties:
+        cartId:
+          type: string
+          format: uuid
+        customerId:
+          type: string
+          format: uuid
+        status:
+          type: string
+          enum: [OPEN, CHECKED_OUT, ABANDONED]
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/CartItem'
+        subtotal:
+          type: integer
+          description: Total before discounts, in minor units (e.g. cents).
+        discount:
+          type: integer
+          description: Total discount applied, in minor units (e.g. cents).
+        total:
+          type: integer
+          description: Final total, in minor units (e.g. cents).
+        currency:
+          type: string
+          pattern: '^[A-Z]{3}$'
+    CartItem:
+      type: object
+      required: [productId, quantity, unitPrice]
+      properties:
+        productId:
+          type: string
+          format: uuid
+        quantity:
+          type: integer
+          minimum: 1
+        unitPrice:
+          type: integer
+          description: Price per unit in minor units (e.g. cents).
+    AddItemRequest:
+      type: object
+      required: [productId, quantity]
+      properties:
+        productId:
+          type: string
+          format: uuid
+        quantity:
+          type: integer
+          minimum: 1
+    CheckoutRequest:
+      type: object
+      required: [customerId]
+      properties:
+        customerId:
+          type: string
+          format: uuid
+        promotionCode:
+          type: string
+    Error:
+      type: object
+      required: [code, message]
+      properties:
+        code:
+          type: string
+        message:
+          type: string

--- a/packages/core/eventcatalog/src/components/SideNav/NestedSideBar/index.tsx
+++ b/packages/core/eventcatalog/src/components/SideNav/NestedSideBar/index.tsx
@@ -13,7 +13,7 @@ import {
   removeFavorite as removeFavoriteAction,
   type FavoriteItem,
 } from '@stores/favorites-store';
-import { getBadgeClasses, isGroupCollapsed } from './utils';
+import { canCollapseGroup, getBadgeClasses, getGroupLabel, isGroupCollapsed } from './utils';
 import { resolveIconUrl } from '@utils/icon';
 
 const cn = (...classes: (string | false | undefined)[]) => classes.filter(Boolean).join(' ');
@@ -57,7 +57,7 @@ export default function NestedSideBar() {
   const [slideDirection, setSlideDirection] = useState<'forward' | 'backward' | null>(null);
   const [isInitialized, setIsInitialized] = useState(false);
   const [currentPath, setCurrentPath] = useState<string>('');
-  const [collapsedSections, setCollapsedSections] = useState<Set<string>>(new Set());
+  const [sectionCollapsePreferences, setSectionCollapsePreferences] = useState(loadCollapsedSections);
   const [showPathPreview, setShowPathPreview] = useState(false);
   const [showFullPath, setShowFullPath] = useState(false);
 
@@ -95,28 +95,22 @@ export default function NestedSideBar() {
    * Toggle section collapse state
    */
   const toggleSectionCollapse = (sectionId: string) => {
-    setCollapsedSections((prev) => {
-      const next = new Set(prev);
-      if (next.has(sectionId)) {
-        next.delete(sectionId);
+    setSectionCollapsePreferences((previousPreferences) => {
+      const nextPreferences = {
+        expanded: new Set(previousPreferences.expanded),
+      };
+      const isCurrentlyCollapsed = isGroupCollapsed(true, sectionId, previousPreferences);
+
+      if (isCurrentlyCollapsed) {
+        nextPreferences.expanded.add(sectionId);
       } else {
-        next.add(sectionId);
+        nextPreferences.expanded.delete(sectionId);
       }
-      // Save to localStorage
-      saveCollapsedSections(next);
-      return next;
+
+      saveCollapsedSections(nextPreferences);
+      return nextPreferences;
     });
   };
-
-  /**
-   * Load collapsed sections from localStorage on mount
-   */
-  useEffect(() => {
-    const saved = loadCollapsedSections();
-    if (saved.size > 0) {
-      setCollapsedSections(saved);
-    }
-  }, []);
 
   /**
    * Update navigation stack when roots become available
@@ -521,7 +515,7 @@ export default function NestedSideBar() {
   // Show loading state if no data yet
   if (!data || roots.length === 0) {
     return (
-      <aside className="w-full min-h-full flex-1 flex flex-col font-sans bg-[rgb(var(--ec-rail-bg))]">
+      <aside className="flex h-full min-h-0 w-full flex-1 flex-col bg-[rgb(var(--ec-rail-bg))] font-sans">
         {/* Search skeleton */}
         <div className="px-4 py-3 border-b border-[rgb(var(--ec-content-border))] bg-[rgb(var(--ec-rail-bg))]">
           <div className="h-10 bg-[rgb(var(--ec-content-hover))] rounded-xl animate-pulse" />
@@ -754,9 +748,9 @@ export default function NestedSideBar() {
         return child && isVisible(child);
       }) ?? [];
 
-    const groupId = groupKey || group.collapseKey || `group-${index}`;
-    const canCollapse = visibleChildren.length > 3;
-    const isCollapsed = isGroupCollapsed(canCollapse, groupId, collapsedSections);
+    const groupId = groupKey || group.collapseKey || `${currentLevel.key ?? 'root'}:group:${group.title}`;
+    const canCollapse = canCollapseGroup(visibleChildren.length);
+    const isCollapsed = isGroupCollapsed(canCollapse, groupId, sectionCollapsePreferences);
 
     // When a group's children are subtle subgroups (e.g. Resources > Services/Flows/Data Stores),
     // they render flush under the parent icon instead of inside the indented border guide.
@@ -787,7 +781,7 @@ export default function NestedSideBar() {
                 : 'text-[12px] font-semibold tracking-tight text-[rgb(var(--ec-content-text))]'
             )}
           >
-            {group.title}
+            {getGroupLabel(group.title, visibleChildren.length)}
           </span>
         </div>
         {canCollapse && (
@@ -973,7 +967,7 @@ export default function NestedSideBar() {
   };
 
   return (
-    <aside className="w-full min-h-full flex-1 flex flex-col font-sans bg-[rgb(var(--ec-rail-bg))]">
+    <aside className="flex h-full min-h-0 w-full flex-1 flex-col bg-[rgb(var(--ec-rail-bg))] font-sans">
       {isTopLevel && (
         <div className="flex h-[60px] items-center px-6 bg-[rgb(var(--ec-rail-bg)/0.98)] backdrop-blur-sm border-b border-[rgb(var(--ec-content-border))] sticky top-0 z-10">
           <span className="text-[0.65rem] font-semibold uppercase tracking-[0.18em] text-[rgb(var(--ec-sidebar-text)/0.5)] truncate">
@@ -1128,7 +1122,7 @@ export default function NestedSideBar() {
       {/* Navigation Content */}
       <nav
         key={animationKey}
-        className={cn('flex-1 overflow-y-auto overflow-x-hidden p-4 px-2', getAnimationClass())}
+        className={cn('min-h-0 flex-1 overflow-y-auto overflow-x-hidden p-4 px-2', getAnimationClass())}
         style={{
           scrollbarWidth: 'thin',
           scrollbarColor: 'rgb(var(--ec-content-border)) transparent',

--- a/packages/core/eventcatalog/src/components/SideNav/NestedSideBar/storage.ts
+++ b/packages/core/eventcatalog/src/components/SideNav/NestedSideBar/storage.ts
@@ -1,9 +1,11 @@
+import type { SectionCollapsePreferences } from './utils';
+
 // ============================================
 // Local Storage Persistence
 // ============================================
 
 const STORAGE_KEY = 'eventcatalog-sidebar-nav';
-const COLLAPSED_SECTIONS_KEY = 'eventcatalog-sidebar-collapsed';
+const SECTION_PREFERENCES_KEY = 'eventcatalog-sidebar-sections:v2';
 const FAVORITES_KEY = 'eventcatalog-sidebar-favorites';
 
 // ============================================
@@ -49,21 +51,28 @@ export const loadState = (): PersistedState | null => {
 // Collapsed Sections
 // ============================================
 
-export const saveCollapsedSections = (sections: Set<string>): void => {
+export const saveCollapsedSections = (preferences: SectionCollapsePreferences): void => {
   try {
-    localStorage.setItem(COLLAPSED_SECTIONS_KEY, JSON.stringify([...sections]));
+    localStorage.setItem(SECTION_PREFERENCES_KEY, JSON.stringify({ expanded: [...preferences.expanded] }));
   } catch (e) {
     console.warn('Failed to save collapsed sections:', e);
   }
 };
 
-export const loadCollapsedSections = (): Set<string> => {
+export const loadCollapsedSections = (): SectionCollapsePreferences => {
   try {
-    const stored = localStorage.getItem(COLLAPSED_SECTIONS_KEY);
-    return stored ? new Set(JSON.parse(stored)) : new Set();
+    const stored = localStorage.getItem(SECTION_PREFERENCES_KEY);
+    if (stored) {
+      const preferences = JSON.parse(stored);
+      return {
+        expanded: new Set(Array.isArray(preferences.expanded) ? preferences.expanded : []),
+      };
+    }
+
+    return { expanded: new Set() };
   } catch (e) {
     console.warn('Failed to load collapsed sections:', e);
-    return new Set();
+    return { expanded: new Set() };
   }
 };
 

--- a/packages/core/eventcatalog/src/components/SideNav/NestedSideBar/utils.spec.ts
+++ b/packages/core/eventcatalog/src/components/SideNav/NestedSideBar/utils.spec.ts
@@ -1,12 +1,35 @@
 import { describe, expect, it } from 'vitest';
-import { isGroupCollapsed } from './utils';
+import { canCollapseGroup, getGroupLabel, isGroupCollapsed } from './utils';
 
-describe('isGroupCollapsed', () => {
-  it('ignores persisted collapse state when the group cannot be expanded', () => {
-    expect(isGroupCollapsed(false, 'group-1', new Set(['group-1']))).toBe(false);
+const preferences = (expanded: string[] = []) => ({
+  expanded: new Set(expanded),
+});
+
+describe('sidebar group presentation', () => {
+  it('includes the visible child count in the group label', () => {
+    expect(getGroupLabel('Outbound Messages', 10)).toBe('Outbound Messages (10)');
   });
 
-  it('uses persisted collapse state when the group can be expanded', () => {
-    expect(isGroupCollapsed(true, 'adrs:status:superseded', new Set(['adrs:status:superseded']))).toBe(true);
+  it.each(['Quick Reference', 'Architecture', 'Resources'])('does not include the child count for %s', (title) => {
+    expect(getGroupLabel(title, 10)).toBe(title);
+  });
+
+  it('only allows groups with more than five children to collapse', () => {
+    expect(canCollapseGroup(5)).toBe(false);
+    expect(canCollapseGroup(6)).toBe(true);
+  });
+});
+
+describe('isGroupCollapsed', () => {
+  it('keeps groups without a caret expanded', () => {
+    expect(isGroupCollapsed(false, 'group-1', preferences())).toBe(false);
+  });
+
+  it('collapses expandable groups by default', () => {
+    expect(isGroupCollapsed(true, 'outbound-messages', preferences())).toBe(true);
+  });
+
+  it('uses an explicit expanded preference', () => {
+    expect(isGroupCollapsed(true, 'outbound-messages', preferences(['outbound-messages']))).toBe(false);
   });
 });

--- a/packages/core/eventcatalog/src/components/SideNav/NestedSideBar/utils.ts
+++ b/packages/core/eventcatalog/src/components/SideNav/NestedSideBar/utils.ts
@@ -1,7 +1,20 @@
 // Shared utilities for NestedSideBar components
 
-export const isGroupCollapsed = (canCollapse: boolean, groupId: string, collapsedSections: Set<string>): boolean =>
-  canCollapse && collapsedSections.has(groupId);
+export const SIDEBAR_GROUP_COLLAPSE_THRESHOLD = 5;
+const GROUP_TITLES_WITHOUT_COUNT = new Set(['Quick Reference', 'Architecture', 'Resources']);
+
+export type SectionCollapsePreferences = {
+  expanded: Set<string>;
+};
+
+export const canCollapseGroup = (childCount: number): boolean => childCount > SIDEBAR_GROUP_COLLAPSE_THRESHOLD;
+
+export const getGroupLabel = (title: string, childCount: number): string =>
+  GROUP_TITLES_WITHOUT_COUNT.has(title) ? title : `${title} (${childCount})`;
+
+export const isGroupCollapsed = (canCollapse: boolean, groupId: string, preferences: SectionCollapsePreferences): boolean => {
+  return canCollapse && !preferences.expanded.has(groupId);
+};
 
 /**
  * Returns Tailwind classes for badge styling based on badge type.

--- a/packages/core/eventcatalog/src/enterprise/custom-documentation/pages/docs/custom/index.astro
+++ b/packages/core/eventcatalog/src/enterprise/custom-documentation/pages/docs/custom/index.astro
@@ -93,18 +93,15 @@ const editUrl =
   (config.editUrl && (props as any)?.filePath ? buildEditUrlForResource(config.editUrl, (props as any).filePath) : '');
 ---
 
-<VerticalSideBarLayout title={doc.title || 'Documentation'} showNestedSideBar={false}>
-  <div class="custom-docs-shell flex w-full" data-pagefind-body data-pagefind-meta={`title:${doc.title}`}>
-    <!-- Left Sidebar Navigation -->
-    <aside
-      class="sidebar-transition fixed top-0 bottom-0 left-[var(--ec-vertical-nav-width,14rem)] z-10 w-[var(--ec-custom-docs-sidebar-width,20rem)] overflow-hidden border-r border-[rgb(var(--ec-page-border))] bg-[rgb(var(--ec-rail-bg))]"
-    >
-      <div class="h-full">
-        <CustomDocsNav />
-      </div>
-    </aside>
+<VerticalSideBarLayout title={doc.title || 'Documentation'}>
+  <Fragment slot="sidebar-content">
+    <div class="h-full min-h-0">
+      <CustomDocsNav />
+    </div>
+  </Fragment>
 
-    <div class="sidebar-transition flex w-full min-w-0" style="margin-left: var(--ec-custom-docs-sidebar-width, 20rem);">
+  <div class="custom-docs-shell flex w-full" data-pagefind-body data-pagefind-meta={`title:${doc.title}`}>
+    <div class="flex w-full min-w-0">
       <main class="min-w-0 flex-1">
         <div
           class="w-full lg:mr-2 pr-10 py-10 bg-[rgb(var(--ec-page-bg))]"
@@ -275,19 +272,6 @@ const editUrl =
 </VerticalSideBarLayout>
 
 <style is:global>
-  :root {
-    --ec-custom-docs-sidebar-width: 20rem;
-  }
-
-  #eventcatalog-header {
-    left: calc(var(--ec-vertical-nav-width, 14rem) + var(--ec-custom-docs-sidebar-width, 20rem)) !important;
-  }
-
-  .custom-docs-shell {
-    margin-left: calc(var(--ec-app-content-padding-left, 5rem) * -1);
-    margin-right: calc(var(--ec-app-content-padding-right, 5rem) * -1);
-  }
-
   .mermaid svg {
     margin: 1em auto 2em;
   }

--- a/packages/core/eventcatalog/src/layouts/VerticalSideBarLayout.astro
+++ b/packages/core/eventcatalog/src/layouts/VerticalSideBarLayout.astro
@@ -449,9 +449,25 @@ const verticalNavAutoCollapsePaths = [buildUrl('/discover', true), buildUrl('/do
         }
       })();
     </script>
+    <script is:inline>
+      (() => {
+        const sidebarWidthStorageKey = 'eventcatalog-sidebar-width:v1';
+        const minimumSidebarWidth = 224;
+        const maximumSidebarWidth = 576;
+
+        try {
+          const savedWidth = Number(localStorage.getItem(sidebarWidthStorageKey));
+          if (Number.isFinite(savedWidth) && savedWidth > 0) {
+            const width = Math.min(maximumSidebarWidth, Math.max(minimumSidebarWidth, savedWidth));
+            document.documentElement.style.setProperty('--ec-sidebar-panel-width', `${width}px`);
+          }
+        } catch (error) {}
+      })();
+    </script>
     <style is:global>
       :root {
         --ec-vertical-nav-width: 14rem;
+        --ec-sidebar-panel-width: 17rem;
       }
 
       :root[data-vertical-nav-collapsed='true'] {
@@ -472,7 +488,6 @@ const verticalNavAutoCollapsePaths = [buildUrl('/discover', true), buildUrl('/do
         min-height: 100vh;
         min-height: 100dvh;
         background-color: rgb(var(--ec-page-bg));
-        --ec-sidebar-panel-width: 17rem;
         display: flex;
         flex-direction: column;
       }
@@ -580,7 +595,44 @@ const verticalNavAutoCollapsePaths = [buildUrl('/discover', true), buildUrl('/do
         top: 0;
         left: var(--ec-vertical-nav-width);
         z-index: 20;
-        overflow-y: auto;
+        overflow: hidden;
+      }
+      .sidebar-resize-handle {
+        position: absolute;
+        top: 0;
+        right: 0;
+        z-index: 30;
+        width: 8px;
+        height: 100%;
+        cursor: col-resize;
+        touch-action: none;
+      }
+      .sidebar-resize-handle::after {
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 50%;
+        width: 2px;
+        content: '';
+        background: rgb(var(--ec-accent) / 0.65);
+        opacity: 0;
+        transform: translateX(-50%);
+        transition: opacity 150ms ease;
+      }
+      .sidebar-resize-handle:hover::after,
+      .sidebar-resize-handle:focus-visible::after,
+      body.sidebar-is-resizing .sidebar-resize-handle::after {
+        opacity: 1;
+      }
+      .sidebar-resize-handle:focus-visible {
+        outline: none;
+      }
+      body.sidebar-is-resizing {
+        cursor: col-resize;
+        user-select: none;
+      }
+      body.sidebar-is-resizing .sidebar-transition {
+        transition: none;
       }
       .content-panel {
         min-width: 0;
@@ -754,14 +806,22 @@ const verticalNavAutoCollapsePaths = [buildUrl('/discover', true), buildUrl('/do
         </div>
       </aside>
       {
-        showNestedSideBar &&
-          (Astro.slots.has('sidebar-content') ? (
-            <aside id="sidebar" class="sidebar-panel sidebar-transition">
-              <slot name="sidebar-content" />
-            </aside>
-          ) : (
-            <SideNav id="sidebar" class={`sidebar-panel sidebar-transition`} />
-          ))
+        showNestedSideBar && (
+          <aside id="sidebar" class="sidebar-panel sidebar-transition">
+            {Astro.slots.has('sidebar-content') ? <slot name="sidebar-content" /> : <SideNav class="h-full min-h-0" />}
+            <div
+              id="sidebar-resize-handle"
+              class="sidebar-resize-handle"
+              role="separator"
+              aria-label="Resize sidebar"
+              aria-orientation="vertical"
+              aria-valuemin="224"
+              aria-valuemax="576"
+              aria-valuenow="272"
+              tabindex="0"
+            />
+          </aside>
+        )
       }
       <main class="content-panel sidebar-transition w-full bg-[rgb(var(--ec-page-bg))]" id="content">
         {
@@ -803,6 +863,9 @@ const verticalNavAutoCollapsePaths = [buildUrl('/discover', true), buildUrl('/do
   }}
 >
   const VERTICAL_NAV_STORAGE_KEY = 'eventcatalog-vertical-nav-collapsed';
+  const SIDEBAR_WIDTH_STORAGE_KEY = 'eventcatalog-sidebar-width:v1';
+  const MINIMUM_SIDEBAR_WIDTH = 224;
+  const MAXIMUM_SIDEBAR_WIDTH = 576;
   const ACTIVE_NAV_CLASSES = [
     'border-[rgb(var(--ec-accent)/0.2)]',
     'bg-[rgb(var(--ec-page-bg)/0.88)]',
@@ -926,6 +989,80 @@ const verticalNavAutoCollapsePaths = [buildUrl('/discover', true), buildUrl('/do
     }
   };
 
+  const clampSidebarWidth = (width) => Math.min(MAXIMUM_SIDEBAR_WIDTH, Math.max(MINIMUM_SIDEBAR_WIDTH, width));
+
+  const applySidebarWidth = (width) => {
+    const nextWidth = clampSidebarWidth(width);
+    document.documentElement.style.setProperty('--ec-sidebar-panel-width', `${nextWidth}px`);
+
+    const resizeHandle = document.getElementById('sidebar-resize-handle');
+    resizeHandle?.setAttribute('aria-valuenow', String(Math.round(nextWidth)));
+    return nextWidth;
+  };
+
+  const persistSidebarWidth = (width) => {
+    try {
+      localStorage.setItem(SIDEBAR_WIDTH_STORAGE_KEY, String(Math.round(width)));
+    } catch (error) {}
+  };
+
+  const getPersistedSidebarWidth = () => {
+    try {
+      const savedWidth = Number(localStorage.getItem(SIDEBAR_WIDTH_STORAGE_KEY));
+      return Number.isFinite(savedWidth) && savedWidth > 0 ? clampSidebarWidth(savedWidth) : null;
+    } catch (error) {
+      return null;
+    }
+  };
+
+  const setupSidebarResize = () => {
+    const sidebar = document.getElementById('sidebar');
+    const resizeHandle = document.getElementById('sidebar-resize-handle');
+    if (!sidebar || !resizeHandle) return;
+
+    const persistedWidth = getPersistedSidebarWidth();
+    const currentWidth = persistedWidth ?? sidebar.getBoundingClientRect().width;
+    applySidebarWidth(currentWidth);
+
+    resizeHandle.onpointerdown = (event) => {
+      if (event.button !== 0) return;
+
+      const startX = event.clientX;
+      const startWidth = sidebar.getBoundingClientRect().width;
+      document.body.classList.add('sidebar-is-resizing');
+      resizeHandle.setPointerCapture(event.pointerId);
+
+      resizeHandle.onpointermove = (moveEvent) => {
+        applySidebarWidth(startWidth + moveEvent.clientX - startX);
+      };
+
+      const finishResize = (upEvent) => {
+        const finalWidth = applySidebarWidth(startWidth + upEvent.clientX - startX);
+        persistSidebarWidth(finalWidth);
+        document.body.classList.remove('sidebar-is-resizing');
+        if (resizeHandle.hasPointerCapture(upEvent.pointerId)) {
+          resizeHandle.releasePointerCapture(upEvent.pointerId);
+        }
+        resizeHandle.onpointermove = null;
+        resizeHandle.onpointerup = null;
+        resizeHandle.onpointercancel = null;
+      };
+
+      resizeHandle.onpointerup = finishResize;
+      resizeHandle.onpointercancel = finishResize;
+    };
+
+    resizeHandle.onkeydown = (event) => {
+      if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return;
+
+      event.preventDefault();
+      const direction = event.key === 'ArrowLeft' ? -1 : 1;
+      const step = event.shiftKey ? 32 : 16;
+      const nextWidth = applySidebarWidth(sidebar.getBoundingClientRect().width + direction * step);
+      persistSidebarWidth(nextWidth);
+    };
+  };
+
   // Apply immediately when this script executes so transitions don't briefly re-open the rail.
   applyPersistedVerticalNavState();
 
@@ -1015,6 +1152,7 @@ const verticalNavAutoCollapsePaths = [buildUrl('/discover', true), buildUrl('/do
     }
 
     setVerticalNavCollapsedState(getPersistedVerticalNavCollapsedState());
+    setupSidebarResize();
 
     syncNavItemStates();
 

--- a/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/sidebar-builder.spec.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/sidebar-builder.spec.ts
@@ -226,12 +226,12 @@ describe('getNestedSideBarData', () => {
 
       expect(adrsNode.pages).toEqual([
         expect.objectContaining({
-          title: 'Accepted (1)',
+          title: 'Accepted',
           collapseKey: 'adrs:status:accepted',
           pages: ['adr:accepted-decision:1.0.0'],
         }),
         expect.objectContaining({
-          title: 'Superseded (1)',
+          title: 'Superseded',
           collapseKey: 'adrs:status:superseded',
           pages: ['adr:superseded-decision:1.0.0'],
         }),

--- a/packages/core/eventcatalog/src/stores/sidebar-store/state.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/state.ts
@@ -68,7 +68,7 @@ const groupAdrsByStatus = (adrs: Adr[]): NavNode[] =>
 
     groups.push({
       type: 'group',
-      title: `${formatAdrStatus(status)} (${adrsForStatus.length})`,
+      title: formatAdrStatus(status),
       collapseKey: `adrs:status:${status}`,
       subtle: true,
       pages: [...adrsForStatus].sort(byResourceName).map(getAdrNodeKey),


### PR DESCRIPTION
## What This PR Does

Reworks how the nested sidebar navigation persists and displays collapsible groups, and adds a draggable/keyboard-resizable sidebar panel. Also includes new example content for the default catalog (Order lifecycle events and a second CartAPI OpenAPI spec) used to exercise the sidebar changes with a richer nav tree.

## Changes Overview

### Key Changes
- Sidebar group collapse state is now stored as an "expanded" set (`SectionCollapsePreferences`) instead of a "collapsed" set, so new groups default to collapsed rather than expanded
- Groups now collapse based on a shared threshold (`SIDEBAR_GROUP_COLLAPSE_THRESHOLD = 5`) via `canCollapseGroup`, replacing the previous inline `> 3` check
- Group labels now show child counts (e.g. `Events (12)`) via `getGroupLabel`, except for a fixed set of titles (`Quick Reference`, `Architecture`, `Resources`)
- localStorage key for section preferences bumped to `eventcatalog-sidebar-sections:v2` to avoid conflicts with the old collapsed-set format
- `VerticalSideBarLayout.astro` sidebar panel is now resizable via a drag handle (mouse) and arrow keys (keyboard), with width persisted to `eventcatalog-sidebar-width:v1` and clamped between 224px and 576px
- Sidebar panel scrolling reworked to use `min-h-0`/`overflow: hidden` on the outer panel so internal content scrolls correctly instead of the whole page
- Added new Order lifecycle events to the example catalog: `OrderAmended`, `OrderArchived`, `OrderConfirmed`, `OrderDeliveryAddressChanged`, `OrderFulfilmentStarted`, `OrderHoldReleased`, `OrderPlacedOnHold`, `OrderStatusChanged`
- Added `CartAPI/openapi-2.yml` and updated `OrderService/asyncapi.yml` and `OrderService/index.mdx` in the example catalog

## How It Works

The sidebar previously tracked which groups were *collapsed* in a `Set<string>`, defaulting all groups to expanded. This is inverted: preferences now track which groups are *expanded*, so any group above the collapse threshold defaults to collapsed unless the user has explicitly expanded it (`isGroupCollapsed` returns `canCollapse && !preferences.expanded.has(groupId)`).

The resizable sidebar adds a `sidebar-resize-handle` element with `role="separator"` inside the `#sidebar` aside. An inline script wires up `pointerdown`/`pointermove`/`pointerup` handlers to resize via the `--ec-sidebar-panel-width` CSS variable, plus arrow-key support for accessibility. Width is clamped to [224, 576]px and persisted to localStorage; a separate inline script in `<head>` applies the persisted width before hydration to avoid a layout flash.

## Breaking Changes

None. The old `eventcatalog-sidebar-collapsed` localStorage key is abandoned in favor of the new `:v2` key — existing users will simply see all sidebar groups reset to their new default (collapsed above the threshold) once.

## Additional Notes

The `examples/default` catalog content changes are unrelated to the sidebar work itself but are bundled in this PR to provide realistic nav depth for testing the new collapse/resize behavior.