### PR TITLE
Add federation pipeline to the SDK (build-index, resolve, hydrate)

### DIFF
--- a/.changeset/quiet-comets-federate.md
+++ b/.changeset/quiet-comets-federate.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/sdk": minor
+---
+
+Add the federation pipeline to the SDK: `buildIndex` discovers and describes catalog content into a portable index, `resolve` combines indexes from multiple sources into a single graph (with conflict detection, externals and edges), and `hydrate` materializes the resolved content to disk (fetching, verifying, caching and referencing artifacts). Also adds `parseIndex` for validating an index, and exports the new federation types.

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ git-push.sh
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+/federated-catalog/
 
 src/__tests__/example-catalog-dependencies/dependencies
 
@@ -81,3 +82,4 @@ ec-test/
 docs/superpowers/*
 .worktrees/
 .pnpm-store/
+federationv2.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,17 @@ Vitest is the default test framework across packages. Tests are placed either ne
 - For multiline CLI export DSL assertions, use the shared `dsl` template tag with `toBe(...)` so expected blocks stay readable and indented in the test file.
 - For core/UI-impacting changes, also verify catalog build paths (`pnpm verify-build:catalog`).
 
+## Federation Pipeline Checks
+
+Federation is a three-stage pipeline in `packages/sdk`: `buildIndex` discovers and describes catalog content, `resolve` combines indexes into a graph, and `hydrate` materializes the resolved content. Any future change to resources, relationships, schemas/specifications, sidecars, assets, paths, hashes, or catalog filesystem conventions must be reviewed across all three stages, even when the requested change initially appears to affect only one stage.
+
+- Check whether `packages/sdk/src/build-index.ts` and its index types need to capture the new or changed data.
+- Check whether `packages/sdk/src/resolve.ts` must preserve, merge, validate, conflict-check, or create edges for that data.
+- Check whether `packages/sdk/src/hydrate.ts` must fetch, verify, cache, write, reference, or remove that data safely.
+- Add or update focused tests in `build-index.test.ts`, `resolve.test.ts`, and `hydrate.test.ts` wherever the behavior crosses those boundaries.
+- Run the relevant focused tests and the complete SDK suite (`pnpm --filter @eventcatalog/sdk test`) before considering federation-related work complete.
+- When filesystem output changes, rerun the default-catalog federation integration review and inspect the diff against `examples/default` so missing, extra, or stale files are deliberate.
+
 ## Commit & Pull Request Guidelines
 Recent history favors Conventional Commit style with scopes:
 - `feat(cli): add import command`

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "start:catalog": "pnpm --filter @eventcatalog/core run start:catalog",
     "export:catalog": "pnpm --filter @eventcatalog/core run export:catalog",
     "preview:catalog": "pnpm --filter @eventcatalog/core run preview:catalog",
+    "review:federation": "pnpm --filter @eventcatalog/sdk build && node packages/sdk/scripts/review-default-federation.mjs",
     "start:catalog:server": "pnpm --filter @eventcatalog/core run start:catalog:server",
     "verify-build:catalog": "pnpm --filter @eventcatalog/core run verify-build:catalog",
     "changeset": "changeset",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -47,9 +47,11 @@
     "fs-extra": "^11.3.2",
     "glob": "^13.0.6",
     "gray-matter": "^4.0.3",
+    "ignore": "^7.0.5",
     "proper-lockfile": "^4.1.2",
     "semver": "7.7.3",
-    "slugify": "^1.6.6"
+    "slugify": "^1.6.6",
+    "zod": "^4.3.6"
   },
   "repository": {
     "type": "git",

--- a/packages/sdk/scripts/review-default-federation.mjs
+++ b/packages/sdk/scripts/review-default-federation.mjs
@@ -1,0 +1,56 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import createSdk, { hydrate, resolve } from '../dist/index.mjs';
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(scriptDirectory, '../../..');
+const catalogDirectory = path.join(repositoryRoot, 'examples/default');
+const outDir = path.join(repositoryRoot, 'federated-catalog');
+const source = 'eventcatalog/examples/default';
+const commit = 'working-tree';
+
+const fetch = async (request) => {
+  if (request.source !== source || request.commit !== commit) {
+    throw new Error(`Unexpected fetch source: ${request.source}@${request.commit}`);
+  }
+
+  const requestedPath = path.resolve(catalogDirectory, request.path);
+  const catalogPrefix = `${catalogDirectory}${path.sep}`;
+  if (!requestedPath.startsWith(catalogPrefix)) {
+    throw new Error(`Fetch path escapes examples/default: ${request.path}`);
+  }
+
+  return fs.readFile(requestedPath);
+};
+
+const index = await createSdk(catalogDirectory).buildIndex({ source, commit });
+const graph = resolve([index]);
+const hydrateResult = await hydrate(graph, {
+  outDir,
+  localSource: 'eventcatalog/federation-review',
+  fetch,
+});
+
+await Promise.all([
+  fs.writeFile(path.join(outDir, 'index.json'), `${JSON.stringify(index, null, 2)}\n`),
+  fs.writeFile(path.join(outDir, 'resolved-graph.json'), `${JSON.stringify(graph, null, 2)}\n`),
+  fs.writeFile(path.join(outDir, 'hydrate-result.json'), `${JSON.stringify(hydrateResult, null, 2)}\n`),
+]);
+
+console.log(
+  JSON.stringify(
+    {
+      catalogDirectory,
+      outDir,
+      resources: index.resources.length,
+      entities: graph.entities.length,
+      edges: graph.edges.length,
+      conflicts: graph.conflicts.length,
+      externals: graph.externals.length,
+      hydrate: hydrateResult,
+    },
+    null,
+    2
+  )
+);

--- a/packages/sdk/src/build-index.ts
+++ b/packages/sdk/src/build-index.ts
@@ -5,6 +5,7 @@ import ignore from 'ignore';
 import { rcompare, valid } from 'semver';
 import { getAdrs } from './adrs';
 import { getAgents } from './agents';
+import { getChannels } from './channels';
 import { getCommands } from './commands';
 import { getDataProducts } from './data-products';
 import { getDataStores } from './data-stores';
@@ -22,6 +23,8 @@ import { getTeams } from './teams';
 import type {
   Adr,
   BaseSchema,
+  Channel,
+  ChannelPointer,
   Container,
   DataProductOutputPointer,
   FlowStep,
@@ -66,6 +69,12 @@ type IndexableResource = {
   diagrams?: ResourcePointer[];
   sends?: SendsPointer[];
   receives?: ReceivesPointer[];
+  channels?: ChannelPointer[];
+  address?: Channel['address'];
+  protocols?: Channel['protocols'];
+  deliveryGuarantee?: Channel['deliveryGuarantee'];
+  routes?: Channel['routes'];
+  parameters?: Channel['parameters'];
   services?: ResourcePointer[];
   agents?: ResourcePointer[];
   domains?: ResourcePointer[];
@@ -337,6 +346,12 @@ const toIndexResource = async (
     ...(resource.steps === undefined ? {} : { references: getFlowReferences(resource.steps) }),
     ...(resource.sends === undefined ? {} : { sends: resource.sends }),
     ...(resource.receives === undefined ? {} : { receives: resource.receives }),
+    ...(resource.channels === undefined ? {} : { channels: resource.channels }),
+    ...(resource.address === undefined ? {} : { address: resource.address }),
+    ...(resource.protocols === undefined ? {} : { protocols: resource.protocols }),
+    ...(resource.deliveryGuarantee === undefined ? {} : { deliveryGuarantee: resource.deliveryGuarantee }),
+    ...(resource.routes === undefined ? {} : { routes: resource.routes }),
+    ...(resource.parameters === undefined ? {} : { parameters: resource.parameters }),
     ...(resource.services === undefined ? {} : { services: resource.services }),
     ...(resource.agents === undefined ? {} : { agents: resource.agents }),
     ...(resource.domains === undefined ? {} : { domains: resource.domains }),
@@ -367,6 +382,7 @@ export const buildIndex =
   async ({ source, commit, hashContent = true }: BuildIndexOptions): Promise<Index> => {
     const [
       domains,
+      channels,
       events,
       commands,
       queries,
@@ -383,6 +399,7 @@ export const buildIndex =
       diagrams,
     ] = await Promise.all([
       getDomains(directory)(),
+      getChannels(directory)(),
       getEvents(directory)(),
       getCommands(directory)(),
       getQueries(directory)(),
@@ -400,6 +417,7 @@ export const buildIndex =
     ]);
     const indexableResources: IndexableResourceEntry[] = [
       ...(domains ?? []).map((resource) => ({ type: 'domain' as const, resource })),
+      ...(channels ?? []).map((resource) => ({ type: 'channel' as const, resource })),
       ...(events ?? []).map((resource) => ({ type: 'event' as const, resource })),
       ...(commands ?? []).map((resource) => ({ type: 'command' as const, resource })),
       ...(queries ?? []).map((resource) => ({ type: 'query' as const, resource })),

--- a/packages/sdk/src/build-index.ts
+++ b/packages/sdk/src/build-index.ts
@@ -1,0 +1,455 @@
+import { createHash } from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import ignore from 'ignore';
+import { rcompare, valid } from 'semver';
+import { getAdrs } from './adrs';
+import { getAgents } from './agents';
+import { getCommands } from './commands';
+import { getDataProducts } from './data-products';
+import { getDataStores } from './data-stores';
+import { getDiagrams } from './diagrams';
+import { getDomains } from './domains';
+import { getEntities } from './entities';
+import { getEvents } from './events';
+import { getFlows } from './flows';
+import type { Index, IndexAsset, IndexResource, IndexResourceType, IndexSidecar } from './index-types';
+import { getResourcePath } from './internal/resources';
+import { getQueries } from './queries';
+import { getServices } from './services';
+import { getSystems } from './systems';
+import { getTeams } from './teams';
+import type {
+  Adr,
+  BaseSchema,
+  Container,
+  DataProductOutputPointer,
+  FlowStep,
+  ReceivesPointer,
+  ResourcePointer,
+  SchemaPointer,
+  SendsPointer,
+  Specification,
+  Specifications,
+  SystemActorRelationship,
+  SystemRelationshipPointer,
+  Team,
+} from './types';
+import { getUsers } from './users';
+
+type BuildIndexOptions = {
+  source: string;
+  commit: string;
+  hashContent?: boolean;
+};
+
+type IndexableResource = {
+  id: string;
+  version?: string;
+  name: string;
+  draft?: BaseSchema['draft'];
+  deprecated?: BaseSchema['deprecated'];
+  owners?: string[];
+  schemaPath?: string;
+  schemas?: SchemaPointer[];
+  specifications?: Specifications | Specification[];
+  container_type?: Container['container_type'];
+  steps?: FlowStep[];
+  status?: Adr['status'];
+  appliesTo?: Adr['appliesTo'];
+  supersedes?: Adr['supersedes'];
+  supersededBy?: Adr['supersededBy'];
+  amends?: Adr['amends'];
+  amendedBy?: Adr['amendedBy'];
+  related?: Adr['related'];
+  members?: Team['members'];
+  diagrams?: ResourcePointer[];
+  sends?: SendsPointer[];
+  receives?: ReceivesPointer[];
+  services?: ResourcePointer[];
+  agents?: ResourcePointer[];
+  domains?: ResourcePointer[];
+  systems?: ResourcePointer[];
+  entities?: ResourcePointer[];
+  dataProducts?: ResourcePointer[];
+  flows?: ResourcePointer[];
+  writesTo?: ResourcePointer[];
+  readsFrom?: ResourcePointer[];
+  containers?: ResourcePointer[];
+  relationships?: SystemRelationshipPointer[];
+  actors?: SystemActorRelationship[];
+  inputs?: ResourcePointer[];
+  outputs?: DataProductOutputPointer[];
+};
+
+type IndexableResourceEntry = {
+  type: IndexResourceType;
+  resource: IndexableResource;
+  sourcePath?: string;
+};
+
+const normalizeSpecifications = async (resource: IndexableResource, resourcePath: string, hashContent: boolean) => {
+  if (resource.specifications === undefined) return undefined;
+
+  const specifications: Specification[] = Array.isArray(resource.specifications)
+    ? resource.specifications
+    : [
+        { type: 'asyncapi' as const, path: resource.specifications.asyncapiPath },
+        { type: 'openapi' as const, path: resource.specifications.openapiPath },
+        { type: 'graphql' as const, path: resource.specifications.graphqlPath },
+      ].flatMap(({ type, path }) => (path ? [{ type, path }] : []));
+
+  return Promise.all(
+    specifications.map(async (specification) => ({
+      ...specification,
+      ...(hashContent
+        ? {
+            hash: `sha256:${createHash('sha256')
+              .update(await fs.readFile(path.join(path.dirname(resourcePath), specification.path)))
+              .digest('hex')}`,
+          }
+        : {}),
+    }))
+  );
+};
+
+const getFlowReferences = (steps: FlowStep[]) =>
+  steps.flatMap((step) => [
+    ...(step.service ? [{ kind: 'service' as const, ...step.service }] : []),
+    ...(step.message ? [{ kind: 'message' as const, ...step.message }] : []),
+    ...(step.agent ? [{ kind: 'agent' as const, ...step.agent }] : []),
+    ...(step.container ? [{ kind: 'container' as const, ...step.container }] : []),
+    ...(step.dataProduct ? [{ kind: 'data-product' as const, ...step.dataProduct }] : []),
+    ...(step.flow ? [{ kind: 'flow' as const, ...step.flow }] : []),
+  ]);
+
+const compareText = (left: string, right: string) => (left < right ? -1 : left > right ? 1 : 0);
+
+const compareVersions = (left?: string, right?: string) => {
+  if (left === right) return 0;
+  if (left === undefined) return 1;
+  if (right === undefined) return -1;
+  if (valid(left) && valid(right)) return rcompare(left, right);
+  return compareText(right, left);
+};
+
+const compareIndexResources = (
+  left: { type: string; id: string; version?: string },
+  right: { type: string; id: string; version?: string }
+) => compareText(left.type, right.type) || compareText(left.id, right.id) || compareVersions(left.version, right.version);
+
+const toCatalogPath = (directory: string, filePath: string) => path.relative(directory, filePath).split(path.sep).join('/');
+
+const loadIgnoreRules = async (directory: string) => {
+  try {
+    return ignore().add(await fs.readFile(path.join(directory, '.eventcatalogignore'), 'utf8'));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+    throw error;
+  }
+};
+
+const normalizeAssets = async (directory: string, hashContent: boolean, ignoreRules?: ignore.Ignore) => {
+  const collectFiles = async (currentDirectory: string): Promise<string[]> => {
+    let entries;
+
+    try {
+      entries = await fs.readdir(currentDirectory, { withFileTypes: true });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+      throw error;
+    }
+
+    const files = await Promise.all(
+      entries
+        .sort((left, right) => compareText(left.name, right.name))
+        .map(async (entry): Promise<string[]> => {
+          const entryPath = path.join(currentDirectory, entry.name);
+          const catalogPath = toCatalogPath(directory, entryPath);
+
+          if (entry.isDirectory()) return ignoreRules?.ignores(`${catalogPath}/`) ? [] : collectFiles(entryPath);
+          return entry.isFile() && !ignoreRules?.ignores(catalogPath) ? [entryPath] : [];
+        })
+    );
+
+    return files.flat();
+  };
+  const assetPaths = (
+    await Promise.all(['components', 'public'].map((assetDirectory) => collectFiles(path.join(directory, assetDirectory))))
+  )
+    .flat()
+    .sort(compareText);
+  const assets: IndexAsset[] = await Promise.all(
+    assetPaths.map(async (assetPath) => ({
+      path: toCatalogPath(directory, assetPath),
+      ...(hashContent
+        ? {
+            hash: `sha256:${createHash('sha256')
+              .update(await fs.readFile(assetPath))
+              .digest('hex')}`,
+          }
+        : {}),
+    }))
+  );
+
+  return assets.length === 0 ? undefined : assets;
+};
+
+const normalizeSchemas = async (resource: IndexableResource, resourcePath: string, hashContent: boolean) => {
+  const schemas = resource.schemas ?? (resource.schemaPath ? [{ path: resource.schemaPath, default: true }] : undefined);
+
+  if (schemas === undefined) return undefined;
+
+  return Promise.all(
+    schemas.map(async ({ file, ...schema }) => {
+      const schemaPath = file ?? schema.path;
+
+      return {
+        ...schema,
+        ...(schemaPath === undefined ? {} : { path: schemaPath }),
+        ...(hashContent && schemaPath
+          ? {
+              hash: `sha256:${createHash('sha256')
+                .update(await fs.readFile(path.join(path.dirname(resourcePath), schemaPath)))
+                .digest('hex')}`,
+            }
+          : {}),
+      };
+    })
+  );
+};
+
+const IGNORED_SIDECAR_FILES = new Set(['.DS_Store', '.gitignore', '.gitkeep', '.npmignore', 'Thumbs.db', 'desktop.ini']);
+const IGNORED_SIDECAR_DIRECTORIES = new Set(['.git', '.hg', '.svn', 'node_modules']);
+
+const normalizeSidecars = async (
+  directory: string,
+  resourcePath: string,
+  resourceDirectories: Set<string>,
+  representedPaths: Set<string>,
+  hashContent: boolean,
+  ignoreRules?: ignore.Ignore
+) => {
+  // Teams and users are individual files in shared directories. Only resources
+  // backed by their own index file own the surrounding directory tree.
+  if (!/^index\.mdx?$/i.test(path.basename(resourcePath))) return undefined;
+
+  const collectFiles = async (currentDirectory: string): Promise<string[]> => {
+    let entries;
+
+    try {
+      entries = await fs.readdir(currentDirectory, { withFileTypes: true });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+      throw error;
+    }
+
+    const files = await Promise.all(
+      entries
+        .sort((left, right) => compareText(left.name, right.name))
+        .map(async (entry): Promise<string[]> => {
+          const entryPath = path.join(currentDirectory, entry.name);
+          const resolvedEntryPath = path.resolve(entryPath);
+          const catalogPath = toCatalogPath(directory, entryPath);
+
+          if (entry.isDirectory()) {
+            if (IGNORED_SIDECAR_DIRECTORIES.has(entry.name) || resourceDirectories.has(resolvedEntryPath)) return [];
+            if (ignoreRules?.ignores(`${catalogPath}/`)) return [];
+            return collectFiles(entryPath);
+          }
+          if (!entry.isFile()) return [];
+          if (IGNORED_SIDECAR_FILES.has(entry.name) || representedPaths.has(resolvedEntryPath)) return [];
+          if (entry.name.endsWith('~') || /^\..*\.sw[op]$/.test(entry.name)) return [];
+          if (ignoreRules?.ignores(catalogPath)) return [];
+
+          return [entryPath];
+        })
+    );
+
+    return files.flat();
+  };
+  const sidecarPaths = (await collectFiles(path.dirname(resourcePath))).sort(compareText);
+  const sidecars: IndexSidecar[] = await Promise.all(
+    sidecarPaths.map(async (sidecarPath) => ({
+      path: toCatalogPath(directory, sidecarPath),
+      ...(hashContent
+        ? {
+            hash: `sha256:${createHash('sha256')
+              .update(await fs.readFile(sidecarPath))
+              .digest('hex')}`,
+          }
+        : {}),
+    }))
+  );
+
+  return sidecars.length === 0 ? undefined : sidecars;
+};
+
+const toIndexResource = async (
+  directory: string,
+  type: IndexResourceType,
+  resource: IndexableResource,
+  hashContent: boolean,
+  sourcePath: string,
+  resourceDirectories: Set<string>,
+  ignoreRules?: ignore.Ignore
+): Promise<IndexResource> => {
+  const { id, version, name } = resource;
+  const schemas = await normalizeSchemas(resource, sourcePath, hashContent);
+  const specifications = await normalizeSpecifications(resource, sourcePath, hashContent);
+  const representedPaths = new Set(
+    [
+      sourcePath,
+      ...(schemas ?? []).flatMap((schema) => (schema.path ? [path.join(path.dirname(sourcePath), schema.path)] : [])),
+      ...(specifications ?? []).map((specification) => path.join(path.dirname(sourcePath), specification.path)),
+    ].map((representedPath) => path.resolve(representedPath))
+  );
+  const sidecars = await normalizeSidecars(
+    directory,
+    sourcePath,
+    resourceDirectories,
+    representedPaths,
+    hashContent,
+    ignoreRules
+  );
+
+  return {
+    type,
+    id,
+    ...(version === undefined ? {} : { version }),
+    name,
+    contentPath: toCatalogPath(directory, sourcePath),
+    ...(hashContent
+      ? {
+          contentHash: `sha256:${createHash('sha256')
+            .update(await fs.readFile(sourcePath))
+            .digest('hex')}`,
+        }
+      : {}),
+    ...(resource.draft === undefined ? {} : { draft: resource.draft }),
+    ...(resource.deprecated === undefined ? {} : { deprecated: resource.deprecated }),
+    ...(resource.owners === undefined ? {} : { owners: resource.owners }),
+    ...(resource.diagrams === undefined ? {} : { diagrams: resource.diagrams }),
+    ...(schemas === undefined ? {} : { schemas }),
+    ...(specifications === undefined ? {} : { specifications }),
+    ...(sidecars === undefined ? {} : { sidecars }),
+    ...(resource.container_type === undefined ? {} : { container_type: resource.container_type }),
+    ...(resource.steps === undefined ? {} : { references: getFlowReferences(resource.steps) }),
+    ...(resource.sends === undefined ? {} : { sends: resource.sends }),
+    ...(resource.receives === undefined ? {} : { receives: resource.receives }),
+    ...(resource.services === undefined ? {} : { services: resource.services }),
+    ...(resource.agents === undefined ? {} : { agents: resource.agents }),
+    ...(resource.domains === undefined ? {} : { domains: resource.domains }),
+    ...(resource.systems === undefined ? {} : { systems: resource.systems }),
+    ...(resource.entities === undefined ? {} : { entities: resource.entities }),
+    ...(resource.dataProducts === undefined ? {} : { dataProducts: resource.dataProducts }),
+    ...(resource.flows === undefined ? {} : { flows: resource.flows }),
+    ...(resource.writesTo === undefined ? {} : { writesTo: resource.writesTo }),
+    ...(resource.readsFrom === undefined ? {} : { readsFrom: resource.readsFrom }),
+    ...(resource.containers === undefined ? {} : { containers: resource.containers }),
+    ...(resource.relationships === undefined ? {} : { relationships: resource.relationships }),
+    ...(resource.actors === undefined ? {} : { actors: resource.actors }),
+    ...(resource.inputs === undefined ? {} : { inputs: resource.inputs }),
+    ...(resource.outputs === undefined ? {} : { outputs: resource.outputs }),
+    ...(resource.status === undefined ? {} : { status: resource.status }),
+    ...(resource.appliesTo === undefined ? {} : { appliesTo: resource.appliesTo }),
+    ...(resource.supersedes === undefined ? {} : { supersedes: resource.supersedes }),
+    ...(resource.supersededBy === undefined ? {} : { supersededBy: resource.supersededBy }),
+    ...(resource.amends === undefined ? {} : { amends: resource.amends }),
+    ...(resource.amendedBy === undefined ? {} : { amendedBy: resource.amendedBy }),
+    ...(resource.related === undefined ? {} : { related: resource.related }),
+    ...(resource.members === undefined ? {} : { members: resource.members }),
+  };
+};
+
+export const buildIndex =
+  (directory: string) =>
+  async ({ source, commit, hashContent = true }: BuildIndexOptions): Promise<Index> => {
+    const [
+      domains,
+      events,
+      commands,
+      queries,
+      services,
+      systems,
+      dataProducts,
+      dataStores,
+      entities,
+      flows,
+      adrs,
+      agents,
+      teams,
+      users,
+      diagrams,
+    ] = await Promise.all([
+      getDomains(directory)(),
+      getEvents(directory)(),
+      getCommands(directory)(),
+      getQueries(directory)(),
+      getServices(directory)(),
+      getSystems(directory)(),
+      getDataProducts(directory)(),
+      getDataStores(directory)(),
+      getEntities(directory)(),
+      getFlows(directory)(),
+      getAdrs(directory)(),
+      getAgents(directory)(),
+      getTeams(path.join(directory, 'teams'))(),
+      getUsers(directory)(),
+      getDiagrams(directory)(),
+    ]);
+    const indexableResources: IndexableResourceEntry[] = [
+      ...(domains ?? []).map((resource) => ({ type: 'domain' as const, resource })),
+      ...(events ?? []).map((resource) => ({ type: 'event' as const, resource })),
+      ...(commands ?? []).map((resource) => ({ type: 'command' as const, resource })),
+      ...(queries ?? []).map((resource) => ({ type: 'query' as const, resource })),
+      ...(services ?? []).map((resource) => ({ type: 'service' as const, resource })),
+      ...(systems ?? []).map((resource) => ({ type: 'system' as const, resource })),
+      ...(dataProducts ?? []).map((resource) => ({ type: 'data-product' as const, resource })),
+      ...(dataStores ?? []).map((resource) => ({ type: 'container' as const, resource })),
+      ...(entities ?? []).map((resource) => ({ type: 'entity' as const, resource })),
+      ...(flows ?? []).map((resource) => ({ type: 'flow' as const, resource })),
+      ...(adrs ?? []).map((resource) => ({ type: 'adr' as const, resource })),
+      ...(agents ?? []).map((resource) => ({ type: 'agent' as const, resource })),
+      ...(teams ?? []).map((resource) => ({
+        type: 'team' as const,
+        resource,
+        sourcePath: path.join(directory, 'teams', `${resource.id}.mdx`),
+      })),
+      ...(users ?? []).map((resource) => ({
+        type: 'user' as const,
+        resource,
+        sourcePath: path.join(directory, 'users', `${resource.id}.mdx`),
+      })),
+      ...(diagrams ?? []).map((resource) => ({ type: 'diagram' as const, resource })),
+    ];
+    const locatedResources = await Promise.all(
+      indexableResources.map(async (entry) => {
+        const sourcePath =
+          entry.sourcePath ?? (await getResourcePath(directory, entry.resource.id, entry.resource.version))?.fullPath;
+
+        if (!sourcePath) throw new Error(`Cannot find ${entry.type} ${entry.resource.id} (${entry.resource.version})`);
+        return { ...entry, sourcePath };
+      })
+    );
+    const resourceDirectories = new Set(
+      locatedResources
+        .filter(({ sourcePath }) => /^index\.mdx?$/i.test(path.basename(sourcePath)))
+        .map(({ sourcePath }) => path.resolve(path.dirname(sourcePath)))
+    );
+    const ignoreRules = await loadIgnoreRules(directory);
+    const resources = await Promise.all(
+      locatedResources.map(({ type, resource, sourcePath }) =>
+        toIndexResource(directory, type, resource, hashContent, sourcePath, resourceDirectories, ignoreRules)
+      )
+    );
+    const assets = await normalizeAssets(directory, hashContent, ignoreRules);
+
+    return {
+      indexVersion: 1 as const,
+      source,
+      commit,
+      resources: resources.sort(compareIndexResources),
+      ...(assets === undefined ? {} : { assets }),
+    };
+  };

--- a/packages/sdk/src/domains.ts
+++ b/packages/sdk/src/domains.ts
@@ -89,6 +89,12 @@ export const getDomains =
         '**/queries/**',
         '**/flows/**',
         '**/entities/**',
+        '**/systems/**',
+        '**/containers/**',
+        '**/data-products/**',
+        '**/adrs/**',
+        '**/diagrams/**',
+        '**/channels/**',
       ],
       ...options,
     }) as Promise<Domain[]>;

--- a/packages/sdk/src/hydrate.ts
+++ b/packages/sdk/src/hydrate.ts
@@ -1,0 +1,199 @@
+import { createHash, randomUUID } from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import type { ResolvedGraph } from './index-types';
+
+export type Fetcher = (request: { source: string; commit: string; path: string }) => Promise<Buffer>;
+
+export type Cache = {
+  get(key: string): Promise<Buffer | undefined>;
+  set(key: string, value: Buffer): Promise<void>;
+};
+
+export type HydrateOptions = {
+  outDir: string;
+  localSource: string;
+  fetch: Fetcher;
+  modes?: Record<string, 'hydrate' | 'reference'>;
+  cache?: Cache;
+};
+
+export type HydrateResult = {
+  fetched: number;
+  written: number;
+  referenced: number;
+};
+
+type Artifact = {
+  source: string;
+  commit: string;
+  path: string;
+  hash?: string;
+  target: string;
+  shared?: boolean;
+};
+
+const getSourceDirectory = (source: string) => {
+  const slug = source.replace(/[^a-zA-Z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'source';
+  const digest = createHash('sha256').update(source).digest('hex').slice(0, 12);
+  return `${slug}--${digest}`;
+};
+
+const getArtifactOutputPath = (artifact: Artifact, outDir: string) => {
+  const allowedDirectory = path.resolve(artifact.shared ? outDir : path.join(outDir, getSourceDirectory(artifact.source)));
+  const portableTarget = artifact.target.replaceAll('\\', '/');
+  const normalizedTarget = path.posix.normalize(portableTarget);
+  const hasUnsafePathSyntax =
+    artifact.target.length === 0 ||
+    artifact.target.includes('\0') ||
+    artifact.target.includes('\\') ||
+    path.posix.isAbsolute(portableTarget) ||
+    /^[a-zA-Z]:\//.test(portableTarget) ||
+    normalizedTarget === '..' ||
+    normalizedTarget.startsWith('../');
+  const outputPath = path.resolve(allowedDirectory, artifact.target);
+  const relativeOutputPath = path.relative(allowedDirectory, outputPath);
+  const escapesAllowedDirectory =
+    relativeOutputPath === '' ||
+    relativeOutputPath === '..' ||
+    relativeOutputPath.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relativeOutputPath);
+
+  if (hasUnsafePathSyntax || escapesAllowedDirectory) {
+    throw new Error(`Artifact path "${artifact.target}" escapes its allowed output directory`);
+  }
+
+  return outputPath;
+};
+
+const replaceDirectory = async (stagingDirectory: string, outDir: string) => {
+  const backupDirectory = `${outDir}.backup-${randomUUID()}`;
+  let hasBackup = false;
+
+  try {
+    await fs.rename(outDir, backupDirectory);
+    hasBackup = true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
+
+  try {
+    await fs.rename(stagingDirectory, outDir);
+  } catch (error) {
+    if (hasBackup) await fs.rename(backupDirectory, outDir);
+    throw error;
+  }
+
+  if (hasBackup) await fs.rm(backupDirectory, { recursive: true, force: true });
+};
+
+export async function hydrate(graph: ResolvedGraph, options: HydrateOptions): Promise<HydrateResult> {
+  const result: HydrateResult = {
+    fetched: 0,
+    written: 0,
+    referenced: 0,
+  };
+  const artifacts: Artifact[] = [];
+
+  for (const entity of graph.entities) {
+    const { source, commit } = entity.resolvedFrom;
+    if (source === options.localSource) continue;
+
+    if (options.modes?.[source] === 'reference') {
+      result.referenced++;
+      continue;
+    }
+
+    if (!entity.contentPath) continue;
+
+    artifacts.push({
+      source,
+      commit,
+      path: entity.contentPath,
+      hash: entity.contentHash,
+      target: entity.contentPath,
+    });
+
+    const entityDirectory = path.posix.dirname(entity.contentPath);
+
+    for (const schema of entity.schemas ?? []) {
+      if (!schema.path) continue;
+      const artifactPath = path.posix.join(entityDirectory, schema.path);
+      artifacts.push({ source, commit, path: artifactPath, hash: schema.hash, target: artifactPath });
+    }
+
+    for (const specification of entity.specifications ?? []) {
+      const artifactPath = path.posix.join(entityDirectory, specification.path);
+      artifacts.push({ source, commit, path: artifactPath, hash: specification.hash, target: artifactPath });
+    }
+
+    for (const sidecar of entity.sidecars ?? []) {
+      artifacts.push({ source, commit, path: sidecar.path, hash: sidecar.hash, target: sidecar.path });
+    }
+  }
+
+  for (const asset of graph.assets) {
+    const { source, commit } = asset.resolvedFrom;
+    if (source === options.localSource || options.modes?.[source] === 'reference') continue;
+
+    artifacts.push({
+      source,
+      commit,
+      path: asset.path,
+      hash: asset.hash,
+      target: asset.path,
+      shared: true,
+    });
+  }
+
+  for (const artifact of artifacts) getArtifactOutputPath(artifact, options.outDir);
+
+  if (artifacts.length === 0) {
+    await fs.rm(options.outDir, { recursive: true, force: true });
+    return result;
+  }
+
+  const resolvedOutDir = path.resolve(options.outDir);
+  const outDirParent = path.dirname(resolvedOutDir);
+  await fs.mkdir(outDirParent, { recursive: true });
+  const stagingDirectory = await fs.mkdtemp(path.join(outDirParent, `.${path.basename(resolvedOutDir)}.staging-`));
+
+  try {
+    for (const artifact of artifacts) {
+      let content: Buffer | undefined = artifact.hash ? await options.cache?.get(artifact.hash) : undefined;
+
+      if (content === undefined) {
+        content = await options.fetch({
+          source: artifact.source,
+          commit: artifact.commit,
+          path: artifact.path,
+        });
+        result.fetched++;
+
+        if (artifact.hash) {
+          const actualHash = `sha256:${createHash('sha256').update(content).digest('hex')}`;
+
+          if (actualHash !== artifact.hash) {
+            throw new Error(
+              `Content hash mismatch for "${artifact.source}/${artifact.path}": expected "${artifact.hash}", received "${actualHash}"`
+            );
+          }
+
+          await options.cache?.set(artifact.hash, content);
+        }
+      }
+
+      const outputPath = getArtifactOutputPath(artifact, stagingDirectory);
+      await fs.mkdir(path.dirname(outputPath), { recursive: true });
+      await fs.writeFile(outputPath, content);
+      result.written++;
+    }
+
+    await replaceDirectory(stagingDirectory, resolvedOutDir);
+  } catch (error) {
+    await fs.rm(stagingDirectory, { recursive: true, force: true });
+    throw error;
+  }
+
+  return result;
+}

--- a/packages/sdk/src/hydrate.ts
+++ b/packages/sdk/src/hydrate.ts
@@ -39,6 +39,8 @@ const getSourceDirectory = (source: string) => {
   return `${slug}--${digest}`;
 };
 
+const getContentHash = (content: Buffer) => `sha256:${createHash('sha256').update(content).digest('hex')}`;
+
 const getArtifactOutputPath = (artifact: Artifact, outDir: string) => {
   const allowedDirectory = path.resolve(artifact.shared ? outDir : path.join(outDir, getSourceDirectory(artifact.source)));
   const portableTarget = artifact.target.replaceAll('\\', '/');
@@ -162,6 +164,10 @@ export async function hydrate(graph: ResolvedGraph, options: HydrateOptions): Pr
     for (const artifact of artifacts) {
       let content: Buffer | undefined = artifact.hash ? await options.cache?.get(artifact.hash) : undefined;
 
+      if (content !== undefined && artifact.hash && getContentHash(content) !== artifact.hash) {
+        content = undefined;
+      }
+
       if (content === undefined) {
         content = await options.fetch({
           source: artifact.source,
@@ -171,7 +177,7 @@ export async function hydrate(graph: ResolvedGraph, options: HydrateOptions): Pr
         result.fetched++;
 
         if (artifact.hash) {
-          const actualHash = `sha256:${createHash('sha256').update(content).digest('hex')}`;
+          const actualHash = getContentHash(content);
 
           if (actualHash !== artifact.hash) {
             throw new Error(

--- a/packages/sdk/src/index-types.ts
+++ b/packages/sdk/src/index-types.ts
@@ -3,6 +3,8 @@ import type {
   AdrResourcePointer,
   AdrStatus,
   BaseSchema,
+  Channel,
+  ChannelPointer,
   Container,
   DataProductOutputPointer,
   ResourcePointer,
@@ -18,6 +20,7 @@ import type {
 export type IndexResourceType =
   | 'adr'
   | 'agent'
+  | 'channel'
   | 'command'
   | 'container'
   | 'data-product'
@@ -72,6 +75,12 @@ export type IndexResource = {
   references?: IndexReference[];
   sends?: SendsPointer[];
   receives?: ReceivesPointer[];
+  channels?: ChannelPointer[];
+  address?: Channel['address'];
+  protocols?: Channel['protocols'];
+  deliveryGuarantee?: Channel['deliveryGuarantee'];
+  routes?: Channel['routes'];
+  parameters?: Channel['parameters'];
   services?: ResourcePointer[];
   agents?: ResourcePointer[];
   domains?: ResourcePointer[];

--- a/packages/sdk/src/index-types.ts
+++ b/packages/sdk/src/index-types.ts
@@ -1,0 +1,183 @@
+import type {
+  AdrPointer,
+  AdrResourcePointer,
+  AdrStatus,
+  BaseSchema,
+  Container,
+  DataProductOutputPointer,
+  ResourcePointer,
+  SchemaPointer,
+  SendsPointer,
+  ReceivesPointer,
+  Specification,
+  SystemActorRelationship,
+  SystemRelationshipPointer,
+  Team,
+} from './types';
+
+export type IndexResourceType =
+  | 'adr'
+  | 'agent'
+  | 'command'
+  | 'container'
+  | 'data-product'
+  | 'diagram'
+  | 'domain'
+  | 'entity'
+  | 'event'
+  | 'flow'
+  | 'query'
+  | 'service'
+  | 'system'
+  | 'team'
+  | 'user';
+
+export type IndexSchema = Omit<SchemaPointer, 'file'> & {
+  hash?: string;
+};
+
+export type IndexSpecification = Specification & {
+  hash?: string;
+};
+
+export type IndexSidecar = {
+  path: string;
+  hash?: string;
+};
+
+export type IndexAsset = {
+  path: string;
+  hash?: string;
+};
+
+export type IndexReference = ResourcePointer & {
+  kind: 'agent' | 'container' | 'data-product' | 'flow' | 'message' | 'service';
+};
+
+export type IndexResource = {
+  type: IndexResourceType;
+  id: string;
+  version?: string;
+  name: string;
+  contentPath: string;
+  contentHash?: string;
+  draft?: BaseSchema['draft'];
+  deprecated?: BaseSchema['deprecated'];
+  owners?: string[];
+  diagrams?: ResourcePointer[];
+  schemas?: IndexSchema[];
+  specifications?: IndexSpecification[];
+  sidecars?: IndexSidecar[];
+  container_type?: Container['container_type'];
+  references?: IndexReference[];
+  sends?: SendsPointer[];
+  receives?: ReceivesPointer[];
+  services?: ResourcePointer[];
+  agents?: ResourcePointer[];
+  domains?: ResourcePointer[];
+  systems?: ResourcePointer[];
+  entities?: ResourcePointer[];
+  dataProducts?: ResourcePointer[];
+  flows?: ResourcePointer[];
+  writesTo?: ResourcePointer[];
+  readsFrom?: ResourcePointer[];
+  containers?: ResourcePointer[];
+  relationships?: SystemRelationshipPointer[];
+  actors?: SystemActorRelationship[];
+  inputs?: ResourcePointer[];
+  outputs?: DataProductOutputPointer[];
+  status?: AdrStatus;
+  appliesTo?: AdrResourcePointer[];
+  supersedes?: AdrPointer[];
+  supersededBy?: AdrPointer[];
+  amends?: AdrPointer[];
+  amendedBy?: AdrPointer[];
+  related?: AdrPointer[];
+  members?: Team['members'];
+};
+
+export type Index = {
+  indexVersion: 1;
+  source: string;
+  commit: string;
+  resources: IndexResource[];
+  assets?: IndexAsset[];
+};
+
+export type ResolvedGraph = {
+  entities: ResolvedEntity[];
+  assets: ResolvedAsset[];
+  edges: ResolvedEdge[];
+  conflicts: Conflict[];
+  warnings: ResolutionWarning[];
+  externals: External[];
+};
+
+export type ResolvedEntity = IndexResource & {
+  resolvedFrom: {
+    source: string;
+    commit: string;
+  };
+  contributors?: string[];
+};
+
+export type ResolvedAsset = IndexAsset & {
+  resolvedFrom: {
+    source: string;
+    commit: string;
+  };
+  contributors?: string[];
+};
+
+export type ResolutionWarning = {
+  kind: 'asset-collision';
+  path: string;
+  sources: string[];
+  winner: string;
+};
+
+export type EdgeDirection =
+  | 'sends'
+  | 'receives'
+  | 'writesTo'
+  | 'readsFrom'
+  | 'contains'
+  | 'references'
+  | 'appliesTo'
+  | 'relatesTo';
+
+export type ResolvedEdge = {
+  from: string;
+  fromVersion: string | null;
+  fromResolvedFrom: {
+    source: string;
+    commit: string;
+  };
+  to: string;
+  direction: EdgeDirection;
+  via?: string;
+  label?: string;
+  pointer: string | null;
+  resolved: string | null;
+  resolvedFrom?: {
+    source: string;
+    commit: string;
+  };
+  status: 'resolved' | 'unresolved' | 'external';
+};
+
+export type ConflictKind = 'duplicate-source' | 'type-collision' | 'facet-disagreement' | 'pointer-type-mismatch';
+
+export type Conflict = {
+  kind: ConflictKind;
+  id: string;
+  sources: string[];
+  detail?: string;
+};
+
+export type External = {
+  id: string;
+  version?: string;
+  referencedBy: string[];
+  didYouMean?: string[];
+};

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -153,6 +153,7 @@ import { writeUser, getUser, getUsers, rmUserById } from './users';
 import { dumpCatalog, getEventCatalogConfigurationFile } from './eventcatalog';
 import { getGraph } from './graph';
 import { createSnapshot, diffSnapshots, listSnapshots } from './snapshots';
+import { buildIndex } from './build-index';
 import { writeChangelog, appendChangelog, getChangelog, rmChangelog } from './changelogs';
 import {
   getEntity,
@@ -222,8 +223,12 @@ import { addFileToAdr, adrHasVersion, getAdr, getAdrs, rmAdr, rmAdrById, version
 
 // Export the types
 export type * from './types';
+export type * from './index-types';
 export type * from './snapshot-types';
 export type * from './flow-builder';
+export { resolve } from './resolve';
+export * from './hydrate';
+export * from './parse-index';
 
 /**
  * Init the SDK for EventCatalog
@@ -1730,6 +1735,7 @@ export default (path: string) => {
      * ```
      */
     createSnapshot: createSnapshot(join(path)),
+    buildIndex: buildIndex(join(path)),
     diffSnapshots: diffSnapshots(join(path)),
     listSnapshots: listSnapshots(join(path)),
 

--- a/packages/sdk/src/parse-index.ts
+++ b/packages/sdk/src/parse-index.ts
@@ -1,0 +1,277 @@
+import { z } from 'zod';
+import type { Index } from './index-types';
+
+export type IndexValidationIssue = {
+  path: (string | number)[];
+  message: string;
+};
+
+export class InvalidIndexError extends Error {
+  readonly issues: IndexValidationIssue[];
+
+  constructor(issues: IndexValidationIssue[]) {
+    super(
+      [
+        'Invalid federation index',
+        ...issues.map(({ path, message }) => `${path.length ? path.join('.') : '<root>'}: ${message}`),
+      ].join('\n')
+    );
+    this.name = 'InvalidIndexError';
+    this.issues = issues;
+  }
+}
+
+const nonEmptyString = z.string().min(1);
+const contentHash = z.string().regex(/^sha256:[a-f0-9]{64}$/, 'Expected a full sha256 digest');
+
+const ResourcePointerSchema = z
+  .object({
+    id: nonEmptyString,
+    version: nonEmptyString.optional(),
+    type: nonEmptyString.optional(),
+  })
+  .strict();
+
+const ChannelPointerSchema = ResourcePointerSchema.extend({
+  label: z.string().optional(),
+  direction: z.enum(['inbound', 'outbound']).optional(),
+});
+
+const TriggerPointerSchema = z
+  .object({
+    id: nonEmptyString,
+    version: nonEmptyString.optional(),
+    condition: z.string().optional(),
+  })
+  .strict();
+
+const SendsPointerSchema = z
+  .object({
+    id: nonEmptyString,
+    version: nonEmptyString.optional(),
+    fields: z.array(z.string()).optional(),
+    to: z.array(ChannelPointerSchema).optional(),
+    group: z.string().optional(),
+  })
+  .strict();
+
+const ReceivesPointerSchema = z
+  .object({
+    id: nonEmptyString,
+    version: nonEmptyString.optional(),
+    fields: z.array(z.string()).optional(),
+    from: z.array(ChannelPointerSchema).optional(),
+    group: z.string().optional(),
+    triggers: z.array(TriggerPointerSchema).optional(),
+  })
+  .strict();
+
+const SystemRelationshipPointerSchema = z
+  .object({
+    id: nonEmptyString,
+    version: nonEmptyString.optional(),
+    label: z.string().optional(),
+  })
+  .strict();
+
+const SystemActorRelationshipSchema = z
+  .object({
+    id: nonEmptyString,
+    name: z.string().optional(),
+    label: z.string().optional(),
+    direction: z.enum(['inbound', 'outbound']).optional(),
+  })
+  .strict();
+
+const IndexSchemaPointerSchema = z
+  .object({
+    id: z.string().optional(),
+    ref: z.string().optional(),
+    path: z.string().optional(),
+    name: z.string().optional(),
+    format: z.string().optional(),
+    environments: z.array(z.string()).optional(),
+    default: z.boolean().optional(),
+    hash: contentHash.optional(),
+  })
+  .strict();
+
+const IndexSpecificationSchema = z
+  .object({
+    type: z.enum(['openapi', 'asyncapi', 'graphql']),
+    path: nonEmptyString,
+    name: z.string().optional(),
+    hash: contentHash.optional(),
+  })
+  .strict();
+
+const IndexSidecarSchema = z
+  .object({
+    path: nonEmptyString,
+    hash: contentHash.optional(),
+  })
+  .strict();
+
+const IndexAssetSchema = z
+  .object({
+    path: nonEmptyString,
+    hash: contentHash.optional(),
+  })
+  .strict();
+
+const IndexReferenceSchema = ResourcePointerSchema.extend({
+  kind: z.enum(['agent', 'container', 'data-product', 'flow', 'message', 'service']),
+});
+
+const AdrPointerSchema = z
+  .object({
+    id: nonEmptyString,
+    version: nonEmptyString.optional(),
+  })
+  .strict();
+
+const AdrResourcePointerSchema = AdrPointerSchema.extend({
+  type: z.enum([
+    'agent',
+    'service',
+    'event',
+    'command',
+    'query',
+    'flow',
+    'channel',
+    'domain',
+    'system',
+    'user',
+    'team',
+    'container',
+    'entity',
+    'diagram',
+    'data-product',
+  ]),
+});
+
+const DataProductOutputPointerSchema = z
+  .object({
+    id: nonEmptyString,
+    version: nonEmptyString.optional(),
+    contract: z
+      .object({
+        path: nonEmptyString,
+        name: nonEmptyString,
+        type: z.string().optional(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict();
+
+const UserMemberSchema = z
+  .object({
+    id: nonEmptyString,
+    name: nonEmptyString,
+    avatarUrl: z.string().optional(),
+    role: z.string().optional(),
+    hidden: z.boolean().optional(),
+    source: z
+      .object({
+        provider: nonEmptyString,
+        id: z.string().optional(),
+        url: z.string().optional(),
+      })
+      .strict()
+      .optional(),
+    readOnly: z.boolean().optional(),
+    email: z.string().optional(),
+    slackDirectMessageUrl: z.string().optional(),
+    markdown: z.string(),
+  })
+  .passthrough();
+
+const IndexResourceSchema = z
+  .object({
+    type: z.enum([
+      'adr',
+      'agent',
+      'command',
+      'container',
+      'data-product',
+      'diagram',
+      'domain',
+      'entity',
+      'event',
+      'flow',
+      'query',
+      'service',
+      'system',
+      'team',
+      'user',
+    ]),
+    id: nonEmptyString,
+    version: nonEmptyString.optional(),
+    name: nonEmptyString,
+    contentPath: nonEmptyString,
+    contentHash: contentHash.optional(),
+    draft: z.union([z.boolean(), z.object({ title: z.string().optional(), message: z.string().optional() }).strict()]).optional(),
+    deprecated: z
+      .union([z.boolean(), z.object({ date: z.string().optional(), message: z.string().optional() }).strict()])
+      .optional(),
+    owners: z.array(z.string()).optional(),
+    diagrams: z.array(ResourcePointerSchema).optional(),
+    schemas: z.array(IndexSchemaPointerSchema).optional(),
+    specifications: z.array(IndexSpecificationSchema).optional(),
+    sidecars: z.array(IndexSidecarSchema).optional(),
+    container_type: z
+      .enum(['database', 'cache', 'objectStore', 'searchIndex', 'dataWarehouse', 'dataLake', 'externalSaaS', 'other'])
+      .optional(),
+    references: z.array(IndexReferenceSchema).optional(),
+    sends: z.array(SendsPointerSchema).optional(),
+    receives: z.array(ReceivesPointerSchema).optional(),
+    services: z.array(ResourcePointerSchema).optional(),
+    agents: z.array(ResourcePointerSchema).optional(),
+    domains: z.array(ResourcePointerSchema).optional(),
+    systems: z.array(ResourcePointerSchema).optional(),
+    entities: z.array(ResourcePointerSchema).optional(),
+    dataProducts: z.array(ResourcePointerSchema).optional(),
+    flows: z.array(ResourcePointerSchema).optional(),
+    writesTo: z.array(ResourcePointerSchema).optional(),
+    readsFrom: z.array(ResourcePointerSchema).optional(),
+    containers: z.array(ResourcePointerSchema).optional(),
+    relationships: z.array(SystemRelationshipPointerSchema).optional(),
+    actors: z.array(SystemActorRelationshipSchema).optional(),
+    inputs: z.array(ResourcePointerSchema).optional(),
+    outputs: z.array(DataProductOutputPointerSchema).optional(),
+    status: z.enum(['proposed', 'accepted', 'rejected', 'deprecated', 'superseded']).optional(),
+    appliesTo: z.array(AdrResourcePointerSchema).optional(),
+    supersedes: z.array(AdrPointerSchema).optional(),
+    supersededBy: z.array(AdrPointerSchema).optional(),
+    amends: z.array(AdrPointerSchema).optional(),
+    amendedBy: z.array(AdrPointerSchema).optional(),
+    related: z.array(AdrPointerSchema).optional(),
+    members: z.union([z.array(z.string()), z.array(UserMemberSchema)]).optional(),
+  })
+  .strict();
+
+export const FederationIndexSchema = z
+  .object({
+    indexVersion: z.literal(1),
+    source: nonEmptyString,
+    commit: nonEmptyString,
+    resources: z.array(IndexResourceSchema),
+    assets: z.array(IndexAssetSchema).optional(),
+  })
+  .strict();
+
+export const parseIndex = (input: unknown): Index => {
+  const result = FederationIndexSchema.safeParse(input);
+
+  if (!result.success) {
+    throw new InvalidIndexError(
+      result.error.issues.map((issue) => ({
+        path: issue.path.map((segment) => (typeof segment === 'symbol' ? segment.toString() : segment)),
+        message: issue.message,
+      }))
+    );
+  }
+
+  return result.data;
+};

--- a/packages/sdk/src/parse-index.ts
+++ b/packages/sdk/src/parse-index.ts
@@ -35,7 +35,19 @@ const ResourcePointerSchema = z
 const ChannelPointerSchema = ResourcePointerSchema.extend({
   label: z.string().optional(),
   direction: z.enum(['inbound', 'outbound']).optional(),
+  parameters: z.record(z.string(), z.string()).optional(),
 });
+
+const ChannelParametersSchema = z.record(
+  z.string(),
+  z
+    .object({
+      enum: z.array(z.string()).optional(),
+      default: z.string().optional(),
+      examples: z.array(z.string()).optional(),
+    })
+    .strict()
+);
 
 const TriggerPointerSchema = z
   .object({
@@ -192,6 +204,7 @@ const IndexResourceSchema = z
     type: z.enum([
       'adr',
       'agent',
+      'channel',
       'command',
       'container',
       'data-product',
@@ -226,6 +239,12 @@ const IndexResourceSchema = z
     references: z.array(IndexReferenceSchema).optional(),
     sends: z.array(SendsPointerSchema).optional(),
     receives: z.array(ReceivesPointerSchema).optional(),
+    channels: z.array(ChannelPointerSchema).optional(),
+    address: z.string().optional(),
+    protocols: z.array(z.string()).optional(),
+    deliveryGuarantee: z.enum(['at-most-once', 'at-least-once', 'exactly-once']).optional(),
+    routes: z.array(ChannelPointerSchema).optional(),
+    parameters: ChannelParametersSchema.optional(),
     services: z.array(ResourcePointerSchema).optional(),
     agents: z.array(ResourcePointerSchema).optional(),
     domains: z.array(ResourcePointerSchema).optional(),

--- a/packages/sdk/src/resolve.ts
+++ b/packages/sdk/src/resolve.ts
@@ -39,6 +39,9 @@ const getPointerFields = (entity: ResolvedEntity): PointerField[] => [
   { direction: 'writesTo', pointers: entity.writesTo },
   { direction: 'readsFrom', pointers: entity.readsFrom },
   { direction: 'contains', via: 'services', pointers: entity.services },
+  { direction: 'contains', via: 'agents', pointers: entity.agents },
+  { direction: 'contains', via: 'domains', pointers: entity.domains },
+  { direction: 'contains', via: 'dataProducts', pointers: entity.dataProducts },
   { direction: 'contains', via: 'systems', pointers: entity.systems },
   { direction: 'contains', via: 'entities', pointers: entity.entities },
   { direction: 'contains', via: 'containers', pointers: entity.containers },
@@ -49,6 +52,15 @@ const getPointerFields = (entity: ResolvedEntity): PointerField[] => [
   { direction: 'references', via: 'steps', pointers: entity.references },
   { direction: 'appliesTo', pointers: entity.appliesTo },
   { direction: 'relatesTo', via: 'related', pointers: entity.related },
+  { direction: 'relatesTo', via: 'supersedes', pointers: entity.supersedes },
+  { direction: 'relatesTo', via: 'supersededBy', pointers: entity.supersededBy },
+  { direction: 'relatesTo', via: 'amends', pointers: entity.amends },
+  { direction: 'relatesTo', via: 'amendedBy', pointers: entity.amendedBy },
+  { direction: 'relatesTo', via: 'diagrams', pointers: entity.diagrams },
+  { direction: 'references', via: 'channels', pointers: entity.channels },
+  { direction: 'references', via: 'routes', pointers: entity.routes },
+  { direction: 'sends', via: 'sends.to', pointers: entity.sends?.flatMap((pointer) => pointer.to ?? []) },
+  { direction: 'receives', via: 'receives.from', pointers: entity.receives?.flatMap((pointer) => pointer.from ?? []) },
 ];
 
 export const resolve = (indexes: Index[]): ResolvedGraph => {

--- a/packages/sdk/src/resolve.ts
+++ b/packages/sdk/src/resolve.ts
@@ -1,0 +1,245 @@
+import { gt, valid } from 'semver';
+import type {
+  Conflict,
+  ConflictKind,
+  EdgeDirection,
+  External,
+  Index,
+  ResolutionWarning,
+  ResolvedAsset,
+  ResolvedEdge,
+  ResolvedEntity,
+  ResolvedGraph,
+} from './index-types';
+
+type Pointer = {
+  id: string;
+  version?: string;
+  type?: string;
+  label?: string;
+};
+
+type PointerField = {
+  direction: EdgeDirection;
+  via?: string;
+  pointers?: Pointer[];
+};
+
+const compareText = (left: string, right: string) => (left < right ? -1 : left > right ? 1 : 0);
+const isHigherVersion = (candidate?: string, current?: string) => {
+  if (candidate === current || candidate === undefined) return false;
+  if (current === undefined) return true;
+  if (valid(candidate) && valid(current)) return gt(candidate, current);
+  return compareText(candidate, current) > 0;
+};
+
+const getPointerFields = (entity: ResolvedEntity): PointerField[] => [
+  { direction: 'sends', pointers: entity.sends },
+  { direction: 'receives', pointers: entity.receives },
+  { direction: 'writesTo', pointers: entity.writesTo },
+  { direction: 'readsFrom', pointers: entity.readsFrom },
+  { direction: 'contains', via: 'services', pointers: entity.services },
+  { direction: 'contains', via: 'systems', pointers: entity.systems },
+  { direction: 'contains', via: 'entities', pointers: entity.entities },
+  { direction: 'contains', via: 'containers', pointers: entity.containers },
+  { direction: 'contains', via: 'flows', pointers: entity.flows },
+  { direction: 'relatesTo', via: 'relationships', pointers: entity.relationships },
+  { direction: 'receives', via: 'inputs', pointers: entity.inputs },
+  { direction: 'sends', via: 'outputs', pointers: entity.outputs },
+  { direction: 'references', via: 'steps', pointers: entity.references },
+  { direction: 'appliesTo', pointers: entity.appliesTo },
+  { direction: 'relatesTo', via: 'related', pointers: entity.related },
+];
+
+export const resolve = (indexes: Index[]): ResolvedGraph => {
+  const assetCandidatesByPath = new Map<string, ResolvedAsset[]>();
+
+  for (const { source, commit, assets = [] } of indexes) {
+    for (const asset of assets) {
+      const candidates = assetCandidatesByPath.get(asset.path) ?? [];
+      candidates.push({ ...asset, resolvedFrom: { source, commit } });
+      assetCandidatesByPath.set(asset.path, candidates);
+    }
+  }
+
+  const assets: ResolvedAsset[] = [];
+  const warnings: ResolutionWarning[] = [];
+
+  for (const [assetPath, candidates] of assetCandidatesByPath) {
+    candidates.sort(
+      (left, right) =>
+        compareText(left.resolvedFrom.source, right.resolvedFrom.source) ||
+        compareText(left.resolvedFrom.commit, right.resolvedFrom.commit)
+    );
+    const [winner] = candidates;
+    const sources = [...new Set(candidates.map((candidate) => candidate.resolvedFrom.source))].sort(compareText);
+    const hashes = new Set(candidates.map((candidate) => candidate.hash));
+    const hashesCanBeCompared = candidates.every((candidate) => candidate.hash !== undefined);
+    const hasCollision = candidates.length > 1 && (!hashesCanBeCompared || hashes.size > 1);
+
+    assets.push({
+      ...winner,
+      ...(!hasCollision && candidates.length > 1
+        ? { contributors: sources.filter((source) => source !== winner.resolvedFrom.source) }
+        : {}),
+    });
+
+    if (hasCollision) {
+      warnings.push({
+        kind: 'asset-collision',
+        path: assetPath,
+        sources,
+        winner: winner.resolvedFrom.source,
+      });
+    }
+  }
+
+  assets.sort((left, right) => compareText(left.path, right.path));
+  warnings.sort((left, right) => compareText(left.path, right.path));
+
+  const entities = indexes
+    .flatMap(({ source, commit, resources }) =>
+      resources.map((resource) => ({
+        ...resource,
+        resolvedFrom: { source, commit },
+      }))
+    )
+    .sort(
+      (left, right) =>
+        compareText(left.id, right.id) ||
+        compareText(left.version ?? '', right.version ?? '') ||
+        compareText(left.type, right.type) ||
+        compareText(left.resolvedFrom.source, right.resolvedFrom.source)
+    );
+  const entitiesById = new Map<string, ResolvedEntity[]>();
+
+  for (const entity of entities) {
+    const matches = entitiesById.get(entity.id) ?? [];
+    matches.push(entity);
+    entitiesById.set(entity.id, matches);
+  }
+
+  const conflictsByKindAndId = new Map<string, Conflict>();
+  const addConflict = (kind: ConflictKind, id: string, sources: string[], detail?: string) => {
+    const key = `${kind}:${id}`;
+    const conflict = conflictsByKindAndId.get(key);
+
+    if (conflict) {
+      conflict.sources = [...new Set([...conflict.sources, ...sources])].sort(compareText);
+      if (conflict.detail === undefined) conflict.detail = detail;
+      return;
+    }
+
+    conflictsByKindAndId.set(key, {
+      kind,
+      id,
+      sources: [...new Set(sources)].sort(compareText),
+      ...(detail === undefined ? {} : { detail }),
+    });
+  };
+
+  for (const [id, matches] of entitiesById) {
+    const sources = [...new Set(matches.map((entity) => entity.resolvedFrom.source))];
+    const types = new Set(matches.map((entity) => entity.type));
+
+    // A type collision is the more actionable diagnosis, so it deliberately suppresses
+    // the duplicate-source conflict that would otherwise describe the same ownership group.
+    if (types.size > 1) {
+      addConflict('type-collision', id, sources);
+    } else if (sources.length > 1) {
+      addConflict('duplicate-source', id, sources);
+    }
+  }
+
+  const externalsByPointer = new Map<string, External>();
+  const edges: ResolvedEdge[] = [];
+
+  for (const entity of entities) {
+    for (const field of getPointerFields(entity)) {
+      for (const pointer of field.pointers ?? []) {
+        const candidates = entitiesById.get(pointer.id);
+        const followsLatest = pointer.version === undefined || pointer.version === 'latest';
+        const target = followsLatest
+          ? candidates?.reduce((latest, candidate) => (isHigherVersion(candidate.version, latest.version) ? candidate : latest))
+          : candidates?.find((candidate) => candidate.version === pointer.version);
+
+        if (!target) {
+          if (candidates) {
+            edges.push({
+              from: entity.id,
+              fromVersion: entity.version ?? null,
+              fromResolvedFrom: entity.resolvedFrom,
+              to: pointer.id,
+              direction: field.direction,
+              ...(field.via === undefined ? {} : { via: field.via }),
+              ...(pointer.label === undefined ? {} : { label: pointer.label }),
+              pointer: pointer.version ?? null,
+              resolved: null,
+              status: 'unresolved',
+            });
+            continue;
+          }
+
+          const key = `${pointer.id}@${pointer.version ?? ''}`;
+          const external = externalsByPointer.get(key) ?? {
+            id: pointer.id,
+            ...(pointer.version === undefined ? {} : { version: pointer.version }),
+            referencedBy: [],
+          };
+
+          if (!external.referencedBy.includes(entity.id)) external.referencedBy.push(entity.id);
+          externalsByPointer.set(key, external);
+          edges.push({
+            from: entity.id,
+            fromVersion: entity.version ?? null,
+            fromResolvedFrom: entity.resolvedFrom,
+            to: pointer.id,
+            direction: field.direction,
+            ...(field.via === undefined ? {} : { via: field.via }),
+            ...(pointer.label === undefined ? {} : { label: pointer.label }),
+            pointer: pointer.version ?? null,
+            resolved: null,
+            status: 'external',
+          });
+          continue;
+        }
+
+        if (pointer.type !== undefined && pointer.type !== target.type) {
+          addConflict(
+            'pointer-type-mismatch',
+            pointer.id,
+            [entity.resolvedFrom.source, target.resolvedFrom.source],
+            `Expected ${pointer.type} but found ${target.type}`
+          );
+        }
+
+        // Pointer type validates author intent but never participates in lookup. The ID still
+        // resolves, so keep the edge and report the mismatch separately for the caller to decide.
+        edges.push({
+          from: entity.id,
+          fromVersion: entity.version ?? null,
+          fromResolvedFrom: entity.resolvedFrom,
+          to: target.id,
+          direction: field.direction,
+          ...(field.via === undefined ? {} : { via: field.via }),
+          ...(pointer.label === undefined ? {} : { label: pointer.label }),
+          pointer: pointer.version ?? null,
+          resolved: target.version ?? null,
+          resolvedFrom: target.resolvedFrom,
+          status: 'resolved',
+        });
+      }
+    }
+  }
+
+  return {
+    entities,
+    assets,
+    edges,
+    conflicts: [...conflictsByKindAndId.values()].sort(
+      (left, right) => compareText(left.id, right.id) || compareText(left.kind, right.kind)
+    ),
+    warnings,
+    externals: [...externalsByPointer.values()],
+  };
+};

--- a/packages/sdk/src/resolve.ts
+++ b/packages/sdk/src/resolve.ts
@@ -81,6 +81,7 @@ const getPointerFields = (entity: ResolvedEntity): PointerField[] => [
   { direction: 'references', via: 'routes', pointers: entity.routes },
   { direction: 'sends', via: 'sends.to', pointers: entity.sends?.flatMap((pointer) => pointer.to ?? []) },
   { direction: 'receives', via: 'receives.from', pointers: entity.receives?.flatMap((pointer) => pointer.from ?? []) },
+  { direction: 'sends', via: 'receives.triggers', pointers: entity.receives?.flatMap((pointer) => pointer.triggers ?? []) },
 ];
 
 export const resolve = (indexes: Index[]): ResolvedGraph => {

--- a/packages/sdk/src/resolve.ts
+++ b/packages/sdk/src/resolve.ts
@@ -1,4 +1,4 @@
-import { gt, valid } from 'semver';
+import { gt, satisfies, valid, validRange } from 'semver';
 import type {
   Conflict,
   ConflictKind,
@@ -31,6 +31,26 @@ const isHigherVersion = (candidate?: string, current?: string) => {
   if (current === undefined) return true;
   if (valid(candidate) && valid(current)) return gt(candidate, current);
   return compareText(candidate, current) > 0;
+};
+
+const selectTarget = (candidates: ResolvedEntity[] | undefined, pointerVersion?: string) => {
+  if (!candidates?.length) return undefined;
+
+  if (pointerVersion === undefined || pointerVersion === 'latest') {
+    return candidates.reduce((latest, candidate) => (isHigherVersion(candidate.version, latest.version) ? candidate : latest));
+  }
+
+  const exactMatch = candidates.find((candidate) => candidate.version === pointerVersion);
+  if (exactMatch) return exactMatch;
+
+  const range = validRange(pointerVersion);
+  if (!range) return undefined;
+
+  return candidates.reduce<ResolvedEntity | undefined>((latest, candidate) => {
+    if (candidate.version === undefined || !valid(candidate.version) || !satisfies(candidate.version, range)) return latest;
+    if (latest === undefined || isHigherVersion(candidate.version, latest.version)) return candidate;
+    return latest;
+  }, undefined);
 };
 
 const getPointerFields = (entity: ResolvedEntity): PointerField[] => [
@@ -170,10 +190,7 @@ export const resolve = (indexes: Index[]): ResolvedGraph => {
     for (const field of getPointerFields(entity)) {
       for (const pointer of field.pointers ?? []) {
         const candidates = entitiesById.get(pointer.id);
-        const followsLatest = pointer.version === undefined || pointer.version === 'latest';
-        const target = followsLatest
-          ? candidates?.reduce((latest, candidate) => (isHigherVersion(candidate.version, latest.version) ? candidate : latest))
-          : candidates?.find((candidate) => candidate.version === pointer.version);
+        const target = selectTarget(candidates, pointer.version);
 
         if (!target) {
           if (candidates) {

--- a/packages/sdk/src/test/build-index-default-catalog.test.ts
+++ b/packages/sdk/src/test/build-index-default-catalog.test.ts
@@ -1,0 +1,25 @@
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import utils, { parseIndex } from '../index';
+
+const CATALOG_PATH = path.resolve(__dirname, '../../../../examples/default');
+const INDEX_SNAPSHOT_PATH = path.join(__dirname, 'fixtures/build-index/default-catalog-index.json');
+
+describe('buildIndex against the default example catalog', () => {
+  it('matches the committed index snapshot', async () => {
+    const index = await utils(CATALOG_PATH).buildIndex({
+      source: 'eventcatalog/examples/default',
+      commit: 'fixture',
+    });
+
+    const contentPaths = index.resources.map((resource) => resource.contentPath);
+    const duplicateContentPaths = [
+      ...new Set(contentPaths.filter((contentPath, index) => contentPaths.indexOf(contentPath) !== index)),
+    ];
+
+    expect(duplicateContentPaths).toEqual([]);
+    expect(parseIndex(index)).toEqual(index);
+
+    await expect(`${JSON.stringify(index, null, 2)}\n`).toMatchFileSnapshot(INDEX_SNAPSHOT_PATH);
+  });
+});

--- a/packages/sdk/src/test/build-index-default-catalog.test.ts
+++ b/packages/sdk/src/test/build-index-default-catalog.test.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs/promises';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import utils, { parseIndex } from '../index';
@@ -20,6 +21,7 @@ describe('buildIndex against the default example catalog', () => {
     expect(duplicateContentPaths).toEqual([]);
     expect(parseIndex(index)).toEqual(index);
 
-    await expect(`${JSON.stringify(index, null, 2)}\n`).toMatchFileSnapshot(INDEX_SNAPSHOT_PATH);
+    const snapshot = JSON.parse(await fs.readFile(INDEX_SNAPSHOT_PATH, 'utf8'));
+    expect(snapshot).toEqual(index);
   });
 });

--- a/packages/sdk/src/test/build-index.test.ts
+++ b/packages/sdk/src/test/build-index.test.ts
@@ -1,0 +1,1474 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { createHash } from 'node:crypto';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import utils from '../index';
+
+const CATALOG_PATH = path.join(__dirname, 'catalog-build-index');
+
+const sdk = utils(CATALOG_PATH);
+
+const rawHashFile = (contentPath: string) =>
+  createHash('sha256')
+    .update(fs.readFileSync(path.join(CATALOG_PATH, contentPath)))
+    .digest('hex');
+
+const hashFile = (contentPath: string) => `sha256:${rawHashFile(contentPath)}`;
+
+beforeEach(() => {
+  fs.rmSync(CATALOG_PATH, { recursive: true, force: true });
+  fs.mkdirSync(CATALOG_PATH, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(CATALOG_PATH, { recursive: true, force: true });
+});
+
+// if hashContent is set to true the MDX content and schema files are hashed
+// What it toggles
+// hashContent: true (default) — for each resource, read the MDX file and the schema file, SHA-256 the bytes, put the digests in the index:
+
+describe('buildIndex', () => {
+  it('builds a valid index for an empty catalog', async () => {
+    await expect(sdk.buildIndex({ source: 'acme/payments', commit: '4a1b7e2' })).resolves.toEqual({
+      indexVersion: 1,
+      source: 'acme/payments',
+      commit: '4a1b7e2',
+      resources: [],
+    });
+  });
+
+  it('indexes public files and components as assets', async () => {
+    fs.mkdirSync(path.join(CATALOG_PATH, 'public/icons/languages'), { recursive: true });
+    fs.mkdirSync(path.join(CATALOG_PATH, 'components'), { recursive: true });
+    fs.writeFileSync(path.join(CATALOG_PATH, 'public/icons/languages/nodejs.svg'), '<svg>Node.js</svg>');
+    fs.writeFileSync(path.join(CATALOG_PATH, 'components/TeamBadge.astro'), '<span>Team badge</span>');
+
+    const index = await sdk.buildIndex({ source: 'acme/payments', commit: '4a1b7e2' });
+
+    expect(index).toEqual({
+      indexVersion: 1,
+      source: 'acme/payments',
+      commit: '4a1b7e2',
+      resources: [],
+      assets: [
+        {
+          path: 'components/TeamBadge.astro',
+          hash: hashFile('components/TeamBadge.astro'),
+        },
+        {
+          path: 'public/icons/languages/nodejs.svg',
+          hash: hashFile('public/icons/languages/nodejs.svg'),
+        },
+      ],
+    });
+  });
+
+  it('creates a basic index from resources from eventcatalog', async () => {
+    await sdk.writeEvent({
+      id: 'payment-captured',
+      name: 'Payment Captured',
+      version: '2.0.0',
+      draft: true,
+      diagrams: [{ id: 'payment-lifecycle', version: '1.0.0' }, { id: 'payment-errors' }],
+      markdown: '# Payment Captured',
+    });
+    await sdk.writeService({
+      id: 'payment-service',
+      name: 'Payment Service',
+      version: '1.0.0',
+      deprecated: true,
+      markdown: '# Payment Service',
+    });
+
+    const index = await sdk.buildIndex({ source: 'acme/payments', commit: '4a1b7e2' });
+
+    expect(index).toEqual({
+      indexVersion: 1,
+      source: 'acme/payments',
+      commit: '4a1b7e2',
+      resources: [
+        {
+          type: 'event',
+          id: 'payment-captured',
+          version: '2.0.0',
+          name: 'Payment Captured',
+          draft: true,
+          diagrams: [{ id: 'payment-lifecycle', version: '1.0.0' }, { id: 'payment-errors' }],
+          contentPath: 'events/payment-captured/index.mdx',
+          contentHash: hashFile('events/payment-captured/index.mdx'),
+        },
+        {
+          type: 'service',
+          id: 'payment-service',
+          version: '1.0.0',
+          name: 'Payment Service',
+          deprecated: true,
+          contentPath: 'services/payment-service/index.mdx',
+          contentHash: hashFile('services/payment-service/index.mdx'),
+        },
+      ],
+    });
+  });
+
+  it('does not hash resource content when `hashContent` is false', async () => {
+    await sdk.writeEvent({
+      id: 'payment-captured',
+      name: 'Payment Captured',
+      version: '2.0.0',
+      markdown: '# Payment Captured',
+    });
+
+    const index = await sdk.buildIndex({
+      source: 'acme/payments',
+      commit: '4a1b7e2',
+      hashContent: false,
+    });
+
+    expect(index).toEqual({
+      indexVersion: 1,
+      source: 'acme/payments',
+      commit: '4a1b7e2',
+      resources: [
+        {
+          type: 'event',
+          id: 'payment-captured',
+          version: '2.0.0',
+          name: 'Payment Captured',
+          contentPath: 'events/payment-captured/index.mdx',
+        },
+      ],
+    });
+  });
+
+  it('verioned resources in eventcatalog are also in the index', async () => {
+    await sdk.writeEvent({
+      id: 'payment-captured',
+      name: 'Payment Captured',
+      version: '1.0.0',
+      markdown: '',
+    });
+    await sdk.versionEvent('payment-captured');
+    await sdk.writeEvent({
+      id: 'payment-captured',
+      name: 'Payment Captured',
+      version: '2.0.0',
+      markdown: '',
+    });
+
+    const index = await sdk.buildIndex({ source: 'acme/payments', commit: '4a1b7e2' });
+
+    expect(index).toEqual({
+      indexVersion: 1,
+      source: 'acme/payments',
+      commit: '4a1b7e2',
+      resources: [
+        {
+          type: 'event',
+          id: 'payment-captured',
+          version: '2.0.0',
+          name: 'Payment Captured',
+          contentPath: 'events/payment-captured/index.mdx',
+          contentHash: hashFile('events/payment-captured/index.mdx'),
+        },
+        {
+          type: 'event',
+          id: 'payment-captured',
+          version: '1.0.0',
+          name: 'Payment Captured',
+          contentPath: 'events/payment-captured/versioned/1.0.0/index.mdx',
+          contentHash: hashFile('events/payment-captured/versioned/1.0.0/index.mdx'),
+        },
+      ],
+    });
+  });
+
+  it('hashes schemas and specifications relative to each resource version', async () => {
+    await sdk.writeEvent({
+      id: 'payment-captured',
+      name: 'Payment Captured',
+      version: '1.0.0',
+      schemaPath: 'schema.json',
+      markdown: '# Payment Captured v1',
+    });
+    await sdk.addSchemaToEvent('payment-captured', {
+      fileName: 'schema.json',
+      schema: '{"version":1}',
+    });
+    await sdk.versionEvent('payment-captured');
+    await sdk.writeEvent({
+      id: 'payment-captured',
+      name: 'Payment Captured',
+      version: '2.0.0',
+      schemaPath: 'schema.json',
+      markdown: '# Payment Captured v2',
+    });
+    await sdk.addSchemaToEvent('payment-captured', {
+      fileName: 'schema.json',
+      schema: '{"version":2}',
+    });
+
+    await sdk.writeService({
+      id: 'payment-service',
+      name: 'Payment Service',
+      version: '1.0.0',
+      specifications: { openapiPath: 'openapi.yaml' },
+      markdown: '# Payment Service v1',
+    });
+    await sdk.addFileToService('payment-service', {
+      fileName: 'openapi.yaml',
+      content: 'openapi: 3.0.0',
+    });
+    await sdk.versionService('payment-service');
+    await sdk.writeService({
+      id: 'payment-service',
+      name: 'Payment Service',
+      version: '2.0.0',
+      specifications: { openapiPath: 'openapi.yaml' },
+      markdown: '# Payment Service v2',
+    });
+    await sdk.addFileToService('payment-service', {
+      fileName: 'openapi.yaml',
+      content: 'openapi: 3.1.0',
+    });
+
+    const index = await sdk.buildIndex({ source: 'acme/payments', commit: '4a1b7e2' });
+
+    expect(index).toEqual({
+      indexVersion: 1,
+      source: 'acme/payments',
+      commit: '4a1b7e2',
+      resources: [
+        {
+          type: 'event',
+          id: 'payment-captured',
+          version: '2.0.0',
+          name: 'Payment Captured',
+          contentPath: 'events/payment-captured/index.mdx',
+          contentHash: hashFile('events/payment-captured/index.mdx'),
+          schemas: [
+            {
+              path: 'schema.json',
+              default: true,
+              hash: hashFile('events/payment-captured/schema.json'),
+            },
+          ],
+        },
+        {
+          type: 'event',
+          id: 'payment-captured',
+          version: '1.0.0',
+          name: 'Payment Captured',
+          contentPath: 'events/payment-captured/versioned/1.0.0/index.mdx',
+          contentHash: hashFile('events/payment-captured/versioned/1.0.0/index.mdx'),
+          schemas: [
+            {
+              path: 'schema.json',
+              default: true,
+              hash: hashFile('events/payment-captured/versioned/1.0.0/schema.json'),
+            },
+          ],
+        },
+        {
+          type: 'service',
+          id: 'payment-service',
+          version: '2.0.0',
+          name: 'Payment Service',
+          contentPath: 'services/payment-service/index.mdx',
+          contentHash: hashFile('services/payment-service/index.mdx'),
+          specifications: [
+            {
+              type: 'openapi',
+              path: 'openapi.yaml',
+              hash: hashFile('services/payment-service/openapi.yaml'),
+            },
+          ],
+        },
+        {
+          type: 'service',
+          id: 'payment-service',
+          version: '1.0.0',
+          name: 'Payment Service',
+          contentPath: 'services/payment-service/versioned/1.0.0/index.mdx',
+          contentHash: hashFile('services/payment-service/versioned/1.0.0/index.mdx'),
+          specifications: [
+            {
+              type: 'openapi',
+              path: 'openapi.yaml',
+              hash: hashFile('services/payment-service/versioned/1.0.0/openapi.yaml'),
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('returns resources in stable type, id, and version order regardless of creation order', async () => {
+    await sdk.writeService({ id: 'z-service', name: 'Z Service', version: '1.0.0', markdown: '# Z Service' });
+    await sdk.writeEvent({ id: 'z-event', name: 'Z Event', version: '1.0.0', markdown: '# Z Event' });
+    await sdk.writeEvent({ id: 'a-event', name: 'A Event', version: '1.0.0', markdown: '# A Event v1' });
+    await sdk.versionEvent('a-event');
+    await sdk.writeEvent({ id: 'a-event', name: 'A Event', version: '2.0.0', markdown: '# A Event v2' });
+    await sdk.writeCommand({ id: 'a-command', name: 'A Command', version: '1.0.0', markdown: '# A Command' });
+
+    const first = await sdk.buildIndex({ source: 'acme/catalog', commit: 'abc1234' });
+    const second = await sdk.buildIndex({ source: 'acme/catalog', commit: 'abc1234' });
+    const expectedIndex = {
+      indexVersion: 1,
+      source: 'acme/catalog',
+      commit: 'abc1234',
+      resources: [
+        {
+          type: 'command',
+          id: 'a-command',
+          version: '1.0.0',
+          name: 'A Command',
+          contentPath: 'commands/a-command/index.mdx',
+          contentHash: hashFile('commands/a-command/index.mdx'),
+        },
+        {
+          type: 'event',
+          id: 'a-event',
+          version: '2.0.0',
+          name: 'A Event',
+          contentPath: 'events/a-event/index.mdx',
+          contentHash: hashFile('events/a-event/index.mdx'),
+        },
+        {
+          type: 'event',
+          id: 'a-event',
+          version: '1.0.0',
+          name: 'A Event',
+          contentPath: 'events/a-event/versioned/1.0.0/index.mdx',
+          contentHash: hashFile('events/a-event/versioned/1.0.0/index.mdx'),
+        },
+        {
+          type: 'event',
+          id: 'z-event',
+          version: '1.0.0',
+          name: 'Z Event',
+          contentPath: 'events/z-event/index.mdx',
+          contentHash: hashFile('events/z-event/index.mdx'),
+        },
+        {
+          type: 'service',
+          id: 'z-service',
+          version: '1.0.0',
+          name: 'Z Service',
+          contentPath: 'services/z-service/index.mdx',
+          contentHash: hashFile('services/z-service/index.mdx'),
+        },
+      ],
+    };
+
+    expect(first).toEqual(expectedIndex);
+    expect(second).toEqual(expectedIndex);
+  });
+
+  it('indexes resource owners when they are set', async () => {
+    await sdk.writeEvent({
+      id: 'payment-captured',
+      name: 'Payment Captured',
+      version: '2.0.0',
+      markdown: '# Payment Captured',
+      owners: ['team-payments', 'team-platform'],
+    });
+
+    const index = await sdk.buildIndex({ source: 'acme/payments', commit: '4a1b7e2' });
+
+    expect(index).toEqual({
+      indexVersion: 1,
+      source: 'acme/payments',
+      commit: '4a1b7e2',
+      resources: [
+        {
+          type: 'event',
+          id: 'payment-captured',
+          version: '2.0.0',
+          name: 'Payment Captured',
+          owners: ['team-payments', 'team-platform'],
+          contentPath: 'events/payment-captured/index.mdx',
+          contentHash: hashFile('events/payment-captured/index.mdx'),
+        },
+      ],
+    });
+  });
+
+  describe('domains', () => {
+    it('indexes domain relationships with and without versions', async () => {
+      await sdk.writeDomain({
+        id: 'payments',
+        name: 'Payments',
+        version: '1.0.0',
+        markdown: '# Payments',
+        services: [{ id: 'payment-service', version: '1.0.0' }, { id: 'refund-service' }],
+        agents: [{ id: 'fraud-agent', version: '2.0.0' }, { id: 'support-agent' }],
+        domains: [{ id: 'commerce', version: '1.0.0' }, { id: 'reporting' }],
+        systems: [{ id: 'payment-processing', version: '3.0.0' }, { id: 'ledger' }],
+        entities: [{ id: 'payment', version: '1.0.0' }, { id: 'refund' }],
+        dataProducts: [{ id: 'payment-analytics', version: '1.0.0' }, { id: 'finance-reporting' }],
+        flows: [{ id: 'checkout', version: '2.0.0' }, { id: 'issue-refund' }],
+        sends: [{ id: 'payment-captured', version: '2.0.0' }, { id: 'payment-failed' }],
+        receives: [{ id: 'capture-payment', version: '1.0.0' }, { id: 'refund-payment' }],
+      });
+
+      const index = await sdk.buildIndex({ source: 'acme/payments', commit: '4a1b7e2' });
+
+      expect(index).toEqual({
+        indexVersion: 1,
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'domain',
+            id: 'payments',
+            version: '1.0.0',
+            name: 'Payments',
+            contentPath: 'domains/payments/index.mdx',
+            contentHash: hashFile('domains/payments/index.mdx'),
+            services: [{ id: 'payment-service', version: '1.0.0' }, { id: 'refund-service' }],
+            agents: [{ id: 'fraud-agent', version: '2.0.0' }, { id: 'support-agent' }],
+            domains: [{ id: 'commerce', version: '1.0.0' }, { id: 'reporting' }],
+            systems: [{ id: 'payment-processing', version: '3.0.0' }, { id: 'ledger' }],
+            entities: [{ id: 'payment', version: '1.0.0' }, { id: 'refund' }],
+            dataProducts: [{ id: 'payment-analytics', version: '1.0.0' }, { id: 'finance-reporting' }],
+            flows: [{ id: 'checkout', version: '2.0.0' }, { id: 'issue-refund' }],
+            sends: [{ id: 'payment-captured', version: '2.0.0' }, { id: 'payment-failed' }],
+            receives: [{ id: 'capture-payment', version: '1.0.0' }, { id: 'refund-payment' }],
+          },
+        ],
+      });
+    });
+
+    it('indexes ubiquitous language and changelogs as sidecars beside a resource', async () => {
+      await sdk.writeDomain({
+        id: 'payments',
+        name: 'Payments',
+        version: '1.0.0',
+        markdown: '# Payments',
+      });
+      await sdk.addUbiquitousLanguageToDomain('payments', {
+        dictionary: [
+          {
+            id: 'payment',
+            name: 'Payment',
+            summary: 'An exchange of money for goods or services.',
+          },
+        ],
+      });
+      await sdk.writeChangelog('payments', {
+        createdAt: '2026-08-07',
+        markdown: '### Added payment terminology',
+      });
+
+      const index = await sdk.buildIndex({ source: 'acme/payments', commit: '4a1b7e2' });
+
+      expect(index).toEqual({
+        indexVersion: 1,
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'domain',
+            id: 'payments',
+            version: '1.0.0',
+            name: 'Payments',
+            contentPath: 'domains/payments/index.mdx',
+            contentHash: hashFile('domains/payments/index.mdx'),
+            sidecars: [
+              {
+                path: 'domains/payments/changelog.mdx',
+                hash: hashFile('domains/payments/changelog.mdx'),
+              },
+              {
+                path: 'domains/payments/ubiquitous-language.mdx',
+                hash: hashFile('domains/payments/ubiquitous-language.mdx'),
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    it('indexes resource-level docs as sidecars', async () => {
+      await sdk.writeDomain({
+        id: 'payments',
+        name: 'Payments',
+        version: '1.0.0',
+        markdown: '# Payments',
+      });
+      fs.mkdirSync(path.join(CATALOG_PATH, 'domains/payments/docs'), { recursive: true });
+      fs.mkdirSync(path.join(CATALOG_PATH, 'domains/payments/docs/runbooks'), { recursive: true });
+      fs.writeFileSync(path.join(CATALOG_PATH, 'domains/payments/docs/onboarding.mdx'), '# Onboarding');
+      fs.writeFileSync(path.join(CATALOG_PATH, 'domains/payments/docs/runbook.mdx'), '# Runbook');
+      fs.writeFileSync(path.join(CATALOG_PATH, 'domains/payments/docs/runbooks/incident-response.mdx'), '# Incident Response');
+      fs.writeFileSync(
+        path.join(CATALOG_PATH, 'domains/payments/docs/runbooks/category.json'),
+        JSON.stringify({ label: 'Operational Runbooks', position: 1 })
+      );
+
+      const index = await sdk.buildIndex({ source: 'acme/payments', commit: '4a1b7e2' });
+
+      expect(index).toEqual({
+        indexVersion: 1,
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'domain',
+            id: 'payments',
+            version: '1.0.0',
+            name: 'Payments',
+            contentPath: 'domains/payments/index.mdx',
+            contentHash: hashFile('domains/payments/index.mdx'),
+            sidecars: [
+              {
+                path: 'domains/payments/docs/onboarding.mdx',
+                hash: hashFile('domains/payments/docs/onboarding.mdx'),
+              },
+              {
+                path: 'domains/payments/docs/runbook.mdx',
+                hash: hashFile('domains/payments/docs/runbook.mdx'),
+              },
+              {
+                path: 'domains/payments/docs/runbooks/category.json',
+                hash: hashFile('domains/payments/docs/runbooks/category.json'),
+              },
+              {
+                path: 'domains/payments/docs/runbooks/incident-response.mdx',
+                hash: hashFile('domains/payments/docs/runbooks/incident-response.mdx'),
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    it('indexes arbitrary files within each resource boundary as sidecars', async () => {
+      await sdk.writeDomain({
+        id: 'payments',
+        name: 'Payments',
+        version: '1.0.0',
+        markdown: '# Payments',
+      });
+      await sdk.writeServiceToDomain(
+        {
+          id: 'payment-service',
+          name: 'Payment Service',
+          version: '1.0.0',
+          markdown: '# Payment Service',
+        },
+        { id: 'payments' }
+      );
+      fs.mkdirSync(path.join(CATALOG_PATH, 'domains/payments/attachments'), { recursive: true });
+      fs.writeFileSync(path.join(CATALOG_PATH, 'domains/payments/attachments/context.txt'), 'Domain context');
+      fs.writeFileSync(path.join(CATALOG_PATH, 'domains/payments/services/payment-service/schema.sql'), 'CREATE TABLE payments;');
+
+      const index = await sdk.buildIndex({ source: 'acme/payments', commit: '4a1b7e2' });
+
+      expect(index).toEqual({
+        indexVersion: 1,
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'domain',
+            id: 'payments',
+            version: '1.0.0',
+            name: 'Payments',
+            contentPath: 'domains/payments/index.mdx',
+            contentHash: hashFile('domains/payments/index.mdx'),
+            sidecars: [
+              {
+                path: 'domains/payments/attachments/context.txt',
+                hash: hashFile('domains/payments/attachments/context.txt'),
+              },
+            ],
+          },
+          {
+            type: 'service',
+            id: 'payment-service',
+            version: '1.0.0',
+            name: 'Payment Service',
+            contentPath: 'domains/payments/services/payment-service/index.mdx',
+            contentHash: hashFile('domains/payments/services/payment-service/index.mdx'),
+            sidecars: [
+              {
+                path: 'domains/payments/services/payment-service/schema.sql',
+                hash: hashFile('domains/payments/services/payment-service/schema.sql'),
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    it('ignores common non-content files while collecting resource sidecars', async () => {
+      await sdk.writeDomain({
+        id: 'payments',
+        name: 'Payments',
+        version: '1.0.0',
+        markdown: '# Payments',
+      });
+      fs.writeFileSync(path.join(CATALOG_PATH, 'domains/payments/notes.txt'), 'Useful notes');
+      fs.writeFileSync(path.join(CATALOG_PATH, 'domains/payments/.DS_Store'), 'finder metadata');
+      fs.writeFileSync(path.join(CATALOG_PATH, 'domains/payments/Thumbs.db'), 'windows metadata');
+      fs.writeFileSync(path.join(CATALOG_PATH, 'domains/payments/.gitkeep'), '');
+      fs.mkdirSync(path.join(CATALOG_PATH, 'domains/payments/node_modules/example'), { recursive: true });
+      fs.writeFileSync(path.join(CATALOG_PATH, 'domains/payments/node_modules/example/index.js'), 'generated dependency');
+
+      const index = await sdk.buildIndex({ source: 'acme/payments', commit: '4a1b7e2' });
+
+      expect(index.resources[0].sidecars).toEqual([
+        {
+          path: 'domains/payments/notes.txt',
+          hash: hashFile('domains/payments/notes.txt'),
+        },
+      ]);
+    });
+
+    it('honors an optional .eventcatalogignore when collecting resource sidecars', async () => {
+      await sdk.writeDomain({
+        id: 'payments',
+        name: 'Payments',
+        version: '1.0.0',
+        markdown: '# Payments',
+      });
+      fs.writeFileSync(path.join(CATALOG_PATH, '.eventcatalogignore'), ['**/*.log', 'domains/payments/generated/**'].join('\n'));
+      fs.mkdirSync(path.join(CATALOG_PATH, 'domains/payments/attachments'), { recursive: true });
+      fs.mkdirSync(path.join(CATALOG_PATH, 'domains/payments/generated'), { recursive: true });
+      fs.mkdirSync(path.join(CATALOG_PATH, 'public/logs'), { recursive: true });
+      fs.writeFileSync(path.join(CATALOG_PATH, 'domains/payments/attachments/context.txt'), 'Domain context');
+      fs.writeFileSync(path.join(CATALOG_PATH, 'domains/payments/attachments/debug.log'), 'Debug output');
+      fs.writeFileSync(path.join(CATALOG_PATH, 'domains/payments/generated/report.json'), '{"generated":true}');
+      fs.writeFileSync(path.join(CATALOG_PATH, 'public/logs/debug.log'), 'Public debug output');
+
+      const index = await sdk.buildIndex({ source: 'acme/payments', commit: '4a1b7e2' });
+
+      expect(index.resources[0].sidecars).toEqual([
+        {
+          path: 'domains/payments/attachments/context.txt',
+          hash: hashFile('domains/payments/attachments/context.txt'),
+        },
+      ]);
+      expect(index.assets).toBeUndefined();
+    });
+  });
+
+  describe('systems', () => {
+    it('indexes system relationships with and without versions', async () => {
+      await sdk.writeSystem({
+        id: 'payment-processing',
+        name: 'Payment Processing',
+        version: '1.0.0',
+        markdown: '# Payment Processing',
+        services: [{ id: 'payment-service', version: '1.0.0' }, { id: 'refund-service' }],
+        flows: [{ id: 'checkout', version: '2.0.0' }, { id: 'issue-refund' }],
+        entities: [{ id: 'payment', version: '1.0.0' }, { id: 'refund' }],
+        containers: [{ id: 'payments-database', version: '2.0.0' }, { id: 'audit-log' }],
+        relationships: [
+          { id: 'stripe', version: '1.0.0', label: 'charges through' },
+          { id: 'fraud-detection', label: 'screens with' },
+        ],
+        actors: [
+          { id: 'customer', name: 'Customer', label: 'initiates payments', direction: 'inbound' },
+          { id: 'operator', direction: 'outbound' },
+        ],
+      });
+
+      const index = await sdk.buildIndex({ source: 'acme/payments', commit: '4a1b7e2' });
+
+      expect(index).toEqual({
+        indexVersion: 1,
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'system',
+            id: 'payment-processing',
+            version: '1.0.0',
+            name: 'Payment Processing',
+            contentPath: 'systems/payment-processing/index.mdx',
+            contentHash: hashFile('systems/payment-processing/index.mdx'),
+            services: [{ id: 'payment-service', version: '1.0.0' }, { id: 'refund-service' }],
+            flows: [{ id: 'checkout', version: '2.0.0' }, { id: 'issue-refund' }],
+            entities: [{ id: 'payment', version: '1.0.0' }, { id: 'refund' }],
+            containers: [{ id: 'payments-database', version: '2.0.0' }, { id: 'audit-log' }],
+            relationships: [
+              { id: 'stripe', version: '1.0.0', label: 'charges through' },
+              { id: 'fraud-detection', label: 'screens with' },
+            ],
+            actors: [
+              { id: 'customer', name: 'Customer', label: 'initiates payments', direction: 'inbound' },
+              { id: 'operator', direction: 'outbound' },
+            ],
+          },
+        ],
+      });
+    });
+  });
+
+  describe('services', () => {
+    it('indexes service relationships with and without versions', async () => {
+      await sdk.writeService({
+        id: 'payment-service',
+        name: 'Payment Service',
+        version: '1.0.0',
+        markdown: '# Payment Service',
+        sends: [{ id: 'payment-captured', version: '2.0.0' }, { id: 'payment-failed' }],
+        receives: [{ id: 'capture-payment', version: '1.0.0' }, { id: 'refund-payment' }],
+        entities: [{ id: 'payment', version: '1.0.0' }, { id: 'ledger-entry' }],
+        writesTo: [{ id: 'payments-database', version: '2.0.0' }, { id: 'audit-log' }],
+        readsFrom: [{ id: 'customer-database', version: '3.0.0' }, { id: 'exchange-rates' }],
+        flows: [{ id: 'checkout', version: '2.0.0' }, { id: 'issue-refund' }],
+      });
+
+      const index = await sdk.buildIndex({ source: 'acme/payments', commit: '4a1b7e2' });
+
+      expect(index).toEqual({
+        indexVersion: 1,
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'service',
+            id: 'payment-service',
+            version: '1.0.0',
+            name: 'Payment Service',
+            contentPath: 'services/payment-service/index.mdx',
+            contentHash: hashFile('services/payment-service/index.mdx'),
+            sends: [{ id: 'payment-captured', version: '2.0.0' }, { id: 'payment-failed' }],
+            receives: [{ id: 'capture-payment', version: '1.0.0' }, { id: 'refund-payment' }],
+            entities: [{ id: 'payment', version: '1.0.0' }, { id: 'ledger-entry' }],
+            writesTo: [{ id: 'payments-database', version: '2.0.0' }, { id: 'audit-log' }],
+            readsFrom: [{ id: 'customer-database', version: '3.0.0' }, { id: 'exchange-rates' }],
+            flows: [{ id: 'checkout', version: '2.0.0' }, { id: 'issue-refund' }],
+          },
+        ],
+      });
+    });
+
+    it('indexes the channels used to send and receive messages', async () => {
+      await sdk.writeService({
+        id: 'payment-service',
+        name: 'Payment Service',
+        version: '1.0.0',
+        markdown: '# Payment Service',
+        sends: [
+          {
+            id: 'payment-captured',
+            version: '2.0.0',
+            to: [{ id: 'payments-topic', version: '1.0.0' }, { id: 'audit-topic' }],
+          },
+        ],
+        receives: [
+          {
+            id: 'capture-payment',
+            version: '1.0.0',
+            from: [{ id: 'payments-commands', version: '2.0.0' }, { id: 'retry-queue' }],
+          },
+        ],
+      });
+
+      const index = await sdk.buildIndex({ source: 'acme/payments', commit: '4a1b7e2' });
+
+      expect(index).toEqual({
+        indexVersion: 1,
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'service',
+            id: 'payment-service',
+            version: '1.0.0',
+            name: 'Payment Service',
+            contentPath: 'services/payment-service/index.mdx',
+            contentHash: hashFile('services/payment-service/index.mdx'),
+            sends: [
+              {
+                id: 'payment-captured',
+                version: '2.0.0',
+                to: [{ id: 'payments-topic', version: '1.0.0' }, { id: 'audit-topic' }],
+              },
+            ],
+            receives: [
+              {
+                id: 'capture-payment',
+                version: '1.0.0',
+                from: [{ id: 'payments-commands', version: '2.0.0' }, { id: 'retry-queue' }],
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    it('normalizes and hashes service specifications', async () => {
+      await sdk.writeService({
+        id: 'payment-service',
+        name: 'Payment Service',
+        version: '1.0.0',
+        markdown: '# Payment Service',
+        specifications: {
+          asyncapiPath: 'asyncapi.yaml',
+          openapiPath: 'openapi.yaml',
+          graphqlPath: 'schema.graphql',
+        },
+      });
+      await sdk.addFileToService('payment-service', {
+        fileName: 'asyncapi.yaml',
+        content: 'asyncapi: 3.0.0',
+      });
+      await sdk.addFileToService('payment-service', {
+        fileName: 'openapi.yaml',
+        content: 'openapi: 3.1.0',
+      });
+      await sdk.addFileToService('payment-service', {
+        fileName: 'schema.graphql',
+        content: 'type Query { payment: Payment }',
+      });
+
+      const index = await sdk.buildIndex({ source: 'acme/payments', commit: '4a1b7e2' });
+
+      expect(index).toEqual({
+        indexVersion: 1,
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'service',
+            id: 'payment-service',
+            version: '1.0.0',
+            name: 'Payment Service',
+            contentPath: 'services/payment-service/index.mdx',
+            contentHash: hashFile('services/payment-service/index.mdx'),
+            specifications: [
+              {
+                type: 'asyncapi',
+                path: 'asyncapi.yaml',
+                hash: hashFile('services/payment-service/asyncapi.yaml'),
+              },
+              {
+                type: 'openapi',
+                path: 'openapi.yaml',
+                hash: hashFile('services/payment-service/openapi.yaml'),
+              },
+              {
+                type: 'graphql',
+                path: 'schema.graphql',
+                hash: hashFile('services/payment-service/schema.graphql'),
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    it('does not hash service specifications when `hashContent` is false', async () => {
+      await sdk.writeService({
+        id: 'payment-service',
+        name: 'Payment Service',
+        version: '1.0.0',
+        markdown: '# Payment Service',
+        specifications: {
+          asyncapiPath: 'asyncapi.yaml',
+        },
+      });
+      await sdk.addFileToService('payment-service', {
+        fileName: 'asyncapi.yaml',
+        content: 'asyncapi: 3.0.0',
+      });
+
+      const index = await sdk.buildIndex({
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        hashContent: false,
+      });
+
+      expect(index).toEqual({
+        indexVersion: 1,
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'service',
+            id: 'payment-service',
+            version: '1.0.0',
+            name: 'Payment Service',
+            contentPath: 'services/payment-service/index.mdx',
+            specifications: [
+              {
+                type: 'asyncapi',
+                path: 'asyncapi.yaml',
+              },
+            ],
+          },
+        ],
+      });
+    });
+  });
+
+  describe('data products', () => {
+    it('indexes data product inputs and outputs with and without versions', async () => {
+      await sdk.writeDataProduct({
+        id: 'payment-analytics',
+        name: 'Payment Analytics',
+        version: '1.0.0',
+        markdown: '# Payment Analytics',
+        inputs: [{ id: 'payment-captured', version: '2.0.0' }, { id: 'payment-failed' }],
+        outputs: [{ id: 'daily-payments', version: '1.0.0' }, { id: 'refund-report' }],
+      });
+
+      const index = await sdk.buildIndex({ source: 'acme/payments', commit: '4a1b7e2' });
+
+      expect(index).toEqual({
+        indexVersion: 1,
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'data-product',
+            id: 'payment-analytics',
+            version: '1.0.0',
+            name: 'Payment Analytics',
+            contentPath: 'data-products/payment-analytics/index.mdx',
+            contentHash: hashFile('data-products/payment-analytics/index.mdx'),
+            inputs: [{ id: 'payment-captured', version: '2.0.0' }, { id: 'payment-failed' }],
+            outputs: [{ id: 'daily-payments', version: '1.0.0' }, { id: 'refund-report' }],
+          },
+        ],
+      });
+    });
+  });
+
+  describe('data stores', () => {
+    it('indexes data stores as containers', async () => {
+      await sdk.writeDataStore({
+        id: 'payments-database',
+        name: 'Payments Database',
+        version: '1.0.0',
+        markdown: '# Payments Database',
+        container_type: 'database',
+      });
+
+      const index = await sdk.buildIndex({ source: 'acme/payments', commit: '4a1b7e2' });
+
+      expect(index).toEqual({
+        indexVersion: 1,
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'container',
+            id: 'payments-database',
+            version: '1.0.0',
+            name: 'Payments Database',
+            container_type: 'database',
+            contentPath: 'containers/payments-database/index.mdx',
+            contentHash: hashFile('containers/payments-database/index.mdx'),
+          },
+        ],
+      });
+    });
+  });
+
+  describe('entities', () => {
+    it('indexes entities', async () => {
+      await sdk.writeEntity({
+        id: 'payment',
+        name: 'Payment',
+        version: '1.0.0',
+        markdown: '# Payment',
+      });
+
+      const index = await sdk.buildIndex({ source: 'acme/payments', commit: '4a1b7e2' });
+
+      expect(index).toEqual({
+        indexVersion: 1,
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'entity',
+            id: 'payment',
+            version: '1.0.0',
+            name: 'Payment',
+            contentPath: 'entities/payment/index.mdx',
+            contentHash: hashFile('entities/payment/index.mdx'),
+          },
+        ],
+      });
+    });
+  });
+
+  describe('flows', () => {
+    it('flattens flow step pointers into references', async () => {
+      await sdk.writeFlow({
+        id: 'payment-capture-flow',
+        name: 'Payment Capture',
+        version: '1.0.0',
+        owners: ['team-payments'],
+        markdown: '# Payment Capture',
+        steps: [
+          {
+            id: 'payment-service',
+            title: 'Capture payment',
+            service: { id: 'payment-service' },
+            next_step: 'payment-captured',
+          },
+          {
+            id: 'payment-captured',
+            title: 'Publish payment captured',
+            message: { id: 'payment-captured', version: '2.0.0' },
+            next_step: 'ledger-service',
+          },
+          {
+            id: 'ledger-service',
+            title: 'Record payment',
+            service: { id: 'ledger-service' },
+            next_step: 'payments-db',
+          },
+          {
+            id: 'payments-db',
+            title: 'Store payment',
+            container: { id: 'payments-db' },
+            next_step: 'settlement-flow',
+          },
+          {
+            id: 'settlement-flow',
+            title: 'Settle payment',
+            flow: { id: 'settlement-flow' },
+          },
+        ],
+      });
+
+      const index = await sdk.buildIndex({ source: 'acme/payments', commit: '4a1b7e2' });
+
+      expect(index).toEqual({
+        indexVersion: 1,
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'flow',
+            id: 'payment-capture-flow',
+            version: '1.0.0',
+            name: 'Payment Capture',
+            owners: ['team-payments'],
+            contentPath: 'flows/payment-capture-flow/index.mdx',
+            contentHash: hashFile('flows/payment-capture-flow/index.mdx'),
+            references: [
+              { kind: 'service', id: 'payment-service' },
+              { kind: 'message', id: 'payment-captured', version: '2.0.0' },
+              { kind: 'service', id: 'ledger-service' },
+              { kind: 'container', id: 'payments-db' },
+              { kind: 'flow', id: 'settlement-flow' },
+            ],
+          },
+        ],
+      });
+    });
+  });
+
+  describe('ADRs', () => {
+    it('indexes ADR relationships with and without versions', async () => {
+      await sdk.writeAdr(
+        {
+          id: 'adr-118',
+          name: 'Use Avro for all payment events',
+          version: '1.0.0',
+          owners: ['team-architecture'],
+          status: 'accepted',
+          date: '2026-08-07',
+          appliesTo: [
+            { type: 'service', id: 'payment-service' },
+            { type: 'event', id: 'payment-captured', version: '2.0.0' },
+            { type: 'domain', id: 'finance' },
+          ],
+          supersedes: [{ id: 'adr-092' }],
+          supersededBy: [],
+          amends: [],
+          amendedBy: [{ id: 'adr-131' }],
+          related: [{ id: 'adr-104' }],
+          markdown: '# Use Avro for all payment events',
+        },
+        { path: '/118-avro-for-payment-events' }
+      );
+
+      const index = await sdk.buildIndex({ source: 'acme/payments', commit: '4a1b7e2' });
+
+      expect(index).toEqual({
+        indexVersion: 1,
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'adr',
+            id: 'adr-118',
+            version: '1.0.0',
+            name: 'Use Avro for all payment events',
+            owners: ['team-architecture'],
+            status: 'accepted',
+            appliesTo: [
+              { type: 'service', id: 'payment-service' },
+              { type: 'event', id: 'payment-captured', version: '2.0.0' },
+              { type: 'domain', id: 'finance' },
+            ],
+            supersedes: [{ id: 'adr-092' }],
+            supersededBy: [],
+            amends: [],
+            amendedBy: [{ id: 'adr-131' }],
+            related: [{ id: 'adr-104' }],
+            contentPath: 'adrs/118-avro-for-payment-events/index.mdx',
+            contentHash: hashFile('adrs/118-avro-for-payment-events/index.mdx'),
+          },
+        ],
+      });
+    });
+  });
+
+  describe('agents', () => {
+    it('indexes agent relationships with and without versions', async () => {
+      await sdk.writeAgent({
+        id: 'payment-support-agent',
+        name: 'Payment Support Agent',
+        version: '1.0.0',
+        markdown: '# Payment Support Agent',
+        sends: [
+          {
+            id: 'support-response',
+            version: '2.0.0',
+            to: [{ id: 'support-responses', version: '1.0.0' }],
+          },
+          { id: 'escalation-requested' },
+        ],
+        receives: [
+          {
+            id: 'support-request',
+            version: '1.0.0',
+            from: [{ id: 'support-requests' }],
+          },
+          { id: 'customer-replied' },
+        ],
+        writesTo: [{ id: 'support-memory', version: '2.0.0' }, { id: 'audit-log' }],
+        readsFrom: [{ id: 'payments-database', version: '3.0.0' }, { id: 'customer-database' }],
+        flows: [{ id: 'resolve-payment-issue', version: '1.0.0' }, { id: 'escalate-payment-issue' }],
+      });
+
+      const index = await sdk.buildIndex({ source: 'acme/payments', commit: '4a1b7e2' });
+
+      expect(index).toEqual({
+        indexVersion: 1,
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'agent',
+            id: 'payment-support-agent',
+            version: '1.0.0',
+            name: 'Payment Support Agent',
+            contentPath: 'agents/payment-support-agent/index.mdx',
+            contentHash: hashFile('agents/payment-support-agent/index.mdx'),
+            sends: [
+              {
+                id: 'support-response',
+                version: '2.0.0',
+                to: [{ id: 'support-responses', version: '1.0.0' }],
+              },
+              { id: 'escalation-requested' },
+            ],
+            receives: [
+              {
+                id: 'support-request',
+                version: '1.0.0',
+                from: [{ id: 'support-requests' }],
+              },
+              { id: 'customer-replied' },
+            ],
+            writesTo: [{ id: 'support-memory', version: '2.0.0' }, { id: 'audit-log' }],
+            readsFrom: [{ id: 'payments-database', version: '3.0.0' }, { id: 'customer-database' }],
+            flows: [{ id: 'resolve-payment-issue', version: '1.0.0' }, { id: 'escalate-payment-issue' }],
+          },
+        ],
+      });
+    });
+  });
+
+  describe('teams', () => {
+    it('indexes teams and their members', async () => {
+      await sdk.writeTeam({
+        id: 'team-payments',
+        name: 'Payments Team',
+        members: ['alice', 'bob'],
+        markdown: '# Payments Team',
+      });
+
+      const index = await sdk.buildIndex({ source: 'acme/payments', commit: '4a1b7e2' });
+
+      expect(index).toEqual({
+        indexVersion: 1,
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'team',
+            id: 'team-payments',
+            name: 'Payments Team',
+            members: ['alice', 'bob'],
+            contentPath: 'teams/team-payments.mdx',
+            contentHash: hashFile('teams/team-payments.mdx'),
+          },
+        ],
+      });
+    });
+  });
+
+  describe('users', () => {
+    it('indexes users', async () => {
+      await sdk.writeUser({
+        id: 'alice',
+        name: 'Alice',
+        markdown: '# Alice',
+      });
+
+      const index = await sdk.buildIndex({ source: 'acme/payments', commit: '4a1b7e2' });
+
+      expect(index).toEqual({
+        indexVersion: 1,
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'user',
+            id: 'alice',
+            name: 'Alice',
+            contentPath: 'users/alice.mdx',
+            contentHash: hashFile('users/alice.mdx'),
+          },
+        ],
+      });
+    });
+  });
+
+  describe('diagrams', () => {
+    it('indexes diagrams', async () => {
+      await sdk.writeDiagram({
+        id: 'payment-lifecycle',
+        name: 'Payment Lifecycle',
+        version: '1.0.0',
+        markdown: '# Payment Lifecycle',
+      });
+
+      const index = await sdk.buildIndex({ source: 'acme/payments', commit: '4a1b7e2' });
+
+      expect(index).toEqual({
+        indexVersion: 1,
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'diagram',
+            id: 'payment-lifecycle',
+            version: '1.0.0',
+            name: 'Payment Lifecycle',
+            contentPath: 'diagrams/payment-lifecycle/index.mdx',
+            contentHash: hashFile('diagrams/payment-lifecycle/index.mdx'),
+          },
+        ],
+      });
+    });
+  });
+
+  describe('messages', () => {
+    it('indexes commands', async () => {
+      await sdk.writeCommand({
+        id: 'capture-payment',
+        name: 'Capture Payment',
+        version: '1.0.0',
+        markdown: '# Capture Payment',
+      });
+
+      const index = await sdk.buildIndex({ source: 'acme/payments', commit: '4a1b7e2' });
+
+      expect(index).toEqual({
+        indexVersion: 1,
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'command',
+            id: 'capture-payment',
+            version: '1.0.0',
+            name: 'Capture Payment',
+            contentPath: 'commands/capture-payment/index.mdx',
+            contentHash: hashFile('commands/capture-payment/index.mdx'),
+          },
+        ],
+      });
+    });
+
+    it('indexes queries', async () => {
+      await sdk.writeQuery({
+        id: 'get-payment',
+        name: 'Get Payment',
+        version: '1.0.0',
+        markdown: '# Get Payment',
+      });
+
+      const index = await sdk.buildIndex({ source: 'acme/payments', commit: '4a1b7e2' });
+
+      expect(index).toEqual({
+        indexVersion: 1,
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'query',
+            id: 'get-payment',
+            version: '1.0.0',
+            name: 'Get Payment',
+            contentPath: 'queries/get-payment/index.mdx',
+            contentHash: hashFile('queries/get-payment/index.mdx'),
+          },
+        ],
+      });
+    });
+
+    it('normalizes schemaPath into the schemas array', async () => {
+      await sdk.writeEvent({
+        id: 'payment-captured',
+        name: 'Payment Captured',
+        version: '2.0.0',
+        markdown: '# Payment Captured',
+        schemaPath: 'schema.avsc',
+      });
+      await sdk.addSchemaToEvent('payment-captured', {
+        fileName: 'schema.avsc',
+        schema: '{"type":"record","name":"PaymentCaptured","fields":[]}',
+      });
+
+      const index = await sdk.buildIndex({ source: 'acme/payments', commit: '4a1b7e2' });
+
+      expect(index).toEqual({
+        indexVersion: 1,
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'event',
+            id: 'payment-captured',
+            version: '2.0.0',
+            name: 'Payment Captured',
+            contentPath: 'events/payment-captured/index.mdx',
+            contentHash: hashFile('events/payment-captured/index.mdx'),
+            schemas: [
+              {
+                path: 'schema.avsc',
+                default: true,
+                hash: hashFile('events/payment-captured/schema.avsc'),
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    it('normalizes and hashes multiple schemas', async () => {
+      await sdk.writeEvent({
+        id: 'payment-captured',
+        name: 'Payment Captured',
+        version: '2.0.0',
+        markdown: '# Payment Captured',
+        schemas: [
+          {
+            id: 'avro',
+            file: 'schema.avsc',
+            format: 'avro',
+            environments: ['production'],
+            default: true,
+          },
+          { id: 'json', path: 'schema.json', format: 'json-schema' },
+        ],
+      });
+      await sdk.addFileToEvent('payment-captured', {
+        fileName: 'schema.avsc',
+        content: '{"type":"record","name":"PaymentCaptured","fields":[]}',
+      });
+      await sdk.addFileToEvent('payment-captured', {
+        fileName: 'schema.json',
+        content: '{"type":"object","properties":{}}',
+      });
+
+      const index = await sdk.buildIndex({ source: 'acme/payments', commit: '4a1b7e2' });
+
+      expect(index).toEqual({
+        indexVersion: 1,
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'event',
+            id: 'payment-captured',
+            version: '2.0.0',
+            name: 'Payment Captured',
+            contentPath: 'events/payment-captured/index.mdx',
+            contentHash: hashFile('events/payment-captured/index.mdx'),
+            schemas: [
+              {
+                id: 'avro',
+                path: 'schema.avsc',
+                format: 'avro',
+                environments: ['production'],
+                default: true,
+                hash: hashFile('events/payment-captured/schema.avsc'),
+              },
+              {
+                id: 'json',
+                path: 'schema.json',
+                format: 'json-schema',
+                hash: hashFile('events/payment-captured/schema.json'),
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    it('does not hash schemas when `hashContent` is false', async () => {
+      await sdk.writeEvent({
+        id: 'payment-captured',
+        name: 'Payment Captured',
+        version: '2.0.0',
+        markdown: '# Payment Captured',
+        schemaPath: 'schema.avsc',
+      });
+      await sdk.addSchemaToEvent('payment-captured', {
+        fileName: 'schema.avsc',
+        schema: '{"type":"record","name":"PaymentCaptured","fields":[]}',
+      });
+
+      const index = await sdk.buildIndex({ source: 'acme/payments', commit: '4a1b7e2', hashContent: false });
+
+      expect(index).toEqual({
+        indexVersion: 1,
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'event',
+            id: 'payment-captured',
+            version: '2.0.0',
+            name: 'Payment Captured',
+            contentPath: 'events/payment-captured/index.mdx',
+            schemas: [
+              {
+                path: 'schema.avsc',
+                default: true,
+              },
+            ],
+          },
+        ],
+      });
+    });
+  });
+});

--- a/packages/sdk/src/test/build-index.test.ts
+++ b/packages/sdk/src/test/build-index.test.ts
@@ -111,6 +111,71 @@ describe('buildIndex', () => {
     });
   });
 
+  it('indexes channels and channel pointers from messages', async () => {
+    await sdk.writeChannel({
+      id: 'payments.events',
+      name: 'Payments Events',
+      version: '2.0.0',
+      address: 'payments.{region}.events',
+      protocols: ['kafka'],
+      deliveryGuarantee: 'at-least-once',
+      routes: [{ id: 'payments.dead-letter', version: '1.0.0' }],
+      parameters: {
+        region: {
+          enum: ['eu', 'us'],
+          default: 'eu',
+          examples: ['eu'],
+        },
+      },
+      markdown: '# Payments Events',
+    });
+    await sdk.writeEvent({
+      id: 'payment-captured',
+      name: 'Payment Captured',
+      version: '1.0.0',
+      channels: [{ id: 'payments.events', version: '2.0.0', parameters: { region: 'eu' } }],
+      markdown: '# Payment Captured',
+    });
+
+    const index = await sdk.buildIndex({ source: 'acme/payments', commit: '4a1b7e2' });
+
+    expect(index).toEqual({
+      indexVersion: 1,
+      source: 'acme/payments',
+      commit: '4a1b7e2',
+      resources: [
+        {
+          type: 'channel',
+          id: 'payments.events',
+          version: '2.0.0',
+          name: 'Payments Events',
+          contentPath: 'channels/payments.events/index.mdx',
+          contentHash: hashFile('channels/payments.events/index.mdx'),
+          address: 'payments.{region}.events',
+          protocols: ['kafka'],
+          deliveryGuarantee: 'at-least-once',
+          routes: [{ id: 'payments.dead-letter', version: '1.0.0' }],
+          parameters: {
+            region: {
+              enum: ['eu', 'us'],
+              default: 'eu',
+              examples: ['eu'],
+            },
+          },
+        },
+        {
+          type: 'event',
+          id: 'payment-captured',
+          version: '1.0.0',
+          name: 'Payment Captured',
+          contentPath: 'events/payment-captured/index.mdx',
+          contentHash: hashFile('events/payment-captured/index.mdx'),
+          channels: [{ id: 'payments.events', version: '2.0.0', parameters: { region: 'eu' } }],
+        },
+      ],
+    });
+  });
+
   it('does not hash resource content when `hashContent` is false', async () => {
     await sdk.writeEvent({
       id: 'payment-captured',

--- a/packages/sdk/src/test/fixtures/build-index/default-catalog-index.json
+++ b/packages/sdk/src/test/fixtures/build-index/default-catalog-index.json
@@ -10,9 +10,7 @@
       "name": "ADR-001: Publish product events via a transactional outbox",
       "contentPath": "domains/Catalog/systems/product-catalog-system/adrs/adr-001-use-transactional-outbox/index.mdx",
       "contentHash": "sha256:c0185646b1da56e022231f3d695f20c97a403567da77279e4b7024c7204666ed",
-      "owners": [
-        "product-platform"
-      ],
+      "owners": ["product-platform"],
       "status": "accepted",
       "appliesTo": [
         {
@@ -36,9 +34,7 @@
       "name": "ADR-002: Use PostgreSQL as the product system of record",
       "contentPath": "domains/Catalog/systems/product-catalog-system/adrs/adr-002-postgres-as-system-of-record/index.mdx",
       "contentHash": "sha256:9bbad6f6da920176c6b15ca1d85f0539bfd0bd70b633cadb40f13ffda835904a",
-      "owners": [
-        "product-platform"
-      ],
+      "owners": ["product-platform"],
       "status": "accepted",
       "appliesTo": [
         {
@@ -63,9 +59,7 @@
       "name": "ADR-003: Offload long-running catalog work to a dedicated worker",
       "contentPath": "domains/Catalog/systems/product-catalog-system/adrs/adr-003-offload-async-work-to-worker/index.mdx",
       "contentHash": "sha256:785ae3411472e1bc46630beaa7c3d5fbcc6f194cd45e4136f870b3cd63e7f498",
-      "owners": [
-        "product-platform"
-      ],
+      "owners": ["product-platform"],
       "status": "accepted",
       "appliesTo": [
         {
@@ -89,9 +83,7 @@
       "name": "Add Item To Cart",
       "contentPath": "domains/Shopping/systems/cart-system/services/CartAPI/commands/AddItemToCart/index.mdx",
       "contentHash": "sha256:abc8fbe0d646a8e2b04477527ba29d66d4584c87d04856eb1e1a53ee0909160c",
-      "owners": [
-        "shopping-platform"
-      ],
+      "owners": ["shopping-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -107,9 +99,7 @@
       "name": "Authenticate Customer",
       "contentPath": "domains/Customer/systems/identity-provider/services/OAuthAPI/commands/AuthenticateCustomer/index.mdx",
       "contentHash": "sha256:b1937000c87557427c582493e31b182afdf13381b18222f1a131f98306560889",
-      "owners": [
-        "customer-platform"
-      ],
+      "owners": ["customer-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -125,9 +115,7 @@
       "name": "Authorize Payment",
       "contentPath": "domains/Ordering/systems/checkout-system/services/CheckoutOrchestrator/commands/AuthorizePayment/index.mdx",
       "contentHash": "sha256:9c6016de966e994812916b83f919d8e444668adc48e448a9b7616d9ebf70feed",
-      "owners": [
-        "ordering-platform"
-      ],
+      "owners": ["ordering-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -143,9 +131,7 @@
       "name": "Calculate Discount",
       "contentPath": "domains/Shopping/systems/promotion-system/services/PromotionService/commands/CalculateDiscount/index.mdx",
       "contentHash": "sha256:66a076f717e47b4c66f8d39e48fbe7b6df780e958cd594bfec4963e900f7b71b",
-      "owners": [
-        "shopping-platform"
-      ],
+      "owners": ["shopping-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -161,9 +147,7 @@
       "name": "Cancel Order",
       "contentPath": "domains/Ordering/systems/order-management-system/services/OrderService/commands/CancelOrder/index.mdx",
       "contentHash": "sha256:aebba775afbccd0a643355994e63beac6b3013a313cd3db6f5758c22adb7a5e2",
-      "owners": [
-        "ordering-platform"
-      ],
+      "owners": ["ordering-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -179,9 +163,7 @@
       "name": "Checkout Cart",
       "contentPath": "domains/Shopping/systems/cart-system/services/CartAPI/commands/CheckoutCart/index.mdx",
       "contentHash": "sha256:b94912418764a5773b3f007bbcd411e7ed19b36b4cde57d5b0fa203132e83839",
-      "owners": [
-        "shopping-platform"
-      ],
+      "owners": ["shopping-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -197,9 +179,7 @@
       "name": "Create Order",
       "contentPath": "domains/Ordering/systems/order-management-system/services/OrderService/commands/CreateOrder/index.mdx",
       "contentHash": "sha256:6c8a877d504e8595a81cf0bbe52b5a805f2d3bcf38575d37980d31119da6bbba",
-      "owners": [
-        "ordering-platform"
-      ],
+      "owners": ["ordering-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -215,9 +195,7 @@
       "name": "Create Product",
       "contentPath": "domains/Catalog/systems/product-catalog-system/services/ProductAPI/commands/CreateProduct/index.mdx",
       "contentHash": "sha256:9c9f0f63cecd86ca8ac535848590edf481dc3c2bcc745d7836c259cd9a5f11d7",
-      "owners": [
-        "product-platform"
-      ],
+      "owners": ["product-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -233,9 +211,7 @@
       "name": "Create Shipment",
       "contentPath": "domains/Fulfilment/systems/shipping-system/services/CarrierAdapter/commands/CreateShipment/index.mdx",
       "contentHash": "sha256:ff68fec3e6cdbcf51f067f58215e8d4f59dc967018cb50a2ecb8cfa5c3056123",
-      "owners": [
-        "fulfilment-platform"
-      ],
+      "owners": ["fulfilment-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -251,9 +227,7 @@
       "name": "Delete Product",
       "contentPath": "domains/Catalog/systems/product-catalog-system/services/ProductAPI/commands/DeleteProduct/index.mdx",
       "contentHash": "sha256:942391cb113de771e68f9338baed771b66e2b6bc80e65eb18e35f6fb447edd47",
-      "owners": [
-        "product-platform"
-      ],
+      "owners": ["product-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -269,9 +243,7 @@
       "name": "Flag Review",
       "contentPath": "domains/Reviews/services/ReviewAPI/commands/flag-review/index.mdx",
       "contentHash": "sha256:bd89586f38ffe3444c62c20dfdae739a8562d5e88acf5807d6429cfde869df70",
-      "owners": [
-        "reviews-platform"
-      ],
+      "owners": ["reviews-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -287,9 +259,7 @@
       "name": "Register Customer",
       "contentPath": "domains/Customer/systems/customer-management-system/services/CustomerAPI/commands/RegisterCustomer/index.mdx",
       "contentHash": "sha256:fdab08abc43439d8d6371cdb1b1686f653c3dcad80270139631e9f9d92824c4e",
-      "owners": [
-        "customer-platform"
-      ],
+      "owners": ["customer-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -305,9 +275,7 @@
       "name": "Release Inventory",
       "contentPath": "domains/Fulfilment/systems/inventory-system/services/InventoryService/commands/ReleaseInventory/index.mdx",
       "contentHash": "sha256:db153f4cab02671ddf4d2844b067a3cd17f4bedc53cc7dba06d5162ba92b32e8",
-      "owners": [
-        "fulfilment-platform"
-      ],
+      "owners": ["fulfilment-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -323,9 +291,7 @@
       "name": "Remove Item From Cart",
       "contentPath": "domains/Shopping/systems/cart-system/services/CartAPI/commands/RemoveItemFromCart/index.mdx",
       "contentHash": "sha256:9568cb298a80f6af3cc7fb6ccff3707da811e3c37c5d95f581de8332b10e1044",
-      "owners": [
-        "shopping-platform"
-      ],
+      "owners": ["shopping-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -341,9 +307,7 @@
       "name": "Reserve Inventory",
       "contentPath": "domains/Ordering/systems/checkout-system/services/CheckoutOrchestrator/commands/ReserveInventory/index.mdx",
       "contentHash": "sha256:3f42b85d4574e8095026eb8f497fbe35a993a197a21399e34af44e65154e9e93",
-      "owners": [
-        "ordering-platform"
-      ],
+      "owners": ["ordering-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -359,9 +323,7 @@
       "name": "Submit Review",
       "contentPath": "domains/Reviews/services/ReviewAPI/commands/submit-review/index.mdx",
       "contentHash": "sha256:9bad501de35445445cca4de0db1d45c8be830390be926bdb73d6585bc7624439",
-      "owners": [
-        "reviews-platform"
-      ],
+      "owners": ["reviews-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -377,9 +339,7 @@
       "name": "Update Customer",
       "contentPath": "domains/Customer/systems/customer-management-system/services/CustomerAPI/commands/UpdateCustomer/index.mdx",
       "contentHash": "sha256:04cd655ae882fc0bcf98dc60d663dffa60b9214c27722ba8e81efdaab3c16d9f",
-      "owners": [
-        "customer-platform"
-      ],
+      "owners": ["customer-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -395,9 +355,7 @@
       "name": "Update Product",
       "contentPath": "domains/Catalog/systems/product-catalog-system/services/ProductAPI/commands/UpdateProduct/index.mdx",
       "contentHash": "sha256:56ff9296c9043bad438a57472116b92bd486b21171db491201b44a069994b335",
-      "owners": [
-        "product-platform"
-      ],
+      "owners": ["product-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -413,9 +371,7 @@
       "name": "Vote Review Helpful",
       "contentPath": "domains/Reviews/services/ReviewAPI/commands/vote-review-helpful/index.mdx",
       "contentHash": "sha256:181e7343185b3bd89d2b394840336f9487fbabdd52a49544dfa3079a9982b7f1",
-      "owners": [
-        "reviews-platform"
-      ],
+      "owners": ["reviews-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -587,9 +543,7 @@
       "name": "Catalog",
       "contentPath": "domains/Catalog/index.mdx",
       "contentHash": "sha256:73da6896ccad4dc201c8199a89e103cba2e71a2bd2bfc8d16c86d403586fa5f9",
-      "owners": [
-        "product-platform"
-      ],
+      "owners": ["product-platform"],
       "sidecars": [
         {
           "path": "domains/Catalog/ubiquitous-language.mdx",
@@ -632,9 +586,7 @@
       "name": "Customer",
       "contentPath": "domains/Customer/index.mdx",
       "contentHash": "sha256:df6811c1a5e418757516b27c54d30cd473af7bf5a017b58ba46e38d00d8f18c6",
-      "owners": [
-        "customer-platform"
-      ],
+      "owners": ["customer-platform"],
       "sidecars": [
         {
           "path": "domains/Customer/ubiquitous-language.mdx",
@@ -677,9 +629,7 @@
       "name": "Fulfilment",
       "contentPath": "domains/Fulfilment/index.mdx",
       "contentHash": "sha256:4c135222dcc67e7872a40668050b3056b98932a38cd21968b050c0f9bf37440a",
-      "owners": [
-        "fulfilment-platform"
-      ],
+      "owners": ["fulfilment-platform"],
       "sidecars": [
         {
           "path": "domains/Fulfilment/ubiquitous-language.mdx",
@@ -730,9 +680,7 @@
       "name": "Ordering",
       "contentPath": "domains/Ordering/index.mdx",
       "contentHash": "sha256:b8897d88a778080bd1e00b8afba2566e855f59927a831e4e0197ce492401e07a",
-      "owners": [
-        "ordering-platform"
-      ],
+      "owners": ["ordering-platform"],
       "sidecars": [
         {
           "path": "domains/Ordering/ubiquitous-language.mdx",
@@ -781,9 +729,7 @@
       "name": "Payments",
       "contentPath": "domains/Payments/index.mdx",
       "contentHash": "sha256:82dcb892b91e5cec3d3abb0ef98f02637516314240070158adf365369ea009dc",
-      "owners": [
-        "payments-platform"
-      ],
+      "owners": ["payments-platform"],
       "sidecars": [
         {
           "path": "domains/Payments/ubiquitous-language.mdx",
@@ -830,9 +776,7 @@
       "name": "Reviews & Ratings",
       "contentPath": "domains/Reviews/index.mdx",
       "contentHash": "sha256:5d8f7212fceb1c29e04ae25e22aeea6e230bbaa4e8daba564a7f3cf70a7c54bc",
-      "owners": [
-        "reviews-platform"
-      ],
+      "owners": ["reviews-platform"],
       "specifications": [
         {
           "type": "openapi",
@@ -948,9 +892,7 @@
       "name": "Shopping",
       "contentPath": "domains/Shopping/index.mdx",
       "contentHash": "sha256:013ccf530b88fb9b343966f85b4fdc74062afab262dbc9bc5b306cfae046920e",
-      "owners": [
-        "shopping-platform"
-      ],
+      "owners": ["shopping-platform"],
       "sidecars": [
         {
           "path": "domains/Shopping/ubiquitous-language.mdx",
@@ -993,9 +935,7 @@
       "name": "Authentication Session",
       "contentPath": "domains/Customer/entities/authentication-session/index.mdx",
       "contentHash": "sha256:2013fa6e82e44b2ee9c24619c01733803e3650b2f35b7aa5705e69fec0f19bff",
-      "owners": [
-        "customer-platform"
-      ]
+      "owners": ["customer-platform"]
     },
     {
       "type": "entity",
@@ -1004,9 +944,7 @@
       "name": "Cart",
       "contentPath": "domains/Shopping/entities/cart/index.mdx",
       "contentHash": "sha256:13e8c5197b46effe9fb67d88645df3acb5beeb0ea3f84af0c0163b6c0af0bf34",
-      "owners": [
-        "shopping-platform"
-      ]
+      "owners": ["shopping-platform"]
     },
     {
       "type": "entity",
@@ -1015,9 +953,7 @@
       "name": "Cart Item",
       "contentPath": "domains/Shopping/entities/cart-item/index.mdx",
       "contentHash": "sha256:24f5c084a504ff9292ea01ee893bd38e2a5ddc6aca2b3bf3acb0fbf59c466252",
-      "owners": [
-        "shopping-platform"
-      ]
+      "owners": ["shopping-platform"]
     },
     {
       "type": "entity",
@@ -1026,9 +962,7 @@
       "name": "Category",
       "contentPath": "domains/Catalog/entities/category/index.mdx",
       "contentHash": "sha256:e35fcfbcab26cc281a0cd273c1eac6bd323970334d550bf52537e9d8f3d68430",
-      "owners": [
-        "product-platform"
-      ]
+      "owners": ["product-platform"]
     },
     {
       "type": "entity",
@@ -1037,9 +971,7 @@
       "name": "Checkout Session",
       "contentPath": "domains/Ordering/entities/checkout-session/index.mdx",
       "contentHash": "sha256:3ee14c6040224665c474cb68424016f65360a0ab0f82ca735986bec6fcf0a835",
-      "owners": [
-        "ordering-platform"
-      ]
+      "owners": ["ordering-platform"]
     },
     {
       "type": "entity",
@@ -1048,9 +980,7 @@
       "name": "Customer Account",
       "contentPath": "domains/Customer/entities/customer-account/index.mdx",
       "contentHash": "sha256:fb88c9721d2b0485044b0bbfd5a05329a3377d2eeebe0541da035001ffba91b9",
-      "owners": [
-        "customer-platform"
-      ]
+      "owners": ["customer-platform"]
     },
     {
       "type": "entity",
@@ -1059,9 +989,7 @@
       "name": "Customer Address",
       "contentPath": "domains/Customer/entities/customer-address/index.mdx",
       "contentHash": "sha256:459070f15f7952a8b09979bc8f2b81d0210fefff716838741602d789e37f2ec2",
-      "owners": [
-        "customer-platform"
-      ]
+      "owners": ["customer-platform"]
     },
     {
       "type": "entity",
@@ -1070,9 +998,7 @@
       "name": "Customer Profile",
       "contentPath": "domains/Customer/entities/customer-profile/index.mdx",
       "contentHash": "sha256:560b630624fdb659713b9746509793de2adc266f051f23aa78442587d4d5dfc9",
-      "owners": [
-        "customer-platform"
-      ]
+      "owners": ["customer-platform"]
     },
     {
       "type": "entity",
@@ -1081,9 +1007,7 @@
       "name": "Discount",
       "contentPath": "domains/Shopping/entities/discount/index.mdx",
       "contentHash": "sha256:45b3a29a361f996eacee0d85ced8da2c998dc057cf24363bb775d04657ff65b0",
-      "owners": [
-        "shopping-platform"
-      ]
+      "owners": ["shopping-platform"]
     },
     {
       "type": "entity",
@@ -1092,9 +1016,7 @@
       "name": "Fraud Check",
       "contentPath": "domains/Payments/entities/fraud-check/index.mdx",
       "contentHash": "sha256:fb1b7161b2d1bec64ea64e9ba6884b7a9f1d59cf94d0ce5b5582c2f1e190d873",
-      "owners": [
-        "payments-platform"
-      ]
+      "owners": ["payments-platform"]
     },
     {
       "type": "entity",
@@ -1103,9 +1025,7 @@
       "name": "Inventory Reservation",
       "contentPath": "domains/Fulfilment/entities/inventory-reservation/index.mdx",
       "contentHash": "sha256:f7bce8239350941425a5e32562ed80e6175581a04680caa7e0fe9f88d1fd46be",
-      "owners": [
-        "fulfilment-platform"
-      ]
+      "owners": ["fulfilment-platform"]
     },
     {
       "type": "entity",
@@ -1114,9 +1034,7 @@
       "name": "Moderation Decision",
       "contentPath": "domains/Reviews/entities/moderation-decision/index.mdx",
       "contentHash": "sha256:d4693cd868bfb55f035763ff8ce9971875db0933cb3ce94d161ed6bf62f0f76c",
-      "owners": [
-        "reviews-platform"
-      ]
+      "owners": ["reviews-platform"]
     },
     {
       "type": "entity",
@@ -1125,9 +1043,7 @@
       "name": "Order",
       "contentPath": "domains/Ordering/entities/order/index.mdx",
       "contentHash": "sha256:0510ec6a21d0956735895b19bb910e6d5606bbef9f2d0e098ce92f6e3b1fef68",
-      "owners": [
-        "ordering-platform"
-      ]
+      "owners": ["ordering-platform"]
     },
     {
       "type": "entity",
@@ -1136,9 +1052,7 @@
       "name": "Order Line",
       "contentPath": "domains/Ordering/entities/order-line/index.mdx",
       "contentHash": "sha256:ef9395747d87801ffe60f64d542ddfef593cd2d66da3dfcee735fff8fa8df52c",
-      "owners": [
-        "ordering-platform"
-      ]
+      "owners": ["ordering-platform"]
     },
     {
       "type": "entity",
@@ -1147,9 +1061,7 @@
       "name": "Order Status History",
       "contentPath": "domains/Ordering/entities/order-status-history/index.mdx",
       "contentHash": "sha256:7fdb1ffbdc2bd41648506017d32d7e8f75f38293a39a2f4161aaba33687fa2f1",
-      "owners": [
-        "ordering-platform"
-      ]
+      "owners": ["ordering-platform"]
     },
     {
       "type": "entity",
@@ -1158,9 +1070,7 @@
       "name": "Payment",
       "contentPath": "domains/Payments/entities/payment/index.mdx",
       "contentHash": "sha256:d07eff34070105f0a088952a4e054ea4b4b2e141b5f122b5f034acbb2ff24426",
-      "owners": [
-        "payments-platform"
-      ]
+      "owners": ["payments-platform"]
     },
     {
       "type": "entity",
@@ -1169,9 +1079,7 @@
       "name": "Payment Authorization",
       "contentPath": "domains/Payments/entities/payment-authorization/index.mdx",
       "contentHash": "sha256:ed173c6eb128fe449231c71e2c3f741365643c9baa57a93ede67f8f8a9feda8d",
-      "owners": [
-        "payments-platform"
-      ]
+      "owners": ["payments-platform"]
     },
     {
       "type": "entity",
@@ -1180,9 +1088,7 @@
       "name": "Product",
       "contentPath": "domains/Catalog/entities/product/index.mdx",
       "contentHash": "sha256:a543f2c0ad0bd456b62008ab11d25a3a07956d64cb3294fa8a7882bb8f2e186e",
-      "owners": [
-        "product-platform"
-      ]
+      "owners": ["product-platform"]
     },
     {
       "type": "entity",
@@ -1191,9 +1097,7 @@
       "name": "Product Variant",
       "contentPath": "domains/Catalog/entities/product-variant/index.mdx",
       "contentHash": "sha256:344131f93c86111c846475819b4ae213ea2155ee412597d1eb8094ac8cdf3395",
-      "owners": [
-        "product-platform"
-      ]
+      "owners": ["product-platform"]
     },
     {
       "type": "entity",
@@ -1202,9 +1106,7 @@
       "name": "Promotion",
       "contentPath": "domains/Shopping/entities/promotion/index.mdx",
       "contentHash": "sha256:c236f1ed81af6111aecd30ea0edd74f18cf8cd369ac0fb079002280242534c87",
-      "owners": [
-        "shopping-platform"
-      ]
+      "owners": ["shopping-platform"]
     },
     {
       "type": "entity",
@@ -1213,9 +1115,7 @@
       "name": "Rating Summary",
       "contentPath": "domains/Reviews/entities/rating-summary/index.mdx",
       "contentHash": "sha256:826d1c04ae82cdfefb77e7898e27c3d3490bddbae1732ccfe798f58fc9eb7fdb",
-      "owners": [
-        "reviews-platform"
-      ]
+      "owners": ["reviews-platform"]
     },
     {
       "type": "entity",
@@ -1224,9 +1124,7 @@
       "name": "Refund",
       "contentPath": "domains/Payments/entities/refund/index.mdx",
       "contentHash": "sha256:eb5590e3ef60f0b62a8ad3114050dee6857f3bdf135b35148436597d16ce2af5",
-      "owners": [
-        "payments-platform"
-      ]
+      "owners": ["payments-platform"]
     },
     {
       "type": "entity",
@@ -1235,9 +1133,7 @@
       "name": "Review",
       "contentPath": "domains/Reviews/entities/review/index.mdx",
       "contentHash": "sha256:366551bdd368d9082d6dacc5de269ce1aae142f60e53cb1ee505d7c189b05c9f",
-      "owners": [
-        "reviews-platform"
-      ]
+      "owners": ["reviews-platform"]
     },
     {
       "type": "entity",
@@ -1246,9 +1142,7 @@
       "name": "Review Flag",
       "contentPath": "domains/Reviews/entities/review-flag/index.mdx",
       "contentHash": "sha256:fd66ed6031c497cec108f3305ceb081e1b0873deebe2f544dc91a05df3ae7b09",
-      "owners": [
-        "reviews-platform"
-      ]
+      "owners": ["reviews-platform"]
     },
     {
       "type": "entity",
@@ -1257,9 +1151,7 @@
       "name": "Review Vote",
       "contentPath": "domains/Reviews/entities/review-vote/index.mdx",
       "contentHash": "sha256:6cd86d97e921f785d7005e675d91a3fa520158a0ff59809b75805caf24fa9c64",
-      "owners": [
-        "reviews-platform"
-      ]
+      "owners": ["reviews-platform"]
     },
     {
       "type": "entity",
@@ -1268,9 +1160,7 @@
       "name": "Search Document",
       "contentPath": "domains/Catalog/entities/search-document/index.mdx",
       "contentHash": "sha256:eedc787bbf94f71a22364a8a0f59a9f7a792c68ff1f5613966197f708bfb4281",
-      "owners": [
-        "search-platform"
-      ]
+      "owners": ["search-platform"]
     },
     {
       "type": "entity",
@@ -1279,9 +1169,7 @@
       "name": "Shipment",
       "contentPath": "domains/Fulfilment/entities/shipment/index.mdx",
       "contentHash": "sha256:195db6af532bdd79d4d2b8d9256f510dd6d181e1a286dc130ab392e144ffb3ab",
-      "owners": [
-        "fulfilment-platform"
-      ]
+      "owners": ["fulfilment-platform"]
     },
     {
       "type": "entity",
@@ -1290,9 +1178,7 @@
       "name": "Stock Item",
       "contentPath": "domains/Fulfilment/entities/stock-item/index.mdx",
       "contentHash": "sha256:da08793f7992d3b84e2077a552dab91aaea028f4ec5aaa054ce906ce7e1befae",
-      "owners": [
-        "fulfilment-platform"
-      ]
+      "owners": ["fulfilment-platform"]
     },
     {
       "type": "entity",
@@ -1301,9 +1187,7 @@
       "name": "Warehouse Pick",
       "contentPath": "domains/Fulfilment/entities/warehouse-pick/index.mdx",
       "contentHash": "sha256:54408bf5ba5e8cc06592d144b9736fda55ff503fb1e0fbc5ccf70e4668797bd9",
-      "owners": [
-        "fulfilment-platform"
-      ]
+      "owners": ["fulfilment-platform"]
     },
     {
       "type": "event",
@@ -1312,9 +1196,7 @@
       "name": "Cart Checked Out",
       "contentPath": "domains/Shopping/systems/cart-system/services/CartAPI/events/CartCheckedOut/index.mdx",
       "contentHash": "sha256:a04639e4b42de63b5124533dc8a13ab5eac2cffdc8d2750362d64e04e4077290",
-      "owners": [
-        "shopping-platform"
-      ],
+      "owners": ["shopping-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -1330,9 +1212,7 @@
       "name": "Customer Authenticated",
       "contentPath": "domains/Customer/systems/identity-provider/services/OAuthAPI/events/CustomerAuthenticated/index.mdx",
       "contentHash": "sha256:6fb98c97e0e670a24534efcc5bbbc2eee8b6e57c04b83cf5864e99ae9dc12d6b",
-      "owners": [
-        "customer-platform"
-      ],
+      "owners": ["customer-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -1348,9 +1228,7 @@
       "name": "Customer Registered",
       "contentPath": "domains/Customer/systems/customer-management-system/services/CustomerAPI/events/CustomerRegistered/index.mdx",
       "contentHash": "sha256:c2656bef3e0cf36fd25843cd44115e03ac7f9a79b1a04ce5462254b8ea9c4859",
-      "owners": [
-        "customer-platform"
-      ],
+      "owners": ["customer-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -1366,9 +1244,7 @@
       "name": "Customer Updated",
       "contentPath": "domains/Customer/systems/customer-management-system/services/CustomerAPI/events/CustomerUpdated/index.mdx",
       "contentHash": "sha256:06c7b2eaf41a72807b32ba08f0d8f34b1f4ae4fc85e9f6dd5a238f1047573aa2",
-      "owners": [
-        "customer-platform"
-      ],
+      "owners": ["customer-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -1384,9 +1260,7 @@
       "name": "Discount Calculated",
       "contentPath": "domains/Shopping/systems/promotion-system/services/PromotionService/events/DiscountCalculated/index.mdx",
       "contentHash": "sha256:0e17391666ff7e5318264bab2af4d80be509073fe5eb9c3eb6ea0063583ad983",
-      "owners": [
-        "shopping-platform"
-      ],
+      "owners": ["shopping-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -1402,9 +1276,7 @@
       "name": "Fraud Check Failed",
       "contentPath": "domains/Payments/systems/fraud-detection/services/FraudAPI/events/FraudCheckFailed/index.mdx",
       "contentHash": "sha256:56a493a3e9369cba492f8d2aeb89af6f926130bd200b29eeb317701aeee2d123",
-      "owners": [
-        "payments-platform"
-      ],
+      "owners": ["payments-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -1420,9 +1292,7 @@
       "name": "Fraud Check Passed",
       "contentPath": "domains/Payments/systems/fraud-detection/services/FraudAPI/events/FraudCheckPassed/index.mdx",
       "contentHash": "sha256:f8d21c547ed420bea14e4eb7a73ecda50b153819f3fbe32fc100b612069b2147",
-      "owners": [
-        "payments-platform"
-      ],
+      "owners": ["payments-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -1438,9 +1308,7 @@
       "name": "Inventory Reserved",
       "contentPath": "domains/Fulfilment/systems/inventory-system/services/InventoryService/events/InventoryReserved/index.mdx",
       "contentHash": "sha256:54ed26f49ffcd48e677942e98402218a0af39ef4eabaf16c2018bcfb96679cda",
-      "owners": [
-        "fulfilment-platform"
-      ],
+      "owners": ["fulfilment-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -1456,9 +1324,7 @@
       "name": "Inventory Unavailable",
       "contentPath": "domains/Fulfilment/systems/inventory-system/services/InventoryService/events/InventoryUnavailable/index.mdx",
       "contentHash": "sha256:e6fb19aac2b6b8d795603750f334e3eef1da0ec292a991898d0e5538cb0a078e",
-      "owners": [
-        "fulfilment-platform"
-      ],
+      "owners": ["fulfilment-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -1474,9 +1340,7 @@
       "name": "Order Amended",
       "contentPath": "domains/Ordering/systems/order-management-system/services/OrderService/events/OrderAmended/index.mdx",
       "contentHash": "sha256:b6a9e5ee5d5250cc6b0829813435125254e6ee61c25c1bf2f8975ee7056aaf5f",
-      "owners": [
-        "ordering-platform"
-      ],
+      "owners": ["ordering-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -1492,9 +1356,7 @@
       "name": "Order Archived",
       "contentPath": "domains/Ordering/systems/order-management-system/services/OrderService/events/OrderArchived/index.mdx",
       "contentHash": "sha256:1f0333a638c6f2b99c04f1dc31adf68f66140e2a84d9a390edf06df94ec1ca5a",
-      "owners": [
-        "ordering-platform"
-      ],
+      "owners": ["ordering-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -1510,9 +1372,7 @@
       "name": "Order Cancelled",
       "contentPath": "domains/Ordering/systems/order-management-system/services/OrderService/events/OrderCancelled/index.mdx",
       "contentHash": "sha256:40a682a027b00c641a45cb49e856e5b60274b7f4edd64e7bf01c85d647231b98",
-      "owners": [
-        "ordering-platform"
-      ],
+      "owners": ["ordering-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -1528,9 +1388,7 @@
       "name": "Order Completed",
       "contentPath": "domains/Ordering/systems/order-management-system/services/OrderService/events/OrderCompleted/index.mdx",
       "contentHash": "sha256:9029654089b4aeead7915189d5300198556a33e4e1cdf541906811da29b5f74b",
-      "owners": [
-        "ordering-platform"
-      ],
+      "owners": ["ordering-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -1546,9 +1404,7 @@
       "name": "Order Confirmed",
       "contentPath": "domains/Ordering/systems/order-management-system/services/OrderService/events/OrderConfirmed/index.mdx",
       "contentHash": "sha256:636963f59ccc0ad83199f328bcd24cc17680e73581870827ea8c53cf150ccdf6",
-      "owners": [
-        "ordering-platform"
-      ],
+      "owners": ["ordering-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -1564,9 +1420,7 @@
       "name": "Order Created",
       "contentPath": "domains/Ordering/systems/order-management-system/services/OrderService/events/OrderCreated/index.mdx",
       "contentHash": "sha256:93e32711132a7fb660e478eaf9155531e70bf7d92511c02b6b645ebe4ebc31b0",
-      "owners": [
-        "ordering-platform"
-      ],
+      "owners": ["ordering-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -1582,9 +1436,7 @@
       "name": "Order Created",
       "contentPath": "domains/Ordering/systems/order-management-system/services/OrderService/events/OrderCreated/versioned/0.6.0/index.mdx",
       "contentHash": "sha256:c9da26cf097e09d0423565d8ffea75f7c8c2b1e1fede038bf16de0e8b0b4384d",
-      "owners": [
-        "ordering-platform"
-      ],
+      "owners": ["ordering-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -1600,9 +1452,7 @@
       "name": "Order Created",
       "contentPath": "domains/Ordering/systems/order-management-system/services/OrderService/events/OrderCreated/versioned/0.3.0/index.mdx",
       "contentHash": "sha256:314e14146fb80ce3425a01460102bf945eb2698af5eec9f59916047e1a4f014f",
-      "owners": [
-        "ordering-platform"
-      ],
+      "owners": ["ordering-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -1618,9 +1468,7 @@
       "name": "Order Delivery Address Changed",
       "contentPath": "domains/Ordering/systems/order-management-system/services/OrderService/events/OrderDeliveryAddressChanged/index.mdx",
       "contentHash": "sha256:62408a60bf04499b857c46c112fd3018c77e9a4c1ce35a85544732ea533909b1",
-      "owners": [
-        "ordering-platform"
-      ],
+      "owners": ["ordering-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -1636,9 +1484,7 @@
       "name": "Order Fulfilment Started",
       "contentPath": "domains/Ordering/systems/order-management-system/services/OrderService/events/OrderFulfilmentStarted/index.mdx",
       "contentHash": "sha256:555ac845cf9ec5775972b12cecc006d2ef969baf58cd85c4bb6d178e05c16ced",
-      "owners": [
-        "ordering-platform"
-      ],
+      "owners": ["ordering-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -1654,9 +1500,7 @@
       "name": "Order Hold Released",
       "contentPath": "domains/Ordering/systems/order-management-system/services/OrderService/events/OrderHoldReleased/index.mdx",
       "contentHash": "sha256:7f44d1b27e6c599550fd0790094eac402ef7247406f781fa47fb543ebe7191b7",
-      "owners": [
-        "ordering-platform"
-      ],
+      "owners": ["ordering-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -1672,9 +1516,7 @@
       "name": "Order Packed",
       "contentPath": "domains/Fulfilment/systems/warehouse-system/services/PickingWorker/events/OrderPacked/index.mdx",
       "contentHash": "sha256:963bc6551b123549927d9ecaa111e5877a525cecdb56e375fd1492fa2d515bf2",
-      "owners": [
-        "fulfilment-platform"
-      ],
+      "owners": ["fulfilment-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -1690,9 +1532,7 @@
       "name": "Order Placed On Hold",
       "contentPath": "domains/Ordering/systems/order-management-system/services/OrderService/events/OrderPlacedOnHold/index.mdx",
       "contentHash": "sha256:a4ac2a2773712fbf3f7a5636d0353e5af39f909f7b8b2d377713412bf24802f7",
-      "owners": [
-        "ordering-platform"
-      ],
+      "owners": ["ordering-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -1708,9 +1548,7 @@
       "name": "Order Ready For Shipping",
       "contentPath": "domains/Fulfilment/systems/warehouse-system/services/WarehouseService/events/OrderReadyForShipping/index.mdx",
       "contentHash": "sha256:5dfb23724776e2814703630962b157ef7efb3f71dcd05a53c3e381fe029263e6",
-      "owners": [
-        "fulfilment-platform"
-      ],
+      "owners": ["fulfilment-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -1726,9 +1564,7 @@
       "name": "Order Status Changed",
       "contentPath": "domains/Ordering/systems/order-management-system/services/OrderService/events/OrderStatusChanged/index.mdx",
       "contentHash": "sha256:7b332a4731b6b299e406a90533e0abbfa1d05573e612a02e36e262cffb355fc0",
-      "owners": [
-        "ordering-platform"
-      ],
+      "owners": ["ordering-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -1744,9 +1580,7 @@
       "name": "Payment Failed",
       "contentPath": "domains/Payments/systems/stripe/services/StripeWebhookEndpoint/events/PaymentFailed/index.mdx",
       "contentHash": "sha256:423fb82c1690e8f49e446a0583c47546481d793383eeea524d26ca4b527a956e",
-      "owners": [
-        "payments-platform"
-      ],
+      "owners": ["payments-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -1762,9 +1596,7 @@
       "name": "Payment Requested",
       "contentPath": "domains/Payments/systems/payment-processing-system/services/PaymentWorker/events/PaymentRequested/index.mdx",
       "contentHash": "sha256:67db48cc0527ebd98e780ff2884ca93f762311f3fc8ba86d899b5f542cc481f2",
-      "owners": [
-        "payments-platform"
-      ],
+      "owners": ["payments-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -1780,9 +1612,7 @@
       "name": "Payment Succeeded",
       "contentPath": "domains/Payments/systems/stripe/services/StripeWebhookEndpoint/events/PaymentSucceeded/index.mdx",
       "contentHash": "sha256:4d166455f15f000435e8ebee4c735442dad4577530b12633a02c1a28a68388ad",
-      "owners": [
-        "payments-platform"
-      ],
+      "owners": ["payments-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -1798,9 +1628,7 @@
       "name": "Product Created",
       "contentPath": "domains/Catalog/systems/product-catalog-system/services/ProductAPI/events/ProductCreated/index.mdx",
       "contentHash": "sha256:e1f9a5a4e9c6e0373501a8eb7088fcf134544e47a71de6e3f9e1b3618e347b02",
-      "owners": [
-        "product-platform"
-      ],
+      "owners": ["product-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -1816,9 +1644,7 @@
       "name": "Product Deleted",
       "contentPath": "domains/Catalog/systems/product-catalog-system/services/ProductAPI/events/ProductDeleted/index.mdx",
       "contentHash": "sha256:2ab5906b2b54e86789f464c030fea4e7f9624082081b21500a3a0b51b2c5f2c2",
-      "owners": [
-        "product-platform"
-      ],
+      "owners": ["product-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -1834,9 +1660,7 @@
       "name": "Product Updated",
       "contentPath": "domains/Catalog/systems/product-catalog-system/services/ProductAPI/events/ProductUpdated/index.mdx",
       "contentHash": "sha256:c27b06cd5369639ca4eda268af8b8158cacde6646ce9053cbf3c39b0d20e4879",
-      "owners": [
-        "product-platform"
-      ],
+      "owners": ["product-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -1852,9 +1676,7 @@
       "name": "Rating Updated",
       "contentPath": "domains/Reviews/services/RatingAggregator/events/rating-updated/index.mdx",
       "contentHash": "sha256:0aa40cf2d95dcb22ca3bfc9ca835ef050f6321365ab65172cdcea4fbf0f3f13b",
-      "owners": [
-        "reviews-platform"
-      ],
+      "owners": ["reviews-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -1870,9 +1692,7 @@
       "name": "Refund Processed",
       "contentPath": "domains/Payments/systems/stripe/services/StripeWebhookEndpoint/events/RefundProcessed/index.mdx",
       "contentHash": "sha256:5fab76c0a685b1bc26b41d0ca106158cd638aa3d45f3b8f56e4afe95f76ef2bb",
-      "owners": [
-        "payments-platform"
-      ],
+      "owners": ["payments-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -1888,9 +1708,7 @@
       "name": "Refund Requested",
       "contentPath": "domains/Payments/systems/payment-processing-system/services/PaymentWorker/events/RefundRequested/index.mdx",
       "contentHash": "sha256:c06b201508538f37e6d00878ab63f03d34fb5130e5445d993bcdc180a52f0aff",
-      "owners": [
-        "payments-platform"
-      ],
+      "owners": ["payments-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -1906,9 +1724,7 @@
       "name": "Review Flagged",
       "contentPath": "domains/Reviews/services/ReviewAPI/events/review-flagged/index.mdx",
       "contentHash": "sha256:b6703a382299791339fbdb9337c4d9e223f94603d3be8296f1e9b63d7130aec9",
-      "owners": [
-        "reviews-platform"
-      ],
+      "owners": ["reviews-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -1924,9 +1740,7 @@
       "name": "Review Helpful Voted",
       "contentPath": "domains/Reviews/services/ReviewAPI/events/review-helpful-voted/index.mdx",
       "contentHash": "sha256:61b3430cf7f553490d5ff5f0624a25961ccaea33ebba76dc81a178668cc63999",
-      "owners": [
-        "reviews-platform"
-      ],
+      "owners": ["reviews-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -1942,9 +1756,7 @@
       "name": "Review Published",
       "contentPath": "domains/Reviews/services/ReviewModerationWorker/events/review-published/index.mdx",
       "contentHash": "sha256:a4ad0789f3e123ef6011a2e2a95580dcf9881d41b556f8fb9dc3c39679f9871b",
-      "owners": [
-        "reviews-platform"
-      ],
+      "owners": ["reviews-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -1960,9 +1772,7 @@
       "name": "Review Rejected",
       "contentPath": "domains/Reviews/services/ReviewModerationWorker/events/review-rejected/index.mdx",
       "contentHash": "sha256:349c419f78e405790b9b1001b0f36723100bb81ae0a494eaa8ae33b5ca405836",
-      "owners": [
-        "reviews-platform"
-      ],
+      "owners": ["reviews-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -1978,9 +1788,7 @@
       "name": "Review Submitted",
       "contentPath": "domains/Reviews/services/ReviewAPI/events/review-submitted/index.mdx",
       "contentHash": "sha256:c53eb50074a8e0857c37d84e5ff7828e1b79508bd771e787745acc8bdf61552d",
-      "owners": [
-        "reviews-platform"
-      ],
+      "owners": ["reviews-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -1996,9 +1804,7 @@
       "name": "Shipment Created",
       "contentPath": "domains/Fulfilment/systems/carrier/services/CarrierTrackingAPI/events/ShipmentCreated/index.mdx",
       "contentHash": "sha256:42a936b002bfc3c81126f78b6e43cbfdcdb3961d224e254918bb3dacca064299",
-      "owners": [
-        "fulfilment-platform"
-      ],
+      "owners": ["fulfilment-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -2014,9 +1820,7 @@
       "name": "Shipment Delivered",
       "contentPath": "domains/Fulfilment/systems/carrier/services/CarrierTrackingAPI/events/ShipmentDelivered/index.mdx",
       "contentHash": "sha256:ded00744eb8f809c9f3f5f62bfffe6f434754a14c067b47d3730f8b761054bc1",
-      "owners": [
-        "fulfilment-platform"
-      ],
+      "owners": ["fulfilment-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -2032,9 +1836,7 @@
       "name": "Shipment Failed",
       "contentPath": "domains/Fulfilment/systems/carrier/services/CarrierTrackingAPI/events/ShipmentFailed/index.mdx",
       "contentHash": "sha256:48dc7e9c1315366924056fe853e8728469ef79f47b9b9d66fc3d577d06955644",
-      "owners": [
-        "fulfilment-platform"
-      ],
+      "owners": ["fulfilment-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -2050,9 +1852,7 @@
       "name": "Checkout Saga",
       "contentPath": "domains/Ordering/systems/checkout-system/flows/CheckoutSaga/index.mdx",
       "contentHash": "sha256:5d22c06fda75bcb53ede4bd5860252bfc4ce58a3e015386c1895295ee61999d7",
-      "owners": [
-        "ordering-platform"
-      ],
+      "owners": ["ordering-platform"],
       "references": [
         {
           "kind": "message",
@@ -2093,9 +1893,7 @@
       "name": "Order Cancellation",
       "contentPath": "domains/Ordering/systems/order-management-system/flows/OrderCancellation/index.mdx",
       "contentHash": "sha256:0db604e655dee81b049ea49960ecf48d82d92b1fdc191e0ead704ecfd60b34d5",
-      "owners": [
-        "ordering-platform"
-      ],
+      "owners": ["ordering-platform"],
       "references": [
         {
           "kind": "message",
@@ -2125,9 +1923,7 @@
       "name": "Place an Order",
       "contentPath": "domains/Ordering/flows/PlaceAnOrder/index.mdx",
       "contentHash": "sha256:a0bc2d64cfce55a17ae5118c25c7b227cf83558a0d3bfae0bb20c4543d1e4506",
-      "owners": [
-        "ordering-platform"
-      ],
+      "owners": ["ordering-platform"],
       "references": [
         {
           "kind": "message",
@@ -2193,9 +1989,7 @@
       "name": "Product Search Indexing",
       "contentPath": "domains/Catalog/systems/search-system/flows/ProductSearchIndexing/index.mdx",
       "contentHash": "sha256:eea8987eca0408e6a4cc53f8f4d5379946b9902c1ab7dfe779135c1bbb4a5cfd",
-      "owners": [
-        "search-platform"
-      ],
+      "owners": ["search-platform"],
       "references": [
         {
           "kind": "service",
@@ -2244,9 +2038,7 @@
       "name": "Review Submission",
       "contentPath": "domains/Reviews/flows/review-submission/index.mdx",
       "contentHash": "sha256:e7d5a4ba77445cd62c68fca3b6c3643295bc2c572a0a9dc79d92ac185aac7ad5",
-      "owners": [
-        "reviews-platform"
-      ],
+      "owners": ["reviews-platform"],
       "references": [
         {
           "kind": "service",
@@ -2295,9 +2087,7 @@
       "name": "Get Customer",
       "contentPath": "domains/Customer/systems/customer-management-system/services/CustomerAPI/queries/GetCustomer/index.mdx",
       "contentHash": "sha256:6c802a77ffdabbd7c001b1a328a9968cabb63319c2cc5d967dcaaffd850cb424",
-      "owners": [
-        "customer-platform"
-      ],
+      "owners": ["customer-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -2313,9 +2103,7 @@
       "name": "Get Order",
       "contentPath": "domains/Ordering/systems/order-management-system/services/OrderService/queries/GetOrder/index.mdx",
       "contentHash": "sha256:ab5969012363be01584ac52e0f0974216826b8def5ab8b06bac87a93ce3fe657",
-      "owners": [
-        "ordering-platform"
-      ],
+      "owners": ["ordering-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -2331,9 +2119,7 @@
       "name": "Get Product",
       "contentPath": "domains/Catalog/systems/product-catalog-system/services/ProductAPI/queries/GetProduct/index.mdx",
       "contentHash": "sha256:ba1274e127aa40b2fd8c1bbfb3defa7b4dcef5d3d896f0522487d37fcb28ea53",
-      "owners": [
-        "product-platform"
-      ],
+      "owners": ["product-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -2349,9 +2135,7 @@
       "name": "Get Product Reviews",
       "contentPath": "domains/Reviews/services/ReviewAPI/queries/get-product-reviews/index.mdx",
       "contentHash": "sha256:f4cb0f9f112137eab2a1c356993a12415487fc1ab68949784d51b5f8b373a172",
-      "owners": [
-        "reviews-platform"
-      ],
+      "owners": ["reviews-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -2367,9 +2151,7 @@
       "name": "Get Stock Level",
       "contentPath": "domains/Fulfilment/systems/inventory-system/services/InventoryService/queries/GetStockLevel/index.mdx",
       "contentHash": "sha256:33375b042f9f2b51b159a8ca15cff7e77e6aa4b2aca4b732c9b1e24a3ee8780d",
-      "owners": [
-        "fulfilment-platform"
-      ],
+      "owners": ["fulfilment-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -2385,9 +2167,7 @@
       "name": "Search Products",
       "contentPath": "domains/Catalog/systems/search-system/services/SearchAPI/queries/SearchProducts/index.mdx",
       "contentHash": "sha256:e02a0060acbfd9cd4e0405ef76a6cebb055ec7a95b6947fc67e6b4f29951b584",
-      "owners": [
-        "search-platform"
-      ],
+      "owners": ["search-platform"],
       "schemas": [
         {
           "path": "schema.json",
@@ -2403,9 +2183,7 @@
       "name": "Carrier Adapter",
       "contentPath": "domains/Fulfilment/systems/shipping-system/services/CarrierAdapter/index.mdx",
       "contentHash": "sha256:1194ad01f16f233dadefa14925ec4af2cd73715f03bac9bae45e5c27650e423d",
-      "owners": [
-        "fulfilment-platform"
-      ],
+      "owners": ["fulfilment-platform"],
       "sends": [
         {
           "id": "create-shipment",
@@ -2420,9 +2198,7 @@
       "name": "Shipping API",
       "contentPath": "domains/Fulfilment/systems/carrier/services/CarrierShippingAPI/index.mdx",
       "contentHash": "sha256:a106c0dcc0e853de68dc765501a14a75dbe16523056023fa9d0a7240ad90fa70",
-      "owners": [
-        "fulfilment-platform"
-      ],
+      "owners": ["fulfilment-platform"],
       "receives": [
         {
           "id": "create-shipment",
@@ -2437,9 +2213,7 @@
       "name": "Tracking API",
       "contentPath": "domains/Fulfilment/systems/carrier/services/CarrierTrackingAPI/index.mdx",
       "contentHash": "sha256:aa38f11ebb650eafa0c0a9ef1ead89befe179d0ca4b223050cb22e215351d3a5",
-      "owners": [
-        "fulfilment-platform"
-      ],
+      "owners": ["fulfilment-platform"],
       "sends": [
         {
           "id": "shipment-created",
@@ -2462,9 +2236,7 @@
       "name": "Cart API",
       "contentPath": "domains/Shopping/systems/cart-system/services/CartAPI/index.mdx",
       "contentHash": "sha256:eb381f0cf346618df09415a2b0eda11f4f52b24b240c38d664e025a1ba941080",
-      "owners": [
-        "shopping-platform"
-      ],
+      "owners": ["shopping-platform"],
       "specifications": [
         {
           "type": "openapi",
@@ -2521,9 +2293,7 @@
       "name": "Checkout API",
       "contentPath": "domains/Ordering/systems/checkout-system/services/CheckoutAPI/index.mdx",
       "contentHash": "sha256:6cb716edeac80b6ea038e75e10d07e3fe46cd88b08e8cc76bf6060a7ea26367b",
-      "owners": [
-        "ordering-platform"
-      ],
+      "owners": ["ordering-platform"],
       "receives": [
         {
           "id": "checkout-cart",
@@ -2538,9 +2308,7 @@
       "name": "Checkout Orchestrator",
       "contentPath": "domains/Ordering/systems/checkout-system/services/CheckoutOrchestrator/index.mdx",
       "contentHash": "sha256:71bffdf03696cfc7103373e98e8f7225b55710f2e9fa28dcabcb08ffff3989a5",
-      "owners": [
-        "ordering-platform"
-      ],
+      "owners": ["ordering-platform"],
       "sends": [
         {
           "id": "reserve-inventory",
@@ -2563,9 +2331,7 @@
       "name": "Customer API",
       "contentPath": "domains/Customer/systems/customer-management-system/services/CustomerAPI/index.mdx",
       "contentHash": "sha256:5e17549a539f95cf781b0add84c974af553ae799bbd47043dcf1cec4dab1c3a8",
-      "owners": [
-        "customer-platform"
-      ],
+      "owners": ["customer-platform"],
       "specifications": [
         {
           "type": "openapi",
@@ -2630,9 +2396,7 @@
       "name": "Fraud API",
       "contentPath": "domains/Payments/systems/fraud-detection/services/FraudAPI/index.mdx",
       "contentHash": "sha256:932017c595046697606a669cb2a324b15e4e7f0377855b9d78809c62b9aff05b",
-      "owners": [
-        "payments-platform"
-      ],
+      "owners": ["payments-platform"],
       "sends": [
         {
           "id": "fraud-check-passed",
@@ -2657,9 +2421,7 @@
       "name": "Inventory Service",
       "contentPath": "domains/Fulfilment/systems/inventory-system/services/InventoryService/index.mdx",
       "contentHash": "sha256:ab784d0b72d31fa49a6d40cc22db6620a59505bac10576527abd26c3d59ba798",
-      "owners": [
-        "fulfilment-platform"
-      ],
+      "owners": ["fulfilment-platform"],
       "sends": [
         {
           "id": "inventory-reserved",
@@ -2714,9 +2476,7 @@
       "name": "OAuth API",
       "contentPath": "domains/Customer/systems/identity-provider/services/OAuthAPI/index.mdx",
       "contentHash": "sha256:c0655f4ce95d422a1cf95d05902de331876dac094a5330be65586175ccb44824",
-      "owners": [
-        "customer-platform"
-      ],
+      "owners": ["customer-platform"],
       "sends": [
         {
           "id": "customer-authenticated",
@@ -2742,9 +2502,7 @@
       "name": "Order Service",
       "contentPath": "domains/Ordering/systems/order-management-system/services/OrderService/index.mdx",
       "contentHash": "sha256:6603ecb47b7fbf521db0c9b9499304ab75d086cd837de3200101707500fc5907",
-      "owners": [
-        "ordering-platform"
-      ],
+      "owners": ["ordering-platform"],
       "specifications": [
         {
           "type": "asyncapi",
@@ -2845,9 +2603,7 @@
       "name": "Payment API",
       "contentPath": "domains/Payments/systems/payment-processing-system/services/PaymentAPI/index.mdx",
       "contentHash": "sha256:0678b124dbfa077a6f9957fb03f248ed4816dc25f5a8167c1fe17f0abf29144b",
-      "owners": [
-        "payments-platform"
-      ],
+      "owners": ["payments-platform"],
       "receives": [
         {
           "id": "authorize-payment",
@@ -2872,9 +2628,7 @@
       "name": "Payment Worker",
       "contentPath": "domains/Payments/systems/payment-processing-system/services/PaymentWorker/index.mdx",
       "contentHash": "sha256:d4b1681bf27fe7042d1de20d1b2ad1971a1b8c3e2a9c09d996b11a2b578ae621",
-      "owners": [
-        "payments-platform"
-      ],
+      "owners": ["payments-platform"],
       "sends": [
         {
           "id": "payment-requested",
@@ -2913,9 +2667,7 @@
       "name": "Picking Worker",
       "contentPath": "domains/Fulfilment/systems/warehouse-system/services/PickingWorker/index.mdx",
       "contentHash": "sha256:496cadc6168e1b0fce2090a86bc26014144222375b6db79cae694a59bd401f85",
-      "owners": [
-        "fulfilment-platform"
-      ],
+      "owners": ["fulfilment-platform"],
       "sends": [
         {
           "id": "order-packed",
@@ -2940,9 +2692,7 @@
       "name": "Product API",
       "contentPath": "domains/Catalog/systems/product-catalog-system/services/ProductAPI/index.mdx",
       "contentHash": "sha256:0a3d73879bba3a2719e9d013d19f884693e4dd06328e0f88b4ee7a1c68318bcc",
-      "owners": [
-        "product-platform"
-      ],
+      "owners": ["product-platform"],
       "specifications": [
         {
           "type": "openapi",
@@ -2987,9 +2737,7 @@
       "name": "Product Search Publisher",
       "contentPath": "domains/Catalog/systems/product-catalog-system/services/ProductSearchPublisher/index.mdx",
       "contentHash": "sha256:9d2a6756bb5804c706d9005e42a9f1dbd6e7bace9e01a86ed3104cb85f04551e",
-      "owners": [
-        "product-platform"
-      ],
+      "owners": ["product-platform"],
       "sends": [
         {
           "id": "product-created",
@@ -3017,9 +2765,7 @@
       "name": "Product Worker",
       "contentPath": "domains/Catalog/systems/product-catalog-system/services/ProductWorker/index.mdx",
       "contentHash": "sha256:adf3f9fdb74608583125b78bcb273dfb76c96330182581a7077592c2e8a351d1",
-      "owners": [
-        "product-platform"
-      ],
+      "owners": ["product-platform"],
       "writesTo": [
         {
           "id": "product-database"
@@ -3038,9 +2784,7 @@
       "name": "Promotion Service",
       "contentPath": "domains/Shopping/systems/promotion-system/services/PromotionService/index.mdx",
       "contentHash": "sha256:e0cfb37cdf3efb1d2e663b331ba827afdc612d28f411da8bb2c4e4c62f601371",
-      "owners": [
-        "shopping-platform"
-      ],
+      "owners": ["shopping-platform"],
       "sends": [
         {
           "id": "discount-calculated",
@@ -3066,9 +2810,7 @@
       "name": "Rating Aggregator",
       "contentPath": "domains/Reviews/services/RatingAggregator/index.mdx",
       "contentHash": "sha256:b07c78b76dcc84cf5c816e36f17647a103ec67c0e38ed5ef9c9f3870ee76edde",
-      "owners": [
-        "reviews-platform"
-      ],
+      "owners": ["reviews-platform"],
       "sends": [
         {
           "id": "rating-updated",
@@ -3102,9 +2844,7 @@
       "name": "Review API",
       "contentPath": "domains/Reviews/services/ReviewAPI/index.mdx",
       "contentHash": "sha256:f3f5c2dae565225460249cc415a19e1759ea8837d09c44c531b0911f3b6253a0",
-      "owners": [
-        "reviews-platform"
-      ],
+      "owners": ["reviews-platform"],
       "sends": [
         {
           "id": "review-submitted",
@@ -3179,9 +2919,7 @@
       "name": "Review Moderation Worker",
       "contentPath": "domains/Reviews/services/ReviewModerationWorker/index.mdx",
       "contentHash": "sha256:2b66e27f7fbd0f1a713fa8086193052ba085549ca6859e8f8c169b0f40c36ffd",
-      "owners": [
-        "reviews-platform"
-      ],
+      "owners": ["reviews-platform"],
       "sends": [
         {
           "id": "review-published",
@@ -3272,9 +3010,7 @@
       "name": "Search API",
       "contentPath": "domains/Catalog/systems/search-system/services/SearchAPI/index.mdx",
       "contentHash": "sha256:8e6443b5e473763d4cf2fc519f2881cc8a559b38b72db16d53bb122bf2ce916d",
-      "owners": [
-        "search-platform"
-      ],
+      "owners": ["search-platform"],
       "specifications": [
         {
           "type": "openapi",
@@ -3302,9 +3038,7 @@
       "name": "Search Indexer",
       "contentPath": "domains/Catalog/systems/search-system/services/SearchIndexer/index.mdx",
       "contentHash": "sha256:a17f511a27a86746d7f0801fac55dfde5e3d4ec234e69d479d6eedc340871730",
-      "owners": [
-        "search-platform"
-      ],
+      "owners": ["search-platform"],
       "receives": [
         {
           "id": "product-created",
@@ -3332,9 +3066,7 @@
       "name": "Shipping API",
       "contentPath": "domains/Fulfilment/systems/shipping-system/services/ShippingAPI/index.mdx",
       "contentHash": "sha256:7df18c714ce25d3886e622777d159f150e8ea4c6888f14411194054a6cb26dfe",
-      "owners": [
-        "fulfilment-platform"
-      ],
+      "owners": ["fulfilment-platform"],
       "receives": [
         {
           "id": "order-ready-for-shipping",
@@ -3349,9 +3081,7 @@
       "name": "Payments API",
       "contentPath": "domains/Payments/systems/stripe/services/StripePaymentsAPI/index.mdx",
       "contentHash": "sha256:d7b9837a988fb26b4e238578611e30defb975f25bc7b4d69f0abec583854dec4",
-      "owners": [
-        "payments-platform"
-      ],
+      "owners": ["payments-platform"],
       "receives": [
         {
           "id": "payment-requested",
@@ -3370,9 +3100,7 @@
       "name": "Webhook Endpoint",
       "contentPath": "domains/Payments/systems/stripe/services/StripeWebhookEndpoint/index.mdx",
       "contentHash": "sha256:dbfc35004da0d76264be521b176e988f83683fa72e591ea4a3411a6120250589",
-      "owners": [
-        "payments-platform"
-      ],
+      "owners": ["payments-platform"],
       "sends": [
         {
           "id": "payment-succeeded",
@@ -3395,9 +3123,7 @@
       "name": "Warehouse Service",
       "contentPath": "domains/Fulfilment/systems/warehouse-system/services/WarehouseService/index.mdx",
       "contentHash": "sha256:5901cf452763f2b3e4f62670d2b453f58ef16018804e0d6c84ff96d2b38fa9f4",
-      "owners": [
-        "fulfilment-platform"
-      ],
+      "owners": ["fulfilment-platform"],
       "sends": [
         {
           "id": "order-ready-for-shipping",
@@ -3428,9 +3154,7 @@
       "name": "Carrier",
       "contentPath": "domains/Fulfilment/systems/carrier/index.mdx",
       "contentHash": "sha256:a2d22fdb7c62a55f66439cb4e3c0f4e75dd452d757e054980b2379ffa687d3d8",
-      "owners": [
-        "fulfilment-platform"
-      ],
+      "owners": ["fulfilment-platform"],
       "services": [
         {
           "id": "carrier-shipping-api"
@@ -3453,9 +3177,7 @@
       "name": "Cart System",
       "contentPath": "domains/Shopping/systems/cart-system/index.mdx",
       "contentHash": "sha256:3b89ccf6acf17443fb6874ee89a647e43a386fd7bc511c1abb529917f27a994a",
-      "owners": [
-        "shopping-platform"
-      ],
+      "owners": ["shopping-platform"],
       "services": [
         {
           "id": "cart-api"
@@ -3488,9 +3210,7 @@
       "name": "Checkout System",
       "contentPath": "domains/Ordering/systems/checkout-system/index.mdx",
       "contentHash": "sha256:9df555d237da11df686f4346f18d7964902d39d5ca34ef4430c01a195ed93d66",
-      "owners": [
-        "ordering-platform"
-      ],
+      "owners": ["ordering-platform"],
       "services": [
         {
           "id": "checkout-api"
@@ -3527,9 +3247,7 @@
       "name": "Customer Management System",
       "contentPath": "domains/Customer/systems/customer-management-system/index.mdx",
       "contentHash": "sha256:b6361cb86b544f413cf8ae25b1bb8fb6cc51ce030c4c18f8abccfd4a88ebf381",
-      "owners": [
-        "customer-platform"
-      ],
+      "owners": ["customer-platform"],
       "services": [
         {
           "id": "customer-api"
@@ -3568,9 +3286,7 @@
       "name": "Fraud Detection",
       "contentPath": "domains/Payments/systems/fraud-detection/index.mdx",
       "contentHash": "sha256:29e00250036fcacf881a6fb10064f569f30694d2c24a59d29e0fb735454ce31d",
-      "owners": [
-        "payments-platform"
-      ],
+      "owners": ["payments-platform"],
       "services": [
         {
           "id": "fraud-api"
@@ -3590,9 +3306,7 @@
       "name": "Identity Provider",
       "contentPath": "domains/Customer/systems/identity-provider/index.mdx",
       "contentHash": "sha256:747ba079f40e7b82fc7f8197e37edbd0dabe11ba1bf015b3e2a02b29c67c75b3",
-      "owners": [
-        "customer-platform"
-      ],
+      "owners": ["customer-platform"],
       "services": [
         {
           "id": "oauth-api"
@@ -3625,9 +3339,7 @@
       "name": "Inventory System",
       "contentPath": "domains/Fulfilment/systems/inventory-system/index.mdx",
       "contentHash": "sha256:a88d7076165db3888ca9e807d7ec06a94944776d9049d8875f6007309ea7ffb1",
-      "owners": [
-        "fulfilment-platform"
-      ],
+      "owners": ["fulfilment-platform"],
       "services": [
         {
           "id": "inventory-service"
@@ -3652,9 +3364,7 @@
       "name": "Order Management System",
       "contentPath": "domains/Ordering/systems/order-management-system/index.mdx",
       "contentHash": "sha256:72cb22f41588c983432fa578290a003c8f13081f5890be351cf6fba03afb6713",
-      "owners": [
-        "ordering-platform"
-      ],
+      "owners": ["ordering-platform"],
       "services": [
         {
           "id": "order-service"
@@ -3685,9 +3395,7 @@
       "name": "Payment Processing System",
       "contentPath": "domains/Payments/systems/payment-processing-system/index.mdx",
       "contentHash": "sha256:e1a217680abdef59166f26371d05648b1246461835f3b4fc75fd0239e59edd1c",
-      "owners": [
-        "payments-platform"
-      ],
+      "owners": ["payments-platform"],
       "services": [
         {
           "id": "payment-api"
@@ -3719,9 +3427,7 @@
       "name": "Product Catalog System",
       "contentPath": "domains/Catalog/systems/product-catalog-system/index.mdx",
       "contentHash": "sha256:90524af32593eef0ed601bd7a81cbdc2c2d544b180390f230c3ebc0a904f414f",
-      "owners": [
-        "product-platform"
-      ],
+      "owners": ["product-platform"],
       "services": [
         {
           "id": "product-api"
@@ -3766,9 +3472,7 @@
       "name": "Promotion System",
       "contentPath": "domains/Shopping/systems/promotion-system/index.mdx",
       "contentHash": "sha256:146f2cddf6af2edd54271a719d765050f4806287dbc9ef2e5a55fc89f0066759",
-      "owners": [
-        "shopping-platform"
-      ],
+      "owners": ["shopping-platform"],
       "services": [
         {
           "id": "promotion-service"
@@ -3793,9 +3497,7 @@
       "name": "Search System",
       "contentPath": "domains/Catalog/systems/search-system/index.mdx",
       "contentHash": "sha256:39d88953fc10b9accd655d8cd82e6f5365dfa760203c923f398cd352b83e2092",
-      "owners": [
-        "search-platform"
-      ],
+      "owners": ["search-platform"],
       "services": [
         {
           "id": "search-api"
@@ -3843,9 +3545,7 @@
       "name": "Shipping System",
       "contentPath": "domains/Fulfilment/systems/shipping-system/index.mdx",
       "contentHash": "sha256:48afd68c277e5ddba65c2f5b4ed9ff7abbdcd426494e7c26e43c2cdea885e356",
-      "owners": [
-        "fulfilment-platform"
-      ],
+      "owners": ["fulfilment-platform"],
       "services": [
         {
           "id": "shipping-api"
@@ -3868,9 +3568,7 @@
       "name": "Stripe",
       "contentPath": "domains/Payments/systems/stripe/index.mdx",
       "contentHash": "sha256:6463ce40da6017ae82b4b951405181f55b3c688a7ad3ae12c55a95ef2a36fadd",
-      "owners": [
-        "payments-platform"
-      ],
+      "owners": ["payments-platform"],
       "services": [
         {
           "id": "stripe-payments-api"
@@ -3893,9 +3591,7 @@
       "name": "Warehouse System",
       "contentPath": "domains/Fulfilment/systems/warehouse-system/index.mdx",
       "contentHash": "sha256:d9230318d5127bdbd70bc402fe01cbbdeb6673211d9422044c1ee63fc9594da1",
-      "owners": [
-        "fulfilment-platform"
-      ],
+      "owners": ["fulfilment-platform"],
       "services": [
         {
           "id": "warehouse-service"
@@ -3926,9 +3622,7 @@
       "name": "Customer Platform",
       "contentPath": "teams/customer-platform.mdx",
       "contentHash": "sha256:a5865e613537e0ec886b515f497c8abbe2ab91d93414615ecd1995fc1b17949d",
-      "members": [
-        "dboyne"
-      ]
+      "members": ["dboyne"]
     },
     {
       "type": "team",
@@ -3936,9 +3630,7 @@
       "name": "Fulfilment Platform",
       "contentPath": "teams/fulfilment-platform.mdx",
       "contentHash": "sha256:b2e5f80040dde9cced0e3ff2a26d422dcc4238e9a618a1cc625523edf69c1985",
-      "members": [
-        "dboyne"
-      ]
+      "members": ["dboyne"]
     },
     {
       "type": "team",
@@ -3946,9 +3638,7 @@
       "name": "Ordering Platform",
       "contentPath": "teams/ordering-platform.mdx",
       "contentHash": "sha256:d2088a46ab8add0968cfcb6c865e68de127a7c4fdd3efbd6a950d44a8d00bfa8",
-      "members": [
-        "dboyne"
-      ]
+      "members": ["dboyne"]
     },
     {
       "type": "team",
@@ -3956,9 +3646,7 @@
       "name": "Payments Platform",
       "contentPath": "teams/payments-platform.mdx",
       "contentHash": "sha256:58d97145ee7cc31c85af7347abd768d3f7ae0dd6a292f5bea78fc04cab2645c1",
-      "members": [
-        "dboyne"
-      ]
+      "members": ["dboyne"]
     },
     {
       "type": "team",
@@ -3966,9 +3654,7 @@
       "name": "Product Platform",
       "contentPath": "teams/product-platform.mdx",
       "contentHash": "sha256:372afd93e071c5028733401e5da44476a8c930a2a88676de80bb30b59729ec8a",
-      "members": [
-        "dboyne"
-      ]
+      "members": ["dboyne"]
     },
     {
       "type": "team",
@@ -3976,9 +3662,7 @@
       "name": "Reviews Platform",
       "contentPath": "teams/reviews-platform.mdx",
       "contentHash": "sha256:978fd39afcdb01941fc5ceba4e08f29d190d06efddbf75794d0d98302c96f849",
-      "members": [
-        "dboyne"
-      ]
+      "members": ["dboyne"]
     },
     {
       "type": "team",
@@ -3986,9 +3670,7 @@
       "name": "Search Platform",
       "contentPath": "teams/search-platform.mdx",
       "contentHash": "sha256:6749c5b36d9e66e9d057e566cf9b4f3f8bb8637555712f732f8c887eae9452bb",
-      "members": [
-        "dboyne"
-      ]
+      "members": ["dboyne"]
     },
     {
       "type": "team",
@@ -3996,9 +3678,7 @@
       "name": "Shopping Platform",
       "contentPath": "teams/shopping-platform.mdx",
       "contentHash": "sha256:cd5a80efd5c3d4e2783d7b266a2d285faff4b2e5018e72f31dca58ce6818ba27",
-      "members": [
-        "dboyne"
-      ]
+      "members": ["dboyne"]
     },
     {
       "type": "user",

--- a/packages/sdk/src/test/fixtures/build-index/default-catalog-index.json
+++ b/packages/sdk/src/test/fixtures/build-index/default-catalog-index.json
@@ -1,0 +1,4049 @@
+{
+  "indexVersion": 1,
+  "source": "eventcatalog/examples/default",
+  "commit": "fixture",
+  "resources": [
+    {
+      "type": "adr",
+      "id": "adr-001-use-transactional-outbox",
+      "version": "1.0.0",
+      "name": "ADR-001: Publish product events via a transactional outbox",
+      "contentPath": "domains/Catalog/systems/product-catalog-system/adrs/adr-001-use-transactional-outbox/index.mdx",
+      "contentHash": "sha256:c0185646b1da56e022231f3d695f20c97a403567da77279e4b7024c7204666ed",
+      "owners": [
+        "product-platform"
+      ],
+      "status": "accepted",
+      "appliesTo": [
+        {
+          "type": "system",
+          "id": "product-catalog-system"
+        },
+        {
+          "type": "service",
+          "id": "product-search-publisher"
+        },
+        {
+          "type": "container",
+          "id": "product-database"
+        }
+      ]
+    },
+    {
+      "type": "adr",
+      "id": "adr-002-postgres-as-system-of-record",
+      "version": "1.0.0",
+      "name": "ADR-002: Use PostgreSQL as the product system of record",
+      "contentPath": "domains/Catalog/systems/product-catalog-system/adrs/adr-002-postgres-as-system-of-record/index.mdx",
+      "contentHash": "sha256:9bbad6f6da920176c6b15ca1d85f0539bfd0bd70b633cadb40f13ffda835904a",
+      "owners": [
+        "product-platform"
+      ],
+      "status": "accepted",
+      "appliesTo": [
+        {
+          "type": "system",
+          "id": "product-catalog-system"
+        },
+        {
+          "type": "container",
+          "id": "product-database"
+        }
+      ],
+      "related": [
+        {
+          "id": "adr-001-use-transactional-outbox"
+        }
+      ]
+    },
+    {
+      "type": "adr",
+      "id": "adr-003-offload-async-work-to-worker",
+      "version": "1.0.0",
+      "name": "ADR-003: Offload long-running catalog work to a dedicated worker",
+      "contentPath": "domains/Catalog/systems/product-catalog-system/adrs/adr-003-offload-async-work-to-worker/index.mdx",
+      "contentHash": "sha256:785ae3411472e1bc46630beaa7c3d5fbcc6f194cd45e4136f870b3cd63e7f498",
+      "owners": [
+        "product-platform"
+      ],
+      "status": "accepted",
+      "appliesTo": [
+        {
+          "type": "system",
+          "id": "product-catalog-system"
+        },
+        {
+          "type": "service",
+          "id": "product-worker"
+        },
+        {
+          "type": "service",
+          "id": "product-api"
+        }
+      ]
+    },
+    {
+      "type": "command",
+      "id": "add-item-to-cart",
+      "version": "1.0.0",
+      "name": "Add Item To Cart",
+      "contentPath": "domains/Shopping/systems/cart-system/services/CartAPI/commands/AddItemToCart/index.mdx",
+      "contentHash": "sha256:abc8fbe0d646a8e2b04477527ba29d66d4584c87d04856eb1e1a53ee0909160c",
+      "owners": [
+        "shopping-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:c8585c8107da10c4c9c02dc4384f8ccadaffc43a28a985197a2045791bfbd298"
+        }
+      ]
+    },
+    {
+      "type": "command",
+      "id": "authenticate-customer",
+      "version": "1.0.0",
+      "name": "Authenticate Customer",
+      "contentPath": "domains/Customer/systems/identity-provider/services/OAuthAPI/commands/AuthenticateCustomer/index.mdx",
+      "contentHash": "sha256:b1937000c87557427c582493e31b182afdf13381b18222f1a131f98306560889",
+      "owners": [
+        "customer-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:c1e2a8315c1ec4b3f85888ca623f642859a3c3f44028bdabbc10b53c959c82a1"
+        }
+      ]
+    },
+    {
+      "type": "command",
+      "id": "authorize-payment",
+      "version": "1.0.0",
+      "name": "Authorize Payment",
+      "contentPath": "domains/Ordering/systems/checkout-system/services/CheckoutOrchestrator/commands/AuthorizePayment/index.mdx",
+      "contentHash": "sha256:9c6016de966e994812916b83f919d8e444668adc48e448a9b7616d9ebf70feed",
+      "owners": [
+        "ordering-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:e4461a01e92ca0d396b19f884d426f81a305cda3594a80d65b3c953f557b6a82"
+        }
+      ]
+    },
+    {
+      "type": "command",
+      "id": "calculate-discount",
+      "version": "1.0.0",
+      "name": "Calculate Discount",
+      "contentPath": "domains/Shopping/systems/promotion-system/services/PromotionService/commands/CalculateDiscount/index.mdx",
+      "contentHash": "sha256:66a076f717e47b4c66f8d39e48fbe7b6df780e958cd594bfec4963e900f7b71b",
+      "owners": [
+        "shopping-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:e72302bd6fa5fee8e82c156594d7e07c818b4e79608c677a7cda02ffc509b6a9"
+        }
+      ]
+    },
+    {
+      "type": "command",
+      "id": "cancel-order",
+      "version": "1.0.0",
+      "name": "Cancel Order",
+      "contentPath": "domains/Ordering/systems/order-management-system/services/OrderService/commands/CancelOrder/index.mdx",
+      "contentHash": "sha256:aebba775afbccd0a643355994e63beac6b3013a313cd3db6f5758c22adb7a5e2",
+      "owners": [
+        "ordering-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:a9ab236c652dee4791b6ca16ae9e3200a7138c4b5d53969a380506e4580b24d7"
+        }
+      ]
+    },
+    {
+      "type": "command",
+      "id": "checkout-cart",
+      "version": "1.0.0",
+      "name": "Checkout Cart",
+      "contentPath": "domains/Shopping/systems/cart-system/services/CartAPI/commands/CheckoutCart/index.mdx",
+      "contentHash": "sha256:b94912418764a5773b3f007bbcd411e7ed19b36b4cde57d5b0fa203132e83839",
+      "owners": [
+        "shopping-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:6806eb7322e799445b36aeb1fd260c1987d217eaaacabe92da6c0e544059a858"
+        }
+      ]
+    },
+    {
+      "type": "command",
+      "id": "create-order",
+      "version": "1.0.0",
+      "name": "Create Order",
+      "contentPath": "domains/Ordering/systems/order-management-system/services/OrderService/commands/CreateOrder/index.mdx",
+      "contentHash": "sha256:6c8a877d504e8595a81cf0bbe52b5a805f2d3bcf38575d37980d31119da6bbba",
+      "owners": [
+        "ordering-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:0651de9a9cf07a1f34b50d31cfaee4d63e92c252d1e6cc516b24040ba48b1b11"
+        }
+      ]
+    },
+    {
+      "type": "command",
+      "id": "create-product",
+      "version": "1.0.0",
+      "name": "Create Product",
+      "contentPath": "domains/Catalog/systems/product-catalog-system/services/ProductAPI/commands/CreateProduct/index.mdx",
+      "contentHash": "sha256:9c9f0f63cecd86ca8ac535848590edf481dc3c2bcc745d7836c259cd9a5f11d7",
+      "owners": [
+        "product-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:18ce94dae333fc5613ebc7597f570276b59f92cbea28cfe811f6e8fa67b26a8d"
+        }
+      ]
+    },
+    {
+      "type": "command",
+      "id": "create-shipment",
+      "version": "1.0.0",
+      "name": "Create Shipment",
+      "contentPath": "domains/Fulfilment/systems/shipping-system/services/CarrierAdapter/commands/CreateShipment/index.mdx",
+      "contentHash": "sha256:ff68fec3e6cdbcf51f067f58215e8d4f59dc967018cb50a2ecb8cfa5c3056123",
+      "owners": [
+        "fulfilment-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:55f240b44883de5870b5be707a5eb29e313fedb59bb1a408dadb20076fb8b1a3"
+        }
+      ]
+    },
+    {
+      "type": "command",
+      "id": "delete-product",
+      "version": "1.0.0",
+      "name": "Delete Product",
+      "contentPath": "domains/Catalog/systems/product-catalog-system/services/ProductAPI/commands/DeleteProduct/index.mdx",
+      "contentHash": "sha256:942391cb113de771e68f9338baed771b66e2b6bc80e65eb18e35f6fb447edd47",
+      "owners": [
+        "product-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:4a98cac6c02570a0694601d00e8f6203aff37494d8c17c05da89ddf2c3a383bf"
+        }
+      ]
+    },
+    {
+      "type": "command",
+      "id": "flag-review",
+      "version": "1.0.0",
+      "name": "Flag Review",
+      "contentPath": "domains/Reviews/services/ReviewAPI/commands/flag-review/index.mdx",
+      "contentHash": "sha256:bd89586f38ffe3444c62c20dfdae739a8562d5e88acf5807d6429cfde869df70",
+      "owners": [
+        "reviews-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:f169779389b0873e1bc342c81e85c19055acb6a8c791be8ca3e996084179c433"
+        }
+      ]
+    },
+    {
+      "type": "command",
+      "id": "register-customer",
+      "version": "1.0.0",
+      "name": "Register Customer",
+      "contentPath": "domains/Customer/systems/customer-management-system/services/CustomerAPI/commands/RegisterCustomer/index.mdx",
+      "contentHash": "sha256:fdab08abc43439d8d6371cdb1b1686f653c3dcad80270139631e9f9d92824c4e",
+      "owners": [
+        "customer-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:507be509dba1127f205108d03b241401c5d520b961bac2a925ed765c369b2bcd"
+        }
+      ]
+    },
+    {
+      "type": "command",
+      "id": "release-inventory",
+      "version": "1.0.0",
+      "name": "Release Inventory",
+      "contentPath": "domains/Fulfilment/systems/inventory-system/services/InventoryService/commands/ReleaseInventory/index.mdx",
+      "contentHash": "sha256:db153f4cab02671ddf4d2844b067a3cd17f4bedc53cc7dba06d5162ba92b32e8",
+      "owners": [
+        "fulfilment-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:6ee6aae45206b2d45b1046d92b6fcdcff3451cbd8fdfbe323e84f7036ea28363"
+        }
+      ]
+    },
+    {
+      "type": "command",
+      "id": "remove-item-from-cart",
+      "version": "1.0.0",
+      "name": "Remove Item From Cart",
+      "contentPath": "domains/Shopping/systems/cart-system/services/CartAPI/commands/RemoveItemFromCart/index.mdx",
+      "contentHash": "sha256:9568cb298a80f6af3cc7fb6ccff3707da811e3c37c5d95f581de8332b10e1044",
+      "owners": [
+        "shopping-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:3bd7afab3da2ca6ee11af44879ca30c7ef9bb7fcf9c84708629ba90e6492ebc3"
+        }
+      ]
+    },
+    {
+      "type": "command",
+      "id": "reserve-inventory",
+      "version": "1.0.0",
+      "name": "Reserve Inventory",
+      "contentPath": "domains/Ordering/systems/checkout-system/services/CheckoutOrchestrator/commands/ReserveInventory/index.mdx",
+      "contentHash": "sha256:3f42b85d4574e8095026eb8f497fbe35a993a197a21399e34af44e65154e9e93",
+      "owners": [
+        "ordering-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:25bc5b0a2439ca62a56ec7ea4a591b4775c9831bf3ddb672a0bb25e71c8df32d"
+        }
+      ]
+    },
+    {
+      "type": "command",
+      "id": "submit-review",
+      "version": "1.0.0",
+      "name": "Submit Review",
+      "contentPath": "domains/Reviews/services/ReviewAPI/commands/submit-review/index.mdx",
+      "contentHash": "sha256:9bad501de35445445cca4de0db1d45c8be830390be926bdb73d6585bc7624439",
+      "owners": [
+        "reviews-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:97756439908e0cf16a584ab8b9eaf95adea9ed64b8b16be21978f94449a9471c"
+        }
+      ]
+    },
+    {
+      "type": "command",
+      "id": "update-customer",
+      "version": "1.0.0",
+      "name": "Update Customer",
+      "contentPath": "domains/Customer/systems/customer-management-system/services/CustomerAPI/commands/UpdateCustomer/index.mdx",
+      "contentHash": "sha256:04cd655ae882fc0bcf98dc60d663dffa60b9214c27722ba8e81efdaab3c16d9f",
+      "owners": [
+        "customer-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:2c12ab3f8c9a9b3441d5b6b43b75ad310a56e44acda390807973be4f52b19ad4"
+        }
+      ]
+    },
+    {
+      "type": "command",
+      "id": "update-product",
+      "version": "1.0.0",
+      "name": "Update Product",
+      "contentPath": "domains/Catalog/systems/product-catalog-system/services/ProductAPI/commands/UpdateProduct/index.mdx",
+      "contentHash": "sha256:56ff9296c9043bad438a57472116b92bd486b21171db491201b44a069994b335",
+      "owners": [
+        "product-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:1c256e3ebfe23092b811d630de911f55e2a36ffaf3381ff310c22f0ac965522e"
+        }
+      ]
+    },
+    {
+      "type": "command",
+      "id": "vote-review-helpful",
+      "version": "1.0.0",
+      "name": "Vote Review Helpful",
+      "contentPath": "domains/Reviews/services/ReviewAPI/commands/vote-review-helpful/index.mdx",
+      "contentHash": "sha256:181e7343185b3bd89d2b394840336f9487fbabdd52a49544dfa3079a9982b7f1",
+      "owners": [
+        "reviews-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:0f74b9169425cdbadd8eedf1c9838b2b0ad0a6882a1ce658159e2783c054d03e"
+        }
+      ]
+    },
+    {
+      "type": "container",
+      "id": "cart-database",
+      "version": "1.0.0",
+      "name": "Cart Database",
+      "contentPath": "domains/Shopping/systems/cart-system/containers/cart-database/index.mdx",
+      "contentHash": "sha256:3b082f0171336745026db5179d7a1584c670c94e67dd182fa1d4532850ab933d",
+      "sidecars": [
+        {
+          "path": "domains/Shopping/systems/cart-system/containers/cart-database/schema.sql",
+          "hash": "sha256:f3c14b093ae38083e88153b91e7a7efbb13750a9ba963045cb579602313001c0"
+        }
+      ],
+      "container_type": "database"
+    },
+    {
+      "type": "container",
+      "id": "customer-database",
+      "version": "1.0.0",
+      "name": "Customer Database",
+      "contentPath": "domains/Customer/systems/customer-management-system/containers/customer-database/index.mdx",
+      "contentHash": "sha256:f32c04a27f81c85b8d4419fbd24d76bb0420500d9c4bee5437f58727a5939f01",
+      "sidecars": [
+        {
+          "path": "domains/Customer/systems/customer-management-system/containers/customer-database/schema.sql",
+          "hash": "sha256:eb0e79d21b9b87a8dbde1afb9713449dd0e4235e612ff79ebf8c2e7548e0bfea"
+        }
+      ],
+      "container_type": "database"
+    },
+    {
+      "type": "container",
+      "id": "inventory-database",
+      "version": "1.0.0",
+      "name": "Inventory Database",
+      "contentPath": "domains/Fulfilment/systems/inventory-system/containers/inventory-database/index.mdx",
+      "contentHash": "sha256:41ad98e6c93d6bd9f275846a1166fda1b5791992f5b8128224efef5f915f37bc",
+      "sidecars": [
+        {
+          "path": "domains/Fulfilment/systems/inventory-system/containers/inventory-database/schema.sql",
+          "hash": "sha256:4030b7fb0df9e3c7130cde331867a3ad92f17e4051318f5e3e8f9e6fa622090d"
+        }
+      ],
+      "container_type": "database"
+    },
+    {
+      "type": "container",
+      "id": "order-database",
+      "version": "1.0.0",
+      "name": "Order Database",
+      "contentPath": "domains/Ordering/systems/order-management-system/containers/order-database/index.mdx",
+      "contentHash": "sha256:7e58b7891804c1c9ed7cf38f7ad0b3fb7f1e931fbcf3a9961dd1707b65b9d9b6",
+      "sidecars": [
+        {
+          "path": "domains/Ordering/systems/order-management-system/containers/order-database/schema.sql",
+          "hash": "sha256:e41d0357c3db061ad8ca33a312324b824c8ca1267a7082681f956f2938faa352"
+        }
+      ],
+      "container_type": "database"
+    },
+    {
+      "type": "container",
+      "id": "payment-database",
+      "version": "1.0.0",
+      "name": "Payment Database",
+      "contentPath": "domains/Payments/systems/payment-processing-system/containers/payment-database/index.mdx",
+      "contentHash": "sha256:6d69bde6873683e95e6311ed6832dc4146e90acdc61ba46e15536336de2a21d8",
+      "sidecars": [
+        {
+          "path": "domains/Payments/systems/payment-processing-system/containers/payment-database/schema.sql",
+          "hash": "sha256:4a0cce1c3f96fde7ce883b270a04de6401a282814870c4e392ca03d2c290f6a5"
+        }
+      ],
+      "container_type": "database"
+    },
+    {
+      "type": "container",
+      "id": "product-database",
+      "version": "1.0.0",
+      "name": "Product Database",
+      "contentPath": "domains/Catalog/systems/product-catalog-system/containers/product-database/index.mdx",
+      "contentHash": "sha256:656370626ce89688446e15b64e6450df5d612aae1a2ae5a670ce643df04587fa",
+      "sidecars": [
+        {
+          "path": "domains/Catalog/systems/product-catalog-system/containers/product-database/schema.sql",
+          "hash": "sha256:2328ac660a583d2f2894932852548773b8954110645097d4b98ae5d87b7e1be8"
+        }
+      ],
+      "container_type": "database"
+    },
+    {
+      "type": "container",
+      "id": "promotion-database",
+      "version": "1.0.0",
+      "name": "Promotion Database",
+      "contentPath": "domains/Shopping/systems/promotion-system/containers/promotion-database/index.mdx",
+      "contentHash": "sha256:9e048fe0abcc585a36c963a19e71a5ec1f2b0114e1c5fcb356c2491ff806c90d",
+      "sidecars": [
+        {
+          "path": "domains/Shopping/systems/promotion-system/containers/promotion-database/schema.sql",
+          "hash": "sha256:1f17d1072c865c15bae962c903c07f6ba0c9165cf13989537fcfb2bd91bb9e2c"
+        }
+      ],
+      "container_type": "database"
+    },
+    {
+      "type": "container",
+      "id": "rating-cache",
+      "version": "1.0.0",
+      "name": "Rating Cache",
+      "contentPath": "domains/Reviews/containers/rating-cache/index.mdx",
+      "contentHash": "sha256:1854e2ef4b8f95b217b29c561a6a8d2efbfbc4280c3f8b75c7c0173009ae6b90",
+      "container_type": "cache"
+    },
+    {
+      "type": "container",
+      "id": "review-database",
+      "version": "1.0.0",
+      "name": "Review Database",
+      "contentPath": "domains/Reviews/containers/review-database/index.mdx",
+      "contentHash": "sha256:d7a520e101b9f287524b628fbacd1e10271e7bb6c21b32e96f68479247f8c8cd",
+      "container_type": "database"
+    },
+    {
+      "type": "container",
+      "id": "search-index",
+      "version": "1.0.0",
+      "name": "Search Index",
+      "contentPath": "domains/Catalog/systems/search-system/containers/search-index/index.mdx",
+      "contentHash": "sha256:8af9927731b60a0657904416370dd698f98f253f7f49425fb9bb510b5c7a271d",
+      "container_type": "searchIndex"
+    },
+    {
+      "type": "container",
+      "id": "user-directory",
+      "version": "1.0.0",
+      "name": "User Directory",
+      "contentPath": "domains/Customer/systems/identity-provider/containers/user-directory/index.mdx",
+      "contentHash": "sha256:34495ce55684f685325fd28eb73c0ea1bc0eb3ab069484d9bc64a31e5801735f",
+      "container_type": "database"
+    },
+    {
+      "type": "container",
+      "id": "warehouse-database",
+      "version": "1.0.0",
+      "name": "Warehouse Database",
+      "contentPath": "domains/Fulfilment/systems/warehouse-system/containers/warehouse-database/index.mdx",
+      "contentHash": "sha256:925bbf32084f53fdc5612fda1f4524b3fdc3755ac5d5014aabfe934a2542aa56",
+      "sidecars": [
+        {
+          "path": "domains/Fulfilment/systems/warehouse-system/containers/warehouse-database/schema.sql",
+          "hash": "sha256:6edf05486e723138933207c2c012bcd4aeda2e5b38a444868f5ea0b8358ea366"
+        }
+      ],
+      "container_type": "database"
+    },
+    {
+      "type": "domain",
+      "id": "catalog",
+      "version": "1.0.0",
+      "name": "Catalog",
+      "contentPath": "domains/Catalog/index.mdx",
+      "contentHash": "sha256:73da6896ccad4dc201c8199a89e103cba2e71a2bd2bfc8d16c86d403586fa5f9",
+      "owners": [
+        "product-platform"
+      ],
+      "sidecars": [
+        {
+          "path": "domains/Catalog/ubiquitous-language.mdx",
+          "hash": "sha256:8905dfccffdfc950d1f5aec2fda7c67045a3d3d536b972f1d835297a1284da3a"
+        }
+      ],
+      "systems": [
+        {
+          "id": "product-catalog-system",
+          "version": "1.0.0"
+        },
+        {
+          "id": "search-system",
+          "version": "1.0.0"
+        }
+      ],
+      "entities": [
+        {
+          "id": "product",
+          "version": "1.0.0"
+        },
+        {
+          "id": "product-variant",
+          "version": "1.0.0"
+        },
+        {
+          "id": "category",
+          "version": "1.0.0"
+        },
+        {
+          "id": "search-document",
+          "version": "1.0.0"
+        }
+      ]
+    },
+    {
+      "type": "domain",
+      "id": "customer",
+      "version": "1.0.0",
+      "name": "Customer",
+      "contentPath": "domains/Customer/index.mdx",
+      "contentHash": "sha256:df6811c1a5e418757516b27c54d30cd473af7bf5a017b58ba46e38d00d8f18c6",
+      "owners": [
+        "customer-platform"
+      ],
+      "sidecars": [
+        {
+          "path": "domains/Customer/ubiquitous-language.mdx",
+          "hash": "sha256:3e3c5f510f9807c7b83889b749414716a1669377aaa23ea79e13b38bca4237a4"
+        }
+      ],
+      "systems": [
+        {
+          "id": "customer-management-system",
+          "version": "1.0.0"
+        },
+        {
+          "id": "identity-provider",
+          "version": "1.0.0"
+        }
+      ],
+      "entities": [
+        {
+          "id": "customer-profile",
+          "version": "1.0.0"
+        },
+        {
+          "id": "customer-account",
+          "version": "1.0.0"
+        },
+        {
+          "id": "authentication-session",
+          "version": "1.0.0"
+        },
+        {
+          "id": "customer-address",
+          "version": "1.0.0"
+        }
+      ]
+    },
+    {
+      "type": "domain",
+      "id": "fulfilment",
+      "version": "1.0.0",
+      "name": "Fulfilment",
+      "contentPath": "domains/Fulfilment/index.mdx",
+      "contentHash": "sha256:4c135222dcc67e7872a40668050b3056b98932a38cd21968b050c0f9bf37440a",
+      "owners": [
+        "fulfilment-platform"
+      ],
+      "sidecars": [
+        {
+          "path": "domains/Fulfilment/ubiquitous-language.mdx",
+          "hash": "sha256:513c1fd12c9612c7f8903004aeb8914408fa4355219bb4499f62636d55cc3f69"
+        }
+      ],
+      "systems": [
+        {
+          "id": "inventory-system",
+          "version": "1.0.0"
+        },
+        {
+          "id": "warehouse-system",
+          "version": "1.0.0"
+        },
+        {
+          "id": "shipping-system",
+          "version": "1.0.0"
+        },
+        {
+          "id": "carrier",
+          "version": "1.0.0"
+        }
+      ],
+      "entities": [
+        {
+          "id": "stock-item",
+          "version": "1.0.0"
+        },
+        {
+          "id": "inventory-reservation",
+          "version": "1.0.0"
+        },
+        {
+          "id": "warehouse-pick",
+          "version": "1.0.0"
+        },
+        {
+          "id": "shipment",
+          "version": "1.0.0"
+        }
+      ]
+    },
+    {
+      "type": "domain",
+      "id": "ordering",
+      "version": "1.0.0",
+      "name": "Ordering",
+      "contentPath": "domains/Ordering/index.mdx",
+      "contentHash": "sha256:b8897d88a778080bd1e00b8afba2566e855f59927a831e4e0197ce492401e07a",
+      "owners": [
+        "ordering-platform"
+      ],
+      "sidecars": [
+        {
+          "path": "domains/Ordering/ubiquitous-language.mdx",
+          "hash": "sha256:3f5ece175b8fa2d82aa5f225095a505340a283470a14c5e05c95332a171d455b"
+        }
+      ],
+      "systems": [
+        {
+          "id": "checkout-system",
+          "version": "1.0.0"
+        },
+        {
+          "id": "order-management-system",
+          "version": "1.0.0"
+        }
+      ],
+      "entities": [
+        {
+          "id": "checkout-session",
+          "version": "1.0.0"
+        },
+        {
+          "id": "order",
+          "version": "1.0.0"
+        },
+        {
+          "id": "order-line",
+          "version": "1.0.0"
+        },
+        {
+          "id": "order-status-history",
+          "version": "1.0.0"
+        }
+      ],
+      "flows": [
+        {
+          "id": "place-an-order",
+          "version": "1.0.0"
+        }
+      ]
+    },
+    {
+      "type": "domain",
+      "id": "payments",
+      "version": "1.0.0",
+      "name": "Payments",
+      "contentPath": "domains/Payments/index.mdx",
+      "contentHash": "sha256:82dcb892b91e5cec3d3abb0ef98f02637516314240070158adf365369ea009dc",
+      "owners": [
+        "payments-platform"
+      ],
+      "sidecars": [
+        {
+          "path": "domains/Payments/ubiquitous-language.mdx",
+          "hash": "sha256:37e3eff5e46d471656ac8b1f47a3168a8db31e411ce9ffbd2252df325003c07a"
+        }
+      ],
+      "systems": [
+        {
+          "id": "payment-processing-system",
+          "version": "1.0.0"
+        },
+        {
+          "id": "stripe",
+          "version": "1.0.0"
+        },
+        {
+          "id": "fraud-detection",
+          "version": "1.0.0"
+        }
+      ],
+      "entities": [
+        {
+          "id": "payment",
+          "version": "1.0.0"
+        },
+        {
+          "id": "payment-authorization",
+          "version": "1.0.0"
+        },
+        {
+          "id": "refund",
+          "version": "1.0.0"
+        },
+        {
+          "id": "fraud-check",
+          "version": "1.0.0"
+        }
+      ]
+    },
+    {
+      "type": "domain",
+      "id": "reviews",
+      "version": "1.0.0",
+      "name": "Reviews & Ratings",
+      "contentPath": "domains/Reviews/index.mdx",
+      "contentHash": "sha256:5d8f7212fceb1c29e04ae25e22aeea6e230bbaa4e8daba564a7f3cf70a7c54bc",
+      "owners": [
+        "reviews-platform"
+      ],
+      "specifications": [
+        {
+          "type": "openapi",
+          "path": "openapi.yml",
+          "name": "Review API",
+          "hash": "sha256:45c5adf8ead80a35d0d72df201d48d36755bb6928daf782d6ba1684d157cc236"
+        },
+        {
+          "type": "asyncapi",
+          "path": "asyncapi.yml",
+          "name": "Reviews Eventing",
+          "hash": "sha256:36358abda679dc19a2c22344a6b2eca4fc83a71a5485a31416356fda549e4fbb"
+        }
+      ],
+      "sends": [
+        {
+          "id": "review-submitted",
+          "version": "1.0.0"
+        },
+        {
+          "id": "review-published",
+          "version": "1.0.0"
+        },
+        {
+          "id": "review-rejected",
+          "version": "1.0.0"
+        },
+        {
+          "id": "review-flagged",
+          "version": "1.0.0"
+        },
+        {
+          "id": "review-helpful-voted",
+          "version": "1.0.0"
+        },
+        {
+          "id": "rating-updated",
+          "version": "1.0.0"
+        }
+      ],
+      "receives": [
+        {
+          "id": "submit-review",
+          "version": "1.0.0",
+          "triggers": [
+            {
+              "id": "review-submitted",
+              "version": "1.0.0",
+              "condition": "When the review passes submission validation"
+            }
+          ]
+        },
+        {
+          "id": "flag-review",
+          "version": "1.0.0"
+        },
+        {
+          "id": "vote-review-helpful",
+          "version": "1.0.0"
+        },
+        {
+          "id": "get-product-reviews",
+          "version": "1.0.0"
+        }
+      ],
+      "services": [
+        {
+          "id": "review-api",
+          "version": "1.0.0"
+        },
+        {
+          "id": "review-moderation-worker",
+          "version": "1.0.0"
+        },
+        {
+          "id": "rating-aggregator",
+          "version": "1.0.0"
+        }
+      ],
+      "entities": [
+        {
+          "id": "review",
+          "version": "1.0.0"
+        },
+        {
+          "id": "moderation-decision",
+          "version": "1.0.0"
+        },
+        {
+          "id": "rating-summary",
+          "version": "1.0.0"
+        },
+        {
+          "id": "review-vote",
+          "version": "1.0.0"
+        },
+        {
+          "id": "review-flag",
+          "version": "1.0.0"
+        }
+      ],
+      "flows": [
+        {
+          "id": "review-submission",
+          "version": "1.0.0"
+        }
+      ]
+    },
+    {
+      "type": "domain",
+      "id": "shopping",
+      "version": "1.0.0",
+      "name": "Shopping",
+      "contentPath": "domains/Shopping/index.mdx",
+      "contentHash": "sha256:013ccf530b88fb9b343966f85b4fdc74062afab262dbc9bc5b306cfae046920e",
+      "owners": [
+        "shopping-platform"
+      ],
+      "sidecars": [
+        {
+          "path": "domains/Shopping/ubiquitous-language.mdx",
+          "hash": "sha256:b8dd599829b78e570323150ad08bc65d01262413b9290a996ef63e9797e30f0d"
+        }
+      ],
+      "systems": [
+        {
+          "id": "cart-system",
+          "version": "1.0.0"
+        },
+        {
+          "id": "promotion-system",
+          "version": "1.0.0"
+        }
+      ],
+      "entities": [
+        {
+          "id": "cart",
+          "version": "1.0.0"
+        },
+        {
+          "id": "cart-item",
+          "version": "1.0.0"
+        },
+        {
+          "id": "promotion",
+          "version": "1.0.0"
+        },
+        {
+          "id": "discount",
+          "version": "1.0.0"
+        }
+      ]
+    },
+    {
+      "type": "entity",
+      "id": "authentication-session",
+      "version": "1.0.0",
+      "name": "Authentication Session",
+      "contentPath": "domains/Customer/entities/authentication-session/index.mdx",
+      "contentHash": "sha256:2013fa6e82e44b2ee9c24619c01733803e3650b2f35b7aa5705e69fec0f19bff",
+      "owners": [
+        "customer-platform"
+      ]
+    },
+    {
+      "type": "entity",
+      "id": "cart",
+      "version": "1.0.0",
+      "name": "Cart",
+      "contentPath": "domains/Shopping/entities/cart/index.mdx",
+      "contentHash": "sha256:13e8c5197b46effe9fb67d88645df3acb5beeb0ea3f84af0c0163b6c0af0bf34",
+      "owners": [
+        "shopping-platform"
+      ]
+    },
+    {
+      "type": "entity",
+      "id": "cart-item",
+      "version": "1.0.0",
+      "name": "Cart Item",
+      "contentPath": "domains/Shopping/entities/cart-item/index.mdx",
+      "contentHash": "sha256:24f5c084a504ff9292ea01ee893bd38e2a5ddc6aca2b3bf3acb0fbf59c466252",
+      "owners": [
+        "shopping-platform"
+      ]
+    },
+    {
+      "type": "entity",
+      "id": "category",
+      "version": "1.0.0",
+      "name": "Category",
+      "contentPath": "domains/Catalog/entities/category/index.mdx",
+      "contentHash": "sha256:e35fcfbcab26cc281a0cd273c1eac6bd323970334d550bf52537e9d8f3d68430",
+      "owners": [
+        "product-platform"
+      ]
+    },
+    {
+      "type": "entity",
+      "id": "checkout-session",
+      "version": "1.0.0",
+      "name": "Checkout Session",
+      "contentPath": "domains/Ordering/entities/checkout-session/index.mdx",
+      "contentHash": "sha256:3ee14c6040224665c474cb68424016f65360a0ab0f82ca735986bec6fcf0a835",
+      "owners": [
+        "ordering-platform"
+      ]
+    },
+    {
+      "type": "entity",
+      "id": "customer-account",
+      "version": "1.0.0",
+      "name": "Customer Account",
+      "contentPath": "domains/Customer/entities/customer-account/index.mdx",
+      "contentHash": "sha256:fb88c9721d2b0485044b0bbfd5a05329a3377d2eeebe0541da035001ffba91b9",
+      "owners": [
+        "customer-platform"
+      ]
+    },
+    {
+      "type": "entity",
+      "id": "customer-address",
+      "version": "1.0.0",
+      "name": "Customer Address",
+      "contentPath": "domains/Customer/entities/customer-address/index.mdx",
+      "contentHash": "sha256:459070f15f7952a8b09979bc8f2b81d0210fefff716838741602d789e37f2ec2",
+      "owners": [
+        "customer-platform"
+      ]
+    },
+    {
+      "type": "entity",
+      "id": "customer-profile",
+      "version": "1.0.0",
+      "name": "Customer Profile",
+      "contentPath": "domains/Customer/entities/customer-profile/index.mdx",
+      "contentHash": "sha256:560b630624fdb659713b9746509793de2adc266f051f23aa78442587d4d5dfc9",
+      "owners": [
+        "customer-platform"
+      ]
+    },
+    {
+      "type": "entity",
+      "id": "discount",
+      "version": "1.0.0",
+      "name": "Discount",
+      "contentPath": "domains/Shopping/entities/discount/index.mdx",
+      "contentHash": "sha256:45b3a29a361f996eacee0d85ced8da2c998dc057cf24363bb775d04657ff65b0",
+      "owners": [
+        "shopping-platform"
+      ]
+    },
+    {
+      "type": "entity",
+      "id": "fraud-check",
+      "version": "1.0.0",
+      "name": "Fraud Check",
+      "contentPath": "domains/Payments/entities/fraud-check/index.mdx",
+      "contentHash": "sha256:fb1b7161b2d1bec64ea64e9ba6884b7a9f1d59cf94d0ce5b5582c2f1e190d873",
+      "owners": [
+        "payments-platform"
+      ]
+    },
+    {
+      "type": "entity",
+      "id": "inventory-reservation",
+      "version": "1.0.0",
+      "name": "Inventory Reservation",
+      "contentPath": "domains/Fulfilment/entities/inventory-reservation/index.mdx",
+      "contentHash": "sha256:f7bce8239350941425a5e32562ed80e6175581a04680caa7e0fe9f88d1fd46be",
+      "owners": [
+        "fulfilment-platform"
+      ]
+    },
+    {
+      "type": "entity",
+      "id": "moderation-decision",
+      "version": "1.0.0",
+      "name": "Moderation Decision",
+      "contentPath": "domains/Reviews/entities/moderation-decision/index.mdx",
+      "contentHash": "sha256:d4693cd868bfb55f035763ff8ce9971875db0933cb3ce94d161ed6bf62f0f76c",
+      "owners": [
+        "reviews-platform"
+      ]
+    },
+    {
+      "type": "entity",
+      "id": "order",
+      "version": "1.0.0",
+      "name": "Order",
+      "contentPath": "domains/Ordering/entities/order/index.mdx",
+      "contentHash": "sha256:0510ec6a21d0956735895b19bb910e6d5606bbef9f2d0e098ce92f6e3b1fef68",
+      "owners": [
+        "ordering-platform"
+      ]
+    },
+    {
+      "type": "entity",
+      "id": "order-line",
+      "version": "1.0.0",
+      "name": "Order Line",
+      "contentPath": "domains/Ordering/entities/order-line/index.mdx",
+      "contentHash": "sha256:ef9395747d87801ffe60f64d542ddfef593cd2d66da3dfcee735fff8fa8df52c",
+      "owners": [
+        "ordering-platform"
+      ]
+    },
+    {
+      "type": "entity",
+      "id": "order-status-history",
+      "version": "1.0.0",
+      "name": "Order Status History",
+      "contentPath": "domains/Ordering/entities/order-status-history/index.mdx",
+      "contentHash": "sha256:7fdb1ffbdc2bd41648506017d32d7e8f75f38293a39a2f4161aaba33687fa2f1",
+      "owners": [
+        "ordering-platform"
+      ]
+    },
+    {
+      "type": "entity",
+      "id": "payment",
+      "version": "1.0.0",
+      "name": "Payment",
+      "contentPath": "domains/Payments/entities/payment/index.mdx",
+      "contentHash": "sha256:d07eff34070105f0a088952a4e054ea4b4b2e141b5f122b5f034acbb2ff24426",
+      "owners": [
+        "payments-platform"
+      ]
+    },
+    {
+      "type": "entity",
+      "id": "payment-authorization",
+      "version": "1.0.0",
+      "name": "Payment Authorization",
+      "contentPath": "domains/Payments/entities/payment-authorization/index.mdx",
+      "contentHash": "sha256:ed173c6eb128fe449231c71e2c3f741365643c9baa57a93ede67f8f8a9feda8d",
+      "owners": [
+        "payments-platform"
+      ]
+    },
+    {
+      "type": "entity",
+      "id": "product",
+      "version": "1.0.0",
+      "name": "Product",
+      "contentPath": "domains/Catalog/entities/product/index.mdx",
+      "contentHash": "sha256:a543f2c0ad0bd456b62008ab11d25a3a07956d64cb3294fa8a7882bb8f2e186e",
+      "owners": [
+        "product-platform"
+      ]
+    },
+    {
+      "type": "entity",
+      "id": "product-variant",
+      "version": "1.0.0",
+      "name": "Product Variant",
+      "contentPath": "domains/Catalog/entities/product-variant/index.mdx",
+      "contentHash": "sha256:344131f93c86111c846475819b4ae213ea2155ee412597d1eb8094ac8cdf3395",
+      "owners": [
+        "product-platform"
+      ]
+    },
+    {
+      "type": "entity",
+      "id": "promotion",
+      "version": "1.0.0",
+      "name": "Promotion",
+      "contentPath": "domains/Shopping/entities/promotion/index.mdx",
+      "contentHash": "sha256:c236f1ed81af6111aecd30ea0edd74f18cf8cd369ac0fb079002280242534c87",
+      "owners": [
+        "shopping-platform"
+      ]
+    },
+    {
+      "type": "entity",
+      "id": "rating-summary",
+      "version": "1.0.0",
+      "name": "Rating Summary",
+      "contentPath": "domains/Reviews/entities/rating-summary/index.mdx",
+      "contentHash": "sha256:826d1c04ae82cdfefb77e7898e27c3d3490bddbae1732ccfe798f58fc9eb7fdb",
+      "owners": [
+        "reviews-platform"
+      ]
+    },
+    {
+      "type": "entity",
+      "id": "refund",
+      "version": "1.0.0",
+      "name": "Refund",
+      "contentPath": "domains/Payments/entities/refund/index.mdx",
+      "contentHash": "sha256:eb5590e3ef60f0b62a8ad3114050dee6857f3bdf135b35148436597d16ce2af5",
+      "owners": [
+        "payments-platform"
+      ]
+    },
+    {
+      "type": "entity",
+      "id": "review",
+      "version": "1.0.0",
+      "name": "Review",
+      "contentPath": "domains/Reviews/entities/review/index.mdx",
+      "contentHash": "sha256:366551bdd368d9082d6dacc5de269ce1aae142f60e53cb1ee505d7c189b05c9f",
+      "owners": [
+        "reviews-platform"
+      ]
+    },
+    {
+      "type": "entity",
+      "id": "review-flag",
+      "version": "1.0.0",
+      "name": "Review Flag",
+      "contentPath": "domains/Reviews/entities/review-flag/index.mdx",
+      "contentHash": "sha256:fd66ed6031c497cec108f3305ceb081e1b0873deebe2f544dc91a05df3ae7b09",
+      "owners": [
+        "reviews-platform"
+      ]
+    },
+    {
+      "type": "entity",
+      "id": "review-vote",
+      "version": "1.0.0",
+      "name": "Review Vote",
+      "contentPath": "domains/Reviews/entities/review-vote/index.mdx",
+      "contentHash": "sha256:6cd86d97e921f785d7005e675d91a3fa520158a0ff59809b75805caf24fa9c64",
+      "owners": [
+        "reviews-platform"
+      ]
+    },
+    {
+      "type": "entity",
+      "id": "search-document",
+      "version": "1.0.0",
+      "name": "Search Document",
+      "contentPath": "domains/Catalog/entities/search-document/index.mdx",
+      "contentHash": "sha256:eedc787bbf94f71a22364a8a0f59a9f7a792c68ff1f5613966197f708bfb4281",
+      "owners": [
+        "search-platform"
+      ]
+    },
+    {
+      "type": "entity",
+      "id": "shipment",
+      "version": "1.0.0",
+      "name": "Shipment",
+      "contentPath": "domains/Fulfilment/entities/shipment/index.mdx",
+      "contentHash": "sha256:195db6af532bdd79d4d2b8d9256f510dd6d181e1a286dc130ab392e144ffb3ab",
+      "owners": [
+        "fulfilment-platform"
+      ]
+    },
+    {
+      "type": "entity",
+      "id": "stock-item",
+      "version": "1.0.0",
+      "name": "Stock Item",
+      "contentPath": "domains/Fulfilment/entities/stock-item/index.mdx",
+      "contentHash": "sha256:da08793f7992d3b84e2077a552dab91aaea028f4ec5aaa054ce906ce7e1befae",
+      "owners": [
+        "fulfilment-platform"
+      ]
+    },
+    {
+      "type": "entity",
+      "id": "warehouse-pick",
+      "version": "1.0.0",
+      "name": "Warehouse Pick",
+      "contentPath": "domains/Fulfilment/entities/warehouse-pick/index.mdx",
+      "contentHash": "sha256:54408bf5ba5e8cc06592d144b9736fda55ff503fb1e0fbc5ccf70e4668797bd9",
+      "owners": [
+        "fulfilment-platform"
+      ]
+    },
+    {
+      "type": "event",
+      "id": "cart-checked-out",
+      "version": "1.0.0",
+      "name": "Cart Checked Out",
+      "contentPath": "domains/Shopping/systems/cart-system/services/CartAPI/events/CartCheckedOut/index.mdx",
+      "contentHash": "sha256:a04639e4b42de63b5124533dc8a13ab5eac2cffdc8d2750362d64e04e4077290",
+      "owners": [
+        "shopping-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:90ba194f031512ff883f3071d3e724776d7a223707a64c86a9a245edfa7bcfda"
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "id": "customer-authenticated",
+      "version": "1.0.0",
+      "name": "Customer Authenticated",
+      "contentPath": "domains/Customer/systems/identity-provider/services/OAuthAPI/events/CustomerAuthenticated/index.mdx",
+      "contentHash": "sha256:6fb98c97e0e670a24534efcc5bbbc2eee8b6e57c04b83cf5864e99ae9dc12d6b",
+      "owners": [
+        "customer-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:9f6b870488245af477a0d485f3eb9dcb08429d10962ff4a330aa6420679a66f1"
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "id": "customer-registered",
+      "version": "1.0.0",
+      "name": "Customer Registered",
+      "contentPath": "domains/Customer/systems/customer-management-system/services/CustomerAPI/events/CustomerRegistered/index.mdx",
+      "contentHash": "sha256:c2656bef3e0cf36fd25843cd44115e03ac7f9a79b1a04ce5462254b8ea9c4859",
+      "owners": [
+        "customer-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:683cf1c4ed93d60c43f21a6cfd9e80451a007b6dddd062f92a6726fef758a7d4"
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "id": "customer-updated",
+      "version": "1.0.0",
+      "name": "Customer Updated",
+      "contentPath": "domains/Customer/systems/customer-management-system/services/CustomerAPI/events/CustomerUpdated/index.mdx",
+      "contentHash": "sha256:06c7b2eaf41a72807b32ba08f0d8f34b1f4ae4fc85e9f6dd5a238f1047573aa2",
+      "owners": [
+        "customer-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:ce0ac8a2426ae5278304c59b43170407eaca73236cea49135dca9cc4840723bb"
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "id": "discount-calculated",
+      "version": "1.0.0",
+      "name": "Discount Calculated",
+      "contentPath": "domains/Shopping/systems/promotion-system/services/PromotionService/events/DiscountCalculated/index.mdx",
+      "contentHash": "sha256:0e17391666ff7e5318264bab2af4d80be509073fe5eb9c3eb6ea0063583ad983",
+      "owners": [
+        "shopping-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:b36ccc2449721581564bcfd9bc8a81959e699d9bde1ea94a2df35070f8c413d1"
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "id": "fraud-check-failed",
+      "version": "1.0.0",
+      "name": "Fraud Check Failed",
+      "contentPath": "domains/Payments/systems/fraud-detection/services/FraudAPI/events/FraudCheckFailed/index.mdx",
+      "contentHash": "sha256:56a493a3e9369cba492f8d2aeb89af6f926130bd200b29eeb317701aeee2d123",
+      "owners": [
+        "payments-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:e8943b1f8cf2e26a2b4755fa95c3a572d2c60daf9b43d98b9313d0db374ae207"
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "id": "fraud-check-passed",
+      "version": "1.0.0",
+      "name": "Fraud Check Passed",
+      "contentPath": "domains/Payments/systems/fraud-detection/services/FraudAPI/events/FraudCheckPassed/index.mdx",
+      "contentHash": "sha256:f8d21c547ed420bea14e4eb7a73ecda50b153819f3fbe32fc100b612069b2147",
+      "owners": [
+        "payments-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:386e8ac47d5600ac1a0e00253636781f27485935281350874b3ca1c063662426"
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "id": "inventory-reserved",
+      "version": "1.0.0",
+      "name": "Inventory Reserved",
+      "contentPath": "domains/Fulfilment/systems/inventory-system/services/InventoryService/events/InventoryReserved/index.mdx",
+      "contentHash": "sha256:54ed26f49ffcd48e677942e98402218a0af39ef4eabaf16c2018bcfb96679cda",
+      "owners": [
+        "fulfilment-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:dc94c50a007e3a70156977a49ac5e3987064402c79ecef1bcd5815b2b1a9440a"
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "id": "inventory-unavailable",
+      "version": "1.0.0",
+      "name": "Inventory Unavailable",
+      "contentPath": "domains/Fulfilment/systems/inventory-system/services/InventoryService/events/InventoryUnavailable/index.mdx",
+      "contentHash": "sha256:e6fb19aac2b6b8d795603750f334e3eef1da0ec292a991898d0e5538cb0a078e",
+      "owners": [
+        "fulfilment-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:582fe4df41a588009893340367fa13148fdfcfd44955296c81ca2c52e699e99c"
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "id": "order-amended",
+      "version": "1.0.0",
+      "name": "Order Amended",
+      "contentPath": "domains/Ordering/systems/order-management-system/services/OrderService/events/OrderAmended/index.mdx",
+      "contentHash": "sha256:b6a9e5ee5d5250cc6b0829813435125254e6ee61c25c1bf2f8975ee7056aaf5f",
+      "owners": [
+        "ordering-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:f33ed0af94cf82f717def635e1e1620a7f898d0d364fea39fde0d4c3e18ea9cf"
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "id": "order-archived",
+      "version": "1.0.0",
+      "name": "Order Archived",
+      "contentPath": "domains/Ordering/systems/order-management-system/services/OrderService/events/OrderArchived/index.mdx",
+      "contentHash": "sha256:1f0333a638c6f2b99c04f1dc31adf68f66140e2a84d9a390edf06df94ec1ca5a",
+      "owners": [
+        "ordering-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:f6d7182cf40649839fe9cd71c915ced965a07efbca4155e348d2a0e433e9b999"
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "id": "order-cancelled",
+      "version": "1.0.0",
+      "name": "Order Cancelled",
+      "contentPath": "domains/Ordering/systems/order-management-system/services/OrderService/events/OrderCancelled/index.mdx",
+      "contentHash": "sha256:40a682a027b00c641a45cb49e856e5b60274b7f4edd64e7bf01c85d647231b98",
+      "owners": [
+        "ordering-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:d31eab8d4640bfce048a3e3fc675bba0b00e9be3e8dfdf36049ae17f4827adb6"
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "id": "order-completed",
+      "version": "1.0.0",
+      "name": "Order Completed",
+      "contentPath": "domains/Ordering/systems/order-management-system/services/OrderService/events/OrderCompleted/index.mdx",
+      "contentHash": "sha256:9029654089b4aeead7915189d5300198556a33e4e1cdf541906811da29b5f74b",
+      "owners": [
+        "ordering-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:06a78ae6837672a16a6e613b648beb67739a1ac6f199fa85a9afcf357e3e27e4"
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "id": "order-confirmed",
+      "version": "1.0.0",
+      "name": "Order Confirmed",
+      "contentPath": "domains/Ordering/systems/order-management-system/services/OrderService/events/OrderConfirmed/index.mdx",
+      "contentHash": "sha256:636963f59ccc0ad83199f328bcd24cc17680e73581870827ea8c53cf150ccdf6",
+      "owners": [
+        "ordering-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:6fe7b47557ad2e57357794cb689889b82519ea9d69fa63a6fc1bcfeb0ea68920"
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "id": "order-created",
+      "version": "1.0.0",
+      "name": "Order Created",
+      "contentPath": "domains/Ordering/systems/order-management-system/services/OrderService/events/OrderCreated/index.mdx",
+      "contentHash": "sha256:93e32711132a7fb660e478eaf9155531e70bf7d92511c02b6b645ebe4ebc31b0",
+      "owners": [
+        "ordering-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:af211dfb2198f3db831ec1336b73325f270259adf5e4fd0c955d46d5b0799c27"
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "id": "order-created",
+      "version": "0.6.0",
+      "name": "Order Created",
+      "contentPath": "domains/Ordering/systems/order-management-system/services/OrderService/events/OrderCreated/versioned/0.6.0/index.mdx",
+      "contentHash": "sha256:c9da26cf097e09d0423565d8ffea75f7c8c2b1e1fede038bf16de0e8b0b4384d",
+      "owners": [
+        "ordering-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:9a8034f9c0c3f04246c79a3a88375177bdd310a742dcb8b5697e0d0e017eb98d"
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "id": "order-created",
+      "version": "0.3.0",
+      "name": "Order Created",
+      "contentPath": "domains/Ordering/systems/order-management-system/services/OrderService/events/OrderCreated/versioned/0.3.0/index.mdx",
+      "contentHash": "sha256:314e14146fb80ce3425a01460102bf945eb2698af5eec9f59916047e1a4f014f",
+      "owners": [
+        "ordering-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:db170b23b73c158d10df1aa758eb7397ddb4f938852310615d4507ba1a75012f"
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "id": "order-delivery-address-changed",
+      "version": "1.0.0",
+      "name": "Order Delivery Address Changed",
+      "contentPath": "domains/Ordering/systems/order-management-system/services/OrderService/events/OrderDeliveryAddressChanged/index.mdx",
+      "contentHash": "sha256:62408a60bf04499b857c46c112fd3018c77e9a4c1ce35a85544732ea533909b1",
+      "owners": [
+        "ordering-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:efc8a656bcaf388324237b4968f9b5fbd28a60584ad06a2ef458ac41b544854f"
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "id": "order-fulfilment-started",
+      "version": "1.0.0",
+      "name": "Order Fulfilment Started",
+      "contentPath": "domains/Ordering/systems/order-management-system/services/OrderService/events/OrderFulfilmentStarted/index.mdx",
+      "contentHash": "sha256:555ac845cf9ec5775972b12cecc006d2ef969baf58cd85c4bb6d178e05c16ced",
+      "owners": [
+        "ordering-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:7567fc4be8858b2c433a094254eef992365af572bcf11e9d917dcfcba04d9539"
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "id": "order-hold-released",
+      "version": "1.0.0",
+      "name": "Order Hold Released",
+      "contentPath": "domains/Ordering/systems/order-management-system/services/OrderService/events/OrderHoldReleased/index.mdx",
+      "contentHash": "sha256:7f44d1b27e6c599550fd0790094eac402ef7247406f781fa47fb543ebe7191b7",
+      "owners": [
+        "ordering-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:c8883752252f08165f0d0b82d10df5b5d8624d94e36276ad22313bf9579ac056"
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "id": "order-packed",
+      "version": "1.0.0",
+      "name": "Order Packed",
+      "contentPath": "domains/Fulfilment/systems/warehouse-system/services/PickingWorker/events/OrderPacked/index.mdx",
+      "contentHash": "sha256:963bc6551b123549927d9ecaa111e5877a525cecdb56e375fd1492fa2d515bf2",
+      "owners": [
+        "fulfilment-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:15d36e04f5ef8b8d7534d3ab11bd74c2138c0ec6edbd09d436cf0ce75dcbe73c"
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "id": "order-placed-on-hold",
+      "version": "1.0.0",
+      "name": "Order Placed On Hold",
+      "contentPath": "domains/Ordering/systems/order-management-system/services/OrderService/events/OrderPlacedOnHold/index.mdx",
+      "contentHash": "sha256:a4ac2a2773712fbf3f7a5636d0353e5af39f909f7b8b2d377713412bf24802f7",
+      "owners": [
+        "ordering-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:1fa646b5128121dc7a1f070f425a03ab0b512ade24944ff4fd98695f7e0ff6b2"
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "id": "order-ready-for-shipping",
+      "version": "1.0.0",
+      "name": "Order Ready For Shipping",
+      "contentPath": "domains/Fulfilment/systems/warehouse-system/services/WarehouseService/events/OrderReadyForShipping/index.mdx",
+      "contentHash": "sha256:5dfb23724776e2814703630962b157ef7efb3f71dcd05a53c3e381fe029263e6",
+      "owners": [
+        "fulfilment-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:026538a49f5715f66e2c54b1bbbdaa42078264dba3eb8320f4147680a2bd5892"
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "id": "order-status-changed",
+      "version": "1.0.0",
+      "name": "Order Status Changed",
+      "contentPath": "domains/Ordering/systems/order-management-system/services/OrderService/events/OrderStatusChanged/index.mdx",
+      "contentHash": "sha256:7b332a4731b6b299e406a90533e0abbfa1d05573e612a02e36e262cffb355fc0",
+      "owners": [
+        "ordering-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:41ccc4618a4899d5f5ec486148b10bb9af53a1c16580c08f1e6e154c979a78fa"
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "id": "payment-failed",
+      "version": "1.0.0",
+      "name": "Payment Failed",
+      "contentPath": "domains/Payments/systems/stripe/services/StripeWebhookEndpoint/events/PaymentFailed/index.mdx",
+      "contentHash": "sha256:423fb82c1690e8f49e446a0583c47546481d793383eeea524d26ca4b527a956e",
+      "owners": [
+        "payments-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:518debd8c9f350ef5803e25f387de149f1c9394bd3332e735906430e633b9bb7"
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "id": "payment-requested",
+      "version": "1.0.0",
+      "name": "Payment Requested",
+      "contentPath": "domains/Payments/systems/payment-processing-system/services/PaymentWorker/events/PaymentRequested/index.mdx",
+      "contentHash": "sha256:67db48cc0527ebd98e780ff2884ca93f762311f3fc8ba86d899b5f542cc481f2",
+      "owners": [
+        "payments-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:d3e85e0309df030d8b835bddee99acab7349ee87c34655ae4ca953d44f723ffb"
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "id": "payment-succeeded",
+      "version": "1.0.0",
+      "name": "Payment Succeeded",
+      "contentPath": "domains/Payments/systems/stripe/services/StripeWebhookEndpoint/events/PaymentSucceeded/index.mdx",
+      "contentHash": "sha256:4d166455f15f000435e8ebee4c735442dad4577530b12633a02c1a28a68388ad",
+      "owners": [
+        "payments-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:e15ad586af41416bff2552b281bc0c7830adb5a9f373c852d3ed3b8a66efd1b5"
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "id": "product-created",
+      "version": "1.0.0",
+      "name": "Product Created",
+      "contentPath": "domains/Catalog/systems/product-catalog-system/services/ProductAPI/events/ProductCreated/index.mdx",
+      "contentHash": "sha256:e1f9a5a4e9c6e0373501a8eb7088fcf134544e47a71de6e3f9e1b3618e347b02",
+      "owners": [
+        "product-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:4e56f2f940f9736a0c3eb42d219813ae908402e93fe928cbe79b510cc9863308"
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "id": "product-deleted",
+      "version": "1.0.0",
+      "name": "Product Deleted",
+      "contentPath": "domains/Catalog/systems/product-catalog-system/services/ProductAPI/events/ProductDeleted/index.mdx",
+      "contentHash": "sha256:2ab5906b2b54e86789f464c030fea4e7f9624082081b21500a3a0b51b2c5f2c2",
+      "owners": [
+        "product-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:edc48129f8b3941c8c5ebc44ac2afd09572db433587ef1cf8e78f3f583c3b00d"
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "id": "product-updated",
+      "version": "1.0.0",
+      "name": "Product Updated",
+      "contentPath": "domains/Catalog/systems/product-catalog-system/services/ProductAPI/events/ProductUpdated/index.mdx",
+      "contentHash": "sha256:c27b06cd5369639ca4eda268af8b8158cacde6646ce9053cbf3c39b0d20e4879",
+      "owners": [
+        "product-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:9f712814510b4abd5d8f0b0defaa2daf33afa0a01e2437c3610c814cccfe0956"
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "id": "rating-updated",
+      "version": "1.0.0",
+      "name": "Rating Updated",
+      "contentPath": "domains/Reviews/services/RatingAggregator/events/rating-updated/index.mdx",
+      "contentHash": "sha256:0aa40cf2d95dcb22ca3bfc9ca835ef050f6321365ab65172cdcea4fbf0f3f13b",
+      "owners": [
+        "reviews-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:ac253fc46f7d986e7192b79e7197d3f83e6222a1a4d5feb02e5d54a47ec2e0f8"
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "id": "refund-processed",
+      "version": "1.0.0",
+      "name": "Refund Processed",
+      "contentPath": "domains/Payments/systems/stripe/services/StripeWebhookEndpoint/events/RefundProcessed/index.mdx",
+      "contentHash": "sha256:5fab76c0a685b1bc26b41d0ca106158cd638aa3d45f3b8f56e4afe95f76ef2bb",
+      "owners": [
+        "payments-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:a4f12e2962254dda385b2bf0b20078e59f5d746660940c1eaabd7bf9492beafd"
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "id": "refund-requested",
+      "version": "1.0.0",
+      "name": "Refund Requested",
+      "contentPath": "domains/Payments/systems/payment-processing-system/services/PaymentWorker/events/RefundRequested/index.mdx",
+      "contentHash": "sha256:c06b201508538f37e6d00878ab63f03d34fb5130e5445d993bcdc180a52f0aff",
+      "owners": [
+        "payments-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:1324237f388090a263700d9ac55dd44ca0305b7594d37803022cf145c6f54ea3"
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "id": "review-flagged",
+      "version": "1.0.0",
+      "name": "Review Flagged",
+      "contentPath": "domains/Reviews/services/ReviewAPI/events/review-flagged/index.mdx",
+      "contentHash": "sha256:b6703a382299791339fbdb9337c4d9e223f94603d3be8296f1e9b63d7130aec9",
+      "owners": [
+        "reviews-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:bfad84a870f1580599e26a02ea5145338a8d1255357751697fe5bbc6b7db3e3b"
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "id": "review-helpful-voted",
+      "version": "1.0.0",
+      "name": "Review Helpful Voted",
+      "contentPath": "domains/Reviews/services/ReviewAPI/events/review-helpful-voted/index.mdx",
+      "contentHash": "sha256:61b3430cf7f553490d5ff5f0624a25961ccaea33ebba76dc81a178668cc63999",
+      "owners": [
+        "reviews-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:8f6865aecc46a4e67a8b22de31409dd228996e3879bf28d65e1e3b1bc434be52"
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "id": "review-published",
+      "version": "1.0.0",
+      "name": "Review Published",
+      "contentPath": "domains/Reviews/services/ReviewModerationWorker/events/review-published/index.mdx",
+      "contentHash": "sha256:a4ad0789f3e123ef6011a2e2a95580dcf9881d41b556f8fb9dc3c39679f9871b",
+      "owners": [
+        "reviews-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:4a1870933a64fb56d6e7c6a06d5509d34e0c42661dcbbe277c0d5c80133df293"
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "id": "review-rejected",
+      "version": "1.0.0",
+      "name": "Review Rejected",
+      "contentPath": "domains/Reviews/services/ReviewModerationWorker/events/review-rejected/index.mdx",
+      "contentHash": "sha256:349c419f78e405790b9b1001b0f36723100bb81ae0a494eaa8ae33b5ca405836",
+      "owners": [
+        "reviews-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:5cea41ad2843f285af04bdfa634d0ecc8d31492ae4430ca0af44d6faa08d0a47"
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "id": "review-submitted",
+      "version": "1.0.0",
+      "name": "Review Submitted",
+      "contentPath": "domains/Reviews/services/ReviewAPI/events/review-submitted/index.mdx",
+      "contentHash": "sha256:c53eb50074a8e0857c37d84e5ff7828e1b79508bd771e787745acc8bdf61552d",
+      "owners": [
+        "reviews-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:05564754b8f093f5ac760602a9762df04005e9797ac275d670066210006c9e0e"
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "id": "shipment-created",
+      "version": "1.0.0",
+      "name": "Shipment Created",
+      "contentPath": "domains/Fulfilment/systems/carrier/services/CarrierTrackingAPI/events/ShipmentCreated/index.mdx",
+      "contentHash": "sha256:42a936b002bfc3c81126f78b6e43cbfdcdb3961d224e254918bb3dacca064299",
+      "owners": [
+        "fulfilment-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:c5b489386d762f6eeadf2667a9f1397646ae2b43ca8065cc118e4080b3acea7b"
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "id": "shipment-delivered",
+      "version": "1.0.0",
+      "name": "Shipment Delivered",
+      "contentPath": "domains/Fulfilment/systems/carrier/services/CarrierTrackingAPI/events/ShipmentDelivered/index.mdx",
+      "contentHash": "sha256:ded00744eb8f809c9f3f5f62bfffe6f434754a14c067b47d3730f8b761054bc1",
+      "owners": [
+        "fulfilment-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:72cdaf9a911ea867115b9c4a0cd515352b71d888db90afae76ba573b2ceaa110"
+        }
+      ]
+    },
+    {
+      "type": "event",
+      "id": "shipment-failed",
+      "version": "1.0.0",
+      "name": "Shipment Failed",
+      "contentPath": "domains/Fulfilment/systems/carrier/services/CarrierTrackingAPI/events/ShipmentFailed/index.mdx",
+      "contentHash": "sha256:48dc7e9c1315366924056fe853e8728469ef79f47b9b9d66fc3d577d06955644",
+      "owners": [
+        "fulfilment-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:452721b4301f092406e121da29da4ef1cbb91141e0926bb4155eb41ee18870ab"
+        }
+      ]
+    },
+    {
+      "type": "flow",
+      "id": "checkout-saga",
+      "version": "1.0.0",
+      "name": "Checkout Saga",
+      "contentPath": "domains/Ordering/systems/checkout-system/flows/CheckoutSaga/index.mdx",
+      "contentHash": "sha256:5d22c06fda75bcb53ede4bd5860252bfc4ce58a3e015386c1895295ee61999d7",
+      "owners": [
+        "ordering-platform"
+      ],
+      "references": [
+        {
+          "kind": "message",
+          "id": "cart-checked-out",
+          "version": "1.0.0"
+        },
+        {
+          "kind": "service",
+          "id": "checkout-api",
+          "version": "1.0.0"
+        },
+        {
+          "kind": "service",
+          "id": "checkout-orchestrator",
+          "version": "1.0.0"
+        },
+        {
+          "kind": "message",
+          "id": "reserve-inventory",
+          "version": "1.0.0"
+        },
+        {
+          "kind": "message",
+          "id": "authorize-payment",
+          "version": "1.0.0"
+        },
+        {
+          "kind": "message",
+          "id": "create-order",
+          "version": "1.0.0"
+        }
+      ]
+    },
+    {
+      "type": "flow",
+      "id": "order-cancellation",
+      "version": "1.0.0",
+      "name": "Order Cancellation",
+      "contentPath": "domains/Ordering/systems/order-management-system/flows/OrderCancellation/index.mdx",
+      "contentHash": "sha256:0db604e655dee81b049ea49960ecf48d82d92b1fdc191e0ead704ecfd60b34d5",
+      "owners": [
+        "ordering-platform"
+      ],
+      "references": [
+        {
+          "kind": "message",
+          "id": "cancel-order",
+          "version": "1.0.0"
+        },
+        {
+          "kind": "service",
+          "id": "order-service",
+          "version": "1.0.0"
+        },
+        {
+          "kind": "container",
+          "id": "order-database"
+        },
+        {
+          "kind": "message",
+          "id": "order-cancelled",
+          "version": "1.0.0"
+        }
+      ]
+    },
+    {
+      "type": "flow",
+      "id": "place-an-order",
+      "version": "1.0.0",
+      "name": "Place an Order",
+      "contentPath": "domains/Ordering/flows/PlaceAnOrder/index.mdx",
+      "contentHash": "sha256:a0bc2d64cfce55a17ae5118c25c7b227cf83558a0d3bfae0bb20c4543d1e4506",
+      "owners": [
+        "ordering-platform"
+      ],
+      "references": [
+        {
+          "kind": "message",
+          "id": "checkout-cart",
+          "version": "1.0.0"
+        },
+        {
+          "kind": "service",
+          "id": "cart-api",
+          "version": "1.0.0"
+        },
+        {
+          "kind": "message",
+          "id": "cart-checked-out",
+          "version": "1.0.0"
+        },
+        {
+          "kind": "service",
+          "id": "checkout-api",
+          "version": "1.0.0"
+        },
+        {
+          "kind": "service",
+          "id": "checkout-orchestrator",
+          "version": "1.0.0"
+        },
+        {
+          "kind": "message",
+          "id": "reserve-inventory",
+          "version": "1.0.0"
+        },
+        {
+          "kind": "message",
+          "id": "authorize-payment",
+          "version": "1.0.0"
+        },
+        {
+          "kind": "message",
+          "id": "create-order",
+          "version": "1.0.0"
+        },
+        {
+          "kind": "service",
+          "id": "order-service",
+          "version": "1.0.0"
+        },
+        {
+          "kind": "message",
+          "id": "order-created",
+          "version": "1.0.0"
+        },
+        {
+          "kind": "message",
+          "id": "order-cancelled",
+          "version": "1.0.0"
+        }
+      ]
+    },
+    {
+      "type": "flow",
+      "id": "product-search-indexing",
+      "version": "1.0.0",
+      "name": "Product Search Indexing",
+      "contentPath": "domains/Catalog/systems/search-system/flows/ProductSearchIndexing/index.mdx",
+      "contentHash": "sha256:eea8987eca0408e6a4cc53f8f4d5379946b9902c1ab7dfe779135c1bbb4a5cfd",
+      "owners": [
+        "search-platform"
+      ],
+      "references": [
+        {
+          "kind": "service",
+          "id": "product-api",
+          "version": "1.0.0"
+        },
+        {
+          "kind": "container",
+          "id": "product-database"
+        },
+        {
+          "kind": "service",
+          "id": "product-search-publisher",
+          "version": "1.0.0"
+        },
+        {
+          "kind": "message",
+          "id": "product-created",
+          "version": "1.0.0"
+        },
+        {
+          "kind": "message",
+          "id": "product-updated",
+          "version": "1.0.0"
+        },
+        {
+          "kind": "message",
+          "id": "product-deleted",
+          "version": "1.0.0"
+        },
+        {
+          "kind": "service",
+          "id": "search-indexer",
+          "version": "1.0.0"
+        },
+        {
+          "kind": "container",
+          "id": "search-index"
+        }
+      ]
+    },
+    {
+      "type": "flow",
+      "id": "review-submission",
+      "version": "1.0.0",
+      "name": "Review Submission",
+      "contentPath": "domains/Reviews/flows/review-submission/index.mdx",
+      "contentHash": "sha256:e7d5a4ba77445cd62c68fca3b6c3643295bc2c572a0a9dc79d92ac185aac7ad5",
+      "owners": [
+        "reviews-platform"
+      ],
+      "references": [
+        {
+          "kind": "service",
+          "id": "review-api",
+          "version": "1.0.0"
+        },
+        {
+          "kind": "container",
+          "id": "review-database"
+        },
+        {
+          "kind": "message",
+          "id": "review-submitted",
+          "version": "1.0.0"
+        },
+        {
+          "kind": "service",
+          "id": "review-moderation-worker",
+          "version": "1.0.0"
+        },
+        {
+          "kind": "message",
+          "id": "review-published",
+          "version": "1.0.0"
+        },
+        {
+          "kind": "message",
+          "id": "review-rejected",
+          "version": "1.0.0"
+        },
+        {
+          "kind": "service",
+          "id": "rating-aggregator",
+          "version": "1.0.0"
+        },
+        {
+          "kind": "container",
+          "id": "rating-cache"
+        }
+      ]
+    },
+    {
+      "type": "query",
+      "id": "get-customer",
+      "version": "1.0.0",
+      "name": "Get Customer",
+      "contentPath": "domains/Customer/systems/customer-management-system/services/CustomerAPI/queries/GetCustomer/index.mdx",
+      "contentHash": "sha256:6c802a77ffdabbd7c001b1a328a9968cabb63319c2cc5d967dcaaffd850cb424",
+      "owners": [
+        "customer-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:a3c81226be8efcccd946d5d9f26c07e2cc210c28c39ebc7b1b1eceb27555db76"
+        }
+      ]
+    },
+    {
+      "type": "query",
+      "id": "get-order",
+      "version": "1.0.0",
+      "name": "Get Order",
+      "contentPath": "domains/Ordering/systems/order-management-system/services/OrderService/queries/GetOrder/index.mdx",
+      "contentHash": "sha256:ab5969012363be01584ac52e0f0974216826b8def5ab8b06bac87a93ce3fe657",
+      "owners": [
+        "ordering-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:2d5caf6b8503c08eabfb55e4f75e5501d3d4f9db1d8b20e3c0553de5710b2197"
+        }
+      ]
+    },
+    {
+      "type": "query",
+      "id": "get-product",
+      "version": "1.0.0",
+      "name": "Get Product",
+      "contentPath": "domains/Catalog/systems/product-catalog-system/services/ProductAPI/queries/GetProduct/index.mdx",
+      "contentHash": "sha256:ba1274e127aa40b2fd8c1bbfb3defa7b4dcef5d3d896f0522487d37fcb28ea53",
+      "owners": [
+        "product-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:6d6523bb91ee98b4d2a5cce4cb896111534d660c531d2f2306367c5f9c436116"
+        }
+      ]
+    },
+    {
+      "type": "query",
+      "id": "get-product-reviews",
+      "version": "1.0.0",
+      "name": "Get Product Reviews",
+      "contentPath": "domains/Reviews/services/ReviewAPI/queries/get-product-reviews/index.mdx",
+      "contentHash": "sha256:f4cb0f9f112137eab2a1c356993a12415487fc1ab68949784d51b5f8b373a172",
+      "owners": [
+        "reviews-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:c49dcaabed69d060555f983d64153aafc3e645d34fb26852146af432b7f35b33"
+        }
+      ]
+    },
+    {
+      "type": "query",
+      "id": "get-stock-level",
+      "version": "1.0.0",
+      "name": "Get Stock Level",
+      "contentPath": "domains/Fulfilment/systems/inventory-system/services/InventoryService/queries/GetStockLevel/index.mdx",
+      "contentHash": "sha256:33375b042f9f2b51b159a8ca15cff7e77e6aa4b2aca4b732c9b1e24a3ee8780d",
+      "owners": [
+        "fulfilment-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:f6c62d0e5e0995ad9b503225f79fd013b660ab5bd16bcb33e9598ca29c96bf9d"
+        }
+      ]
+    },
+    {
+      "type": "query",
+      "id": "search-products",
+      "version": "1.0.0",
+      "name": "Search Products",
+      "contentPath": "domains/Catalog/systems/search-system/services/SearchAPI/queries/SearchProducts/index.mdx",
+      "contentHash": "sha256:e02a0060acbfd9cd4e0405ef76a6cebb055ec7a95b6947fc67e6b4f29951b584",
+      "owners": [
+        "search-platform"
+      ],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:03c6b246f91ac07b2f7e8206afb75a26265dafc2b5ec88a1938434f947f12387"
+        }
+      ]
+    },
+    {
+      "type": "service",
+      "id": "carrier-adapter",
+      "version": "1.0.0",
+      "name": "Carrier Adapter",
+      "contentPath": "domains/Fulfilment/systems/shipping-system/services/CarrierAdapter/index.mdx",
+      "contentHash": "sha256:1194ad01f16f233dadefa14925ec4af2cd73715f03bac9bae45e5c27650e423d",
+      "owners": [
+        "fulfilment-platform"
+      ],
+      "sends": [
+        {
+          "id": "create-shipment",
+          "version": "1.0.0"
+        }
+      ]
+    },
+    {
+      "type": "service",
+      "id": "carrier-shipping-api",
+      "version": "1.0.0",
+      "name": "Shipping API",
+      "contentPath": "domains/Fulfilment/systems/carrier/services/CarrierShippingAPI/index.mdx",
+      "contentHash": "sha256:a106c0dcc0e853de68dc765501a14a75dbe16523056023fa9d0a7240ad90fa70",
+      "owners": [
+        "fulfilment-platform"
+      ],
+      "receives": [
+        {
+          "id": "create-shipment",
+          "version": "1.0.0"
+        }
+      ]
+    },
+    {
+      "type": "service",
+      "id": "carrier-tracking-api",
+      "version": "1.0.0",
+      "name": "Tracking API",
+      "contentPath": "domains/Fulfilment/systems/carrier/services/CarrierTrackingAPI/index.mdx",
+      "contentHash": "sha256:aa38f11ebb650eafa0c0a9ef1ead89befe179d0ca4b223050cb22e215351d3a5",
+      "owners": [
+        "fulfilment-platform"
+      ],
+      "sends": [
+        {
+          "id": "shipment-created",
+          "version": "1.0.0"
+        },
+        {
+          "id": "shipment-delivered",
+          "version": "1.0.0"
+        },
+        {
+          "id": "shipment-failed",
+          "version": "1.0.0"
+        }
+      ]
+    },
+    {
+      "type": "service",
+      "id": "cart-api",
+      "version": "1.0.0",
+      "name": "Cart API",
+      "contentPath": "domains/Shopping/systems/cart-system/services/CartAPI/index.mdx",
+      "contentHash": "sha256:eb381f0cf346618df09415a2b0eda11f4f52b24b240c38d664e025a1ba941080",
+      "owners": [
+        "shopping-platform"
+      ],
+      "specifications": [
+        {
+          "type": "openapi",
+          "path": "openapi.yml",
+          "name": "Cart API",
+          "hash": "sha256:7cb9ecbc22ceffbd7626ff3149bfc3fee0d8bd552daac299c0ee6599f49c00c4"
+        }
+      ],
+      "sidecars": [
+        {
+          "path": "domains/Shopping/systems/cart-system/services/CartAPI/openapi-2.yml",
+          "hash": "sha256:7cb9ecbc22ceffbd7626ff3149bfc3fee0d8bd552daac299c0ee6599f49c00c4"
+        }
+      ],
+      "sends": [
+        {
+          "id": "cart-checked-out",
+          "version": "1.0.0"
+        },
+        {
+          "id": "calculate-discount",
+          "version": "1.0.0"
+        }
+      ],
+      "receives": [
+        {
+          "id": "add-item-to-cart",
+          "version": "1.0.0"
+        },
+        {
+          "id": "remove-item-from-cart",
+          "version": "1.0.0"
+        },
+        {
+          "id": "checkout-cart",
+          "version": "1.0.0"
+        }
+      ],
+      "writesTo": [
+        {
+          "id": "cart-database"
+        }
+      ],
+      "readsFrom": [
+        {
+          "id": "cart-database"
+        }
+      ]
+    },
+    {
+      "type": "service",
+      "id": "checkout-api",
+      "version": "1.0.0",
+      "name": "Checkout API",
+      "contentPath": "domains/Ordering/systems/checkout-system/services/CheckoutAPI/index.mdx",
+      "contentHash": "sha256:6cb716edeac80b6ea038e75e10d07e3fe46cd88b08e8cc76bf6060a7ea26367b",
+      "owners": [
+        "ordering-platform"
+      ],
+      "receives": [
+        {
+          "id": "checkout-cart",
+          "version": "1.0.0"
+        }
+      ]
+    },
+    {
+      "type": "service",
+      "id": "checkout-orchestrator",
+      "version": "1.0.0",
+      "name": "Checkout Orchestrator",
+      "contentPath": "domains/Ordering/systems/checkout-system/services/CheckoutOrchestrator/index.mdx",
+      "contentHash": "sha256:71bffdf03696cfc7103373e98e8f7225b55710f2e9fa28dcabcb08ffff3989a5",
+      "owners": [
+        "ordering-platform"
+      ],
+      "sends": [
+        {
+          "id": "reserve-inventory",
+          "version": "1.0.0"
+        },
+        {
+          "id": "authorize-payment",
+          "version": "1.0.0"
+        },
+        {
+          "id": "create-order",
+          "version": "1.0.0"
+        }
+      ]
+    },
+    {
+      "type": "service",
+      "id": "customer-api",
+      "version": "1.0.0",
+      "name": "Customer API",
+      "contentPath": "domains/Customer/systems/customer-management-system/services/CustomerAPI/index.mdx",
+      "contentHash": "sha256:5e17549a539f95cf781b0add84c974af553ae799bbd47043dcf1cec4dab1c3a8",
+      "owners": [
+        "customer-platform"
+      ],
+      "specifications": [
+        {
+          "type": "openapi",
+          "path": "openapi.yml",
+          "name": "Customer API",
+          "hash": "sha256:e980d2e7347221d719bd804b2b4deaa31921824346ffbe2a619980783467e096"
+        }
+      ],
+      "sends": [
+        {
+          "id": "customer-registered",
+          "version": "1.0.0"
+        },
+        {
+          "id": "customer-updated",
+          "version": "1.0.0"
+        }
+      ],
+      "receives": [
+        {
+          "id": "register-customer",
+          "version": "1.0.0",
+          "triggers": [
+            {
+              "id": "customer-registered",
+              "version": "1.0.0",
+              "condition": "When the customer registration is validated and persisted"
+            }
+          ]
+        },
+        {
+          "id": "update-customer",
+          "version": "1.0.0",
+          "triggers": [
+            {
+              "id": "customer-updated",
+              "version": "1.0.0",
+              "condition": "When the customer profile changes are persisted"
+            }
+          ]
+        },
+        {
+          "id": "get-customer",
+          "version": "1.0.0"
+        }
+      ],
+      "writesTo": [
+        {
+          "id": "customer-database"
+        }
+      ],
+      "readsFrom": [
+        {
+          "id": "customer-database"
+        }
+      ]
+    },
+    {
+      "type": "service",
+      "id": "fraud-api",
+      "version": "1.0.0",
+      "name": "Fraud API",
+      "contentPath": "domains/Payments/systems/fraud-detection/services/FraudAPI/index.mdx",
+      "contentHash": "sha256:932017c595046697606a669cb2a324b15e4e7f0377855b9d78809c62b9aff05b",
+      "owners": [
+        "payments-platform"
+      ],
+      "sends": [
+        {
+          "id": "fraud-check-passed",
+          "version": "1.0.0"
+        },
+        {
+          "id": "fraud-check-failed",
+          "version": "1.0.0"
+        }
+      ],
+      "receives": [
+        {
+          "id": "payment-requested",
+          "version": "1.0.0"
+        }
+      ]
+    },
+    {
+      "type": "service",
+      "id": "inventory-service",
+      "version": "1.0.0",
+      "name": "Inventory Service",
+      "contentPath": "domains/Fulfilment/systems/inventory-system/services/InventoryService/index.mdx",
+      "contentHash": "sha256:ab784d0b72d31fa49a6d40cc22db6620a59505bac10576527abd26c3d59ba798",
+      "owners": [
+        "fulfilment-platform"
+      ],
+      "sends": [
+        {
+          "id": "inventory-reserved",
+          "version": "1.0.0"
+        },
+        {
+          "id": "inventory-unavailable",
+          "version": "1.0.0"
+        }
+      ],
+      "receives": [
+        {
+          "id": "reserve-inventory",
+          "version": "1.0.0",
+          "triggers": [
+            {
+              "id": "inventory-reserved",
+              "version": "1.0.0",
+              "condition": "When sufficient stock is available"
+            },
+            {
+              "id": "inventory-unavailable",
+              "version": "1.0.0",
+              "condition": "When there is not enough stock to fulfil the reservation"
+            }
+          ]
+        },
+        {
+          "id": "release-inventory",
+          "version": "1.0.0"
+        },
+        {
+          "id": "get-stock-level",
+          "version": "1.0.0"
+        }
+      ],
+      "writesTo": [
+        {
+          "id": "inventory-database"
+        }
+      ],
+      "readsFrom": [
+        {
+          "id": "inventory-database"
+        }
+      ]
+    },
+    {
+      "type": "service",
+      "id": "oauth-api",
+      "version": "1.0.0",
+      "name": "OAuth API",
+      "contentPath": "domains/Customer/systems/identity-provider/services/OAuthAPI/index.mdx",
+      "contentHash": "sha256:c0655f4ce95d422a1cf95d05902de331876dac094a5330be65586175ccb44824",
+      "owners": [
+        "customer-platform"
+      ],
+      "sends": [
+        {
+          "id": "customer-authenticated",
+          "version": "1.0.0"
+        }
+      ],
+      "receives": [
+        {
+          "id": "authenticate-customer",
+          "version": "1.0.0"
+        }
+      ],
+      "readsFrom": [
+        {
+          "id": "user-directory"
+        }
+      ]
+    },
+    {
+      "type": "service",
+      "id": "order-service",
+      "version": "1.0.0",
+      "name": "Order Service",
+      "contentPath": "domains/Ordering/systems/order-management-system/services/OrderService/index.mdx",
+      "contentHash": "sha256:6603ecb47b7fbf521db0c9b9499304ab75d086cd837de3200101707500fc5907",
+      "owners": [
+        "ordering-platform"
+      ],
+      "specifications": [
+        {
+          "type": "asyncapi",
+          "path": "asyncapi.yml",
+          "name": "Order Service AsyncAPI",
+          "hash": "sha256:acc23a9294215d4c6d1e2f82222014e5755cac40a7b5ecdb7924f2cf49b435ee"
+        }
+      ],
+      "sends": [
+        {
+          "id": "order-created",
+          "version": "1.0.0"
+        },
+        {
+          "id": "order-confirmed",
+          "version": "1.0.0"
+        },
+        {
+          "id": "order-amended",
+          "version": "1.0.0"
+        },
+        {
+          "id": "order-placed-on-hold",
+          "version": "1.0.0"
+        },
+        {
+          "id": "order-hold-released",
+          "version": "1.0.0"
+        },
+        {
+          "id": "order-fulfilment-started",
+          "version": "1.0.0"
+        },
+        {
+          "id": "order-status-changed",
+          "version": "1.0.0"
+        },
+        {
+          "id": "order-delivery-address-changed",
+          "version": "1.0.0"
+        },
+        {
+          "id": "order-archived",
+          "version": "1.0.0"
+        },
+        {
+          "id": "order-completed",
+          "version": "1.0.0"
+        },
+        {
+          "id": "order-cancelled",
+          "version": "1.0.0"
+        }
+      ],
+      "receives": [
+        {
+          "id": "create-order",
+          "version": "1.0.0",
+          "triggers": [
+            {
+              "id": "order-created",
+              "version": "1.0.0",
+              "condition": "When the order is validated and persisted"
+            }
+          ]
+        },
+        {
+          "id": "cancel-order",
+          "version": "1.0.0",
+          "triggers": [
+            {
+              "id": "order-cancelled",
+              "version": "1.0.0",
+              "condition": "When the order can be cancelled successfully"
+            }
+          ]
+        },
+        {
+          "id": "get-order",
+          "version": "1.0.0"
+        }
+      ],
+      "writesTo": [
+        {
+          "id": "order-database"
+        }
+      ],
+      "readsFrom": [
+        {
+          "id": "order-database"
+        }
+      ]
+    },
+    {
+      "type": "service",
+      "id": "payment-api",
+      "version": "1.0.0",
+      "name": "Payment API",
+      "contentPath": "domains/Payments/systems/payment-processing-system/services/PaymentAPI/index.mdx",
+      "contentHash": "sha256:0678b124dbfa077a6f9957fb03f248ed4816dc25f5a8167c1fe17f0abf29144b",
+      "owners": [
+        "payments-platform"
+      ],
+      "receives": [
+        {
+          "id": "authorize-payment",
+          "version": "1.0.0"
+        }
+      ],
+      "writesTo": [
+        {
+          "id": "payment-database"
+        }
+      ],
+      "readsFrom": [
+        {
+          "id": "payment-database"
+        }
+      ]
+    },
+    {
+      "type": "service",
+      "id": "payment-worker",
+      "version": "1.0.0",
+      "name": "Payment Worker",
+      "contentPath": "domains/Payments/systems/payment-processing-system/services/PaymentWorker/index.mdx",
+      "contentHash": "sha256:d4b1681bf27fe7042d1de20d1b2ad1971a1b8c3e2a9c09d996b11a2b578ae621",
+      "owners": [
+        "payments-platform"
+      ],
+      "sends": [
+        {
+          "id": "payment-requested",
+          "version": "1.0.0"
+        },
+        {
+          "id": "refund-requested",
+          "version": "1.0.0"
+        }
+      ],
+      "receives": [
+        {
+          "id": "payment-succeeded",
+          "version": "1.0.0"
+        },
+        {
+          "id": "payment-failed",
+          "version": "1.0.0"
+        }
+      ],
+      "writesTo": [
+        {
+          "id": "payment-database"
+        }
+      ],
+      "readsFrom": [
+        {
+          "id": "payment-database"
+        }
+      ]
+    },
+    {
+      "type": "service",
+      "id": "picking-worker",
+      "version": "1.0.0",
+      "name": "Picking Worker",
+      "contentPath": "domains/Fulfilment/systems/warehouse-system/services/PickingWorker/index.mdx",
+      "contentHash": "sha256:496cadc6168e1b0fce2090a86bc26014144222375b6db79cae694a59bd401f85",
+      "owners": [
+        "fulfilment-platform"
+      ],
+      "sends": [
+        {
+          "id": "order-packed",
+          "version": "1.0.0"
+        }
+      ],
+      "writesTo": [
+        {
+          "id": "warehouse-database"
+        }
+      ],
+      "readsFrom": [
+        {
+          "id": "warehouse-database"
+        }
+      ]
+    },
+    {
+      "type": "service",
+      "id": "product-api",
+      "version": "1.0.0",
+      "name": "Product API",
+      "contentPath": "domains/Catalog/systems/product-catalog-system/services/ProductAPI/index.mdx",
+      "contentHash": "sha256:0a3d73879bba3a2719e9d013d19f884693e4dd06328e0f88b4ee7a1c68318bcc",
+      "owners": [
+        "product-platform"
+      ],
+      "specifications": [
+        {
+          "type": "openapi",
+          "path": "openapi.yml",
+          "name": "Product API",
+          "hash": "sha256:76d20efb09279ff1ccc0ea695f4b3a4c066bf5777a7b195bed66357a44468d18"
+        }
+      ],
+      "receives": [
+        {
+          "id": "create-product",
+          "version": "1.0.0"
+        },
+        {
+          "id": "update-product",
+          "version": "1.0.0"
+        },
+        {
+          "id": "delete-product",
+          "version": "1.0.0"
+        },
+        {
+          "id": "get-product",
+          "version": "1.0.0"
+        }
+      ],
+      "writesTo": [
+        {
+          "id": "product-database"
+        }
+      ],
+      "readsFrom": [
+        {
+          "id": "product-database"
+        }
+      ]
+    },
+    {
+      "type": "service",
+      "id": "product-search-publisher",
+      "version": "1.0.0",
+      "name": "Product Search Publisher",
+      "contentPath": "domains/Catalog/systems/product-catalog-system/services/ProductSearchPublisher/index.mdx",
+      "contentHash": "sha256:9d2a6756bb5804c706d9005e42a9f1dbd6e7bace9e01a86ed3104cb85f04551e",
+      "owners": [
+        "product-platform"
+      ],
+      "sends": [
+        {
+          "id": "product-created",
+          "version": "1.0.0"
+        },
+        {
+          "id": "product-updated",
+          "version": "1.0.0"
+        },
+        {
+          "id": "product-deleted",
+          "version": "1.0.0"
+        }
+      ],
+      "readsFrom": [
+        {
+          "id": "product-database"
+        }
+      ]
+    },
+    {
+      "type": "service",
+      "id": "product-worker",
+      "version": "1.0.0",
+      "name": "Product Worker",
+      "contentPath": "domains/Catalog/systems/product-catalog-system/services/ProductWorker/index.mdx",
+      "contentHash": "sha256:adf3f9fdb74608583125b78bcb273dfb76c96330182581a7077592c2e8a351d1",
+      "owners": [
+        "product-platform"
+      ],
+      "writesTo": [
+        {
+          "id": "product-database"
+        }
+      ],
+      "readsFrom": [
+        {
+          "id": "product-database"
+        }
+      ]
+    },
+    {
+      "type": "service",
+      "id": "promotion-service",
+      "version": "1.0.0",
+      "name": "Promotion Service",
+      "contentPath": "domains/Shopping/systems/promotion-system/services/PromotionService/index.mdx",
+      "contentHash": "sha256:e0cfb37cdf3efb1d2e663b331ba827afdc612d28f411da8bb2c4e4c62f601371",
+      "owners": [
+        "shopping-platform"
+      ],
+      "sends": [
+        {
+          "id": "discount-calculated",
+          "version": "1.0.0"
+        }
+      ],
+      "receives": [
+        {
+          "id": "calculate-discount",
+          "version": "1.0.0"
+        }
+      ],
+      "readsFrom": [
+        {
+          "id": "promotion-database"
+        }
+      ]
+    },
+    {
+      "type": "service",
+      "id": "rating-aggregator",
+      "version": "1.0.0",
+      "name": "Rating Aggregator",
+      "contentPath": "domains/Reviews/services/RatingAggregator/index.mdx",
+      "contentHash": "sha256:b07c78b76dcc84cf5c816e36f17647a103ec67c0e38ed5ef9c9f3870ee76edde",
+      "owners": [
+        "reviews-platform"
+      ],
+      "sends": [
+        {
+          "id": "rating-updated",
+          "version": "1.0.0"
+        }
+      ],
+      "receives": [
+        {
+          "id": "review-published",
+          "version": "1.0.0"
+        }
+      ],
+      "writesTo": [
+        {
+          "id": "rating-cache"
+        }
+      ],
+      "readsFrom": [
+        {
+          "id": "review-database"
+        },
+        {
+          "id": "rating-cache"
+        }
+      ]
+    },
+    {
+      "type": "service",
+      "id": "review-api",
+      "version": "1.0.0",
+      "name": "Review API",
+      "contentPath": "domains/Reviews/services/ReviewAPI/index.mdx",
+      "contentHash": "sha256:f3f5c2dae565225460249cc415a19e1759ea8837d09c44c531b0911f3b6253a0",
+      "owners": [
+        "reviews-platform"
+      ],
+      "sends": [
+        {
+          "id": "review-submitted",
+          "version": "1.0.0"
+        },
+        {
+          "id": "review-flagged",
+          "version": "1.0.0"
+        },
+        {
+          "id": "review-helpful-voted",
+          "version": "1.0.0"
+        }
+      ],
+      "receives": [
+        {
+          "id": "submit-review",
+          "version": "1.0.0",
+          "triggers": [
+            {
+              "id": "review-submitted",
+              "version": "1.0.0",
+              "condition": "When the review passes submission validation"
+            }
+          ]
+        },
+        {
+          "id": "flag-review",
+          "version": "1.0.0",
+          "triggers": [
+            {
+              "id": "review-flagged",
+              "version": "1.0.0",
+              "condition": "When a customer reports a published review"
+            }
+          ]
+        },
+        {
+          "id": "vote-review-helpful",
+          "version": "1.0.0",
+          "triggers": [
+            {
+              "id": "review-helpful-voted",
+              "version": "1.0.0",
+              "condition": "When a helpful vote is recorded successfully"
+            }
+          ]
+        },
+        {
+          "id": "get-product-reviews",
+          "version": "1.0.0"
+        }
+      ],
+      "writesTo": [
+        {
+          "id": "review-database"
+        }
+      ],
+      "readsFrom": [
+        {
+          "id": "review-database"
+        },
+        {
+          "id": "rating-cache"
+        }
+      ]
+    },
+    {
+      "type": "service",
+      "id": "review-moderation-worker",
+      "version": "1.0.0",
+      "name": "Review Moderation Worker",
+      "contentPath": "domains/Reviews/services/ReviewModerationWorker/index.mdx",
+      "contentHash": "sha256:2b66e27f7fbd0f1a713fa8086193052ba085549ca6859e8f8c169b0f40c36ffd",
+      "owners": [
+        "reviews-platform"
+      ],
+      "sends": [
+        {
+          "id": "review-published",
+          "version": "1.0.0"
+        },
+        {
+          "id": "review-rejected",
+          "version": "1.0.0"
+        }
+      ],
+      "receives": [
+        {
+          "id": "review-submitted",
+          "version": "1.0.0",
+          "triggers": [
+            {
+              "id": "review-published",
+              "version": "1.0.0",
+              "condition": "When automated moderation passes with a high confidence score"
+            },
+            {
+              "id": "review-published",
+              "version": "1.0.0",
+              "condition": "When a human moderator approves a queued review"
+            },
+            {
+              "id": "review-published",
+              "version": "1.0.0",
+              "condition": "When a trusted reviewer qualifies for the fast-track policy"
+            },
+            {
+              "id": "review-published",
+              "version": "1.0.0",
+              "condition": "When a verified-purchase review passes all policy checks"
+            },
+            {
+              "id": "review-published",
+              "version": "1.0.0",
+              "condition": "When a resubmitted review clears its original moderation warning"
+            },
+            {
+              "id": "review-rejected",
+              "version": "1.0.0",
+              "condition": "When the content is classified as spam"
+            },
+            {
+              "id": "review-rejected",
+              "version": "1.0.0",
+              "condition": "When prohibited or abusive language exceeds the policy threshold"
+            },
+            {
+              "id": "review-rejected",
+              "version": "1.0.0",
+              "condition": "When the review duplicates an existing submission"
+            },
+            {
+              "id": "review-rejected",
+              "version": "1.0.0",
+              "condition": "When reviewer-risk signals fail the authenticity checks"
+            },
+            {
+              "id": "review-rejected",
+              "version": "1.0.0",
+              "condition": "When a human moderator rejects a queued review"
+            }
+          ]
+        },
+        {
+          "id": "review-flagged",
+          "version": "1.0.0"
+        }
+      ],
+      "writesTo": [
+        {
+          "id": "review-database"
+        }
+      ],
+      "readsFrom": [
+        {
+          "id": "review-database"
+        }
+      ]
+    },
+    {
+      "type": "service",
+      "id": "search-api",
+      "version": "1.0.0",
+      "name": "Search API",
+      "contentPath": "domains/Catalog/systems/search-system/services/SearchAPI/index.mdx",
+      "contentHash": "sha256:8e6443b5e473763d4cf2fc519f2881cc8a559b38b72db16d53bb122bf2ce916d",
+      "owners": [
+        "search-platform"
+      ],
+      "specifications": [
+        {
+          "type": "openapi",
+          "path": "openapi.yml",
+          "name": "Search API",
+          "hash": "sha256:4db552ac30405b8e8a5f7b7fc3ec39b79f213a57e70c87389f87136aafc879ba"
+        }
+      ],
+      "receives": [
+        {
+          "id": "search-products",
+          "version": "1.0.0"
+        }
+      ],
+      "readsFrom": [
+        {
+          "id": "search-index"
+        }
+      ]
+    },
+    {
+      "type": "service",
+      "id": "search-indexer",
+      "version": "1.0.0",
+      "name": "Search Indexer",
+      "contentPath": "domains/Catalog/systems/search-system/services/SearchIndexer/index.mdx",
+      "contentHash": "sha256:a17f511a27a86746d7f0801fac55dfde5e3d4ec234e69d479d6eedc340871730",
+      "owners": [
+        "search-platform"
+      ],
+      "receives": [
+        {
+          "id": "product-created",
+          "version": "1.0.0"
+        },
+        {
+          "id": "product-updated",
+          "version": "1.0.0"
+        },
+        {
+          "id": "product-deleted",
+          "version": "1.0.0"
+        }
+      ],
+      "writesTo": [
+        {
+          "id": "search-index"
+        }
+      ]
+    },
+    {
+      "type": "service",
+      "id": "shipping-api",
+      "version": "1.0.0",
+      "name": "Shipping API",
+      "contentPath": "domains/Fulfilment/systems/shipping-system/services/ShippingAPI/index.mdx",
+      "contentHash": "sha256:7df18c714ce25d3886e622777d159f150e8ea4c6888f14411194054a6cb26dfe",
+      "owners": [
+        "fulfilment-platform"
+      ],
+      "receives": [
+        {
+          "id": "order-ready-for-shipping",
+          "version": "1.0.0"
+        }
+      ]
+    },
+    {
+      "type": "service",
+      "id": "stripe-payments-api",
+      "version": "1.0.0",
+      "name": "Payments API",
+      "contentPath": "domains/Payments/systems/stripe/services/StripePaymentsAPI/index.mdx",
+      "contentHash": "sha256:d7b9837a988fb26b4e238578611e30defb975f25bc7b4d69f0abec583854dec4",
+      "owners": [
+        "payments-platform"
+      ],
+      "receives": [
+        {
+          "id": "payment-requested",
+          "version": "1.0.0"
+        },
+        {
+          "id": "refund-requested",
+          "version": "1.0.0"
+        }
+      ]
+    },
+    {
+      "type": "service",
+      "id": "stripe-webhook-endpoint",
+      "version": "1.0.0",
+      "name": "Webhook Endpoint",
+      "contentPath": "domains/Payments/systems/stripe/services/StripeWebhookEndpoint/index.mdx",
+      "contentHash": "sha256:dbfc35004da0d76264be521b176e988f83683fa72e591ea4a3411a6120250589",
+      "owners": [
+        "payments-platform"
+      ],
+      "sends": [
+        {
+          "id": "payment-succeeded",
+          "version": "1.0.0"
+        },
+        {
+          "id": "payment-failed",
+          "version": "1.0.0"
+        },
+        {
+          "id": "refund-processed",
+          "version": "1.0.0"
+        }
+      ]
+    },
+    {
+      "type": "service",
+      "id": "warehouse-service",
+      "version": "1.0.0",
+      "name": "Warehouse Service",
+      "contentPath": "domains/Fulfilment/systems/warehouse-system/services/WarehouseService/index.mdx",
+      "contentHash": "sha256:5901cf452763f2b3e4f62670d2b453f58ef16018804e0d6c84ff96d2b38fa9f4",
+      "owners": [
+        "fulfilment-platform"
+      ],
+      "sends": [
+        {
+          "id": "order-ready-for-shipping",
+          "version": "1.0.0"
+        }
+      ],
+      "receives": [
+        {
+          "id": "order-completed",
+          "version": "1.0.0"
+        }
+      ],
+      "writesTo": [
+        {
+          "id": "warehouse-database"
+        }
+      ],
+      "readsFrom": [
+        {
+          "id": "warehouse-database"
+        }
+      ]
+    },
+    {
+      "type": "system",
+      "id": "carrier",
+      "version": "1.0.0",
+      "name": "Carrier",
+      "contentPath": "domains/Fulfilment/systems/carrier/index.mdx",
+      "contentHash": "sha256:a2d22fdb7c62a55f66439cb4e3c0f4e75dd452d757e054980b2379ffa687d3d8",
+      "owners": [
+        "fulfilment-platform"
+      ],
+      "services": [
+        {
+          "id": "carrier-shipping-api"
+        },
+        {
+          "id": "carrier-tracking-api"
+        }
+      ],
+      "relationships": [
+        {
+          "id": "shipping-system",
+          "label": "delivers shipments for"
+        }
+      ]
+    },
+    {
+      "type": "system",
+      "id": "cart-system",
+      "version": "1.0.0",
+      "name": "Cart System",
+      "contentPath": "domains/Shopping/systems/cart-system/index.mdx",
+      "contentHash": "sha256:3b89ccf6acf17443fb6874ee89a647e43a386fd7bc511c1abb529917f27a994a",
+      "owners": [
+        "shopping-platform"
+      ],
+      "services": [
+        {
+          "id": "cart-api"
+        }
+      ],
+      "containers": [
+        {
+          "id": "cart-database"
+        }
+      ],
+      "relationships": [
+        {
+          "id": "promotion-system",
+          "label": "calculates discounts via"
+        }
+      ],
+      "actors": [
+        {
+          "id": "shopper",
+          "name": "Shopper",
+          "label": "adds items and checks out",
+          "direction": "inbound"
+        }
+      ]
+    },
+    {
+      "type": "system",
+      "id": "checkout-system",
+      "version": "1.0.0",
+      "name": "Checkout System",
+      "contentPath": "domains/Ordering/systems/checkout-system/index.mdx",
+      "contentHash": "sha256:9df555d237da11df686f4346f18d7964902d39d5ca34ef4430c01a195ed93d66",
+      "owners": [
+        "ordering-platform"
+      ],
+      "services": [
+        {
+          "id": "checkout-api"
+        },
+        {
+          "id": "checkout-orchestrator"
+        }
+      ],
+      "flows": [
+        {
+          "id": "checkout-saga",
+          "version": "1.0.0"
+        }
+      ],
+      "relationships": [
+        {
+          "id": "order-management-system",
+          "label": "creates orders via"
+        }
+      ],
+      "actors": [
+        {
+          "id": "shopper",
+          "name": "Shopper",
+          "label": "confirms checkout",
+          "direction": "inbound"
+        }
+      ]
+    },
+    {
+      "type": "system",
+      "id": "customer-management-system",
+      "version": "1.0.0",
+      "name": "Customer Management System",
+      "contentPath": "domains/Customer/systems/customer-management-system/index.mdx",
+      "contentHash": "sha256:b6361cb86b544f413cf8ae25b1bb8fb6cc51ce030c4c18f8abccfd4a88ebf381",
+      "owners": [
+        "customer-platform"
+      ],
+      "services": [
+        {
+          "id": "customer-api"
+        }
+      ],
+      "containers": [
+        {
+          "id": "customer-database"
+        }
+      ],
+      "relationships": [
+        {
+          "id": "identity-provider",
+          "label": "delegates authentication to"
+        }
+      ],
+      "actors": [
+        {
+          "id": "customer",
+          "name": "Customer",
+          "label": "registers and updates their profile",
+          "direction": "inbound"
+        },
+        {
+          "id": "support-agent",
+          "name": "Support Agent",
+          "label": "looks up customer details",
+          "direction": "inbound"
+        }
+      ]
+    },
+    {
+      "type": "system",
+      "id": "fraud-detection",
+      "version": "1.0.0",
+      "name": "Fraud Detection",
+      "contentPath": "domains/Payments/systems/fraud-detection/index.mdx",
+      "contentHash": "sha256:29e00250036fcacf881a6fb10064f569f30694d2c24a59d29e0fb735454ce31d",
+      "owners": [
+        "payments-platform"
+      ],
+      "services": [
+        {
+          "id": "fraud-api"
+        }
+      ],
+      "relationships": [
+        {
+          "id": "payment-processing-system",
+          "label": "screens payments for"
+        }
+      ]
+    },
+    {
+      "type": "system",
+      "id": "identity-provider",
+      "version": "1.0.0",
+      "name": "Identity Provider",
+      "contentPath": "domains/Customer/systems/identity-provider/index.mdx",
+      "contentHash": "sha256:747ba079f40e7b82fc7f8197e37edbd0dabe11ba1bf015b3e2a02b29c67c75b3",
+      "owners": [
+        "customer-platform"
+      ],
+      "services": [
+        {
+          "id": "oauth-api"
+        }
+      ],
+      "containers": [
+        {
+          "id": "user-directory"
+        }
+      ],
+      "relationships": [
+        {
+          "id": "customer-management-system",
+          "label": "provides authentication for"
+        }
+      ],
+      "actors": [
+        {
+          "id": "customer",
+          "name": "Customer",
+          "label": "signs in",
+          "direction": "inbound"
+        }
+      ]
+    },
+    {
+      "type": "system",
+      "id": "inventory-system",
+      "version": "1.0.0",
+      "name": "Inventory System",
+      "contentPath": "domains/Fulfilment/systems/inventory-system/index.mdx",
+      "contentHash": "sha256:a88d7076165db3888ca9e807d7ec06a94944776d9049d8875f6007309ea7ffb1",
+      "owners": [
+        "fulfilment-platform"
+      ],
+      "services": [
+        {
+          "id": "inventory-service"
+        }
+      ],
+      "containers": [
+        {
+          "id": "inventory-database"
+        }
+      ],
+      "relationships": [
+        {
+          "id": "warehouse-system",
+          "label": "provides stock for"
+        }
+      ]
+    },
+    {
+      "type": "system",
+      "id": "order-management-system",
+      "version": "1.0.0",
+      "name": "Order Management System",
+      "contentPath": "domains/Ordering/systems/order-management-system/index.mdx",
+      "contentHash": "sha256:72cb22f41588c983432fa578290a003c8f13081f5890be351cf6fba03afb6713",
+      "owners": [
+        "ordering-platform"
+      ],
+      "services": [
+        {
+          "id": "order-service"
+        }
+      ],
+      "flows": [
+        {
+          "id": "order-cancellation",
+          "version": "1.0.0"
+        }
+      ],
+      "containers": [
+        {
+          "id": "order-database"
+        }
+      ],
+      "relationships": [
+        {
+          "id": "checkout-system",
+          "label": "receives orders from"
+        }
+      ]
+    },
+    {
+      "type": "system",
+      "id": "payment-processing-system",
+      "version": "1.0.0",
+      "name": "Payment Processing System",
+      "contentPath": "domains/Payments/systems/payment-processing-system/index.mdx",
+      "contentHash": "sha256:e1a217680abdef59166f26371d05648b1246461835f3b4fc75fd0239e59edd1c",
+      "owners": [
+        "payments-platform"
+      ],
+      "services": [
+        {
+          "id": "payment-api"
+        },
+        {
+          "id": "payment-worker"
+        }
+      ],
+      "containers": [
+        {
+          "id": "payment-database"
+        }
+      ],
+      "relationships": [
+        {
+          "id": "stripe",
+          "label": "requests charges from"
+        },
+        {
+          "id": "fraud-detection",
+          "label": "screens payments with"
+        }
+      ]
+    },
+    {
+      "type": "system",
+      "id": "product-catalog-system",
+      "version": "1.0.0",
+      "name": "Product Catalog System",
+      "contentPath": "domains/Catalog/systems/product-catalog-system/index.mdx",
+      "contentHash": "sha256:90524af32593eef0ed601bd7a81cbdc2c2d544b180390f230c3ebc0a904f414f",
+      "owners": [
+        "product-platform"
+      ],
+      "services": [
+        {
+          "id": "product-api"
+        },
+        {
+          "id": "product-worker"
+        },
+        {
+          "id": "product-search-publisher"
+        }
+      ],
+      "containers": [
+        {
+          "id": "product-database"
+        }
+      ],
+      "relationships": [
+        {
+          "id": "search-system",
+          "label": "notifies of product changes"
+        }
+      ],
+      "actors": [
+        {
+          "id": "merchandiser",
+          "name": "Merchandiser",
+          "label": "creates and updates products",
+          "direction": "inbound"
+        },
+        {
+          "id": "catalog-admin",
+          "name": "Catalog Admin",
+          "label": "manages categories and pricing",
+          "direction": "inbound"
+        }
+      ]
+    },
+    {
+      "type": "system",
+      "id": "promotion-system",
+      "version": "1.0.0",
+      "name": "Promotion System",
+      "contentPath": "domains/Shopping/systems/promotion-system/index.mdx",
+      "contentHash": "sha256:146f2cddf6af2edd54271a719d765050f4806287dbc9ef2e5a55fc89f0066759",
+      "owners": [
+        "shopping-platform"
+      ],
+      "services": [
+        {
+          "id": "promotion-service"
+        }
+      ],
+      "containers": [
+        {
+          "id": "promotion-database"
+        }
+      ],
+      "relationships": [
+        {
+          "id": "cart-system",
+          "label": "provides discounts to"
+        }
+      ]
+    },
+    {
+      "type": "system",
+      "id": "search-system",
+      "version": "1.0.0",
+      "name": "Search System",
+      "contentPath": "domains/Catalog/systems/search-system/index.mdx",
+      "contentHash": "sha256:39d88953fc10b9accd655d8cd82e6f5365dfa760203c923f398cd352b83e2092",
+      "owners": [
+        "search-platform"
+      ],
+      "services": [
+        {
+          "id": "search-api"
+        },
+        {
+          "id": "search-indexer"
+        }
+      ],
+      "flows": [
+        {
+          "id": "product-search-indexing",
+          "version": "1.0.0"
+        }
+      ],
+      "containers": [
+        {
+          "id": "search-index"
+        }
+      ],
+      "relationships": [
+        {
+          "id": "product-catalog-system",
+          "label": "indexes product changes from"
+        }
+      ],
+      "actors": [
+        {
+          "id": "shopper",
+          "name": "Shopper",
+          "label": "searches for products",
+          "direction": "inbound"
+        },
+        {
+          "id": "storefront-team",
+          "name": "Storefront Team",
+          "label": "integrates product search",
+          "direction": "inbound"
+        }
+      ]
+    },
+    {
+      "type": "system",
+      "id": "shipping-system",
+      "version": "1.0.0",
+      "name": "Shipping System",
+      "contentPath": "domains/Fulfilment/systems/shipping-system/index.mdx",
+      "contentHash": "sha256:48afd68c277e5ddba65c2f5b4ed9ff7abbdcd426494e7c26e43c2cdea885e356",
+      "owners": [
+        "fulfilment-platform"
+      ],
+      "services": [
+        {
+          "id": "shipping-api"
+        },
+        {
+          "id": "carrier-adapter"
+        }
+      ],
+      "relationships": [
+        {
+          "id": "carrier",
+          "label": "creates shipments with"
+        }
+      ]
+    },
+    {
+      "type": "system",
+      "id": "stripe",
+      "version": "1.0.0",
+      "name": "Stripe",
+      "contentPath": "domains/Payments/systems/stripe/index.mdx",
+      "contentHash": "sha256:6463ce40da6017ae82b4b951405181f55b3c688a7ad3ae12c55a95ef2a36fadd",
+      "owners": [
+        "payments-platform"
+      ],
+      "services": [
+        {
+          "id": "stripe-payments-api"
+        },
+        {
+          "id": "stripe-webhook-endpoint"
+        }
+      ],
+      "relationships": [
+        {
+          "id": "payment-processing-system",
+          "label": "processes payments for"
+        }
+      ]
+    },
+    {
+      "type": "system",
+      "id": "warehouse-system",
+      "version": "1.0.0",
+      "name": "Warehouse System",
+      "contentPath": "domains/Fulfilment/systems/warehouse-system/index.mdx",
+      "contentHash": "sha256:d9230318d5127bdbd70bc402fe01cbbdeb6673211d9422044c1ee63fc9594da1",
+      "owners": [
+        "fulfilment-platform"
+      ],
+      "services": [
+        {
+          "id": "warehouse-service"
+        },
+        {
+          "id": "picking-worker"
+        }
+      ],
+      "containers": [
+        {
+          "id": "warehouse-database"
+        }
+      ],
+      "relationships": [
+        {
+          "id": "shipping-system",
+          "label": "hands packed orders to"
+        },
+        {
+          "id": "inventory-system",
+          "label": "consumes reserved stock from"
+        }
+      ]
+    },
+    {
+      "type": "team",
+      "id": "customer-platform",
+      "name": "Customer Platform",
+      "contentPath": "teams/customer-platform.mdx",
+      "contentHash": "sha256:a5865e613537e0ec886b515f497c8abbe2ab91d93414615ecd1995fc1b17949d",
+      "members": [
+        "dboyne"
+      ]
+    },
+    {
+      "type": "team",
+      "id": "fulfilment-platform",
+      "name": "Fulfilment Platform",
+      "contentPath": "teams/fulfilment-platform.mdx",
+      "contentHash": "sha256:b2e5f80040dde9cced0e3ff2a26d422dcc4238e9a618a1cc625523edf69c1985",
+      "members": [
+        "dboyne"
+      ]
+    },
+    {
+      "type": "team",
+      "id": "ordering-platform",
+      "name": "Ordering Platform",
+      "contentPath": "teams/ordering-platform.mdx",
+      "contentHash": "sha256:d2088a46ab8add0968cfcb6c865e68de127a7c4fdd3efbd6a950d44a8d00bfa8",
+      "members": [
+        "dboyne"
+      ]
+    },
+    {
+      "type": "team",
+      "id": "payments-platform",
+      "name": "Payments Platform",
+      "contentPath": "teams/payments-platform.mdx",
+      "contentHash": "sha256:58d97145ee7cc31c85af7347abd768d3f7ae0dd6a292f5bea78fc04cab2645c1",
+      "members": [
+        "dboyne"
+      ]
+    },
+    {
+      "type": "team",
+      "id": "product-platform",
+      "name": "Product Platform",
+      "contentPath": "teams/product-platform.mdx",
+      "contentHash": "sha256:372afd93e071c5028733401e5da44476a8c930a2a88676de80bb30b59729ec8a",
+      "members": [
+        "dboyne"
+      ]
+    },
+    {
+      "type": "team",
+      "id": "reviews-platform",
+      "name": "Reviews Platform",
+      "contentPath": "teams/reviews-platform.mdx",
+      "contentHash": "sha256:978fd39afcdb01941fc5ceba4e08f29d190d06efddbf75794d0d98302c96f849",
+      "members": [
+        "dboyne"
+      ]
+    },
+    {
+      "type": "team",
+      "id": "search-platform",
+      "name": "Search Platform",
+      "contentPath": "teams/search-platform.mdx",
+      "contentHash": "sha256:6749c5b36d9e66e9d057e566cf9b4f3f8bb8637555712f732f8c887eae9452bb",
+      "members": [
+        "dboyne"
+      ]
+    },
+    {
+      "type": "team",
+      "id": "shopping-platform",
+      "name": "Shopping Platform",
+      "contentPath": "teams/shopping-platform.mdx",
+      "contentHash": "sha256:cd5a80efd5c3d4e2783d7b266a2d285faff4b2e5018e72f31dca58ce6818ba27",
+      "members": [
+        "dboyne"
+      ]
+    },
+    {
+      "type": "user",
+      "id": "dboyne",
+      "name": "David Boyne",
+      "contentPath": "users/dboyne.mdx",
+      "contentHash": "sha256:f677169f4ad6492bed53825c670c33e3bcda9279d02e0781a48f6347a61edc90"
+    }
+  ],
+  "assets": [
+    {
+      "path": "components/footer.astro",
+      "hash": "sha256:2ddabd5a0f25b01b9e4f75d70e1cc9c5814efdd2ae60794855d1634fddcaf628"
+    },
+    {
+      "path": "public/icons/analytics/clickhouse.svg",
+      "hash": "sha256:56b721320616172170bb817a949dd88f71a52254b07caeec6589d0ff9d363cb5"
+    },
+    {
+      "path": "public/icons/cache/redis.svg",
+      "hash": "sha256:4245419834dd111d83a8ed645a2e305c67faa0af5c5b864eb5f0991de156034c"
+    },
+    {
+      "path": "public/icons/database/postgresql.svg",
+      "hash": "sha256:bc45b1c56d0b1501dea387dbec4fda450d2ebc35244a620791815509d8c41dba"
+    },
+    {
+      "path": "public/icons/languages/go.svg",
+      "hash": "sha256:33e31a3d049683755ceb07b4a6abe830b2ee02e6ffeee408fe705ef078d3849e"
+    },
+    {
+      "path": "public/icons/languages/java.svg",
+      "hash": "sha256:71840f3ce1bb6d6684f703583316900a157d7925f6488cfa8119a4dd267f198e"
+    },
+    {
+      "path": "public/icons/languages/nodejs.svg",
+      "hash": "sha256:6c7826737490eb559312b3fdc8853db70ef48a9e035d1bac019efd6e1a1e1371"
+    },
+    {
+      "path": "public/icons/payments/stripe.svg",
+      "hash": "sha256:4a339a433c6eee8e60929b3f339998fc2ecbdd362e243fb48e9701185d546d7e"
+    },
+    {
+      "path": "public/logo.png",
+      "hash": "sha256:c0382065ad58b4c97f1906b36988a73ec712e60de67ccd1833a1f3abf3c98159"
+    }
+  ]
+}

--- a/packages/sdk/src/test/hydrate.test.ts
+++ b/packages/sdk/src/test/hydrate.test.ts
@@ -1,0 +1,939 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { hydrate, type Cache, type Fetcher } from '../hydrate';
+import type { ResolvedGraph } from '../index-types';
+
+describe('hydrate', () => {
+  let testDirectory: string;
+  let outDir: string;
+
+  beforeEach(async () => {
+    testDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'eventcatalog-hydrate-'));
+    outDir = path.join(testDirectory, 'federated');
+  });
+
+  afterEach(async () => {
+    await fs.rm(testDirectory, { recursive: true, force: true });
+  });
+
+  it('writes nothing for a graph with no federated entities', async () => {
+    const fetch = vi.fn<Fetcher>();
+    const graph: ResolvedGraph = {
+      entities: [
+        {
+          type: 'service',
+          id: 'payment-service',
+          version: '1.0.0',
+          name: 'Payment Service',
+          contentPath: 'services/payment-service/index.mdx',
+          contentHash: 'sha256:3e63897b7cc3a92411599289d00d686f1b1fc8e336927efa46101c8943410c70',
+          resolvedFrom: {
+            source: 'acme/central',
+            commit: '4a1b7e2',
+          },
+        },
+      ],
+      assets: [],
+      edges: [],
+      conflicts: [],
+      warnings: [],
+      externals: [],
+    };
+
+    await expect(
+      hydrate(graph, {
+        outDir,
+        localSource: 'acme/central',
+        fetch,
+      })
+    ).resolves.toEqual({
+      fetched: 0,
+      written: 0,
+      referenced: 0,
+    });
+    expect(fetch).not.toHaveBeenCalled();
+    await expect(fs.access(outDir)).rejects.toThrow();
+  });
+
+  it('fetches content for a federated entity', async () => {
+    const content = Buffer.from('# Payment Service');
+    const fetch = vi.fn<Fetcher>().mockResolvedValue(content);
+    const graph: ResolvedGraph = {
+      entities: [
+        {
+          type: 'service',
+          id: 'payment-service',
+          version: '1.0.0',
+          name: 'Payment Service',
+          contentPath: 'services/payment-service/index.mdx',
+          contentHash: 'sha256:3e63897b7cc3a92411599289d00d686f1b1fc8e336927efa46101c8943410c70',
+          resolvedFrom: {
+            source: 'acme/payments',
+            commit: '4a1b7e2',
+          },
+        },
+      ],
+      assets: [],
+      edges: [],
+      conflicts: [],
+      warnings: [],
+      externals: [],
+    };
+
+    const result = await hydrate(graph, {
+      outDir,
+      localSource: 'acme/central',
+      fetch,
+    });
+
+    expect(fetch.mock.calls).toEqual([
+      [
+        {
+          source: 'acme/payments',
+          commit: '4a1b7e2',
+          path: 'services/payment-service/index.mdx',
+        },
+      ],
+    ]);
+    await expect(
+      fs.readFile(path.join(outDir, 'acme-payments--bf264d5186bc', 'services/payment-service/index.mdx'))
+    ).resolves.toEqual(content);
+    expect(result).toEqual({
+      fetched: 1,
+      written: 1,
+      referenced: 0,
+    });
+  });
+
+  it('skips a fetch when contentHash is already cached', async () => {
+    const cachedContent = Buffer.from('# Cached Payment Service');
+    const fetch = vi.fn<Fetcher>().mockResolvedValue(Buffer.from('# Fresh Payment Service'));
+    const get = vi.fn<Cache['get']>().mockResolvedValue(cachedContent);
+    const set = vi.fn<Cache['set']>();
+    const cache: Cache = {
+      get,
+      set,
+    };
+    const graph: ResolvedGraph = {
+      entities: [
+        {
+          type: 'service',
+          id: 'payment-service',
+          version: '1.0.0',
+          name: 'Payment Service',
+          contentPath: 'services/payment-service/index.mdx',
+          contentHash: 'sha256:9b9b66289f3674fc27543c1005631a23cabcb6d09b67225689d2e635829064c1',
+          resolvedFrom: {
+            source: 'acme/payments',
+            commit: '4a1b7e2',
+          },
+        },
+      ],
+      assets: [],
+      edges: [],
+      conflicts: [],
+      warnings: [],
+      externals: [],
+    };
+
+    const result = await hydrate(graph, {
+      outDir,
+      localSource: 'acme/central',
+      fetch,
+      cache,
+    });
+
+    expect(get.mock.calls).toEqual([['sha256:9b9b66289f3674fc27543c1005631a23cabcb6d09b67225689d2e635829064c1']]);
+    expect(set.mock.calls).toEqual([]);
+    expect(fetch.mock.calls).toEqual([]);
+    await expect(
+      fs.readFile(path.join(outDir, 'acme-payments--bf264d5186bc', 'services/payment-service/index.mdx'))
+    ).resolves.toEqual(cachedContent);
+    expect(result).toEqual({
+      fetched: 0,
+      written: 1,
+      referenced: 0,
+    });
+  });
+
+  it('populates the cache after a fetch', async () => {
+    const content = Buffer.from('# Payment Service');
+    const contentHash = 'sha256:3e63897b7cc3a92411599289d00d686f1b1fc8e336927efa46101c8943410c70';
+    const fetch = vi.fn<Fetcher>().mockResolvedValue(content);
+    const get = vi.fn<Cache['get']>().mockResolvedValue(undefined);
+    const set = vi.fn<Cache['set']>();
+    const cache: Cache = {
+      get,
+      set,
+    };
+    const graph: ResolvedGraph = {
+      entities: [
+        {
+          type: 'service',
+          id: 'payment-service',
+          version: '1.0.0',
+          name: 'Payment Service',
+          contentPath: 'services/payment-service/index.mdx',
+          contentHash,
+          resolvedFrom: {
+            source: 'acme/payments',
+            commit: '4a1b7e2',
+          },
+        },
+      ],
+      assets: [],
+      edges: [],
+      conflicts: [],
+      warnings: [],
+      externals: [],
+    };
+
+    const result = await hydrate(graph, {
+      outDir,
+      localSource: 'acme/central',
+      fetch,
+      cache,
+    });
+
+    expect(get.mock.calls).toEqual([[contentHash]]);
+    expect(fetch.mock.calls).toEqual([
+      [
+        {
+          source: 'acme/payments',
+          commit: '4a1b7e2',
+          path: 'services/payment-service/index.mdx',
+        },
+      ],
+    ]);
+    expect(set.mock.calls).toEqual([[contentHash, content]]);
+    await expect(
+      fs.readFile(path.join(outDir, 'acme-payments--bf264d5186bc', 'services/payment-service/index.mdx'))
+    ).resolves.toEqual(content);
+    expect(result).toEqual({
+      fetched: 1,
+      written: 1,
+      referenced: 0,
+    });
+  });
+
+  it('fails when fetched bytes do not match contentHash', async () => {
+    const content = Buffer.from('# Tampered Payment Service');
+    const contentHash = 'sha256:3e63897b7cc3a92411599289d00d686f1b1fc8e336927efa46101c8943410c70';
+    const fetch = vi.fn<Fetcher>().mockResolvedValue(content);
+    const get = vi.fn<Cache['get']>().mockResolvedValue(undefined);
+    const set = vi.fn<Cache['set']>();
+    const cache: Cache = {
+      get,
+      set,
+    };
+    const graph: ResolvedGraph = {
+      entities: [
+        {
+          type: 'service',
+          id: 'payment-service',
+          version: '1.0.0',
+          name: 'Payment Service',
+          contentPath: 'services/payment-service/index.mdx',
+          contentHash,
+          resolvedFrom: {
+            source: 'acme/payments',
+            commit: '4a1b7e2',
+          },
+        },
+      ],
+      assets: [],
+      edges: [],
+      conflicts: [],
+      warnings: [],
+      externals: [],
+    };
+
+    await expect(
+      hydrate(graph, {
+        outDir,
+        localSource: 'acme/central',
+        fetch,
+        cache,
+      })
+    ).rejects.toThrow(
+      new Error(
+        'Content hash mismatch for "acme/payments/services/payment-service/index.mdx": expected "sha256:3e63897b7cc3a92411599289d00d686f1b1fc8e336927efa46101c8943410c70", received "sha256:5d907fd78585e3b4dbd117148b063ad75f24761ac2cb50199dacf87a474fd3d6"'
+      )
+    );
+
+    expect(get.mock.calls).toEqual([[contentHash]]);
+    expect(fetch.mock.calls).toEqual([
+      [
+        {
+          source: 'acme/payments',
+          commit: '4a1b7e2',
+          path: 'services/payment-service/index.mdx',
+        },
+      ],
+    ]);
+    expect(set.mock.calls).toEqual([]);
+    await expect(fs.access(outDir)).rejects.toThrow();
+  });
+
+  it('preserves the previous hydrated catalog when a new hydrate fails', async () => {
+    const existingPath = path.join(outDir, 'existing', 'index.mdx');
+    await fs.mkdir(path.dirname(existingPath), { recursive: true });
+    await fs.writeFile(existingPath, '# Existing catalog');
+
+    const validContent = Buffer.from('# Payment Service');
+    const invalidContent = Buffer.from('# Tampered Refund Service');
+    const fetch = vi
+      .fn<Fetcher>()
+      .mockImplementation(async ({ path: artifactPath }) =>
+        artifactPath === 'services/payment-service/index.mdx' ? validContent : invalidContent
+      );
+    const graph: ResolvedGraph = {
+      entities: [
+        {
+          type: 'service',
+          id: 'payment-service',
+          version: '1.0.0',
+          name: 'Payment Service',
+          contentPath: 'services/payment-service/index.mdx',
+          contentHash: 'sha256:3e63897b7cc3a92411599289d00d686f1b1fc8e336927efa46101c8943410c70',
+          resolvedFrom: {
+            source: 'acme/payments',
+            commit: '4a1b7e2',
+          },
+        },
+        {
+          type: 'service',
+          id: 'refund-service',
+          version: '1.0.0',
+          name: 'Refund Service',
+          contentPath: 'services/refund-service/index.mdx',
+          contentHash: 'sha256:3e63897b7cc3a92411599289d00d686f1b1fc8e336927efa46101c8943410c70',
+          resolvedFrom: {
+            source: 'acme/payments',
+            commit: '4a1b7e2',
+          },
+        },
+      ],
+      assets: [],
+      edges: [],
+      conflicts: [],
+      warnings: [],
+      externals: [],
+    };
+
+    await expect(
+      hydrate(graph, {
+        outDir,
+        localSource: 'acme/central',
+        fetch,
+      })
+    ).rejects.toThrow('Content hash mismatch for "acme/payments/services/refund-service/index.mdx"');
+
+    await expect(fs.readFile(existingPath, 'utf8')).resolves.toBe('# Existing catalog');
+    await expect(
+      fs.access(path.join(outDir, 'acme-payments--bf264d5186bc', 'services/payment-service/index.mdx'))
+    ).rejects.toThrow();
+  });
+
+  it('rejects an entity path that escapes its source output directory', async () => {
+    const outsidePath = path.join(testDirectory, 'outside.mdx');
+    await fs.writeFile(outsidePath, '# Locally authored content');
+
+    const fetch = vi.fn<Fetcher>().mockResolvedValue(Buffer.from('# Malicious federated content'));
+    const graph: ResolvedGraph = {
+      entities: [
+        {
+          type: 'service',
+          id: 'payment-service',
+          version: '1.0.0',
+          name: 'Payment Service',
+          contentPath: '../../outside.mdx',
+          resolvedFrom: {
+            source: 'acme/payments',
+            commit: '4a1b7e2',
+          },
+        },
+      ],
+      assets: [],
+      edges: [],
+      conflicts: [],
+      warnings: [],
+      externals: [],
+    };
+
+    await expect(
+      hydrate(graph, {
+        outDir,
+        localSource: 'acme/central',
+        fetch,
+      })
+    ).rejects.toThrow('Artifact path "../../outside.mdx" escapes its allowed output directory');
+
+    expect(fetch).not.toHaveBeenCalled();
+    await expect(fs.readFile(outsidePath, 'utf8')).resolves.toBe('# Locally authored content');
+    await expect(fs.access(outDir)).rejects.toThrow();
+  });
+
+  it('fetches schemas and specifications as separate files', async () => {
+    const files: Record<string, Buffer> = {
+      'events/payment-captured/index.mdx': Buffer.from('# Payment Captured'),
+      'events/payment-captured/schema.avsc': Buffer.from('{"type":"record","name":"PaymentCaptured","fields":[]}'),
+      'events/payment-captured/asyncapi.yaml': Buffer.from('asyncapi: 3.0.0'),
+    };
+    const fetch = vi.fn<Fetcher>().mockImplementation(async (request) => files[request.path]);
+    const graph: ResolvedGraph = {
+      entities: [
+        {
+          type: 'event',
+          id: 'payment-captured',
+          version: '2.0.0',
+          name: 'Payment Captured',
+          contentPath: 'events/payment-captured/index.mdx',
+          contentHash: 'sha256:3c87a04f4e36f5d89aed98abfeb4bd1c6453d253fe7f165cd2b08a850c4f2a5e',
+          schemas: [
+            {
+              id: 'avro',
+              path: 'schema.avsc',
+              format: 'avro',
+              hash: 'sha256:e48445ded67965113a9897f4afa5a39eb6ccd76850b3a2aa8da751716d05eb20',
+            },
+          ],
+          specifications: [
+            {
+              type: 'asyncapi',
+              path: 'asyncapi.yaml',
+              hash: 'sha256:5a883f95ffcf726b0cd97b2537568783af5a12e9ffd852aeee15bb631629db55',
+            },
+          ],
+          resolvedFrom: {
+            source: 'acme/payments',
+            commit: '4a1b7e2',
+          },
+        },
+      ],
+      assets: [],
+      edges: [],
+      conflicts: [],
+      warnings: [],
+      externals: [],
+    };
+
+    const result = await hydrate(graph, {
+      outDir,
+      localSource: 'acme/central',
+      fetch,
+    });
+
+    expect(fetch.mock.calls).toEqual([
+      [
+        {
+          source: 'acme/payments',
+          commit: '4a1b7e2',
+          path: 'events/payment-captured/index.mdx',
+        },
+      ],
+      [
+        {
+          source: 'acme/payments',
+          commit: '4a1b7e2',
+          path: 'events/payment-captured/schema.avsc',
+        },
+      ],
+      [
+        {
+          source: 'acme/payments',
+          commit: '4a1b7e2',
+          path: 'events/payment-captured/asyncapi.yaml',
+        },
+      ],
+    ]);
+    await expect(
+      Promise.all([
+        fs.readFile(path.join(outDir, 'acme-payments--bf264d5186bc', 'events/payment-captured/index.mdx')),
+        fs.readFile(path.join(outDir, 'acme-payments--bf264d5186bc', 'events/payment-captured/schema.avsc')),
+        fs.readFile(path.join(outDir, 'acme-payments--bf264d5186bc', 'events/payment-captured/asyncapi.yaml')),
+      ])
+    ).resolves.toEqual([
+      files['events/payment-captured/index.mdx'],
+      files['events/payment-captured/schema.avsc'],
+      files['events/payment-captured/asyncapi.yaml'],
+    ]);
+    expect(result).toEqual({
+      fetched: 3,
+      written: 3,
+      referenced: 0,
+    });
+  });
+
+  it('fetches arbitrary resource sidecars as separate files', async () => {
+    const files: Record<string, Buffer> = {
+      'services/payment-service/index.mdx': Buffer.from('# Payment Service'),
+      'services/payment-service/schema.sql': Buffer.from('CREATE TABLE payments;'),
+      'services/payment-service/attachments/context.txt': Buffer.from('Payment context'),
+    };
+    const fetch = vi.fn<Fetcher>().mockImplementation(async (request) => files[request.path]);
+    const graph: ResolvedGraph = {
+      entities: [
+        {
+          type: 'service',
+          id: 'payment-service',
+          version: '1.0.0',
+          name: 'Payment Service',
+          contentPath: 'services/payment-service/index.mdx',
+          contentHash: 'sha256:3e63897b7cc3a92411599289d00d686f1b1fc8e336927efa46101c8943410c70',
+          sidecars: [
+            {
+              path: 'services/payment-service/schema.sql',
+              hash: 'sha256:e44f1f6425e35d3ab653011cb06288b1645df6fa40cc3bcbbcc08f73542c5557',
+            },
+            {
+              path: 'services/payment-service/attachments/context.txt',
+              hash: 'sha256:8b0484119548bb106d52c15578fe3caa6f2aad64ef08e943d8c53ab544ef5e26',
+            },
+          ],
+          resolvedFrom: {
+            source: 'acme/payments',
+            commit: '4a1b7e2',
+          },
+        },
+      ],
+      assets: [],
+      edges: [],
+      conflicts: [],
+      warnings: [],
+      externals: [],
+    };
+
+    const result = await hydrate(graph, {
+      outDir,
+      localSource: 'acme/central',
+      fetch,
+    });
+
+    expect(fetch.mock.calls).toEqual([
+      [
+        {
+          source: 'acme/payments',
+          commit: '4a1b7e2',
+          path: 'services/payment-service/index.mdx',
+        },
+      ],
+      [
+        {
+          source: 'acme/payments',
+          commit: '4a1b7e2',
+          path: 'services/payment-service/schema.sql',
+        },
+      ],
+      [
+        {
+          source: 'acme/payments',
+          commit: '4a1b7e2',
+          path: 'services/payment-service/attachments/context.txt',
+        },
+      ],
+    ]);
+    await expect(
+      Promise.all([
+        fs.readFile(path.join(outDir, 'acme-payments--bf264d5186bc', 'services/payment-service/index.mdx')),
+        fs.readFile(path.join(outDir, 'acme-payments--bf264d5186bc', 'services/payment-service/schema.sql')),
+        fs.readFile(path.join(outDir, 'acme-payments--bf264d5186bc', 'services/payment-service/attachments/context.txt')),
+      ])
+    ).resolves.toEqual([
+      files['services/payment-service/index.mdx'],
+      files['services/payment-service/schema.sql'],
+      files['services/payment-service/attachments/context.txt'],
+    ]);
+    expect(result).toEqual({
+      fetched: 3,
+      written: 3,
+      referenced: 0,
+    });
+  });
+
+  it('fetches resource documents and their category metadata as separate files', async () => {
+    const files: Record<string, Buffer> = {
+      'domains/payments/index.mdx': Buffer.from('# Payments'),
+      'domains/payments/docs/onboarding.mdx': Buffer.from('# Onboarding'),
+      'domains/payments/docs/runbooks/category.json': Buffer.from(JSON.stringify({ label: 'Operational Runbooks', position: 1 })),
+      'domains/payments/docs/runbooks/incident-response.mdx': Buffer.from('# Incident Response'),
+    };
+    const fetch = vi.fn<Fetcher>().mockImplementation(async (request) => files[request.path]);
+    const graph: ResolvedGraph = {
+      entities: [
+        {
+          type: 'domain',
+          id: 'payments',
+          version: '1.0.0',
+          name: 'Payments',
+          contentPath: 'domains/payments/index.mdx',
+          contentHash: 'sha256:c395d26f16032f31a91ace4acd2a5b82afd4b6736fe1ba3a5eef0dec04588164',
+          sidecars: [
+            {
+              path: 'domains/payments/docs/onboarding.mdx',
+              hash: 'sha256:d48985255cee7713590203a844f62d3dfe0adef92316b6316e5bedf7c0c66b31',
+            },
+            {
+              path: 'domains/payments/docs/runbooks/category.json',
+              hash: 'sha256:2c8df9bd7ea9c1915b58b51a4984feb7931c49092889ae755c46a52916902ad8',
+            },
+            {
+              path: 'domains/payments/docs/runbooks/incident-response.mdx',
+              hash: 'sha256:1bab8d3a3cc7ba05fefc924f1755630aebefaba3046a06f6d073c873a64fdb6e',
+            },
+          ],
+          resolvedFrom: {
+            source: 'acme/payments',
+            commit: '4a1b7e2',
+          },
+        },
+      ],
+      assets: [],
+      edges: [],
+      conflicts: [],
+      warnings: [],
+      externals: [],
+    };
+
+    const result = await hydrate(graph, {
+      outDir,
+      localSource: 'acme/central',
+      fetch,
+    });
+
+    expect(fetch.mock.calls).toEqual(
+      Object.keys(files).map((filePath) => [
+        {
+          source: 'acme/payments',
+          commit: '4a1b7e2',
+          path: filePath,
+        },
+      ])
+    );
+    await expect(
+      Promise.all(Object.keys(files).map((filePath) => fs.readFile(path.join(outDir, 'acme-payments--bf264d5186bc', filePath))))
+    ).resolves.toEqual(Object.values(files));
+    expect(result).toEqual({
+      fetched: 4,
+      written: 4,
+      referenced: 0,
+    });
+  });
+
+  describe('assets', () => {
+    it('fetches public files and components into the shared asset directories', async () => {
+      const files: Record<string, Buffer> = {
+        'components/TeamBadge.astro': Buffer.from('<span>Team badge</span>'),
+        'public/icons/payments.svg': Buffer.from('<svg>Payments</svg>'),
+      };
+      const fetch = vi.fn<Fetcher>().mockImplementation(async (request) => files[request.path]);
+      const graph: ResolvedGraph = {
+        entities: [],
+        assets: [
+          {
+            path: 'components/TeamBadge.astro',
+            hash: 'sha256:3062886724e1c5d3d56b85d7d88720d0f679c019ddcfa347241d545d31fcb82e',
+            resolvedFrom: {
+              source: 'acme/payments',
+              commit: '4a1b7e2',
+            },
+          },
+          {
+            path: 'public/icons/payments.svg',
+            hash: 'sha256:4c22e5bcafd94c0d64a92f4d0f45853c2ea14d5e76b0e3c7806ef59fa45b9817',
+            resolvedFrom: {
+              source: 'acme/payments',
+              commit: '4a1b7e2',
+            },
+          },
+        ],
+        edges: [],
+        conflicts: [],
+        warnings: [],
+        externals: [],
+      };
+
+      const result = await hydrate(graph, {
+        outDir,
+        localSource: 'acme/central',
+        fetch,
+      });
+
+      expect(fetch.mock.calls).toEqual(
+        Object.keys(files).map((filePath) => [
+          {
+            source: 'acme/payments',
+            commit: '4a1b7e2',
+            path: filePath,
+          },
+        ])
+      );
+      await expect(Promise.all(Object.keys(files).map((filePath) => fs.readFile(path.join(outDir, filePath))))).resolves.toEqual(
+        Object.values(files)
+      );
+      expect(result).toEqual({
+        fetched: 2,
+        written: 2,
+        referenced: 0,
+      });
+    });
+
+    it('does not fetch assets from a source in reference mode', async () => {
+      const fetch = vi.fn<Fetcher>();
+      const graph: ResolvedGraph = {
+        entities: [],
+        assets: [
+          {
+            path: 'public/icons/payments.svg',
+            hash: 'sha256:4c22e5bcafd94c0d64a92f4d0f45853c2ea14d5e76b0e3c7806ef59fa45b9817',
+            resolvedFrom: {
+              source: 'acme/payments',
+              commit: '4a1b7e2',
+            },
+          },
+        ],
+        edges: [],
+        conflicts: [],
+        warnings: [],
+        externals: [],
+      };
+
+      await expect(
+        hydrate(graph, {
+          outDir,
+          localSource: 'acme/central',
+          fetch,
+          modes: {
+            'acme/payments': 'reference',
+          },
+        })
+      ).resolves.toEqual({
+        fetched: 0,
+        written: 0,
+        referenced: 0,
+      });
+      expect(fetch).not.toHaveBeenCalled();
+      await expect(fs.access(outDir)).rejects.toThrow();
+    });
+
+    it('hydrates the selected asset when a collision warning is present', async () => {
+      const content = Buffer.from('<svg>Fulfilment</svg>');
+      const fetch = vi.fn<Fetcher>().mockResolvedValue(content);
+      const graph: ResolvedGraph = {
+        entities: [],
+        assets: [
+          {
+            path: 'public/logo.svg',
+            hash: 'sha256:d0d43badac07c1be7d31807a734096b3a9e3ac4be1ecdd24323b703e2edb7514',
+            resolvedFrom: {
+              source: 'acme/fulfilment',
+              commit: '8f2c6d0',
+            },
+          },
+        ],
+        edges: [],
+        conflicts: [],
+        warnings: [
+          {
+            kind: 'asset-collision',
+            path: 'public/logo.svg',
+            sources: ['acme/fulfilment', 'acme/payments'],
+            winner: 'acme/fulfilment',
+          },
+        ],
+        externals: [],
+      };
+
+      await expect(
+        hydrate(graph, {
+          outDir,
+          localSource: 'acme/central',
+          fetch,
+        })
+      ).resolves.toEqual({
+        fetched: 1,
+        written: 1,
+        referenced: 0,
+      });
+      expect(fetch.mock.calls).toEqual([
+        [
+          {
+            source: 'acme/fulfilment',
+            commit: '8f2c6d0',
+            path: 'public/logo.svg',
+          },
+        ],
+      ]);
+      await expect(fs.readFile(path.join(outDir, 'public/logo.svg'))).resolves.toEqual(content);
+    });
+  });
+
+  it('does not fetch content for a source in reference mode', async () => {
+    const fetch = vi.fn<Fetcher>().mockResolvedValue(Buffer.from('# Payment Service'));
+    const graph: ResolvedGraph = {
+      entities: [
+        {
+          type: 'service',
+          id: 'payment-service',
+          version: '1.0.0',
+          name: 'Payment Service',
+          contentPath: 'services/payment-service/index.mdx',
+          contentHash: 'sha256:3e63897b7cc3a92411599289d00d686f1b1fc8e336927efa46101c8943410c70',
+          resolvedFrom: {
+            source: 'acme/payments',
+            commit: '4a1b7e2',
+          },
+        },
+      ],
+      assets: [],
+      edges: [],
+      conflicts: [],
+      warnings: [],
+      externals: [],
+    };
+
+    await expect(
+      hydrate(graph, {
+        outDir,
+        localSource: 'acme/central',
+        fetch,
+        modes: {
+          'acme/payments': 'reference',
+        },
+      })
+    ).resolves.toEqual({
+      fetched: 0,
+      written: 0,
+      referenced: 1,
+    });
+    expect(fetch.mock.calls).toEqual([]);
+    await expect(fs.access(outDir)).rejects.toThrow();
+  });
+
+  it('removes files from a previous hydrate that are no longer in the graph', async () => {
+    const stalePath = path.join(outDir, 'acme-payments--bf264d5186bc', 'services/retired-service/index.mdx');
+    const currentPath = path.join(outDir, 'acme-payments--bf264d5186bc', 'services/payment-service/index.mdx');
+    const content = Buffer.from('# Payment Service');
+    await fs.mkdir(path.dirname(stalePath), { recursive: true });
+    await fs.writeFile(stalePath, '# Retired Service');
+
+    const fetch = vi.fn<Fetcher>().mockResolvedValue(content);
+    const graph: ResolvedGraph = {
+      entities: [
+        {
+          type: 'service',
+          id: 'payment-service',
+          version: '1.0.0',
+          name: 'Payment Service',
+          contentPath: 'services/payment-service/index.mdx',
+          contentHash: 'sha256:3e63897b7cc3a92411599289d00d686f1b1fc8e336927efa46101c8943410c70',
+          resolvedFrom: {
+            source: 'acme/payments',
+            commit: '4a1b7e2',
+          },
+        },
+      ],
+      assets: [],
+      edges: [],
+      conflicts: [],
+      warnings: [],
+      externals: [],
+    };
+
+    await expect(
+      hydrate(graph, {
+        outDir,
+        localSource: 'acme/central',
+        fetch,
+      })
+    ).resolves.toEqual({
+      fetched: 1,
+      written: 1,
+      referenced: 0,
+    });
+    await expect(fs.access(stalePath)).rejects.toThrow();
+    await expect(fs.readFile(currentPath)).resolves.toEqual(content);
+  });
+
+  it('preserves locally authored content outside outDir', async () => {
+    const localPath = path.join(testDirectory, 'catalog/services/local-service/index.mdx');
+    const stalePath = path.join(outDir, 'acme-payments--bf264d5186bc', 'services/retired-service/index.mdx');
+    await fs.mkdir(path.dirname(localPath), { recursive: true });
+    await fs.writeFile(localPath, '# Local Service');
+    await fs.mkdir(path.dirname(stalePath), { recursive: true });
+    await fs.writeFile(stalePath, '# Retired Service');
+
+    const fetch = vi.fn<Fetcher>();
+    const graph: ResolvedGraph = {
+      entities: [],
+      assets: [],
+      edges: [],
+      conflicts: [],
+      warnings: [],
+      externals: [],
+    };
+
+    await expect(
+      hydrate(graph, {
+        outDir,
+        localSource: 'acme/central',
+        fetch,
+      })
+    ).resolves.toEqual({
+      fetched: 0,
+      written: 0,
+      referenced: 0,
+    });
+    expect(fetch.mock.calls).toEqual([]);
+    await expect(fs.readFile(localPath, 'utf8')).resolves.toBe('# Local Service');
+    await expect(fs.access(stalePath)).rejects.toThrow();
+  });
+
+  it("removes a source's directory when it leaves the graph", async () => {
+    const departedSourcePath = path.join(outDir, 'acme-legacy--80e013786537', 'services/legacy-service/index.mdx');
+    const departedSourceDirectory = path.join(outDir, 'acme-legacy--80e013786537');
+    const currentPath = path.join(outDir, 'acme-payments--bf264d5186bc', 'services/payment-service/index.mdx');
+    const content = Buffer.from('# Payment Service');
+    await fs.mkdir(path.dirname(departedSourcePath), { recursive: true });
+    await fs.writeFile(departedSourcePath, '# Legacy Service');
+
+    const fetch = vi.fn<Fetcher>().mockResolvedValue(content);
+    const graph: ResolvedGraph = {
+      entities: [
+        {
+          type: 'service',
+          id: 'payment-service',
+          version: '1.0.0',
+          name: 'Payment Service',
+          contentPath: 'services/payment-service/index.mdx',
+          contentHash: 'sha256:3e63897b7cc3a92411599289d00d686f1b1fc8e336927efa46101c8943410c70',
+          resolvedFrom: {
+            source: 'acme/payments',
+            commit: '4a1b7e2',
+          },
+        },
+      ],
+      assets: [],
+      edges: [],
+      conflicts: [],
+      warnings: [],
+      externals: [],
+    };
+
+    await expect(
+      hydrate(graph, {
+        outDir,
+        localSource: 'acme/central',
+        fetch,
+      })
+    ).resolves.toEqual({
+      fetched: 1,
+      written: 1,
+      referenced: 0,
+    });
+    await expect(fs.access(departedSourceDirectory)).rejects.toThrow();
+    await expect(fs.readFile(currentPath)).resolves.toEqual(content);
+  });
+});

--- a/packages/sdk/src/test/hydrate.test.ts
+++ b/packages/sdk/src/test/hydrate.test.ts
@@ -107,6 +107,58 @@ describe('hydrate', () => {
     });
   });
 
+  it('fetches content for a federated channel', async () => {
+    const content = Buffer.from('# Payments Events');
+    const fetch = vi.fn<Fetcher>().mockResolvedValue(content);
+    const graph: ResolvedGraph = {
+      entities: [
+        {
+          type: 'channel',
+          id: 'payments.events',
+          version: '2.0.0',
+          name: 'Payments Events',
+          address: 'payments.{region}.events',
+          protocols: ['kafka'],
+          contentPath: 'channels/payments.events/index.mdx',
+          contentHash: 'sha256:13a1dc9349756c968fe39144ad9092d796262d1afd98135188e8932420f64af2',
+          resolvedFrom: {
+            source: 'acme/payments',
+            commit: '4a1b7e2',
+          },
+        },
+      ],
+      assets: [],
+      edges: [],
+      conflicts: [],
+      warnings: [],
+      externals: [],
+    };
+
+    const result = await hydrate(graph, {
+      outDir,
+      localSource: 'acme/central',
+      fetch,
+    });
+
+    expect(fetch.mock.calls).toEqual([
+      [
+        {
+          source: 'acme/payments',
+          commit: '4a1b7e2',
+          path: 'channels/payments.events/index.mdx',
+        },
+      ],
+    ]);
+    await expect(
+      fs.readFile(path.join(outDir, 'acme-payments--bf264d5186bc', 'channels/payments.events/index.mdx'))
+    ).resolves.toEqual(content);
+    expect(result).toEqual({
+      fetched: 1,
+      written: 1,
+      referenced: 0,
+    });
+  });
+
   it('skips a fetch when contentHash is already cached', async () => {
     const cachedContent = Buffer.from('# Cached Payment Service');
     const fetch = vi.fn<Fetcher>().mockResolvedValue(Buffer.from('# Fresh Payment Service'));
@@ -153,6 +205,63 @@ describe('hydrate', () => {
     ).resolves.toEqual(cachedContent);
     expect(result).toEqual({
       fetched: 0,
+      written: 1,
+      referenced: 0,
+    });
+  });
+
+  it('refetches and replaces cached bytes that do not match contentHash', async () => {
+    const content = Buffer.from('# Payment Service');
+    const contentHash = 'sha256:3e63897b7cc3a92411599289d00d686f1b1fc8e336927efa46101c8943410c70';
+    const fetch = vi.fn<Fetcher>().mockResolvedValue(content);
+    const get = vi.fn<Cache['get']>().mockResolvedValue(Buffer.from('# Corrupted Payment Service'));
+    const set = vi.fn<Cache['set']>();
+    const cache: Cache = { get, set };
+    const graph: ResolvedGraph = {
+      entities: [
+        {
+          type: 'service',
+          id: 'payment-service',
+          version: '1.0.0',
+          name: 'Payment Service',
+          contentPath: 'services/payment-service/index.mdx',
+          contentHash,
+          resolvedFrom: {
+            source: 'acme/payments',
+            commit: '4a1b7e2',
+          },
+        },
+      ],
+      assets: [],
+      edges: [],
+      conflicts: [],
+      warnings: [],
+      externals: [],
+    };
+
+    const result = await hydrate(graph, {
+      outDir,
+      localSource: 'acme/central',
+      fetch,
+      cache,
+    });
+
+    expect(get.mock.calls).toEqual([[contentHash]]);
+    expect(fetch.mock.calls).toEqual([
+      [
+        {
+          source: 'acme/payments',
+          commit: '4a1b7e2',
+          path: 'services/payment-service/index.mdx',
+        },
+      ],
+    ]);
+    expect(set.mock.calls).toEqual([[contentHash, content]]);
+    await expect(
+      fs.readFile(path.join(outDir, 'acme-payments--bf264d5186bc', 'services/payment-service/index.mdx'))
+    ).resolves.toEqual(content);
+    expect(result).toEqual({
+      fetched: 1,
       written: 1,
       referenced: 0,
     });

--- a/packages/sdk/src/test/parse-index.test.ts
+++ b/packages/sdk/src/test/parse-index.test.ts
@@ -23,6 +23,40 @@ describe('parseIndex', () => {
     expect(parseIndex(validIndex)).toEqual(validIndex);
   });
 
+  it('parses channel resources and channel pointers', () => {
+    const index = {
+      indexVersion: 1,
+      source: 'acme/payments',
+      commit: '4a1b7e2',
+      resources: [
+        {
+          type: 'channel',
+          id: 'payments.events',
+          version: '2.0.0',
+          name: 'Payments Events',
+          contentPath: 'channels/payments.events/index.mdx',
+          address: 'payments.{region}.events',
+          protocols: ['kafka'],
+          deliveryGuarantee: 'at-least-once',
+          routes: [{ id: 'payments.dead-letter' }],
+          parameters: {
+            region: { enum: ['eu', 'us'], default: 'eu', examples: ['eu'] },
+          },
+        },
+        {
+          type: 'event',
+          id: 'payment-captured',
+          version: '1.0.0',
+          name: 'Payment Captured',
+          contentPath: 'events/payment-captured/index.mdx',
+          channels: [{ id: 'payments.events', parameters: { region: 'eu' } }],
+        },
+      ],
+    };
+
+    expect(parseIndex(index)).toEqual(index);
+  });
+
   it('rejects an unsupported index version', () => {
     expect(() => parseIndex({ ...validIndex, indexVersion: 2 })).toThrow(
       new InvalidIndexError([{ path: ['indexVersion'], message: 'Invalid input: expected 1' }])

--- a/packages/sdk/src/test/parse-index.test.ts
+++ b/packages/sdk/src/test/parse-index.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { InvalidIndexError, parseIndex } from '../parse-index';
+
+const validIndex = {
+  indexVersion: 1,
+  source: 'acme/payments',
+  commit: '4a1b7e2',
+  resources: [
+    {
+      type: 'service',
+      id: 'payment-service',
+      version: '1.0.0',
+      name: 'Payment Service',
+      contentPath: 'services/payment-service/index.mdx',
+      contentHash: 'sha256:3e63897b7cc3a92411599289d00d686f1b1fc8e336927efa46101c8943410c70',
+      receives: [{ id: 'payment-requested', version: '2.0.0' }],
+    },
+  ],
+};
+
+describe('parseIndex', () => {
+  it('parses a valid federation index', () => {
+    expect(parseIndex(validIndex)).toEqual(validIndex);
+  });
+
+  it('rejects an unsupported index version', () => {
+    expect(() => parseIndex({ ...validIndex, indexVersion: 2 })).toThrow(
+      new InvalidIndexError([{ path: ['indexVersion'], message: 'Invalid input: expected 1' }])
+    );
+  });
+
+  it('reports the path to a malformed nested pointer', () => {
+    const input = structuredClone(validIndex);
+    input.resources[0].receives = [{ version: '2.0.0' } as { id: string; version: string }];
+
+    expect(() => parseIndex(input)).toThrow(
+      new InvalidIndexError([
+        {
+          path: ['resources', 0, 'receives', 0, 'id'],
+          message: 'Invalid input: expected string, received undefined',
+        },
+      ])
+    );
+  });
+
+  it('rejects a malformed content hash', () => {
+    const input = structuredClone(validIndex);
+    input.resources[0].contentHash = 'sha256:not-a-digest';
+
+    expect(() => parseIndex(input)).toThrow(
+      new InvalidIndexError([
+        {
+          path: ['resources', 0, 'contentHash'],
+          message: 'Expected a full sha256 digest',
+        },
+      ])
+    );
+  });
+
+  it('rejects unknown index fields', () => {
+    expect(() => parseIndex({ ...validIndex, unexpected: true })).toThrow(
+      new InvalidIndexError([{ path: [], message: 'Unrecognized key: "unexpected"' }])
+    );
+  });
+});

--- a/packages/sdk/src/test/resolve.test.ts
+++ b/packages/sdk/src/test/resolve.test.ts
@@ -1651,6 +1651,287 @@ describe('resolve', () => {
       });
     });
 
+    it('resolves pinned and unversioned agent, domain, and data-product membership from a domain', () => {
+      const domainsIndex = anIndex({
+        source: 'acme/central',
+        commit: '6b4e8f2',
+        resources: [
+          {
+            type: 'domain',
+            id: 'payments-domain',
+            version: '1.0.0',
+            name: 'Payments Domain',
+            agents: [{ id: 'fraud-agent', version: '1.0.0' }, { id: 'fraud-agent' }],
+            domains: [{ id: 'finance-domain', version: '1.0.0' }, { id: 'finance-domain' }],
+            dataProducts: [{ id: 'payments-report', version: '1.0.0' }, { id: 'payments-report' }],
+            contentPath: 'domains/payments-domain/index.mdx',
+          },
+        ],
+      });
+      const membersIndex = anIndex({
+        source: 'acme/platform',
+        commit: 'd812f09',
+        resources: [
+          ...['1.0.0', '2.0.0'].map((version) => ({
+            type: 'agent' as const,
+            id: 'fraud-agent',
+            version,
+            name: 'Fraud Agent',
+            contentPath: `agents/fraud-agent/${version}/index.mdx`,
+          })),
+          ...['1.0.0', '2.0.0'].map((version) => ({
+            type: 'domain' as const,
+            id: 'finance-domain',
+            version,
+            name: 'Finance Domain',
+            contentPath: `domains/finance-domain/${version}/index.mdx`,
+          })),
+          ...['1.0.0', '2.0.0'].map((version) => ({
+            type: 'data-product' as const,
+            id: 'payments-report',
+            version,
+            name: 'Payments Report',
+            contentPath: `data-products/payments-report/${version}/index.mdx`,
+          })),
+        ],
+      });
+
+      const resolution = resolve([domainsIndex, membersIndex]);
+
+      expect(
+        resolution.edges.map(({ to, direction, via, pointer, resolved, status }) => ({
+          to,
+          direction,
+          via,
+          pointer,
+          resolved,
+          status,
+        }))
+      ).toEqual([
+        {
+          to: 'fraud-agent',
+          direction: 'contains',
+          via: 'agents',
+          pointer: '1.0.0',
+          resolved: '1.0.0',
+          status: 'resolved',
+        },
+        {
+          to: 'fraud-agent',
+          direction: 'contains',
+          via: 'agents',
+          pointer: null,
+          resolved: '2.0.0',
+          status: 'resolved',
+        },
+        {
+          to: 'finance-domain',
+          direction: 'contains',
+          via: 'domains',
+          pointer: '1.0.0',
+          resolved: '1.0.0',
+          status: 'resolved',
+        },
+        {
+          to: 'finance-domain',
+          direction: 'contains',
+          via: 'domains',
+          pointer: null,
+          resolved: '2.0.0',
+          status: 'resolved',
+        },
+        {
+          to: 'payments-report',
+          direction: 'contains',
+          via: 'dataProducts',
+          pointer: '1.0.0',
+          resolved: '1.0.0',
+          status: 'resolved',
+        },
+        {
+          to: 'payments-report',
+          direction: 'contains',
+          via: 'dataProducts',
+          pointer: null,
+          resolved: '2.0.0',
+          status: 'resolved',
+        },
+      ]);
+      expect(resolution.externals).toEqual([]);
+    });
+
+    it('resolves pinned and unversioned ADR lifecycle pointers and reports missing ADRs as external', () => {
+      const architectureIndex = anIndex({
+        source: 'acme/architecture',
+        commit: '9f31c6a',
+        resources: [
+          {
+            type: 'adr',
+            id: 'current-decision',
+            version: '1.0.0',
+            name: 'Current Decision',
+            supersedes: [{ id: 'legacy-decision', version: '1.0.0' }, { id: 'legacy-decision' }],
+            supersededBy: [{ id: 'future-decision', version: '1.0.0' }, { id: 'future-decision' }],
+            amends: [{ id: 'logging-decision', version: '1.0.0' }, { id: 'logging-decision' }],
+            amendedBy: [{ id: 'security-decision', version: '1.0.0' }, { id: 'security-decision' }, { id: 'missing-decision' }],
+            contentPath: 'adrs/current-decision/index.mdx',
+          },
+          ...['legacy-decision', 'future-decision', 'logging-decision', 'security-decision'].flatMap((id) =>
+            ['1.0.0', '2.0.0'].map((version) => ({
+              type: 'adr' as const,
+              id,
+              version,
+              name: id,
+              contentPath: `adrs/${id}/${version}/index.mdx`,
+            }))
+          ),
+        ],
+      });
+
+      const resolution = resolve([architectureIndex]);
+
+      expect(
+        resolution.edges
+          .filter((edge) => edge.from === 'current-decision')
+          .map(({ to, direction, via, pointer, resolved, status }) => ({
+            to,
+            direction,
+            via,
+            pointer,
+            resolved,
+            status,
+          }))
+      ).toEqual([
+        {
+          to: 'legacy-decision',
+          direction: 'relatesTo',
+          via: 'supersedes',
+          pointer: '1.0.0',
+          resolved: '1.0.0',
+          status: 'resolved',
+        },
+        {
+          to: 'legacy-decision',
+          direction: 'relatesTo',
+          via: 'supersedes',
+          pointer: null,
+          resolved: '2.0.0',
+          status: 'resolved',
+        },
+        {
+          to: 'future-decision',
+          direction: 'relatesTo',
+          via: 'supersededBy',
+          pointer: '1.0.0',
+          resolved: '1.0.0',
+          status: 'resolved',
+        },
+        {
+          to: 'future-decision',
+          direction: 'relatesTo',
+          via: 'supersededBy',
+          pointer: null,
+          resolved: '2.0.0',
+          status: 'resolved',
+        },
+        {
+          to: 'logging-decision',
+          direction: 'relatesTo',
+          via: 'amends',
+          pointer: '1.0.0',
+          resolved: '1.0.0',
+          status: 'resolved',
+        },
+        {
+          to: 'logging-decision',
+          direction: 'relatesTo',
+          via: 'amends',
+          pointer: null,
+          resolved: '2.0.0',
+          status: 'resolved',
+        },
+        {
+          to: 'security-decision',
+          direction: 'relatesTo',
+          via: 'amendedBy',
+          pointer: '1.0.0',
+          resolved: '1.0.0',
+          status: 'resolved',
+        },
+        {
+          to: 'security-decision',
+          direction: 'relatesTo',
+          via: 'amendedBy',
+          pointer: null,
+          resolved: '2.0.0',
+          status: 'resolved',
+        },
+        {
+          to: 'missing-decision',
+          direction: 'relatesTo',
+          via: 'amendedBy',
+          pointer: null,
+          resolved: null,
+          status: 'external',
+        },
+      ]);
+      expect(resolution.externals).toEqual([{ id: 'missing-decision', referencedBy: ['current-decision'] }]);
+    });
+
+    it('resolves pinned and unversioned diagram pointers', () => {
+      const centralIndex = anIndex({
+        source: 'acme/central',
+        commit: '6b4e8f2',
+        resources: [
+          {
+            type: 'domain',
+            id: 'payments-domain',
+            version: '1.0.0',
+            name: 'Payments Domain',
+            diagrams: [{ id: 'payments-landscape', version: '1.0.0' }, { id: 'payments-landscape' }],
+            contentPath: 'domains/payments-domain/index.mdx',
+          },
+          ...['1.0.0', '2.0.0'].map((version) => ({
+            type: 'diagram' as const,
+            id: 'payments-landscape',
+            version,
+            name: 'Payments Landscape',
+            contentPath: `diagrams/payments-landscape/${version}/index.mdx`,
+          })),
+        ],
+      });
+
+      const resolution = resolve([centralIndex]);
+
+      expect(
+        resolution.edges.map(({ to, direction, via, pointer, resolved, status }) => ({
+          to,
+          direction,
+          via,
+          pointer,
+          resolved,
+          status,
+        }))
+      ).toEqual([
+        {
+          to: 'payments-landscape',
+          direction: 'relatesTo',
+          via: 'diagrams',
+          pointer: '1.0.0',
+          resolved: '1.0.0',
+          status: 'resolved',
+        },
+        {
+          to: 'payments-landscape',
+          direction: 'relatesTo',
+          via: 'diagrams',
+          pointer: null,
+          resolved: '2.0.0',
+          status: 'resolved',
+        },
+      ]);
+    });
+
     it('records which field produced an edge', () => {
       const centralIndex = anIndex({
         source: 'acme/central',
@@ -2078,6 +2359,136 @@ describe('resolve', () => {
         conflicts: [],
         externals: [],
       });
+    });
+
+    it('resolves versioned and unversioned channel pointers from messages and channel routes', () => {
+      const paymentsIndex = anIndex({
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'event',
+            id: 'payment-captured',
+            version: '1.0.0',
+            name: 'Payment Captured',
+            channels: [{ id: 'payments.events' }],
+            contentPath: 'events/payment-captured/index.mdx',
+          },
+          {
+            type: 'channel',
+            id: 'payments.events',
+            version: '1.0.0',
+            name: 'Payments Events',
+            contentPath: 'channels/payments.events/versioned/1.0.0/index.mdx',
+          },
+          {
+            type: 'channel',
+            id: 'payments.events',
+            version: '2.0.0',
+            name: 'Payments Events',
+            routes: [{ id: 'payments.dead-letter', version: '1.0.0' }],
+            contentPath: 'channels/payments.events/index.mdx',
+          },
+          {
+            type: 'channel',
+            id: 'payments.dead-letter',
+            version: '1.0.0',
+            name: 'Payments Dead Letter',
+            contentPath: 'channels/payments.dead-letter/index.mdx',
+          },
+        ],
+      });
+
+      expect(resolve([paymentsIndex]).edges).toEqual([
+        {
+          from: 'payment-captured',
+          ...fromResource('1.0.0', 'acme/payments', '4a1b7e2'),
+          to: 'payments.events',
+          direction: 'references',
+          via: 'channels',
+          pointer: null,
+          resolved: '2.0.0',
+          resolvedFrom: { source: 'acme/payments', commit: '4a1b7e2' },
+          status: 'resolved',
+        },
+        {
+          from: 'payments.events',
+          ...fromResource('2.0.0', 'acme/payments', '4a1b7e2'),
+          to: 'payments.dead-letter',
+          direction: 'references',
+          via: 'routes',
+          pointer: '1.0.0',
+          resolved: '1.0.0',
+          resolvedFrom: { source: 'acme/payments', commit: '4a1b7e2' },
+          status: 'resolved',
+        },
+      ]);
+    });
+
+    it('resolves channels nested in service sends and receives pointers', () => {
+      const paymentsIndex = anIndex({
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'event',
+            id: 'payment-captured',
+            version: '1.0.0',
+            name: 'Payment Captured',
+            contentPath: 'events/payment-captured/index.mdx',
+          },
+          {
+            type: 'command',
+            id: 'capture-payment',
+            version: '1.0.0',
+            name: 'Capture Payment',
+            contentPath: 'commands/capture-payment/index.mdx',
+          },
+          {
+            type: 'service',
+            id: 'payment-service',
+            version: '1.0.0',
+            name: 'Payment Service',
+            sends: [{ id: 'payment-captured', to: [{ id: 'payments.events' }] }],
+            receives: [{ id: 'capture-payment', from: [{ id: 'payments.events', version: '1.0.0' }] }],
+            contentPath: 'services/payment-service/index.mdx',
+          },
+          {
+            type: 'channel',
+            id: 'payments.events',
+            version: '1.0.0',
+            name: 'Payments Events',
+            contentPath: 'channels/payments.events/index.mdx',
+          },
+        ],
+      });
+
+      const channelEdges = resolve([paymentsIndex]).edges.filter((edge) => edge.to === 'payments.events');
+
+      expect(channelEdges).toEqual([
+        {
+          from: 'payment-service',
+          ...fromResource('1.0.0', 'acme/payments', '4a1b7e2'),
+          to: 'payments.events',
+          direction: 'sends',
+          via: 'sends.to',
+          pointer: null,
+          resolved: '1.0.0',
+          resolvedFrom: { source: 'acme/payments', commit: '4a1b7e2' },
+          status: 'resolved',
+        },
+        {
+          from: 'payment-service',
+          ...fromResource('1.0.0', 'acme/payments', '4a1b7e2'),
+          to: 'payments.events',
+          direction: 'receives',
+          via: 'receives.from',
+          pointer: '1.0.0',
+          resolved: '1.0.0',
+          resolvedFrom: { source: 'acme/payments', commit: '4a1b7e2' },
+          status: 'resolved',
+        },
+      ]);
     });
   });
 

--- a/packages/sdk/src/test/resolve.test.ts
+++ b/packages/sdk/src/test/resolve.test.ts
@@ -2603,6 +2603,114 @@ describe('resolve', () => {
         },
       ]);
     });
+
+    it('resolves pinned, unversioned, and external triggers nested in receives pointers', () => {
+      const paymentsIndex = anIndex({
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'command',
+            id: 'capture-payment',
+            version: '1.0.0',
+            name: 'Capture Payment',
+            contentPath: 'commands/capture-payment/index.mdx',
+          },
+          {
+            type: 'event',
+            id: 'payment-captured',
+            version: '1.0.0',
+            name: 'Payment Captured',
+            contentPath: 'events/payment-captured/index.mdx',
+          },
+          {
+            type: 'event',
+            id: 'payment-captured',
+            version: '2.0.0',
+            name: 'Payment Captured',
+            contentPath: 'events/payment-captured/versioned/2.0.0/index.mdx',
+          },
+          {
+            type: 'event',
+            id: 'payment-failed',
+            version: '1.0.0',
+            name: 'Payment Failed',
+            contentPath: 'events/payment-failed/versioned/1.0.0/index.mdx',
+          },
+          {
+            type: 'event',
+            id: 'payment-failed',
+            version: '2.0.0',
+            name: 'Payment Failed',
+            contentPath: 'events/payment-failed/index.mdx',
+          },
+          {
+            type: 'service',
+            id: 'payment-service',
+            version: '1.0.0',
+            name: 'Payment Service',
+            receives: [
+              {
+                id: 'capture-payment',
+                version: '1.0.0',
+                triggers: [
+                  { id: 'payment-captured', version: '1.0.0', condition: 'When capture succeeds' },
+                  { id: 'payment-failed', condition: 'When capture fails' },
+                  { id: 'payment-reconciliation-requested', condition: 'When the result is uncertain' },
+                ],
+              },
+            ],
+            contentPath: 'services/payment-service/index.mdx',
+          },
+        ],
+      });
+
+      const resolution = resolve([paymentsIndex]);
+      const triggerEdges = resolution.edges.filter((edge) => edge.via === 'receives.triggers');
+
+      expect({ edges: triggerEdges, externals: resolution.externals }).toEqual({
+        edges: [
+          {
+            from: 'payment-service',
+            ...fromResource('1.0.0', 'acme/payments', '4a1b7e2'),
+            to: 'payment-captured',
+            direction: 'sends',
+            via: 'receives.triggers',
+            pointer: '1.0.0',
+            resolved: '1.0.0',
+            resolvedFrom: { source: 'acme/payments', commit: '4a1b7e2' },
+            status: 'resolved',
+          },
+          {
+            from: 'payment-service',
+            ...fromResource('1.0.0', 'acme/payments', '4a1b7e2'),
+            to: 'payment-failed',
+            direction: 'sends',
+            via: 'receives.triggers',
+            pointer: null,
+            resolved: '2.0.0',
+            resolvedFrom: { source: 'acme/payments', commit: '4a1b7e2' },
+            status: 'resolved',
+          },
+          {
+            from: 'payment-service',
+            ...fromResource('1.0.0', 'acme/payments', '4a1b7e2'),
+            to: 'payment-reconciliation-requested',
+            direction: 'sends',
+            via: 'receives.triggers',
+            pointer: null,
+            resolved: null,
+            status: 'external',
+          },
+        ],
+        externals: [
+          {
+            id: 'payment-reconciliation-requested',
+            referencedBy: ['payment-service'],
+          },
+        ],
+      });
+    });
   });
 
   describe('conflicts', () => {

--- a/packages/sdk/src/test/resolve.test.ts
+++ b/packages/sdk/src/test/resolve.test.ts
@@ -1,0 +1,2384 @@
+import { describe, expect, it } from 'vitest';
+import type { Index } from '../index-types';
+import { resolve } from '../resolve';
+
+const anIndex = ({
+  source = 'acme/test',
+  commit = 'test-commit',
+  resources = [],
+  assets,
+}: Partial<Omit<Index, 'indexVersion'>> = {}): Index => ({
+  indexVersion: 1,
+  source,
+  commit,
+  resources,
+  ...(assets === undefined ? {} : { assets }),
+});
+
+const fromResource = (version: string | null, source: string, commit: string) => ({
+  fromVersion: version,
+  fromResolvedFrom: { source, commit },
+});
+
+const createComplexIndexes = (): Index[] => [
+  anIndex({
+    source: 'acme/payments',
+    commit: '4a1b7e2',
+    resources: [
+      {
+        type: 'event',
+        id: 'payment-captured',
+        version: '2.0.0',
+        name: 'Payment Captured',
+        contentPath: 'events/payment-captured/index.mdx',
+        contentHash: 'sha256:04bd91',
+      },
+      {
+        type: 'container',
+        id: 'payments-db',
+        version: '1.0.0',
+        name: 'Payments Database',
+        container_type: 'database',
+        contentPath: 'containers/payments-db/index.mdx',
+        contentHash: 'sha256:af720c',
+      },
+    ],
+  }),
+  anIndex({
+    source: 'acme/legacy-billing',
+    commit: '71c9e30',
+    resources: [
+      {
+        type: 'event',
+        id: 'payment-captured',
+        version: '1.0.0',
+        name: 'Payment Captured',
+        contentPath: 'events/payment-captured/index.mdx',
+        contentHash: 'sha256:d930a6',
+      },
+    ],
+  }),
+  anIndex({
+    source: 'acme/fulfilment',
+    commit: '8f2c6d0',
+    resources: [
+      {
+        type: 'service',
+        id: 'shipping-service',
+        version: '1.0.0',
+        name: 'Shipping Service',
+        receives: [{ id: 'payment-captured' }],
+        writesTo: [{ id: 'payments-db' }],
+        readsFrom: [{ id: 'missing-ledger' }],
+        contentPath: 'services/shipping-service/index.mdx',
+        contentHash: 'sha256:b75e20',
+      },
+    ],
+  }),
+];
+
+describe('resolve', () => {
+  it('returns an empty resolution for no indexes', () => {
+    expect(resolve([])).toEqual({
+      entities: [],
+      assets: [],
+      edges: [],
+      conflicts: [],
+      warnings: [],
+      externals: [],
+    });
+  });
+
+  describe('entities', () => {
+    it('returns one entity for a single resource', () => {
+      const index = anIndex({
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'service',
+            id: 'payment-service',
+            version: '1.0.0',
+            name: 'Payment Service',
+            contentPath: 'services/payment-service/index.mdx',
+            contentHash: 'sha256:c81a4f',
+          },
+        ],
+      });
+
+      expect(resolve([index])).toEqual({
+        entities: [
+          {
+            type: 'service',
+            id: 'payment-service',
+            version: '1.0.0',
+            name: 'Payment Service',
+            contentPath: 'services/payment-service/index.mdx',
+            contentHash: 'sha256:c81a4f',
+            resolvedFrom: {
+              source: 'acme/payments',
+              commit: '4a1b7e2',
+            },
+          },
+        ],
+        assets: [],
+        edges: [],
+        conflicts: [],
+        warnings: [],
+        externals: [],
+      });
+    });
+
+    it('preserves generic sidecars without adding entities or edges', () => {
+      const index = anIndex({
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'service',
+            id: 'payment-service',
+            version: '1.0.0',
+            name: 'Payment Service',
+            contentPath: 'services/payment-service/index.mdx',
+            contentHash: 'sha256:c81a4f',
+            sidecars: [
+              {
+                path: 'services/payment-service/schema.sql',
+                hash: 'sha256:31de86',
+              },
+              {
+                path: 'services/payment-service/attachments/context.txt',
+                hash: 'sha256:b75e20',
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(resolve([index])).toEqual({
+        entities: [
+          {
+            type: 'service',
+            id: 'payment-service',
+            version: '1.0.0',
+            name: 'Payment Service',
+            contentPath: 'services/payment-service/index.mdx',
+            contentHash: 'sha256:c81a4f',
+            sidecars: [
+              {
+                path: 'services/payment-service/schema.sql',
+                hash: 'sha256:31de86',
+              },
+              {
+                path: 'services/payment-service/attachments/context.txt',
+                hash: 'sha256:b75e20',
+              },
+            ],
+            resolvedFrom: {
+              source: 'acme/payments',
+              commit: '4a1b7e2',
+            },
+          },
+        ],
+        assets: [],
+        edges: [],
+        conflicts: [],
+        warnings: [],
+        externals: [],
+      });
+    });
+
+    it('unions entities across two indexes', () => {
+      const paymentsIndex = anIndex({
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'service',
+            id: 'payment-service',
+            version: '1.0.0',
+            name: 'Payment Service',
+            contentPath: 'services/payment-service/index.mdx',
+            contentHash: 'sha256:c81a4f',
+          },
+        ],
+      });
+      const ordersIndex = anIndex({
+        source: 'acme/orders',
+        commit: '9d3e6f1',
+        resources: [
+          {
+            type: 'event',
+            id: 'order-created',
+            version: '2.0.0',
+            name: 'Order Created',
+            contentPath: 'events/order-created/index.mdx',
+            contentHash: 'sha256:7b2d90',
+          },
+        ],
+      });
+
+      expect(resolve([paymentsIndex, ordersIndex])).toEqual({
+        entities: [
+          {
+            type: 'event',
+            id: 'order-created',
+            version: '2.0.0',
+            name: 'Order Created',
+            contentPath: 'events/order-created/index.mdx',
+            contentHash: 'sha256:7b2d90',
+            resolvedFrom: {
+              source: 'acme/orders',
+              commit: '9d3e6f1',
+            },
+          },
+          {
+            type: 'service',
+            id: 'payment-service',
+            version: '1.0.0',
+            name: 'Payment Service',
+            contentPath: 'services/payment-service/index.mdx',
+            contentHash: 'sha256:c81a4f',
+            resolvedFrom: {
+              source: 'acme/payments',
+              commit: '4a1b7e2',
+            },
+          },
+        ],
+        assets: [],
+        edges: [],
+        conflicts: [],
+        warnings: [],
+        externals: [],
+      });
+    });
+
+    it('produces the same resolution regardless of source order', () => {
+      const indexes = createComplexIndexes();
+      const resolution = resolve(indexes);
+
+      expect({
+        edges: resolution.edges.length,
+        conflicts: resolution.conflicts.length,
+        externals: resolution.externals.length,
+      }).toEqual({
+        edges: 3,
+        conflicts: 1,
+        externals: 1,
+      });
+      expect(resolution).toEqual(resolve([...indexes].reverse()));
+    });
+
+    it('is idempotent', () => {
+      const indexes = createComplexIndexes();
+
+      expect(resolve(indexes)).toEqual(resolve(indexes));
+    });
+  });
+
+  describe('assets', () => {
+    it('unions assets across two indexes', () => {
+      const paymentsIndex = anIndex({
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        assets: [
+          {
+            path: 'public/icons/payments.svg',
+            hash: 'sha256:c81a4f',
+          },
+        ],
+      });
+      const fulfilmentIndex = anIndex({
+        source: 'acme/fulfilment',
+        commit: '8f2c6d0',
+        assets: [
+          {
+            path: 'components/TeamBadge.astro',
+            hash: 'sha256:31de86',
+          },
+        ],
+      });
+
+      expect(resolve([paymentsIndex, fulfilmentIndex])).toEqual({
+        entities: [],
+        assets: [
+          {
+            path: 'components/TeamBadge.astro',
+            hash: 'sha256:31de86',
+            resolvedFrom: {
+              source: 'acme/fulfilment',
+              commit: '8f2c6d0',
+            },
+          },
+          {
+            path: 'public/icons/payments.svg',
+            hash: 'sha256:c81a4f',
+            resolvedFrom: {
+              source: 'acme/payments',
+              commit: '4a1b7e2',
+            },
+          },
+        ],
+        edges: [],
+        conflicts: [],
+        warnings: [],
+        externals: [],
+      });
+    });
+
+    it('merges identical assets and records every contributing source', () => {
+      const paymentsIndex = anIndex({
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        assets: [
+          {
+            path: 'public/logo.svg',
+            hash: 'sha256:c81a4f',
+          },
+        ],
+      });
+      const fulfilmentIndex = anIndex({
+        source: 'acme/fulfilment',
+        commit: '8f2c6d0',
+        assets: [
+          {
+            path: 'public/logo.svg',
+            hash: 'sha256:c81a4f',
+          },
+        ],
+      });
+
+      expect(resolve([paymentsIndex, fulfilmentIndex])).toEqual({
+        entities: [],
+        assets: [
+          {
+            path: 'public/logo.svg',
+            hash: 'sha256:c81a4f',
+            resolvedFrom: {
+              source: 'acme/fulfilment',
+              commit: '8f2c6d0',
+            },
+            contributors: ['acme/payments'],
+          },
+        ],
+        edges: [],
+        conflicts: [],
+        warnings: [],
+        externals: [],
+      });
+    });
+
+    it('chooses a deterministic winner and warns when asset hashes differ', () => {
+      const paymentsIndex = anIndex({
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        assets: [
+          {
+            path: 'public/logo.svg',
+            hash: 'sha256:c81a4f',
+          },
+        ],
+      });
+      const fulfilmentIndex = anIndex({
+        source: 'acme/fulfilment',
+        commit: '8f2c6d0',
+        assets: [
+          {
+            path: 'public/logo.svg',
+            hash: 'sha256:31de86',
+          },
+        ],
+      });
+      const expected = {
+        entities: [],
+        assets: [
+          {
+            path: 'public/logo.svg',
+            hash: 'sha256:31de86',
+            resolvedFrom: {
+              source: 'acme/fulfilment',
+              commit: '8f2c6d0',
+            },
+          },
+        ],
+        edges: [],
+        conflicts: [],
+        warnings: [
+          {
+            kind: 'asset-collision',
+            path: 'public/logo.svg',
+            sources: ['acme/fulfilment', 'acme/payments'],
+            winner: 'acme/fulfilment',
+          },
+        ],
+        externals: [],
+      };
+
+      expect(resolve([paymentsIndex, fulfilmentIndex])).toEqual(expected);
+      expect(resolve([fulfilmentIndex, paymentsIndex])).toEqual(expected);
+    });
+  });
+
+  describe('properties', () => {
+    it('does not mutate the input indexes', () => {
+      const indexes = createComplexIndexes();
+      const original = structuredClone(indexes);
+
+      resolve(indexes);
+      resolve(indexes);
+
+      expect(indexes).toEqual(original);
+    });
+
+    it('returns JSON-serialisable output', () => {
+      const resolution = resolve(createComplexIndexes());
+
+      expect(JSON.parse(JSON.stringify(resolution))).toEqual(resolution);
+    });
+  });
+
+  describe('edges', () => {
+    it('resolves an edge to an entity owned by another source', () => {
+      const paymentsIndex = anIndex({
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'event',
+            id: 'payment-captured',
+            version: '2.0.0',
+            name: 'Payment Captured',
+            contentPath: 'events/payment-captured/index.mdx',
+            contentHash: 'sha256:04bd91',
+          },
+        ],
+      });
+      const fulfilmentIndex = anIndex({
+        source: 'acme/fulfilment',
+        commit: '8f2c6d0',
+        resources: [
+          {
+            type: 'service',
+            id: 'shipping-service',
+            version: '1.0.0',
+            name: 'Shipping Service',
+            receives: [{ id: 'payment-captured' }],
+            contentPath: 'services/shipping-service/index.mdx',
+            contentHash: 'sha256:b75e20',
+          },
+        ],
+      });
+
+      expect(resolve([paymentsIndex, fulfilmentIndex])).toEqual({
+        entities: [
+          {
+            type: 'event',
+            id: 'payment-captured',
+            version: '2.0.0',
+            name: 'Payment Captured',
+            contentPath: 'events/payment-captured/index.mdx',
+            contentHash: 'sha256:04bd91',
+            resolvedFrom: {
+              source: 'acme/payments',
+              commit: '4a1b7e2',
+            },
+          },
+          {
+            type: 'service',
+            id: 'shipping-service',
+            version: '1.0.0',
+            name: 'Shipping Service',
+            receives: [{ id: 'payment-captured' }],
+            contentPath: 'services/shipping-service/index.mdx',
+            contentHash: 'sha256:b75e20',
+            resolvedFrom: {
+              source: 'acme/fulfilment',
+              commit: '8f2c6d0',
+            },
+          },
+        ],
+        assets: [],
+        edges: [
+          {
+            from: 'shipping-service',
+            ...fromResource('1.0.0', 'acme/fulfilment', '8f2c6d0'),
+            to: 'payment-captured',
+            direction: 'receives',
+            pointer: null,
+            resolved: '2.0.0',
+            resolvedFrom: {
+              source: 'acme/payments',
+              commit: '4a1b7e2',
+            },
+            status: 'resolved',
+          },
+        ],
+        conflicts: [],
+        warnings: [],
+        externals: [],
+      });
+    });
+
+    it('does not treat a receives pointer as a claim of ownership', () => {
+      const paymentsIndex = anIndex({
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'event',
+            id: 'payment-captured',
+            version: '2.0.0',
+            name: 'Payment Captured',
+            contentPath: 'events/payment-captured/index.mdx',
+            contentHash: 'sha256:04bd91',
+          },
+        ],
+      });
+      const fulfilmentIndex = anIndex({
+        source: 'acme/fulfilment',
+        commit: '8f2c6d0',
+        resources: [
+          {
+            type: 'service',
+            id: 'shipping-service',
+            version: '1.0.0',
+            name: 'Shipping Service',
+            receives: [{ id: 'payment-captured' }],
+            contentPath: 'services/shipping-service/index.mdx',
+            contentHash: 'sha256:b75e20',
+          },
+        ],
+      });
+
+      expect(resolve([paymentsIndex, fulfilmentIndex]).conflicts).toEqual([]);
+    });
+
+    it('renders an unresolved pointer as external rather than failing', () => {
+      const fulfilmentIndex = anIndex({
+        source: 'acme/fulfilment',
+        commit: '8f2c6d0',
+        resources: [
+          {
+            type: 'service',
+            id: 'shipping-service',
+            version: '1.0.0',
+            name: 'Shipping Service',
+            receives: [{ id: 'payment-captured' }],
+            contentPath: 'services/shipping-service/index.mdx',
+            contentHash: 'sha256:b75e20',
+          },
+        ],
+      });
+
+      expect(() => resolve([fulfilmentIndex])).not.toThrow();
+      expect(resolve([fulfilmentIndex])).toEqual({
+        entities: [
+          {
+            type: 'service',
+            id: 'shipping-service',
+            version: '1.0.0',
+            name: 'Shipping Service',
+            receives: [{ id: 'payment-captured' }],
+            contentPath: 'services/shipping-service/index.mdx',
+            contentHash: 'sha256:b75e20',
+            resolvedFrom: {
+              source: 'acme/fulfilment',
+              commit: '8f2c6d0',
+            },
+          },
+        ],
+        assets: [],
+        edges: [
+          {
+            from: 'shipping-service',
+            ...fromResource('1.0.0', 'acme/fulfilment', '8f2c6d0'),
+            to: 'payment-captured',
+            direction: 'receives',
+            pointer: null,
+            resolved: null,
+            status: 'external',
+          },
+        ],
+        conflicts: [],
+        warnings: [],
+        externals: [
+          {
+            id: 'payment-captured',
+            referencedBy: ['shipping-service'],
+          },
+        ],
+      });
+    });
+
+    it('groups multiple referrers into one external node', () => {
+      const fulfilmentIndex = anIndex({
+        source: 'acme/fulfilment',
+        commit: '8f2c6d0',
+        resources: [
+          {
+            type: 'service',
+            id: 'shipping-service',
+            version: '1.0.0',
+            name: 'Shipping Service',
+            receives: [{ id: 'payment-captured' }],
+            contentPath: 'services/shipping-service/index.mdx',
+            contentHash: 'sha256:b75e20',
+          },
+          {
+            type: 'service',
+            id: 'billing-service',
+            version: '1.0.0',
+            name: 'Billing Service',
+            receives: [{ id: 'payment-captured' }],
+            contentPath: 'services/billing-service/index.mdx',
+            contentHash: 'sha256:31de86',
+          },
+        ],
+      });
+
+      expect(resolve([fulfilmentIndex]).externals).toEqual([
+        {
+          id: 'payment-captured',
+          referencedBy: ['billing-service', 'shipping-service'],
+        },
+      ]);
+    });
+
+    it('distinguishes edges produced by different versions of the same resource', () => {
+      const servicesIndex = anIndex({
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'service',
+            id: 'payment-service',
+            version: '1.0.0',
+            name: 'Payment Service',
+            receives: [{ id: 'payment-requested' }],
+            contentPath: 'services/payment-service/1.0.0/index.mdx',
+            contentHash: 'sha256:31de86',
+          },
+          {
+            type: 'service',
+            id: 'payment-service',
+            version: '2.0.0',
+            name: 'Payment Service',
+            receives: [{ id: 'payment-requested' }],
+            contentPath: 'services/payment-service/2.0.0/index.mdx',
+            contentHash: 'sha256:b75e20',
+          },
+        ],
+      });
+      const contractsIndex = anIndex({
+        source: 'acme/contracts',
+        commit: '7c3e91a',
+        resources: [
+          {
+            type: 'event',
+            id: 'payment-requested',
+            version: '2.0.0',
+            name: 'Payment Requested',
+            contentPath: 'events/payment-requested/index.mdx',
+            contentHash: 'sha256:04bd91',
+          },
+        ],
+      });
+
+      expect(resolve([servicesIndex, contractsIndex]).edges).toEqual([
+        {
+          from: 'payment-service',
+          fromVersion: '1.0.0',
+          fromResolvedFrom: {
+            source: 'acme/payments',
+            commit: '4a1b7e2',
+          },
+          to: 'payment-requested',
+          direction: 'receives',
+          pointer: null,
+          resolved: '2.0.0',
+          resolvedFrom: {
+            source: 'acme/contracts',
+            commit: '7c3e91a',
+          },
+          status: 'resolved',
+        },
+        {
+          from: 'payment-service',
+          fromVersion: '2.0.0',
+          fromResolvedFrom: {
+            source: 'acme/payments',
+            commit: '4a1b7e2',
+          },
+          to: 'payment-requested',
+          direction: 'receives',
+          pointer: null,
+          resolved: '2.0.0',
+          resolvedFrom: {
+            source: 'acme/contracts',
+            commit: '7c3e91a',
+          },
+          status: 'resolved',
+        },
+      ]);
+    });
+
+    it('resolves a pinned pointer to that exact version', () => {
+      const paymentsIndex = anIndex({
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'event',
+            id: 'payment-captured',
+            version: '2.0.0',
+            name: 'Payment Captured',
+            contentPath: 'events/payment-captured/2.0.0/index.mdx',
+            contentHash: 'sha256:04bd91',
+          },
+          {
+            type: 'event',
+            id: 'payment-captured',
+            version: '2.1.0',
+            name: 'Payment Captured',
+            contentPath: 'events/payment-captured/2.1.0/index.mdx',
+            contentHash: 'sha256:62ea15',
+          },
+        ],
+      });
+      const fulfilmentIndex = anIndex({
+        source: 'acme/fulfilment',
+        commit: '8f2c6d0',
+        resources: [
+          {
+            type: 'service',
+            id: 'shipping-service',
+            version: '1.0.0',
+            name: 'Shipping Service',
+            receives: [{ id: 'payment-captured', version: '2.0.0' }],
+            contentPath: 'services/shipping-service/index.mdx',
+            contentHash: 'sha256:b75e20',
+          },
+        ],
+      });
+
+      expect(resolve([paymentsIndex, fulfilmentIndex]).edges).toEqual([
+        {
+          from: 'shipping-service',
+          ...fromResource('1.0.0', 'acme/fulfilment', '8f2c6d0'),
+          to: 'payment-captured',
+          direction: 'receives',
+          pointer: '2.0.0',
+          resolved: '2.0.0',
+          resolvedFrom: {
+            source: 'acme/payments',
+            commit: '4a1b7e2',
+          },
+          status: 'resolved',
+        },
+      ]);
+    });
+
+    it('resolves an unversioned pointer to the highest version', () => {
+      const paymentsIndex = anIndex({
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'event',
+            id: 'payment-captured',
+            version: '2.0.0',
+            name: 'Payment Captured',
+            contentPath: 'events/payment-captured/2.0.0/index.mdx',
+            contentHash: 'sha256:04bd91',
+          },
+          {
+            type: 'event',
+            id: 'payment-captured',
+            version: '2.1.0',
+            name: 'Payment Captured',
+            contentPath: 'events/payment-captured/2.1.0/index.mdx',
+            contentHash: 'sha256:62ea15',
+          },
+        ],
+      });
+      const fulfilmentIndex = anIndex({
+        source: 'acme/fulfilment',
+        commit: '8f2c6d0',
+        resources: [
+          {
+            type: 'service',
+            id: 'shipping-service',
+            version: '1.0.0',
+            name: 'Shipping Service',
+            receives: [{ id: 'payment-captured', version: '2.0.0' }, { id: 'payment-captured' }],
+            contentPath: 'services/shipping-service/index.mdx',
+            contentHash: 'sha256:b75e20',
+          },
+        ],
+      });
+
+      expect(resolve([paymentsIndex, fulfilmentIndex]).edges).toEqual([
+        {
+          from: 'shipping-service',
+          ...fromResource('1.0.0', 'acme/fulfilment', '8f2c6d0'),
+          to: 'payment-captured',
+          direction: 'receives',
+          pointer: '2.0.0',
+          resolved: '2.0.0',
+          resolvedFrom: {
+            source: 'acme/payments',
+            commit: '4a1b7e2',
+          },
+          status: 'resolved',
+        },
+        {
+          from: 'shipping-service',
+          ...fromResource('1.0.0', 'acme/fulfilment', '8f2c6d0'),
+          to: 'payment-captured',
+          direction: 'receives',
+          pointer: null,
+          resolved: '2.1.0',
+          resolvedFrom: {
+            source: 'acme/payments',
+            commit: '4a1b7e2',
+          },
+          status: 'resolved',
+        },
+      ]);
+    });
+
+    it('sorts versions by semver, not string comparison', () => {
+      const paymentsIndex = anIndex({
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'event',
+            id: 'payment-captured',
+            version: '9.0.0',
+            name: 'Payment Captured',
+            contentPath: 'events/payment-captured/9.0.0/index.mdx',
+            contentHash: 'sha256:04bd91',
+          },
+          {
+            type: 'event',
+            id: 'payment-captured',
+            version: '10.0.0',
+            name: 'Payment Captured',
+            contentPath: 'events/payment-captured/10.0.0/index.mdx',
+            contentHash: 'sha256:62ea15',
+          },
+        ],
+      });
+      const fulfilmentIndex = anIndex({
+        source: 'acme/fulfilment',
+        commit: '8f2c6d0',
+        resources: [
+          {
+            type: 'service',
+            id: 'shipping-service',
+            version: '1.0.0',
+            name: 'Shipping Service',
+            receives: [{ id: 'payment-captured' }],
+            contentPath: 'services/shipping-service/index.mdx',
+            contentHash: 'sha256:b75e20',
+          },
+        ],
+      });
+
+      expect(resolve([paymentsIndex, fulfilmentIndex]).edges).toEqual([
+        {
+          from: 'shipping-service',
+          ...fromResource('1.0.0', 'acme/fulfilment', '8f2c6d0'),
+          to: 'payment-captured',
+          direction: 'receives',
+          pointer: null,
+          resolved: '10.0.0',
+          resolvedFrom: {
+            source: 'acme/payments',
+            commit: '4a1b7e2',
+          },
+          status: 'resolved',
+        },
+      ]);
+    });
+
+    it("treats an explicit 'latest' the same as an absent version", () => {
+      const paymentsIndex = anIndex({
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'event',
+            id: 'payment-captured',
+            version: '2.0.0',
+            name: 'Payment Captured',
+            contentPath: 'events/payment-captured/2.0.0/index.mdx',
+            contentHash: 'sha256:04bd91',
+          },
+          {
+            type: 'event',
+            id: 'payment-captured',
+            version: '2.1.0',
+            name: 'Payment Captured',
+            contentPath: 'events/payment-captured/2.1.0/index.mdx',
+            contentHash: 'sha256:62ea15',
+          },
+        ],
+      });
+      const fulfilmentIndex = anIndex({
+        source: 'acme/fulfilment',
+        commit: '8f2c6d0',
+        resources: [
+          {
+            type: 'service',
+            id: 'shipping-service',
+            version: '1.0.0',
+            name: 'Shipping Service',
+            receives: [{ id: 'payment-captured' }, { id: 'payment-captured', version: 'latest' }],
+            contentPath: 'services/shipping-service/index.mdx',
+            contentHash: 'sha256:b75e20',
+          },
+        ],
+      });
+
+      const resolution = resolve([paymentsIndex, fulfilmentIndex]);
+
+      expect({ edges: resolution.edges, externals: resolution.externals }).toEqual({
+        edges: [
+          {
+            from: 'shipping-service',
+            ...fromResource('1.0.0', 'acme/fulfilment', '8f2c6d0'),
+            to: 'payment-captured',
+            direction: 'receives',
+            pointer: null,
+            resolved: '2.1.0',
+            resolvedFrom: {
+              source: 'acme/payments',
+              commit: '4a1b7e2',
+            },
+            status: 'resolved',
+          },
+          {
+            from: 'shipping-service',
+            ...fromResource('1.0.0', 'acme/fulfilment', '8f2c6d0'),
+            to: 'payment-captured',
+            direction: 'receives',
+            pointer: 'latest',
+            resolved: '2.1.0',
+            resolvedFrom: {
+              source: 'acme/payments',
+              commit: '4a1b7e2',
+            },
+            status: 'resolved',
+          },
+        ],
+        externals: [],
+      });
+    });
+
+    it('marks a pointer as unresolved when the owner lacks that version', () => {
+      const paymentsIndex = anIndex({
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'event',
+            id: 'payment-captured',
+            version: '2.1.0',
+            name: 'Payment Captured',
+            contentPath: 'events/payment-captured/2.1.0/index.mdx',
+            contentHash: 'sha256:62ea15',
+          },
+        ],
+      });
+      const fulfilmentIndex = anIndex({
+        source: 'acme/fulfilment',
+        commit: '8f2c6d0',
+        resources: [
+          {
+            type: 'service',
+            id: 'shipping-service',
+            version: '1.0.0',
+            name: 'Shipping Service',
+            receives: [{ id: 'payment-captured', version: '2.0.0' }],
+            contentPath: 'services/shipping-service/index.mdx',
+            contentHash: 'sha256:b75e20',
+          },
+        ],
+      });
+
+      const resolution = resolve([paymentsIndex, fulfilmentIndex]);
+
+      expect({ edges: resolution.edges, externals: resolution.externals }).toEqual({
+        edges: [
+          {
+            from: 'shipping-service',
+            ...fromResource('1.0.0', 'acme/fulfilment', '8f2c6d0'),
+            to: 'payment-captured',
+            direction: 'receives',
+            pointer: '2.0.0',
+            resolved: null,
+            status: 'unresolved',
+          },
+        ],
+        externals: [],
+      });
+    });
+
+    it('resolves writesTo and readsFrom pointers to containers', () => {
+      const dataIndex = anIndex({
+        source: 'acme/data',
+        commit: '3d7a9c1',
+        resources: [
+          {
+            type: 'container',
+            id: 'payments-db',
+            version: '1.0.0',
+            name: 'Payments Database',
+            container_type: 'database',
+            contentPath: 'containers/payments-db/index.mdx',
+            contentHash: 'sha256:af720c',
+          },
+        ],
+      });
+      const paymentsIndex = anIndex({
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'service',
+            id: 'payment-service',
+            version: '1.0.0',
+            name: 'Payment Service',
+            writesTo: [{ id: 'payments-db' }],
+            readsFrom: [{ id: 'payments-db' }],
+            contentPath: 'services/payment-service/index.mdx',
+            contentHash: 'sha256:c81a4f',
+          },
+        ],
+      });
+
+      expect(resolve([dataIndex, paymentsIndex]).edges).toEqual([
+        {
+          from: 'payment-service',
+          ...fromResource('1.0.0', 'acme/payments', '4a1b7e2'),
+          to: 'payments-db',
+          direction: 'writesTo',
+          pointer: null,
+          resolved: '1.0.0',
+          resolvedFrom: {
+            source: 'acme/data',
+            commit: '3d7a9c1',
+          },
+          status: 'resolved',
+        },
+        {
+          from: 'payment-service',
+          ...fromResource('1.0.0', 'acme/payments', '4a1b7e2'),
+          to: 'payments-db',
+          direction: 'readsFrom',
+          pointer: null,
+          resolved: '1.0.0',
+          resolvedFrom: {
+            source: 'acme/data',
+            commit: '3d7a9c1',
+          },
+          status: 'resolved',
+        },
+      ]);
+    });
+
+    it('resolves membership pointers from a domain to its services', () => {
+      const centralIndex = anIndex({
+        source: 'acme/central',
+        commit: '6b4e8f2',
+        resources: [
+          {
+            type: 'domain',
+            id: 'payments',
+            version: '1.0.0',
+            name: 'Payments',
+            services: [{ id: 'payment-service' }],
+            contentPath: 'domains/payments/index.mdx',
+            contentHash: 'sha256:ea174b',
+          },
+        ],
+      });
+      const paymentsIndex = anIndex({
+        source: 'acme/team-payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'service',
+            id: 'payment-service',
+            version: '1.0.0',
+            name: 'Payment Service',
+            contentPath: 'services/payment-service/index.mdx',
+            contentHash: 'sha256:c81a4f',
+          },
+        ],
+      });
+
+      expect(resolve([centralIndex, paymentsIndex]).edges).toEqual([
+        {
+          from: 'payments',
+          ...fromResource('1.0.0', 'acme/central', '6b4e8f2'),
+          to: 'payment-service',
+          direction: 'contains',
+          via: 'services',
+          pointer: null,
+          resolved: '1.0.0',
+          resolvedFrom: {
+            source: 'acme/team-payments',
+            commit: '4a1b7e2',
+          },
+          status: 'resolved',
+        },
+      ]);
+    });
+
+    it('resolves pinned and unversioned flow step references to resources owned by another source', () => {
+      const checkoutIndex = anIndex({
+        source: 'acme/checkout',
+        commit: '91e5c4a',
+        resources: [
+          {
+            type: 'flow',
+            id: 'checkout-saga',
+            version: '1.0.0',
+            name: 'Checkout Saga',
+            references: [
+              { kind: 'service', id: 'payment-service', version: '1.0.0' },
+              { kind: 'service', id: 'payment-service' },
+            ],
+            contentPath: 'flows/checkout-saga/index.mdx',
+            contentHash: 'sha256:7f24b1',
+          },
+        ],
+      });
+      const paymentsIndex = anIndex({
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'service',
+            id: 'payment-service',
+            version: '1.0.0',
+            name: 'Payment Service',
+            contentPath: 'services/payment-service/index.mdx',
+            contentHash: 'sha256:c81a4f',
+          },
+          {
+            type: 'service',
+            id: 'payment-service',
+            version: '2.0.0',
+            name: 'Payment Service',
+            contentPath: 'services/payment-service/versioned/2.0.0/index.mdx',
+            contentHash: 'sha256:9b2d6e',
+          },
+        ],
+      });
+
+      const resolution = resolve([checkoutIndex, paymentsIndex]);
+
+      expect({ edges: resolution.edges, conflicts: resolution.conflicts, externals: resolution.externals }).toEqual({
+        edges: [
+          {
+            from: 'checkout-saga',
+            ...fromResource('1.0.0', 'acme/checkout', '91e5c4a'),
+            to: 'payment-service',
+            direction: 'references',
+            via: 'steps',
+            pointer: '1.0.0',
+            resolved: '1.0.0',
+            resolvedFrom: {
+              source: 'acme/payments',
+              commit: '4a1b7e2',
+            },
+            status: 'resolved',
+          },
+          {
+            from: 'checkout-saga',
+            ...fromResource('1.0.0', 'acme/checkout', '91e5c4a'),
+            to: 'payment-service',
+            direction: 'references',
+            via: 'steps',
+            pointer: null,
+            resolved: '2.0.0',
+            resolvedFrom: {
+              source: 'acme/payments',
+              commit: '4a1b7e2',
+            },
+            status: 'resolved',
+          },
+        ],
+        conflicts: [],
+        externals: [],
+      });
+    });
+
+    it('resolves pinned and unversioned container membership from a system', () => {
+      const systemsIndex = anIndex({
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'system',
+            id: 'payments-system',
+            version: '1.0.0',
+            name: 'Payments System',
+            containers: [{ id: 'ledger-db', version: '1.0.0' }, { id: 'audit-db' }],
+            contentPath: 'systems/payments-system/index.mdx',
+            contentHash: 'sha256:fd82b7',
+          },
+        ],
+      });
+      const dataIndex = anIndex({
+        source: 'acme/data',
+        commit: '3d7a9c1',
+        resources: [
+          {
+            type: 'container',
+            id: 'ledger-db',
+            version: '1.0.0',
+            name: 'Ledger Database',
+            container_type: 'database',
+            contentPath: 'containers/ledger-db/index.mdx',
+            contentHash: 'sha256:af720c',
+          },
+          {
+            type: 'container',
+            id: 'audit-db',
+            version: '1.0.0',
+            name: 'Audit Database',
+            container_type: 'database',
+            contentPath: 'containers/audit-db/index.mdx',
+            contentHash: 'sha256:820d4e',
+          },
+          {
+            type: 'container',
+            id: 'audit-db',
+            version: '2.0.0',
+            name: 'Audit Database',
+            container_type: 'database',
+            contentPath: 'containers/audit-db/versioned/2.0.0/index.mdx',
+            contentHash: 'sha256:0c9b35',
+          },
+        ],
+      });
+
+      const resolution = resolve([systemsIndex, dataIndex]);
+
+      expect({ edges: resolution.edges, conflicts: resolution.conflicts, externals: resolution.externals }).toEqual({
+        edges: [
+          {
+            from: 'payments-system',
+            ...fromResource('1.0.0', 'acme/payments', '4a1b7e2'),
+            to: 'ledger-db',
+            direction: 'contains',
+            via: 'containers',
+            pointer: '1.0.0',
+            resolved: '1.0.0',
+            resolvedFrom: {
+              source: 'acme/data',
+              commit: '3d7a9c1',
+            },
+            status: 'resolved',
+          },
+          {
+            from: 'payments-system',
+            ...fromResource('1.0.0', 'acme/payments', '4a1b7e2'),
+            to: 'audit-db',
+            direction: 'contains',
+            via: 'containers',
+            pointer: null,
+            resolved: '2.0.0',
+            resolvedFrom: {
+              source: 'acme/data',
+              commit: '3d7a9c1',
+            },
+            status: 'resolved',
+          },
+        ],
+        conflicts: [],
+        externals: [],
+      });
+    });
+
+    it('resolves pinned and unversioned flow membership from a system', () => {
+      const systemsIndex = anIndex({
+        source: 'acme/checkout',
+        commit: '91e5c4a',
+        resources: [
+          {
+            type: 'system',
+            id: 'checkout-system',
+            version: '1.0.0',
+            name: 'Checkout System',
+            flows: [{ id: 'checkout-saga', version: '1.0.0' }, { id: 'refund-flow' }],
+            contentPath: 'systems/checkout-system/index.mdx',
+            contentHash: 'sha256:7d26c0',
+          },
+        ],
+      });
+      const flowsIndex = anIndex({
+        source: 'acme/orchestration',
+        commit: 'c6f18a0',
+        resources: [
+          {
+            type: 'flow',
+            id: 'checkout-saga',
+            version: '1.0.0',
+            name: 'Checkout Saga',
+            contentPath: 'flows/checkout-saga/index.mdx',
+            contentHash: 'sha256:7f24b1',
+          },
+          {
+            type: 'flow',
+            id: 'refund-flow',
+            version: '1.0.0',
+            name: 'Refund Flow',
+            contentPath: 'flows/refund-flow/index.mdx',
+            contentHash: 'sha256:819bed',
+          },
+          {
+            type: 'flow',
+            id: 'refund-flow',
+            version: '2.0.0',
+            name: 'Refund Flow',
+            contentPath: 'flows/refund-flow/versioned/2.0.0/index.mdx',
+            contentHash: 'sha256:78b601',
+          },
+        ],
+      });
+
+      const resolution = resolve([systemsIndex, flowsIndex]);
+
+      expect({ edges: resolution.edges, conflicts: resolution.conflicts, externals: resolution.externals }).toEqual({
+        edges: [
+          {
+            from: 'checkout-system',
+            ...fromResource('1.0.0', 'acme/checkout', '91e5c4a'),
+            to: 'checkout-saga',
+            direction: 'contains',
+            via: 'flows',
+            pointer: '1.0.0',
+            resolved: '1.0.0',
+            resolvedFrom: {
+              source: 'acme/orchestration',
+              commit: 'c6f18a0',
+            },
+            status: 'resolved',
+          },
+          {
+            from: 'checkout-system',
+            ...fromResource('1.0.0', 'acme/checkout', '91e5c4a'),
+            to: 'refund-flow',
+            direction: 'contains',
+            via: 'flows',
+            pointer: null,
+            resolved: '2.0.0',
+            resolvedFrom: {
+              source: 'acme/orchestration',
+              commit: 'c6f18a0',
+            },
+            status: 'resolved',
+          },
+        ],
+        conflicts: [],
+        externals: [],
+      });
+    });
+
+    it('resolves pinned and unversioned relationships between systems and preserves their labels', () => {
+      const checkoutIndex = anIndex({
+        source: 'acme/checkout',
+        commit: '91e5c4a',
+        resources: [
+          {
+            type: 'system',
+            id: 'checkout-system',
+            version: '1.0.0',
+            name: 'Checkout System',
+            relationships: [
+              { id: 'payments-system', version: '1.0.0', label: 'charges through' },
+              { id: 'fraud-system', label: 'screens with' },
+            ],
+            contentPath: 'systems/checkout-system/index.mdx',
+            contentHash: 'sha256:7d26c0',
+          },
+        ],
+      });
+      const relatedSystemsIndex = anIndex({
+        source: 'acme/platform',
+        commit: 'd812f09',
+        resources: [
+          {
+            type: 'system',
+            id: 'payments-system',
+            version: '1.0.0',
+            name: 'Payments System',
+            contentPath: 'systems/payments-system/index.mdx',
+            contentHash: 'sha256:fd82b7',
+          },
+          {
+            type: 'system',
+            id: 'fraud-system',
+            version: '1.0.0',
+            name: 'Fraud System',
+            contentPath: 'systems/fraud-system/index.mdx',
+            contentHash: 'sha256:b403e9',
+          },
+          {
+            type: 'system',
+            id: 'fraud-system',
+            version: '2.0.0',
+            name: 'Fraud System',
+            contentPath: 'systems/fraud-system/versioned/2.0.0/index.mdx',
+            contentHash: 'sha256:f091c2',
+          },
+        ],
+      });
+
+      const resolution = resolve([checkoutIndex, relatedSystemsIndex]);
+
+      expect({ edges: resolution.edges, conflicts: resolution.conflicts, externals: resolution.externals }).toEqual({
+        edges: [
+          {
+            from: 'checkout-system',
+            ...fromResource('1.0.0', 'acme/checkout', '91e5c4a'),
+            to: 'payments-system',
+            direction: 'relatesTo',
+            via: 'relationships',
+            label: 'charges through',
+            pointer: '1.0.0',
+            resolved: '1.0.0',
+            resolvedFrom: {
+              source: 'acme/platform',
+              commit: 'd812f09',
+            },
+            status: 'resolved',
+          },
+          {
+            from: 'checkout-system',
+            ...fromResource('1.0.0', 'acme/checkout', '91e5c4a'),
+            to: 'fraud-system',
+            direction: 'relatesTo',
+            via: 'relationships',
+            label: 'screens with',
+            pointer: null,
+            resolved: '2.0.0',
+            resolvedFrom: {
+              source: 'acme/platform',
+              commit: 'd812f09',
+            },
+            status: 'resolved',
+          },
+        ],
+        conflicts: [],
+        externals: [],
+      });
+    });
+
+    it('resolves pinned and unversioned system membership from a domain', () => {
+      const domainsIndex = anIndex({
+        source: 'acme/central',
+        commit: '6b4e8f2',
+        resources: [
+          {
+            type: 'domain',
+            id: 'payments-domain',
+            version: '1.0.0',
+            name: 'Payments Domain',
+            systems: [{ id: 'payments-system', version: '1.0.0' }, { id: 'fraud-system' }],
+            contentPath: 'domains/payments-domain/index.mdx',
+            contentHash: 'sha256:ea174b',
+          },
+        ],
+      });
+      const systemsIndex = anIndex({
+        source: 'acme/platform',
+        commit: 'd812f09',
+        resources: [
+          {
+            type: 'system',
+            id: 'payments-system',
+            version: '1.0.0',
+            name: 'Payments System',
+            contentPath: 'systems/payments-system/index.mdx',
+            contentHash: 'sha256:fd82b7',
+          },
+          {
+            type: 'system',
+            id: 'fraud-system',
+            version: '1.0.0',
+            name: 'Fraud System',
+            contentPath: 'systems/fraud-system/index.mdx',
+            contentHash: 'sha256:b403e9',
+          },
+          {
+            type: 'system',
+            id: 'fraud-system',
+            version: '2.0.0',
+            name: 'Fraud System',
+            contentPath: 'systems/fraud-system/versioned/2.0.0/index.mdx',
+            contentHash: 'sha256:f091c2',
+          },
+        ],
+      });
+
+      const resolution = resolve([domainsIndex, systemsIndex]);
+
+      expect({ edges: resolution.edges, conflicts: resolution.conflicts, externals: resolution.externals }).toEqual({
+        edges: [
+          {
+            from: 'payments-domain',
+            ...fromResource('1.0.0', 'acme/central', '6b4e8f2'),
+            to: 'payments-system',
+            direction: 'contains',
+            via: 'systems',
+            pointer: '1.0.0',
+            resolved: '1.0.0',
+            resolvedFrom: {
+              source: 'acme/platform',
+              commit: 'd812f09',
+            },
+            status: 'resolved',
+          },
+          {
+            from: 'payments-domain',
+            ...fromResource('1.0.0', 'acme/central', '6b4e8f2'),
+            to: 'fraud-system',
+            direction: 'contains',
+            via: 'systems',
+            pointer: null,
+            resolved: '2.0.0',
+            resolvedFrom: {
+              source: 'acme/platform',
+              commit: 'd812f09',
+            },
+            status: 'resolved',
+          },
+        ],
+        conflicts: [],
+        externals: [],
+      });
+    });
+
+    it('resolves pinned and unversioned entity membership from a domain', () => {
+      const domainsIndex = anIndex({
+        source: 'acme/central',
+        commit: '6b4e8f2',
+        resources: [
+          {
+            type: 'domain',
+            id: 'payments-domain',
+            version: '1.0.0',
+            name: 'Payments Domain',
+            entities: [{ id: 'payment', version: '1.0.0' }, { id: 'refund' }],
+            contentPath: 'domains/payments-domain/index.mdx',
+            contentHash: 'sha256:ea174b',
+          },
+        ],
+      });
+      const entitiesIndex = anIndex({
+        source: 'acme/data-model',
+        commit: '3d7a9c1',
+        resources: [
+          {
+            type: 'entity',
+            id: 'payment',
+            version: '1.0.0',
+            name: 'Payment',
+            contentPath: 'entities/payment/index.mdx',
+            contentHash: 'sha256:af720c',
+          },
+          {
+            type: 'entity',
+            id: 'refund',
+            version: '1.0.0',
+            name: 'Refund',
+            contentPath: 'entities/refund/index.mdx',
+            contentHash: 'sha256:820d4e',
+          },
+          {
+            type: 'entity',
+            id: 'refund',
+            version: '2.0.0',
+            name: 'Refund',
+            contentPath: 'entities/refund/versioned/2.0.0/index.mdx',
+            contentHash: 'sha256:0c9b35',
+          },
+        ],
+      });
+
+      const resolution = resolve([domainsIndex, entitiesIndex]);
+
+      expect({ edges: resolution.edges, conflicts: resolution.conflicts, externals: resolution.externals }).toEqual({
+        edges: [
+          {
+            from: 'payments-domain',
+            ...fromResource('1.0.0', 'acme/central', '6b4e8f2'),
+            to: 'payment',
+            direction: 'contains',
+            via: 'entities',
+            pointer: '1.0.0',
+            resolved: '1.0.0',
+            resolvedFrom: {
+              source: 'acme/data-model',
+              commit: '3d7a9c1',
+            },
+            status: 'resolved',
+          },
+          {
+            from: 'payments-domain',
+            ...fromResource('1.0.0', 'acme/central', '6b4e8f2'),
+            to: 'refund',
+            direction: 'contains',
+            via: 'entities',
+            pointer: null,
+            resolved: '2.0.0',
+            resolvedFrom: {
+              source: 'acme/data-model',
+              commit: '3d7a9c1',
+            },
+            status: 'resolved',
+          },
+        ],
+        conflicts: [],
+        externals: [],
+      });
+    });
+
+    it('records which field produced an edge', () => {
+      const centralIndex = anIndex({
+        source: 'acme/central',
+        commit: '6b4e8f2',
+        resources: [
+          {
+            type: 'domain',
+            id: 'payments-domain',
+            version: '1.0.0',
+            name: 'Payments Domain',
+            services: [{ id: 'payment-service' }],
+            contentPath: 'domains/payments/index.mdx',
+            contentHash: 'sha256:ea174b',
+          },
+          {
+            type: 'system',
+            id: 'payments-system',
+            version: '1.0.0',
+            name: 'Payments System',
+            services: [{ id: 'payment-service' }],
+            contentPath: 'systems/payments/index.mdx',
+            contentHash: 'sha256:fd82b7',
+          },
+        ],
+      });
+      const paymentsIndex = anIndex({
+        source: 'acme/team-payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'service',
+            id: 'payment-service',
+            version: '1.0.0',
+            name: 'Payment Service',
+            contentPath: 'services/payment-service/index.mdx',
+            contentHash: 'sha256:c81a4f',
+          },
+        ],
+      });
+
+      expect(resolve([centralIndex, paymentsIndex]).edges).toEqual([
+        {
+          from: 'payments-domain',
+          ...fromResource('1.0.0', 'acme/central', '6b4e8f2'),
+          to: 'payment-service',
+          direction: 'contains',
+          via: 'services',
+          pointer: null,
+          resolved: '1.0.0',
+          resolvedFrom: {
+            source: 'acme/team-payments',
+            commit: '4a1b7e2',
+          },
+          status: 'resolved',
+        },
+        {
+          from: 'payments-system',
+          ...fromResource('1.0.0', 'acme/central', '6b4e8f2'),
+          to: 'payment-service',
+          direction: 'contains',
+          via: 'services',
+          pointer: null,
+          resolved: '1.0.0',
+          resolvedFrom: {
+            source: 'acme/team-payments',
+            commit: '4a1b7e2',
+          },
+          status: 'resolved',
+        },
+      ]);
+    });
+
+    it('resolves inputs and outputs on data products', () => {
+      const paymentsIndex = anIndex({
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'event',
+            id: 'payment-requested',
+            version: '1.0.0',
+            name: 'Payment Requested',
+            contentPath: 'events/payment-requested/index.mdx',
+            contentHash: 'sha256:62ea15',
+          },
+          {
+            type: 'event',
+            id: 'payment-captured',
+            version: '2.0.0',
+            name: 'Payment Captured',
+            contentPath: 'events/payment-captured/index.mdx',
+            contentHash: 'sha256:04bd91',
+          },
+        ],
+      });
+      const dataIndex = anIndex({
+        source: 'acme/data',
+        commit: '3d7a9c1',
+        resources: [
+          {
+            type: 'data-product',
+            id: 'payments-analytics',
+            version: '1.0.0',
+            name: 'Payments Analytics',
+            inputs: [{ id: 'payment-requested' }],
+            outputs: [{ id: 'payment-captured' }],
+            contentPath: 'data-products/payments-analytics/index.mdx',
+            contentHash: 'sha256:af720c',
+          },
+        ],
+      });
+
+      expect(resolve([paymentsIndex, dataIndex]).edges).toEqual([
+        {
+          from: 'payments-analytics',
+          ...fromResource('1.0.0', 'acme/data', '3d7a9c1'),
+          to: 'payment-requested',
+          direction: 'receives',
+          via: 'inputs',
+          pointer: null,
+          resolved: '1.0.0',
+          resolvedFrom: {
+            source: 'acme/payments',
+            commit: '4a1b7e2',
+          },
+          status: 'resolved',
+        },
+        {
+          from: 'payments-analytics',
+          ...fromResource('1.0.0', 'acme/data', '3d7a9c1'),
+          to: 'payment-captured',
+          direction: 'sends',
+          via: 'outputs',
+          pointer: null,
+          resolved: '2.0.0',
+          resolvedFrom: {
+            source: 'acme/payments',
+            commit: '4a1b7e2',
+          },
+          status: 'resolved',
+        },
+      ]);
+    });
+
+    it('resolves pinned and unversioned related ADR pointers', () => {
+      const architectureIndex = anIndex({
+        source: 'acme/architecture',
+        commit: '5e2b8d7',
+        resources: [
+          {
+            type: 'adr',
+            id: 'adr-118',
+            version: '1.0.0',
+            name: 'Apply payment event standards',
+            status: 'accepted',
+            related: [{ id: 'adr-042', version: '1.0.0' }, { id: 'adr-077' }],
+            contentPath: 'adrs/118/index.mdx',
+            contentHash: 'sha256:bc18f4',
+          },
+        ],
+      });
+      const governanceIndex = anIndex({
+        source: 'acme/governance',
+        commit: '8c3f1a6',
+        resources: [
+          {
+            type: 'adr',
+            id: 'adr-042',
+            version: '1.0.0',
+            name: 'Use CloudEvents',
+            status: 'accepted',
+            contentPath: 'adrs/042/index.mdx',
+            contentHash: 'sha256:746dc1',
+          },
+          {
+            type: 'adr',
+            id: 'adr-077',
+            version: '1.0.0',
+            name: 'Version event contracts',
+            status: 'accepted',
+            contentPath: 'adrs/077/index.mdx',
+            contentHash: 'sha256:7d5a20',
+          },
+          {
+            type: 'adr',
+            id: 'adr-077',
+            version: '2.0.0',
+            name: 'Version event contracts',
+            status: 'accepted',
+            contentPath: 'adrs/077/versioned/2.0.0/index.mdx',
+            contentHash: 'sha256:a19e54',
+          },
+        ],
+      });
+
+      const resolution = resolve([architectureIndex, governanceIndex]);
+
+      expect({ edges: resolution.edges, conflicts: resolution.conflicts, externals: resolution.externals }).toEqual({
+        edges: [
+          {
+            from: 'adr-118',
+            ...fromResource('1.0.0', 'acme/architecture', '5e2b8d7'),
+            to: 'adr-042',
+            direction: 'relatesTo',
+            via: 'related',
+            pointer: '1.0.0',
+            resolved: '1.0.0',
+            resolvedFrom: {
+              source: 'acme/governance',
+              commit: '8c3f1a6',
+            },
+            status: 'resolved',
+          },
+          {
+            from: 'adr-118',
+            ...fromResource('1.0.0', 'acme/architecture', '5e2b8d7'),
+            to: 'adr-077',
+            direction: 'relatesTo',
+            via: 'related',
+            pointer: null,
+            resolved: '2.0.0',
+            resolvedFrom: {
+              source: 'acme/governance',
+              commit: '8c3f1a6',
+            },
+            status: 'resolved',
+          },
+        ],
+        conflicts: [],
+        externals: [],
+      });
+    });
+
+    it('resolves typed pointers and flags a type mismatch', () => {
+      const paymentsIndex = anIndex({
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'event',
+            id: 'payment-captured',
+            version: '2.0.0',
+            name: 'Payment Captured',
+            contentPath: 'events/payment-captured/index.mdx',
+            contentHash: 'sha256:04bd91',
+          },
+        ],
+      });
+      const architectureIndex = anIndex({
+        source: 'acme/architecture',
+        commit: '5e2b8d7',
+        resources: [
+          {
+            type: 'adr',
+            id: 'adr-118',
+            version: '1.0.0',
+            name: 'Apply payment event standards',
+            status: 'accepted',
+            appliesTo: [{ type: 'service', id: 'payment-captured' }],
+            contentPath: 'adrs/118/index.mdx',
+            contentHash: 'sha256:bc18f4',
+          },
+        ],
+      });
+
+      const resolution = resolve([paymentsIndex, architectureIndex]);
+
+      expect({ edges: resolution.edges, conflicts: resolution.conflicts }).toEqual({
+        edges: [
+          {
+            from: 'adr-118',
+            ...fromResource('1.0.0', 'acme/architecture', '5e2b8d7'),
+            to: 'payment-captured',
+            direction: 'appliesTo',
+            pointer: null,
+            resolved: '2.0.0',
+            resolvedFrom: {
+              source: 'acme/payments',
+              commit: '4a1b7e2',
+            },
+            status: 'resolved',
+          },
+        ],
+        conflicts: [
+          {
+            kind: 'pointer-type-mismatch',
+            id: 'payment-captured',
+            sources: ['acme/architecture', 'acme/payments'],
+            detail: 'Expected service but found event',
+          },
+        ],
+      });
+    });
+
+    it('resolves an edge deterministically when the target id is in conflict', () => {
+      const paymentsIndex = anIndex({
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'event',
+            id: 'payment-captured',
+            version: '2.0.0',
+            name: 'Payment Captured',
+            contentPath: 'events/payment-captured/2.0.0/index.mdx',
+            contentHash: 'sha256:04bd91',
+          },
+        ],
+      });
+      const legacyBillingIndex = anIndex({
+        source: 'acme/legacy-billing',
+        commit: '71c9e30',
+        resources: [
+          {
+            type: 'event',
+            id: 'payment-captured',
+            version: '1.0.0',
+            name: 'Payment Captured',
+            contentPath: 'events/payment-captured/1.0.0/index.mdx',
+            contentHash: 'sha256:d930a6',
+          },
+        ],
+      });
+      const fulfilmentIndex = anIndex({
+        source: 'acme/fulfilment',
+        commit: '8f2c6d0',
+        resources: [
+          {
+            type: 'service',
+            id: 'shipping-service',
+            version: '1.0.0',
+            name: 'Shipping Service',
+            receives: [{ id: 'payment-captured' }],
+            contentPath: 'services/shipping-service/index.mdx',
+            contentHash: 'sha256:b75e20',
+          },
+        ],
+      });
+
+      const resolution = resolve([paymentsIndex, legacyBillingIndex, fulfilmentIndex]);
+
+      expect({ edges: resolution.edges, conflicts: resolution.conflicts }).toEqual({
+        edges: [
+          {
+            from: 'shipping-service',
+            ...fromResource('1.0.0', 'acme/fulfilment', '8f2c6d0'),
+            to: 'payment-captured',
+            direction: 'receives',
+            pointer: null,
+            resolved: '2.0.0',
+            resolvedFrom: {
+              source: 'acme/payments',
+              commit: '4a1b7e2',
+            },
+            status: 'resolved',
+          },
+        ],
+        conflicts: [
+          {
+            kind: 'duplicate-source',
+            id: 'payment-captured',
+            sources: ['acme/legacy-billing', 'acme/payments'],
+          },
+        ],
+      });
+    });
+
+    it('resolves a service that sends and receives a message it owns', () => {
+      const paymentsIndex = anIndex({
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'event',
+            id: 'payment-retry-requested',
+            version: '1.0.0',
+            name: 'Payment Retry Requested',
+            contentPath: 'events/payment-retry-requested/index.mdx',
+            contentHash: 'sha256:62ea15',
+          },
+          {
+            type: 'service',
+            id: 'payment-service',
+            version: '1.0.0',
+            name: 'Payment Service',
+            sends: [{ id: 'payment-retry-requested' }],
+            receives: [{ id: 'payment-retry-requested' }],
+            contentPath: 'services/payment-service/index.mdx',
+            contentHash: 'sha256:c81a4f',
+          },
+        ],
+      });
+
+      const resolution = resolve([paymentsIndex]);
+
+      expect({ edges: resolution.edges, conflicts: resolution.conflicts, externals: resolution.externals }).toEqual({
+        edges: [
+          {
+            from: 'payment-service',
+            ...fromResource('1.0.0', 'acme/payments', '4a1b7e2'),
+            to: 'payment-retry-requested',
+            direction: 'sends',
+            pointer: null,
+            resolved: '1.0.0',
+            resolvedFrom: {
+              source: 'acme/payments',
+              commit: '4a1b7e2',
+            },
+            status: 'resolved',
+          },
+          {
+            from: 'payment-service',
+            ...fromResource('1.0.0', 'acme/payments', '4a1b7e2'),
+            to: 'payment-retry-requested',
+            direction: 'receives',
+            pointer: null,
+            resolved: '1.0.0',
+            resolvedFrom: {
+              source: 'acme/payments',
+              commit: '4a1b7e2',
+            },
+            status: 'resolved',
+          },
+        ],
+        conflicts: [],
+        externals: [],
+      });
+    });
+  });
+
+  describe('conflicts', () => {
+    it('reports a conflict when two sources own the same id', () => {
+      const paymentsIndex = anIndex({
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'event',
+            id: 'payment-captured',
+            version: '2.0.0',
+            name: 'Payment Captured',
+            contentPath: 'events/payment-captured/2.0.0/index.mdx',
+            contentHash: 'sha256:04bd91',
+          },
+        ],
+      });
+      const legacyBillingIndex = anIndex({
+        source: 'acme/legacy-billing',
+        commit: '71c9e30',
+        resources: [
+          {
+            type: 'event',
+            id: 'payment-captured',
+            version: '1.0.0',
+            name: 'Payment Captured',
+            contentPath: 'events/payment-captured/1.0.0/index.mdx',
+            contentHash: 'sha256:d930a6',
+          },
+        ],
+      });
+
+      expect(resolve([paymentsIndex, legacyBillingIndex]).conflicts).toEqual([
+        {
+          kind: 'duplicate-source',
+          id: 'payment-captured',
+          sources: ['acme/legacy-billing', 'acme/payments'],
+        },
+      ]);
+    });
+
+    it('reports one conflict when three sources own the same id', () => {
+      const paymentsIndex = anIndex({
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'event',
+            id: 'payment-captured',
+            version: '2.0.0',
+            name: 'Payment Captured',
+            contentPath: 'events/payment-captured/2.0.0/index.mdx',
+            contentHash: 'sha256:04bd91',
+          },
+        ],
+      });
+      const legacyBillingIndex = anIndex({
+        source: 'acme/legacy-billing',
+        commit: '71c9e30',
+        resources: [
+          {
+            type: 'event',
+            id: 'payment-captured',
+            version: '1.0.0',
+            name: 'Payment Captured',
+            contentPath: 'events/payment-captured/1.0.0/index.mdx',
+            contentHash: 'sha256:d930a6',
+          },
+        ],
+      });
+      const mobilePaymentsIndex = anIndex({
+        source: 'acme/mobile-payments',
+        commit: 'c53d8a4',
+        resources: [
+          {
+            type: 'event',
+            id: 'payment-captured',
+            version: '3.0.0',
+            name: 'Payment Captured',
+            contentPath: 'events/payment-captured/3.0.0/index.mdx',
+            contentHash: 'sha256:85ef42',
+          },
+        ],
+      });
+
+      expect(resolve([paymentsIndex, legacyBillingIndex, mobilePaymentsIndex]).conflicts).toEqual([
+        {
+          kind: 'duplicate-source',
+          id: 'payment-captured',
+          sources: ['acme/legacy-billing', 'acme/mobile-payments', 'acme/payments'],
+        },
+      ]);
+    });
+
+    it('does not conflict when one source has multiple versions of an id', () => {
+      const paymentsIndex = anIndex({
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'event',
+            id: 'payment-captured',
+            version: '2.0.0',
+            name: 'Payment Captured',
+            contentPath: 'events/payment-captured/2.0.0/index.mdx',
+            contentHash: 'sha256:04bd91',
+          },
+          {
+            type: 'event',
+            id: 'payment-captured',
+            version: '2.1.0',
+            name: 'Payment Captured',
+            contentPath: 'events/payment-captured/2.1.0/index.mdx',
+            contentHash: 'sha256:62ea15',
+          },
+          {
+            type: 'event',
+            id: 'payment-captured',
+            version: '2.2.0',
+            name: 'Payment Captured',
+            contentPath: 'events/payment-captured/2.2.0/index.mdx',
+            contentHash: 'sha256:85ef42',
+          },
+        ],
+      });
+
+      expect(resolve([paymentsIndex]).conflicts).toEqual([]);
+    });
+
+    it('reports a type collision when the same id has different types', () => {
+      const paymentsIndex = anIndex({
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'event',
+            id: 'payment-captured',
+            version: '2.0.0',
+            name: 'Payment Captured',
+            contentPath: 'events/payment-captured/2.0.0/index.mdx',
+            contentHash: 'sha256:04bd91',
+          },
+        ],
+      });
+      const legacyBillingIndex = anIndex({
+        source: 'acme/legacy-billing',
+        commit: '71c9e30',
+        resources: [
+          {
+            type: 'command',
+            id: 'payment-captured',
+            version: '1.0.0',
+            name: 'Payment Captured',
+            contentPath: 'commands/payment-captured/1.0.0/index.mdx',
+            contentHash: 'sha256:d930a6',
+          },
+        ],
+      });
+
+      expect(resolve([paymentsIndex, legacyBillingIndex]).conflicts).toEqual([
+        {
+          kind: 'type-collision',
+          id: 'payment-captured',
+          sources: ['acme/legacy-billing', 'acme/payments'],
+        },
+      ]);
+    });
+
+    it('still returns entities and edges when conflicts are present', () => {
+      const paymentsIndex = anIndex({
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'event',
+            id: 'payment-captured',
+            version: '2.0.0',
+            name: 'Payment Captured',
+            contentPath: 'events/payment-captured/2.0.0/index.mdx',
+            contentHash: 'sha256:04bd91',
+          },
+        ],
+      });
+      const legacyBillingIndex = anIndex({
+        source: 'acme/legacy-billing',
+        commit: '71c9e30',
+        resources: [
+          {
+            type: 'event',
+            id: 'payment-captured',
+            version: '1.0.0',
+            name: 'Payment Captured',
+            contentPath: 'events/payment-captured/1.0.0/index.mdx',
+            contentHash: 'sha256:d930a6',
+          },
+        ],
+      });
+      const fulfilmentIndex = anIndex({
+        source: 'acme/fulfilment',
+        commit: '8f2c6d0',
+        resources: [
+          {
+            type: 'event',
+            id: 'shipment-requested',
+            version: '1.0.0',
+            name: 'Shipment Requested',
+            contentPath: 'events/shipment-requested/index.mdx',
+            contentHash: 'sha256:31de86',
+          },
+          {
+            type: 'service',
+            id: 'shipping-service',
+            version: '1.0.0',
+            name: 'Shipping Service',
+            receives: [{ id: 'shipment-requested' }],
+            contentPath: 'services/shipping-service/index.mdx',
+            contentHash: 'sha256:b75e20',
+          },
+        ],
+      });
+
+      expect(resolve([paymentsIndex, legacyBillingIndex, fulfilmentIndex])).toEqual({
+        entities: [
+          {
+            type: 'event',
+            id: 'payment-captured',
+            version: '1.0.0',
+            name: 'Payment Captured',
+            contentPath: 'events/payment-captured/1.0.0/index.mdx',
+            contentHash: 'sha256:d930a6',
+            resolvedFrom: {
+              source: 'acme/legacy-billing',
+              commit: '71c9e30',
+            },
+          },
+          {
+            type: 'event',
+            id: 'payment-captured',
+            version: '2.0.0',
+            name: 'Payment Captured',
+            contentPath: 'events/payment-captured/2.0.0/index.mdx',
+            contentHash: 'sha256:04bd91',
+            resolvedFrom: {
+              source: 'acme/payments',
+              commit: '4a1b7e2',
+            },
+          },
+          {
+            type: 'event',
+            id: 'shipment-requested',
+            version: '1.0.0',
+            name: 'Shipment Requested',
+            contentPath: 'events/shipment-requested/index.mdx',
+            contentHash: 'sha256:31de86',
+            resolvedFrom: {
+              source: 'acme/fulfilment',
+              commit: '8f2c6d0',
+            },
+          },
+          {
+            type: 'service',
+            id: 'shipping-service',
+            version: '1.0.0',
+            name: 'Shipping Service',
+            receives: [{ id: 'shipment-requested' }],
+            contentPath: 'services/shipping-service/index.mdx',
+            contentHash: 'sha256:b75e20',
+            resolvedFrom: {
+              source: 'acme/fulfilment',
+              commit: '8f2c6d0',
+            },
+          },
+        ],
+        assets: [],
+        edges: [
+          {
+            from: 'shipping-service',
+            ...fromResource('1.0.0', 'acme/fulfilment', '8f2c6d0'),
+            to: 'shipment-requested',
+            direction: 'receives',
+            pointer: null,
+            resolved: '1.0.0',
+            resolvedFrom: {
+              source: 'acme/fulfilment',
+              commit: '8f2c6d0',
+            },
+            status: 'resolved',
+          },
+        ],
+        conflicts: [
+          {
+            kind: 'duplicate-source',
+            id: 'payment-captured',
+            sources: ['acme/legacy-billing', 'acme/payments'],
+          },
+        ],
+        warnings: [],
+        externals: [],
+      });
+    });
+  });
+});

--- a/packages/sdk/src/test/resolve.test.ts
+++ b/packages/sdk/src/test/resolve.test.ts
@@ -778,6 +778,119 @@ describe('resolve', () => {
       ]);
     });
 
+    it('resolves a semver range to the highest satisfying version', () => {
+      const paymentsIndex = anIndex({
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'event',
+            id: 'payment-captured',
+            version: '1.0.0',
+            name: 'Payment Captured',
+            contentPath: 'events/payment-captured/1.0.0/index.mdx',
+            contentHash: 'sha256:04bd91',
+          },
+          {
+            type: 'event',
+            id: 'payment-captured',
+            version: '1.2.0',
+            name: 'Payment Captured',
+            contentPath: 'events/payment-captured/1.2.0/index.mdx',
+            contentHash: 'sha256:62ea15',
+          },
+          {
+            type: 'event',
+            id: 'payment-captured',
+            version: '2.0.0',
+            name: 'Payment Captured',
+            contentPath: 'events/payment-captured/2.0.0/index.mdx',
+            contentHash: 'sha256:772af1',
+          },
+        ],
+      });
+      const fulfilmentIndex = anIndex({
+        source: 'acme/fulfilment',
+        commit: '8f2c6d0',
+        resources: [
+          {
+            type: 'service',
+            id: 'shipping-service',
+            version: '1.0.0',
+            name: 'Shipping Service',
+            receives: [{ id: 'payment-captured', version: '^1.0.0' }],
+            contentPath: 'services/shipping-service/index.mdx',
+            contentHash: 'sha256:b75e20',
+          },
+        ],
+      });
+
+      expect(resolve([paymentsIndex, fulfilmentIndex]).edges).toEqual([
+        {
+          from: 'shipping-service',
+          ...fromResource('1.0.0', 'acme/fulfilment', '8f2c6d0'),
+          to: 'payment-captured',
+          direction: 'receives',
+          pointer: '^1.0.0',
+          resolved: '1.2.0',
+          resolvedFrom: {
+            source: 'acme/payments',
+            commit: '4a1b7e2',
+          },
+          status: 'resolved',
+        },
+      ]);
+    });
+
+    it('marks a semver range as unresolved when no version satisfies it', () => {
+      const paymentsIndex = anIndex({
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        resources: [
+          {
+            type: 'event',
+            id: 'payment-captured',
+            version: '2.0.0',
+            name: 'Payment Captured',
+            contentPath: 'events/payment-captured/2.0.0/index.mdx',
+            contentHash: 'sha256:04bd91',
+          },
+        ],
+      });
+      const fulfilmentIndex = anIndex({
+        source: 'acme/fulfilment',
+        commit: '8f2c6d0',
+        resources: [
+          {
+            type: 'service',
+            id: 'shipping-service',
+            version: '1.0.0',
+            name: 'Shipping Service',
+            receives: [{ id: 'payment-captured', version: '^1.0.0' }],
+            contentPath: 'services/shipping-service/index.mdx',
+            contentHash: 'sha256:b75e20',
+          },
+        ],
+      });
+
+      const resolution = resolve([paymentsIndex, fulfilmentIndex]);
+
+      expect({ edges: resolution.edges, externals: resolution.externals }).toEqual({
+        edges: [
+          {
+            from: 'shipping-service',
+            ...fromResource('1.0.0', 'acme/fulfilment', '8f2c6d0'),
+            to: 'payment-captured',
+            direction: 'receives',
+            pointer: '^1.0.0',
+            resolved: null,
+            status: 'unresolved',
+          },
+        ],
+        externals: [],
+      });
+    });
+
     it('resolves an unversioned pointer to the highest version', () => {
       const paymentsIndex = anIndex({
         source: 'acme/payments',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -595,6 +595,9 @@ importers:
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
+      ignore:
+        specifier: ^7.0.5
+        version: 7.0.5
       proper-lockfile:
         specifier: ^4.1.2
         version: 4.1.2
@@ -604,6 +607,9 @@ importers:
       slugify:
         specifier: ^1.6.6
         version: 1.6.6
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@types/fs-extra':
         specifier: ^11.0.4


### PR DESCRIPTION

## What This PR Does

Adds a three-stage federation pipeline to `@eventcatalog/sdk` so that catalogs living in separate repositories can be combined into a single catalog. `buildIndex` walks a catalog and produces a portable, content-addressed index of its resources. `resolve` merges one or more of those indexes into a single graph, detecting conflicts and recording unresolved pointers as externals. `hydrate` takes that graph and materializes the referenced files to disk, fetching, verifying and caching artifacts along the way.

The three stages are deliberately decoupled: indexes are plain JSON that can be published, cached and transported independently of the catalogs that produced them, so resolution and hydration do not need access to every source repository at once.

## Changes Overview

### Key Changes

- **`packages/sdk/src/build-index.ts`** — `buildIndex(catalogPath)({ source, commit, hashContent })` discovers every resource type in a catalog (events, commands, queries, services, domains, flows, entities, systems, containers, data products, data stores, diagrams, ADRs, agents, teams, users) and describes each as an `IndexResource` with its pointers, schemas, specifications, sidecars and assets. Honours ignore files via the `ignore` package, and optionally content-hashes artifacts (`sha256:…`).
- **`packages/sdk/src/resolve.ts`** — `resolve(indexes)` combines indexes into a `ResolvedGraph` of entities, edges, conflicts and externals. Resolves pointers across sources, picks the highest version when several are available (semver-aware with a lexical fallback), and classifies conflicts as `duplicate-source`, `type-collision`, `facet-disagreement` or `pointer-type-mismatch`.
- **`packages/sdk/src/hydrate.ts`** — `hydrate(graph, options)` writes the resolved content to `outDir` using a caller-supplied `Fetcher` and optional `Cache`. Supports per-source `hydrate` vs `reference` modes and returns counts of what was fetched, written and referenced.
- **`packages/sdk/src/parse-index.ts`** — `parseIndex` plus the `FederationIndexSchema` Zod schema and an `InvalidIndexError` that reports validation issues with their paths, so a malformed or untrusted index fails loudly rather than corrupting a resolve.
- **`packages/sdk/src/index-types.ts`** — shared types for the pipeline (`Index`, `IndexResource`, `ResolvedGraph`, `ResolvedEntity`, `ResolvedEdge`, `Conflict`, `External`, `ResolutionWarning`, …), exported from the package root.
- **`packages/sdk/src/domains.ts`** — excludes `systems`, `containers`, `data-products`, `adrs`, `diagrams` and `channels` subdirectories when reading domains, so nested resources are not mistaken for domains.
- **`packages/sdk/scripts/review-default-federation.mjs`** and the `pnpm review:federation` script — run the full pipeline over `examples/default` and write `index.json`, `resolved-graph.json` and `hydrate-result.json` into a gitignored `federated-catalog/` directory for inspecting real output.
- **`AGENTS.md`** — documents that any change touching resources, relationships, schemas, sidecars, assets, paths or hashes must be reviewed across all three stages, with tests in each.
- New dependencies: `zod` (index validation) and `ignore` (catalog ignore-file handling).

## How It Works

The pipeline is a straight line, with a serializable artifact between each stage:

```
catalog on disk ──buildIndex──▶ Index (JSON)
Index[] ──────────resolve─────▶ ResolvedGraph (entities, edges, conflicts, externals)
ResolvedGraph ────hydrate─────▶ files on disk
```

`buildIndex` never resolves anything — it only describes what a single catalog contains, recording pointers as-is. That keeps indexes valid in isolation and lets them be produced by CI in each source repository. `resolve` is pure and synchronous: it takes indexes in, and returns a graph without touching the filesystem or network, which makes conflict behaviour easy to test exhaustively. All I/O is concentrated in `hydrate`, and even there the network is injected via the `Fetcher` callback rather than assumed, so the caller decides how sources are reached (git, HTTP, local filesystem) and how results are cached.

Hydration paths are treated as untrusted: targets are normalized and checked against an allowed directory per source, and absolute paths, `..` traversal, backslashes and null bytes are rejected, so a hostile index cannot write outside `outDir`. Non-shared artifacts land under a per-source directory derived from a slug plus a hash of the source name, which avoids collisions between sources with similar names.

## Breaking Changes

None. Everything here is additive — new exports on the SDK plus a new `buildIndex` method on the SDK instance. The one change to existing behaviour is in `getDomains`, which now excludes additional nested resource directories that should never have been returned as domains.

## Additional Notes

- Test coverage is substantial (~4,900 lines across five new files): `build-index.test.ts`, `resolve.test.ts`, `hydrate.test.ts`, `parse-index.test.ts`, plus `build-index-default-catalog.test.ts` which runs the indexer against the real `examples/default` catalog.
- Nothing in `@eventcatalog/core` consumes this pipeline yet — this PR lands the SDK foundation only. Wiring the UI and CLI to federated catalogs is follow-up work.
- Reviewers may find it useful to run `pnpm review:federation` and inspect the generated `federated-catalog/` output against `examples/default`.
- No corresponding change is needed in the `eventcatalog/eventcatalog-editor` repository — this is SDK-internal and additive, with no editor-facing API change.