### PR TITLE
Make astro-compress an optional dependency

### DIFF
--- a/.changeset/quiet-otters-tap.md
+++ b/.changeset/quiet-otters-tap.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": minor
+---
+
+feat(core): astro-compress is now an optional peer dependency, install it in your catalog to use `compress: true`. Top level sidebar groups now stay expanded.

--- a/packages/core/docs/api/02-config.md
+++ b/packages/core/docs/api/02-config.md
@@ -704,11 +704,19 @@ module.exports = {
 
 - Type: `boolean`
 
-Setting this to true will automatically compress all your CSS, HTML, SVG, JavaScript, JSON and image files in the Astro outDir folder.
+Setting this to true will automatically compress your HTML, SVG, JavaScript, JSON and image files in the Astro outDir folder.
 
 This is disabled by default from EventCatalog v2.61.9.
 
 **This only works for static builds.**
+
+<AddedIn version="4.4.0" />
+
+`astro-compress` is no longer bundled with EventCatalog. Install it in your EventCatalog project before enabling compression:
+
+```bash
+npm install --save-dev astro-compress
+```
 
 ```js title="eventcatalog.config.js"
 module.exports = {

--- a/packages/core/docs/development/deployment/build-and-deploy.md
+++ b/packages/core/docs/development/deployment/build-and-deploy.md
@@ -46,7 +46,13 @@ npx eventcatalog dev --debug -- --env=production --port=3000
 
 You can opt into our build step which will compress your static assets. 
 
-You can enable this by setting the [compress option](/docs/api/config#compress) to `true` in your `eventcatalog.config.js` file.
+First install the compression integration in your EventCatalog project:
+
+```bash
+npm install --save-dev astro-compress
+```
+
+Then set the [compress option](/docs/api/config#compress) to `true` in your `eventcatalog.config.js` file.
 
 :::info "Why is compression disabled by default?"
 Compression can increase your build time and the amount of memory required to build your catalog.

--- a/packages/core/docs/development/guides/98-versioning-resources.md
+++ b/packages/core/docs/development/guides/98-versioning-resources.md
@@ -10,7 +10,6 @@ description: Learn how versioning works for EventCatalog resources.
 ---
 
 import ProjectTree from '@site/src/components/MDX/ProjectTree';
-import AddedIn from '@site/src/components/MDX/AddedIn';
 
 EventCatalog resources can be versioned when you want to preserve how a resource looked at a point in time.
 
@@ -110,20 +109,6 @@ For example:
 | `Orders` service version `1.0.0` | `/docs/services/Orders/1.0.0` |
 
 This lets users compare the current resource with previous versions when they need historical context.
-
-### Stable URLs for the latest version
-
-<AddedIn version="4.3.3" />
-
-For services, the URLs for the latest version and its sub-pages (changelog, specifications, and attached documentation) stay versionless and never change as the service is versioned up.
-
-| Page | URL |
-|------|-----|
-| Overview | `/docs/services/Orders` |
-| Changelog | `/docs/services/Orders/changelog` |
-| OpenAPI spec | `/docs/services/Orders/spec/openapi` |
-
-Share these links freely. When `Orders` moves from `1.0.0` to `2.0.0`, the versionless URLs keep resolving to whatever is latest, so the link never rots. Historical versions keep their versioned URLs, for example `/docs/services/Orders/1.0.0/changelog`.
 
 ## Referencing versions
 

--- a/packages/core/docs/development/guides/resources/services/07-versioning-and-lifecycle/01-version-services.md
+++ b/packages/core/docs/development/guides/resources/services/07-versioning-and-lifecycle/01-version-services.md
@@ -8,8 +8,6 @@ title: Version services
 description: Learn how to version services
 ---
 
-import AddedIn from '@site/src/components/MDX/AddedIn';
-
 All content in EventCatalog can be versioned. This allows you to keep historic versions of content which can give context to users why things are changing.
 
 ## How to version a service

--- a/packages/core/docs/plugins/openapi/03-features.md
+++ b/packages/core/docs/plugins/openapi/03-features.md
@@ -99,11 +99,15 @@ routes: [{ prefix: '/api', suffix: '/events' }]
 routes: [{ match: '/api/*/track' }]
 ```
 
-#### How consumers are created and updated
+#### How consumers are looked up and updated
 
-When the generator runs, each consumer service is looked up by `id` and `version`. If a consumer service does not yet exist, it is created automatically with a basic `<NodeGraph />` page. New consumers are placed inside the configured `domain` if one is defined.
+When the generator runs, each consumer service is looked up by `id` and `version`. The consumer service must already exist in the catalog. If it cannot be found, the consumer entry is skipped; the generator does not create a service page or add the consumer to the configured `domain`.
 
 If the consumer already exists in the catalog, it is updated in-place so its existing markdown, location, and metadata are preserved. The `sends` list on the consumer is merged with the incoming messages, with deduplication applied. If a consumer entry already tracks a versioned message, its version is updated to the latest value from the spec.
+
+:::note
+If another generator creates the consumer service, place that generator before the OpenAPI generator that references it. Otherwise, the consumer relationship is skipped for that generation run.
+:::
 
 ---
 

--- a/packages/core/eventcatalog/astro.config.mjs
+++ b/packages/core/eventcatalog/astro.config.mjs
@@ -15,6 +15,7 @@ import remarkComment from 'remark-comment';
 import rehypeSlug from 'rehype-slug';
 import rehypeAutolinkHeadings from 'rehype-autolink-headings';
 import { eventCatalogLikeC4 } from './src/plugins/likec4';
+import { loadAstroCompressIntegration } from './src/plugins/astro-compress';
 import { astroTrailingSlashEndpointFix } from './src/plugins/astro-trailing-slash-endpoint-fix';
 
 import rehypeExpressiveCode from 'rehype-expressive-code';
@@ -107,12 +108,7 @@ export default defineConfig({
         rehypePlugins: mdxRehypePlugins,
       }),
     }),
