### PR TITLE
fix(core): type wire links as tuples for astro check

### DIFF
--- a/.changeset/spotty-teeth-throw.md
+++ b/.changeset/spotty-teeth-throw.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix(core): type wire links as tuples for astro check

--- a/packages/core/eventcatalog/src/pages/visualiser/graph/index.astro
+++ b/packages/core/eventcatalog/src/pages/visualiser/graph/index.astro
@@ -1,6 +1,7 @@
 ---
 import VisualiserLayout from '@layouts/VisualiserLayout.astro';
 import CatalogForceGraph from '@components/CatalogGraph/CatalogForceGraph';
+import type { CatalogGraphWireLink } from '@components/CatalogGraph/CatalogForceGraph';
 import { getCatalogForceGraph } from '@utils/node-graphs/catalog-force-graph';
 import { isArchitectureGraphEnabled } from '@utils/feature';
 
@@ -26,11 +27,13 @@ const wireNodes = nodes.map(({ id, label, collection, version }) => ({
   version,
 }));
 
-const wireLinks = links.map((link) => [
-  nodeIndexById.get(link.source)!,
-  nodeIndexById.get(link.target)!,
-  labelIndexByLabel.get(link.label)!,
-]);
+const wireLinks = links.map(
+  (link): CatalogGraphWireLink => [
+    nodeIndexById.get(link.source)!,
+    nodeIndexById.get(link.target)!,
+    labelIndexByLabel.get(link.label)!,
+  ]
+);
 ---
 
 <VisualiserLayout title="Visualiser | Architecture Graph" description="Force-directed graph of every resource in the catalog">


### PR DESCRIPTION
## What This PR Does

Fixes a type error in the Architecture Graph page (merged in #2752) that surfaced when running `pnpm run check`: the compact wire-format links were inferred as `number[][]` instead of the `CatalogGraphWireLink` tuple type the component expects.

## Changes Overview

- Annotate the `wireLinks` map callback in `pages/visualiser/graph/index.astro` with the `CatalogGraphWireLink` tuple return type

## Breaking Changes

None — types only, no runtime change (hence no changeset).