-    effectiveOutput !== 'server' &&
-      compress &&
-      (await import('astro-compress')).default({
-        Logger: 0,
-        CSS: false,
-      }),
+    effectiveOutput !== 'server' && compress && (await loadAstroCompressIntegration(projectDirectory)),
     ecstudioWatcher(),
     eventCatalogIntegration(),
   ].filter(Boolean),

--- a/packages/core/eventcatalog/src/components/SideNav/NestedSideBar/index.tsx
+++ b/packages/core/eventcatalog/src/components/SideNav/NestedSideBar/index.tsx
@@ -749,7 +749,7 @@ export default function NestedSideBar() {
       }) ?? [];
 
     const groupId = groupKey || group.collapseKey || `${currentLevel.key ?? 'root'}:group:${group.title}`;
-    const canCollapse = canCollapseGroup(visibleChildren.length);
+    const canCollapse = canCollapseGroup(visibleChildren.length, isTopLevel);
     const isCollapsed = isGroupCollapsed(canCollapse, groupId, sectionCollapsePreferences);
 
     // When a group's children are subtle subgroups (e.g. Resources > Services/Flows/Data Stores),

--- a/packages/core/eventcatalog/src/components/SideNav/NestedSideBar/utils.spec.ts
+++ b/packages/core/eventcatalog/src/components/SideNav/NestedSideBar/utils.spec.ts
@@ -14,9 +14,13 @@ describe('sidebar group presentation', () => {
     expect(getGroupLabel(title, 10)).toBe(title);
   });
 
-  it('only allows groups with more than five children to collapse', () => {
-    expect(canCollapseGroup(5)).toBe(false);
-    expect(canCollapseGroup(6)).toBe(true);
+  it('keeps top-level groups expanded', () => {
+    expect(canCollapseGroup(6, true)).toBe(false);
+  });
+
+  it('only allows nested groups with more than five children to collapse', () => {
+    expect(canCollapseGroup(5, false)).toBe(false);
+    expect(canCollapseGroup(6, false)).toBe(true);
   });
 });
 

--- a/packages/core/eventcatalog/src/components/SideNav/NestedSideBar/utils.ts
+++ b/packages/core/eventcatalog/src/components/SideNav/NestedSideBar/utils.ts
@@ -7,7 +7,8 @@ export type SectionCollapsePreferences = {
   expanded: Set<string>;
 };
 
-export const canCollapseGroup = (childCount: number): boolean => childCount > SIDEBAR_GROUP_COLLAPSE_THRESHOLD;
+export const canCollapseGroup = (childCount: number, isTopLevel: boolean): boolean =>
+  !isTopLevel && childCount > SIDEBAR_GROUP_COLLAPSE_THRESHOLD;
 
 export const getGroupLabel = (title: string, childCount: number): string =>
   GROUP_TITLES_WITHOUT_COUNT.has(title) ? title : `${title} (${childCount})`;

--- a/packages/core/eventcatalog/src/plugins/__tests__/astro-compress.test.ts
+++ b/packages/core/eventcatalog/src/plugins/__tests__/astro-compress.test.ts
@@ -1,0 +1,53 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { loadAstroCompressIntegration } from '../astro-compress';
+
+const testProjectDirectory = path.join(__dirname, 'tmp-astro-compress');
+
+describe('loadAstroCompressIntegration', () => {
+  beforeEach(async () => {
+    await fs.mkdir(testProjectDirectory, { recursive: true });
+    await fs.writeFile(path.join(testProjectDirectory, 'package.json'), '{}');
+  });
+
+  afterEach(async () => {
+    await fs.rm(testProjectDirectory, { recursive: true, force: true });
+  });
+
+  it('loads astro-compress from the EventCatalog project', async () => {
+    const packageDirectory = path.join(testProjectDirectory, 'node_modules', 'astro-compress');
+    await fs.mkdir(packageDirectory, { recursive: true });
+    await fs.writeFile(
+      path.join(packageDirectory, 'package.json'),
+      JSON.stringify({ name: 'astro-compress', type: 'module', exports: './index.js' })
+    );
+    await fs.writeFile(
+      path.join(packageDirectory, 'index.js'),
+      `export default (options) => ({ name: 'astro-compress-test', options });`
+    );
+
+    const integration = (await loadAstroCompressIntegration(testProjectDirectory)) as unknown as {
+      name: string;
+      options: { Logger: number; CSS: boolean };
+    };
+
+    expect(integration).toEqual({
+      name: 'astro-compress-test',
+      options: {
+        Logger: 0,
+        CSS: false,
+      },
+    });
+  });
+
+  it('explains how to install astro-compress when it is missing', async () => {
+    await expect(loadAstroCompressIntegration(testProjectDirectory)).rejects.toThrow(
+      `Compression is enabled, but astro-compress is not installed.
+
+Install it in your EventCatalog project:
+
+  npm install --save-dev astro-compress`
+    );
+  });
+});

--- a/packages/core/eventcatalog/src/plugins/astro-compress.ts
+++ b/packages/core/eventcatalog/src/plugins/astro-compress.ts
@@ -1,0 +1,36 @@
+import type { AstroIntegration } from 'astro';
+import { createRequire } from 'node:module';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const astroCompressInstallMessage = `Compression is enabled, but astro-compress is not installed.
+
+Install it in your EventCatalog project:
+
+  npm install --save-dev astro-compress`;
+
+type AstroCompressModule = {
+  default?: (options: { Logger: number; CSS: boolean }) => AstroIntegration;
+};
+
+export const loadAstroCompressIntegration = async (projectDirectory: string): Promise<AstroIntegration> => {
+  let astroCompressPath: string;
+
+  try {
+    const requireFromCatalog = createRequire(join(projectDirectory, 'package.json'));
+    astroCompressPath = requireFromCatalog.resolve('astro-compress');
+  } catch (error) {
+    throw new Error(`${astroCompressInstallMessage}\n\n${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  const astroCompress = (await import(/* @vite-ignore */ pathToFileURL(astroCompressPath).href)) as AstroCompressModule;
+
+  if (typeof astroCompress.default !== 'function') {
+    throw new Error('The installed astro-compress package does not have a default integration export.');
+  }
+
+  return astroCompress.default({
+    Logger: 0,
+    CSS: false,
+  });
+};

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -90,7 +90,6 @@
     "@xyflow/react": "^12.3.6",
     "ai": "^6.0.17",
     "astro": "^7.1.1",
-    "astro-compress": "^2.4.0",
     "astro-expressive-code": "^0.44.0",
     "astro-seo": "^0.8.4",
     "auth-astro": "^4.2.0",

--- a/packages/core/src/eventcatalog.config.ts
+++ b/packages/core/src/eventcatalog.config.ts
@@ -290,6 +290,10 @@ export interface Config {
     allowAnyEnvInSpecHeaders?: boolean;
   };
   mdxOptimize?: boolean;
+  /**
+   * Compress static build output using astro-compress installed in the EventCatalog project.
+   * @default false
+   */
   compress?: boolean;
   pages?: {
     /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,9 +211,6 @@ importers:
       astro:
         specifier: ^7.1.1
         version: 7.1.1(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.19.21)(jiti@2.7.0)(rollup@4.52.4)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
-      astro-compress:
-        specifier: ^2.4.0
-        version: 2.4.0(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.19.21)(jiti@2.7.0)(rollup@4.52.4)(tsx@4.21.0)(yaml@2.9.0)
       astro-expressive-code:
         specifier: ^0.44.0
         version: 0.44.0(astro@7.1.1(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.19.21)(jiti@2.7.0)(rollup@4.52.4)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
@@ -2284,9 +2281,6 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
-  '@playform/pipe@0.1.4':
-    resolution: {integrity: sha512-SM3iJ5VHA61NsYMrtvk8DAZwkrpPtBCiJnfWjj1iX6Ke/hnHLqVjTmkXG087UMOa9Z+3J/zUoAkzf3Al6tiS8A==}
-
   '@pnpm/config.env-replace@1.1.0':
     resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
     engines: {node: '>=12.22.0'}
@@ -3394,12 +3388,6 @@ packages:
   '@types/cross-spawn@6.0.0':
     resolution: {integrity: sha512-evp2ZGsFw9YKprDbg8ySgC9NA15g3YgiI8ANkGmKKvvi0P2aDGYLPxQIC5qfeKNUOe3TjABVGuah6omPRpIYhg==}
 
-  '@types/css-tree@2.3.11':
-    resolution: {integrity: sha512-aEokibJOI77uIlqoBOkVbaQGC9zII0A+JH1kcTNKW2CwyYWD8KM6qdo+4c77wD3wZOQfJuNWAr9M4hdk+YhDIg==}
-
-  '@types/csso@5.0.4':
-    resolution: {integrity: sha512-W/FsRkm/9c04x9ON+bj+HQ0cSgNkG1LvcfuBCpkP7cpikM7+RkrNFLGtiofb++xBG6KGMUycLoDbi9/K621ZCw==}
-
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
 
@@ -3532,9 +3520,6 @@ packages:
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
-
-  '@types/html-minifier-terser@7.0.2':
-    resolution: {integrity: sha512-mm2HqV22l8lFQh4r2oSsOEVea+m0qqxEmwpc9kC1p/XzmjLWrReR9D/GRs8Pex2NX/imyEH9c5IU/7tMBQCHOA==}
 
   '@types/js-yaml@4.0.9':
     resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
@@ -4029,9 +4014,6 @@ packages:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
     hasBin: true
 
-  astro-compress@2.4.0:
-    resolution: {integrity: sha512-Vmh/HHoufajKORla9pAWToiENe5Ivqh3Dg5jA81qQ84sLfXOXGJcHT+2rz3KW35vL96ym968AUD8taFGrYHthw==}
-
   astro-expressive-code@0.44.0:
     resolution: {integrity: sha512-b1wN/ZvbJprzxlGKIpIes2kQrCY5KRLwys2tWbZAZyjGZcW5ZtgneZnBwzNRiBna9/48d4mQl19KLjcRuhO1hw==}
     peerDependencies:
@@ -4191,9 +4173,6 @@ packages:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
-  camel-case@4.1.2:
-    resolution: {integrity: sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==}
-
   camelcase@7.0.1:
     resolution: {integrity: sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==}
     engines: {node: '>=14.16'}
@@ -4287,10 +4266,6 @@ packages:
   classcat@5.0.5:
     resolution: {integrity: sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==}
 
-  clean-css@5.3.3:
-    resolution: {integrity: sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==}
-    engines: {node: '>= 10.0'}
-
   cli-boxes@3.0.0:
     resolution: {integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==}
     engines: {node: '>=10'}
@@ -4345,10 +4320,6 @@ packages:
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
-  commander@10.0.1:
-    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
-    engines: {node: '>=14'}
-
   commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
     engines: {node: '>=16'}
@@ -4356,10 +4327,6 @@ packages:
   commander@12.1.0:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
     engines: {node: '>=18'}
-
-  commander@14.0.3:
-    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
-    engines: {node: '>=20'}
 
   commander@2.20.0:
     resolution: {integrity: sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==}
@@ -4719,10 +4686,6 @@ packages:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
 
-  deepmerge-ts@7.1.5:
-    resolution: {integrity: sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==}
-    engines: {node: '>=16.0.0'}
-
   defaults@1.0.4:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
 
@@ -4816,9 +4779,6 @@ packages:
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
-
-  dot-case@3.0.4:
-    resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
 
   dot-prop@9.0.0:
     resolution: {integrity: sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ==}
@@ -5444,11 +5404,6 @@ packages:
 
   html-escaper@3.0.3:
     resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
-
-  html-minifier-terser@7.2.0:
-    resolution: {integrity: sha512-tXgn3QfqPIpGl9o+K5tpcj3/MN4SfLtsx2GWwBC3SSd0tXQGyF3gsSqad8loJgKZGM3ZxbYDd5yhiBIdWpmvLA==}
-    engines: {node: ^14.13.1 || >=16.0.0}
-    hasBin: true
 
   html-to-image@1.11.13:
     resolution: {integrity: sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==}
@@ -6171,9 +6126,6 @@ packages:
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
-  lower-case@2.0.2:
-    resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
-
   lowlight@1.20.0:
     resolution: {integrity: sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==}
 
@@ -6557,9 +6509,6 @@ packages:
   nlcst-to-string@4.0.0:
     resolution: {integrity: sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA==}
 
-  no-case@3.0.4:
-    resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
-
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
 
@@ -6744,9 +6693,6 @@ packages:
   pako@2.1.0:
     resolution: {integrity: sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==}
 
-  param-case@3.0.4:
-    resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
-
   parse-entities@2.0.0:
     resolution: {integrity: sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==}
 
@@ -6766,9 +6712,6 @@ packages:
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
-
-  pascal-case@3.1.2:
-    resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
 
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
@@ -7221,10 +7164,6 @@ packages:
 
   rehype-stringify@10.0.1:
     resolution: {integrity: sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==}
-
-  relateurl@0.2.7:
-    resolution: {integrity: sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==}
-    engines: {node: '>= 0.10'}
 
   remark-comment@1.0.0:
     resolution: {integrity: sha512-k8YPo5MGvl8l4gGxOH6Zk4Fa2AhDACN5eqKnKZcHDORZQS15hlnezlBHj2lqyDiqzApNmYOMTibkEJbMSKU25w==}
@@ -10163,7 +10102,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@img/colour@1.0.0': {}
+  '@img/colour@1.0.0':
+    optional: true
 
   '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
@@ -10305,6 +10245,7 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
+    optional: true
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
@@ -10591,12 +10532,6 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
-
-  '@playform/pipe@0.1.4':
-    dependencies:
-      '@types/node': 25.0.3
-      deepmerge-ts: 7.1.5
-      fast-glob: 3.3.3
 
   '@pnpm/config.env-replace@1.1.0': {}
 
@@ -11875,12 +11810,6 @@ snapshots:
     dependencies:
       '@types/node': 20.19.19
 
-  '@types/css-tree@2.3.11': {}
-
-  '@types/csso@5.0.4':
-    dependencies:
-      '@types/css-tree': 2.3.11
-
   '@types/d3-array@3.2.2': {}
 
   '@types/d3-axis@3.0.6':
@@ -12039,8 +11968,6 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
-  '@types/html-minifier-terser@7.0.2': {}
-
   '@types/js-yaml@4.0.9': {}
 
   '@types/json-schema@7.0.15': {}
@@ -12093,6 +12020,7 @@ snapshots:
   '@types/node@25.0.3':
     dependencies:
       undici-types: 7.16.0
+    optional: true
 
   '@types/pako@2.0.4': {}
 
@@ -12616,57 +12544,6 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-compress@2.4.0(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.19.21)(jiti@2.7.0)(rollup@4.52.4)(tsx@4.21.0)(yaml@2.9.0):
-    dependencies:
-      '@playform/pipe': 0.1.4
-      '@types/csso': 5.0.4
-      '@types/html-minifier-terser': 7.0.2
-      astro: 7.1.1(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.19.21)(jiti@2.7.0)(rollup@4.52.4)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
-      commander: 14.0.3
-      csso: 5.0.5
-      deepmerge-ts: 7.1.5
-      fast-glob: 3.3.3
-      html-minifier-terser: 7.2.0
-      kleur: 4.1.5
-      lightningcss: 1.32.0
-      sharp: 0.34.5
-      svgo: 4.0.1
-      terser: 5.46.0
-    transitivePeerDependencies:
-      - '@astrojs/markdown-remark'
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@types/node'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - '@vitejs/devtools'
-      - aws4fetch
-      - db0
-      - idb-keyval
-      - ioredis
-      - jiti
-      - less
-      - rollup
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - tsx
-      - uploadthing
-      - yaml
-
   astro-expressive-code@0.44.0(astro@7.1.1(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.19.21)(jiti@2.7.0)(rollup@4.52.4)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       astro: 7.1.1(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.19.21)(jiti@2.7.0)(rollup@4.52.4)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
@@ -12904,7 +12781,8 @@ snapshots:
 
   buffer-equal-constant-time@1.0.1: {}
 
-  buffer-from@1.1.2: {}
+  buffer-from@1.1.2:
+    optional: true
 
   buffer@5.7.1:
     dependencies:
@@ -12938,11 +12816,6 @@ snapshots:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
-
-  camel-case@4.1.2:
-    dependencies:
-      pascal-case: 3.1.2
-      tslib: 2.8.1
 
   camelcase@7.0.1: {}
 
@@ -13033,10 +12906,6 @@ snapshots:
 
   classcat@5.0.5: {}
 
-  clean-css@5.3.3:
-    dependencies:
-      source-map: 0.6.1
-
   cli-boxes@3.0.0: {}
 
   cli-cursor@3.1.0:
@@ -13082,13 +12951,9 @@ snapshots:
 
   comma-separated-tokens@2.0.3: {}
 
-  commander@10.0.1: {}
-
   commander@11.1.0: {}
 
   commander@12.1.0: {}
-
-  commander@14.0.3: {}
 
   commander@2.20.0: {}
 
@@ -13484,8 +13349,6 @@ snapshots:
 
   deep-extend@0.6.0: {}
 
-  deepmerge-ts@7.1.5: {}
-
   defaults@1.0.4:
     dependencies:
       clone: 1.0.4
@@ -13571,11 +13434,6 @@ snapshots:
       dom-serializer: 2.0.0
       domelementtype: 2.3.0
       domhandler: 5.0.3
-
-  dot-case@3.0.4:
-    dependencies:
-      no-case: 3.0.4
-      tslib: 2.8.1
 
   dot-prop@9.0.0:
     dependencies:
@@ -14510,16 +14368,6 @@ snapshots:
 
   html-escaper@3.0.3: {}
 
-  html-minifier-terser@7.2.0:
-    dependencies:
-      camel-case: 4.1.2
-      clean-css: 5.3.3
-      commander: 10.0.1
-      entities: 4.5.0
-      param-case: 3.0.4
-      relateurl: 0.2.7
-      terser: 5.46.0
-
   html-to-image@1.11.13: {}
 
   html-url-attributes@3.0.1: {}
@@ -15162,10 +15010,6 @@ snapshots:
       js-tokens: 4.0.0
 
   loupe@3.2.1: {}
-
-  lower-case@2.0.2:
-    dependencies:
-      tslib: 2.8.1
 
   lowlight@1.20.0:
     dependencies:
@@ -15832,11 +15676,6 @@ snapshots:
     dependencies:
       '@types/nlcst': 2.0.3
 
-  no-case@3.0.4:
-    dependencies:
-      lower-case: 2.0.2
-      tslib: 2.8.1
-
   node-addon-api@7.1.1: {}
 
   node-fetch-native@1.6.7: {}
@@ -16024,11 +15863,6 @@ snapshots:
 
   pako@2.1.0: {}
 
-  param-case@3.0.4:
-    dependencies:
-      dot-case: 3.0.4
-      tslib: 2.8.1
-
   parse-entities@2.0.0:
     dependencies:
       character-entities: 1.2.4
@@ -16064,11 +15898,6 @@ snapshots:
       entities: 6.0.1
 
   parseurl@1.3.3: {}
-
-  pascal-case@3.1.2:
-    dependencies:
-      no-case: 3.0.4
-      tslib: 2.8.1
 
   path-browserify@1.0.1: {}
 
@@ -16607,8 +16436,6 @@ snapshots:
       hast-util-to-html: 9.0.5
       unified: 11.0.5
 
-  relateurl@0.2.7: {}
-
   remark-comment@1.0.0:
     dependencies:
       micromark-factory-space: 1.1.0
@@ -16979,6 +16806,7 @@ snapshots:
       '@img/sharp-win32-arm64': 0.34.5
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
+    optional: true
 
   shebang-command@1.2.0:
     dependencies:
@@ -17081,6 +16909,7 @@ snapshots:
     dependencies:
       buffer-from: 1.1.2
       source-map: 0.6.1
+    optional: true
 
   source-map@0.6.1: {}
 
@@ -17299,6 +17128,7 @@ snapshots:
       acorn: 8.16.0
       commander: 2.20.0
       source-map-support: 0.5.21
+    optional: true
 
   thenby@1.3.4: {}
 


### PR DESCRIPTION
## What This PR Does

Removes `astro-compress` from the `@eventcatalog/core` dependency list and loads it lazily from the user's own EventCatalog project instead. Compression is off by default, so every catalog was paying the install cost of a package that most builds never used. Catalogs that want `compress: true` now install `astro-compress` themselves.

Also fixes the sidebar so top-level groups always stay expanded regardless of how many children they have.

## Changes Overview

### Key Changes

- Dropped `astro-compress` from `packages/core/package.json` dependencies (188-line reduction in `pnpm-lock.yaml`).
- Added `packages/core/eventcatalog/src/plugins/astro-compress.ts`, which resolves `astro-compress` from the user's project directory and throws an actionable install message when it's missing.
- `astro.config.mjs` now calls `loadAstroCompressIntegration(projectDirectory)` instead of a bare `import('astro-compress')`.
- `canCollapseGroup()` takes an `isTopLevel` flag and returns `false` for top-level sidebar groups.
- Documented the new install step for compression, tagged `<AddedIn version="4.4.0" />`.

## How It Works

The integration is resolved with `createRequire(join(projectDirectory, 'package.json'))` so Node looks for `astro-compress` in the *catalog's* `node_modules`, not EventCatalog's. The resolved path is converted to a file URL before the dynamic `import()` so it works on Windows, and the `/* @vite-ignore */` hint stops Vite from trying to statically analyse the specifier.

Two failure modes are handled explicitly: the package isn't installed (resolution throws, rethrown with install instructions), and the package is installed but doesn't export a default integration function.

Compression options are unchanged — `Logger: 0` and `CSS: false` — so catalogs that add the dependency get identical output to before.

## Breaking Changes

**Yes, for catalogs using `compress: true` on static builds.** These will now fail the build with an install message until `astro-compress` is added as a dev dependency:

```bash
npm install --save-dev astro-compress
```

Catalogs with compression disabled (the default since v2.61.9) and all SSR builds are unaffected. Shipping as `minor` per the changeset.

## Additional Notes

- New unit tests in `astro-compress.test.ts` cover both the happy path and the missing-package error by scaffolding a throwaway project dir with a stub package. Full suite for the touched files: 11 passing.
- The docs pre-commit hook syncs `packages/core/docs` from the sibling `website-2` repo. That sync reverts three unrelated files (`98-versioning-resources.md`, `01-version-services.md`, `03-features.md`) because the versionless-URL docs added in 04e5d190 were written straight into `packages/core/docs` and never landed in website-2. This is pre-existing drift, not something this PR introduces — but it means those `4.3.3` docs need re-adding to website-2 to stop the hook undoing them.
- The compression doc edits were made in `website-2` (the source of truth) and are **uncommitted in that sibling repo** — they need committing and PRing there separately.
- `pnpm run check` currently fails on a stale build artifact in the git-ignored `examples/default/dist/` directory (`FraudCheckCompleted` has a non-`x-` prefixed `tags` property). Unrelated to this change.