### PR TITLE
Add federation pipeline integration test with example catalogs

### DIFF
--- a/.changeset/tidy-pandas-wander.md
+++ b/.changeset/tidy-pandas-wander.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/sdk": patch
+---
+
+Add an end-to-end integration test for the federation pipeline (`buildIndex`, `resolve`, `hydrate`) that runs against real example catalogs on disk, with committed snapshots of the resolved graph and hydrated file tree.

--- a/examples/federation/central/catalog/adrs/federate-commerce-services/index.mdx
+++ b/examples/federation/central/catalog/adrs/federate-commerce-services/index.mdx
@@ -1,0 +1,15 @@
+---
+id: federate-commerce-services
+name: Federate commerce services
+version: 1.0.0
+status: accepted
+appliesTo:
+  - type: service
+    id: payment-service
+  - type: service
+    id: fulfilment-service
+---
+
+## Decision
+
+Payments and fulfilment publish their catalog resources into the central catalog.

--- a/examples/federation/central/catalog/domains/commerce/index.mdx
+++ b/examples/federation/central/catalog/domains/commerce/index.mdx
@@ -1,0 +1,12 @@
+---
+id: commerce
+name: Commerce
+version: 1.0.0
+services:
+  - id: payment-service
+  - id: fulfilment-service
+---
+
+## Commerce
+
+The central view of the payments and fulfilment capabilities.

--- a/examples/federation/central/catalog/domains/commerce/ubiquitous-language.mdx
+++ b/examples/federation/central/catalog/domains/commerce/ubiquitous-language.mdx
@@ -1,0 +1,5 @@
+# Commerce language
+
+## Payment capture
+
+The point at which funds have been secured and fulfilment may begin.

--- a/examples/federation/central/catalog/flows/payment-to-fulfilment/index.mdx
+++ b/examples/federation/central/catalog/flows/payment-to-fulfilment/index.mdx
@@ -1,0 +1,23 @@
+---
+id: payment-to-fulfilment
+name: Payment to fulfilment
+version: 1.0.0
+steps:
+  - id: capture_payment
+    title: Capture payment
+    service:
+      id: payment-service
+      version: 1.0.0
+    next_step:
+      id: start_fulfilment
+      label: Payment captured
+  - id: start_fulfilment
+    title: Start fulfilment
+    service:
+      id: fulfilment-service
+      version: 1.0.0
+---
+
+## Payment to fulfilment
+
+The central flow joins the team-owned services without taking ownership of either one.

--- a/examples/federation/team-fulfilment/catalog/services/fulfilment-service/index.mdx
+++ b/examples/federation/team-fulfilment/catalog/services/fulfilment-service/index.mdx
@@ -1,0 +1,13 @@
+---
+id: fulfilment-service
+name: Fulfilment Service
+version: 1.0.0
+receives:
+  - id: payment-captured
+    version: 1.0.0
+  - id: shipment-dispatched
+---
+
+## Overview
+
+Starts fulfilment when the payments team confirms a successful capture.

--- a/examples/federation/team-payments/catalog/public/icons/nodejs.svg
+++ b/examples/federation/team-payments/catalog/public/icons/nodejs.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <title>Node.js</title>
+  <circle cx="12" cy="12" r="10" />
+</svg>

--- a/examples/federation/team-payments/catalog/services/payment-service/docs/runbook.mdx
+++ b/examples/federation/team-payments/catalog/services/payment-service/docs/runbook.mdx
@@ -1,0 +1,3 @@
+# Payment service runbook
+
+Retry failed captures from the operations console.

--- a/examples/federation/team-payments/catalog/services/payment-service/events/payment-captured/index.mdx
+++ b/examples/federation/team-payments/catalog/services/payment-service/events/payment-captured/index.mdx
@@ -1,0 +1,11 @@
+---
+id: payment-captured
+name: Payment Captured
+version: 2.0.0
+summary: Published after a payment has been captured successfully.
+schemaPath: schema.json
+---
+
+## Payment captured
+
+Consumers use this event to continue order fulfilment.

--- a/examples/federation/team-payments/catalog/services/payment-service/events/payment-captured/schema.json
+++ b/examples/federation/team-payments/catalog/services/payment-service/events/payment-captured/schema.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["paymentId"],
+  "properties": {
+    "paymentId": {
+      "type": "string"
+    }
+  }
+}

--- a/examples/federation/team-payments/catalog/services/payment-service/events/payment-captured/versioned/1.0.0/index.mdx
+++ b/examples/federation/team-payments/catalog/services/payment-service/events/payment-captured/versioned/1.0.0/index.mdx
@@ -1,0 +1,10 @@
+---
+id: payment-captured
+name: Payment Captured
+version: 1.0.0
+summary: The original payment captured contract retained for pinned consumers.
+---
+
+## Payment captured v1
+
+The fulfilment team remains pinned to this historical contract.

--- a/examples/federation/team-payments/catalog/services/payment-service/index.mdx
+++ b/examples/federation/team-payments/catalog/services/payment-service/index.mdx
@@ -1,0 +1,13 @@
+---
+id: payment-service
+name: Payment Service
+version: 1.0.0
+styles:
+  icon: /icons/nodejs.svg
+sends:
+  - id: payment-captured
+---
+
+## Overview
+
+Captures payments and publishes the outcome for downstream teams.

--- a/packages/sdk/src/test/federation-pipeline.integration.test.ts
+++ b/packages/sdk/src/test/federation-pipeline.integration.test.ts
@@ -1,0 +1,203 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import utils, { hydrate, resolve, type Fetcher } from '../index';
+
+/**
+ * Exercises the complete federation pipeline against small, real catalogs on disk:
+ * buildIndex reads their MDX and related files, resolve joins relationships across
+ * source boundaries, and hydrate materializes the federated files through a local
+ * filesystem fetcher.
+ *
+ * The fixtures cover cross-team and unresolved references, pinned and latest version
+ * resolution, central domains and flows, sidecars, assets, and stale-file removal.
+ * Committed snapshots make changes to the resolved graph and hydrated file tree visible
+ * during review, protecting behaviours that hand-written unit fixtures can miss.
+ */
+const FIXTURE_ROOT = path.resolve(__dirname, '../../../../examples/federation');
+const RESOLVED_GRAPH_SNAPSHOT_PATH = path.join(__dirname, 'fixtures/resolve/federation-resolved-graph.json');
+const HYDRATED_TREE_SNAPSHOT_PATH = path.join(__dirname, 'fixtures/hydrate/federation-hydrated-files.json');
+
+const sources = {
+  central: {
+    commit: 'central-fixture',
+    catalogPath: path.join(FIXTURE_ROOT, 'central/catalog'),
+  },
+  'team/payments': {
+    commit: 'payments-fixture',
+    catalogPath: path.join(FIXTURE_ROOT, 'team-payments/catalog'),
+  },
+  'team/fulfilment': {
+    commit: 'fulfilment-fixture',
+    catalogPath: path.join(FIXTURE_ROOT, 'team-fulfilment/catalog'),
+  },
+} as const;
+
+const buildFixtureIndexes = () =>
+  Promise.all(
+    Object.entries(sources).map(([source, fixture]) =>
+      utils(fixture.catalogPath).buildIndex({
+        source,
+        commit: fixture.commit,
+      })
+    )
+  );
+
+const listFiles = async (directory: string, relativeDirectory = ''): Promise<string[]> => {
+  const entries = await fs.readdir(path.join(directory, relativeDirectory), { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const relativePath = path.join(relativeDirectory, entry.name);
+      return entry.isDirectory() ? listFiles(directory, relativePath) : [relativePath.split(path.sep).join('/')];
+    })
+  );
+
+  return files.flat().sort();
+};
+
+describe('federation pipeline integration', () => {
+  let testDirectory: string;
+  let outDir: string;
+
+  beforeEach(async () => {
+    testDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'eventcatalog-federation-integration-'));
+    outDir = path.join(testDirectory, 'federated-catalog');
+  });
+
+  afterEach(async () => {
+    await fs.rm(testDirectory, { recursive: true, force: true });
+  });
+
+  it('matches the committed resolved graph snapshot', async () => {
+    const graph = resolve(await buildFixtureIndexes());
+    const snapshot = JSON.parse(await fs.readFile(RESOLVED_GRAPH_SNAPSHOT_PATH, 'utf8'));
+
+    expect(graph).toEqual(snapshot);
+  });
+
+  it('indexes, resolves, and hydrates real catalogs from disk', async () => {
+    const indexes = await buildFixtureIndexes();
+
+    expect(
+      indexes.map((index) => ({
+        source: index.source,
+        resources: index.resources.map(({ type, id, version }) => `${type}:${id}@${version ?? 'unversioned'}`),
+      }))
+    ).toEqual([
+      {
+        source: 'central',
+        resources: ['adr:federate-commerce-services@1.0.0', 'domain:commerce@1.0.0', 'flow:payment-to-fulfilment@1.0.0'],
+      },
+      {
+        source: 'team/payments',
+        resources: ['event:payment-captured@2.0.0', 'event:payment-captured@1.0.0', 'service:payment-service@1.0.0'],
+      },
+      {
+        source: 'team/fulfilment',
+        resources: ['service:fulfilment-service@1.0.0'],
+      },
+    ]);
+
+    const graph = resolve(indexes);
+
+    expect(graph.conflicts).toEqual([]);
+    expect(graph.warnings).toEqual([]);
+    expect(graph.externals).toEqual([
+      {
+        id: 'shipment-dispatched',
+        referencedBy: ['fulfilment-service'],
+      },
+    ]);
+    expect(graph.edges).toHaveLength(9);
+    expect(graph.edges).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          from: 'payment-service',
+          to: 'payment-captured',
+          direction: 'sends',
+          resolved: '2.0.0',
+          resolvedFrom: { source: 'team/payments', commit: 'payments-fixture' },
+          status: 'resolved',
+        }),
+        expect.objectContaining({
+          from: 'fulfilment-service',
+          to: 'payment-captured',
+          direction: 'receives',
+          resolved: '1.0.0',
+          resolvedFrom: { source: 'team/payments', commit: 'payments-fixture' },
+          status: 'resolved',
+        }),
+        expect.objectContaining({
+          from: 'federate-commerce-services',
+          to: 'fulfilment-service',
+          direction: 'appliesTo',
+          resolvedFrom: { source: 'team/fulfilment', commit: 'fulfilment-fixture' },
+          status: 'resolved',
+        }),
+        expect.objectContaining({
+          from: 'fulfilment-service',
+          to: 'shipment-dispatched',
+          direction: 'receives',
+          resolved: null,
+          status: 'external',
+        }),
+        expect.objectContaining({
+          from: 'payment-to-fulfilment',
+          to: 'payment-service',
+          direction: 'references',
+          via: 'steps',
+          status: 'resolved',
+        }),
+        expect.objectContaining({
+          from: 'payment-to-fulfilment',
+          to: 'fulfilment-service',
+          direction: 'references',
+          via: 'steps',
+          status: 'resolved',
+        }),
+      ])
+    );
+
+    const fetch: Fetcher = async ({ source, commit, path: artifactPath }) => {
+      const fixture = sources[source as keyof typeof sources];
+      if (!fixture) throw new Error(`Unknown fixture source: ${source}`);
+      if (commit !== fixture.commit) throw new Error(`Unexpected commit for ${source}: ${commit}`);
+
+      const absolutePath = path.resolve(fixture.catalogPath, artifactPath);
+      const relativePath = path.relative(fixture.catalogPath, absolutePath);
+      if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+        throw new Error(`Artifact path escapes fixture catalog: ${artifactPath}`);
+      }
+
+      return fs.readFile(absolutePath);
+    };
+
+    const staleFile = path.join(outDir, 'stale-source/services/deleted-service/index.mdx');
+    await fs.mkdir(path.dirname(staleFile), { recursive: true });
+    await fs.writeFile(staleFile, '# Deleted service');
+
+    await expect(
+      hydrate(graph, {
+        outDir,
+        localSource: 'central',
+        fetch,
+      })
+    ).resolves.toEqual({
+      fetched: 7,
+      written: 7,
+      referenced: 0,
+    });
+
+    const hydratedTreeSnapshot = JSON.parse(await fs.readFile(HYDRATED_TREE_SNAPSHOT_PATH, 'utf8'));
+    expect(await listFiles(outDir)).toEqual(hydratedTreeSnapshot);
+
+    await expect(
+      fs.readFile(
+        path.join(outDir, 'team-payments--28eeaeb29a32/services/payment-service/events/payment-captured/schema.json'),
+        'utf8'
+      )
+    ).resolves.toContain('"paymentId"');
+    await expect(fs.readFile(path.join(outDir, 'public/icons/nodejs.svg'), 'utf8')).resolves.toContain('<title>Node.js</title>');
+  });
+});

--- a/packages/sdk/src/test/fixtures/hydrate/federation-hydrated-files.json
+++ b/packages/sdk/src/test/fixtures/hydrate/federation-hydrated-files.json
@@ -1,0 +1,9 @@
+[
+  "public/icons/nodejs.svg",
+  "team-fulfilment--0c3da27500b1/services/fulfilment-service/index.mdx",
+  "team-payments--28eeaeb29a32/services/payment-service/docs/runbook.mdx",
+  "team-payments--28eeaeb29a32/services/payment-service/events/payment-captured/index.mdx",
+  "team-payments--28eeaeb29a32/services/payment-service/events/payment-captured/schema.json",
+  "team-payments--28eeaeb29a32/services/payment-service/events/payment-captured/versioned/1.0.0/index.mdx",
+  "team-payments--28eeaeb29a32/services/payment-service/index.mdx"
+]

--- a/packages/sdk/src/test/fixtures/resolve/federation-resolved-graph.json
+++ b/packages/sdk/src/test/fixtures/resolve/federation-resolved-graph.json
@@ -1,0 +1,325 @@
+{
+  "entities": [
+    {
+      "type": "domain",
+      "id": "commerce",
+      "version": "1.0.0",
+      "name": "Commerce",
+      "contentPath": "domains/commerce/index.mdx",
+      "contentHash": "sha256:bbc343d3a1c620fe25380a823ba5ba2f4c28eb56d83be110baa27e5983a1d408",
+      "sidecars": [
+        {
+          "path": "domains/commerce/ubiquitous-language.mdx",
+          "hash": "sha256:1e2ab5e2cd127b8a4ba782ce8ffa06bee99e0edb898030b9a3569b59883e87b6"
+        }
+      ],
+      "services": [
+        {
+          "id": "payment-service"
+        },
+        {
+          "id": "fulfilment-service"
+        }
+      ],
+      "resolvedFrom": {
+        "source": "central",
+        "commit": "central-fixture"
+      }
+    },
+    {
+      "type": "adr",
+      "id": "federate-commerce-services",
+      "version": "1.0.0",
+      "name": "Federate commerce services",
+      "contentPath": "adrs/federate-commerce-services/index.mdx",
+      "contentHash": "sha256:a95cf8412ea279a498f992fe22e6153edc76e64640845bf6317b24b84259fff9",
+      "status": "accepted",
+      "appliesTo": [
+        {
+          "type": "service",
+          "id": "payment-service"
+        },
+        {
+          "type": "service",
+          "id": "fulfilment-service"
+        }
+      ],
+      "resolvedFrom": {
+        "source": "central",
+        "commit": "central-fixture"
+      }
+    },
+    {
+      "type": "service",
+      "id": "fulfilment-service",
+      "version": "1.0.0",
+      "name": "Fulfilment Service",
+      "contentPath": "services/fulfilment-service/index.mdx",
+      "contentHash": "sha256:b6346a08719b63042c78a428b682843f5a043bbcea98b1af125b5daab55f1cbf",
+      "receives": [
+        {
+          "id": "payment-captured",
+          "version": "1.0.0"
+        },
+        {
+          "id": "shipment-dispatched"
+        }
+      ],
+      "resolvedFrom": {
+        "source": "team/fulfilment",
+        "commit": "fulfilment-fixture"
+      }
+    },
+    {
+      "type": "event",
+      "id": "payment-captured",
+      "version": "1.0.0",
+      "name": "Payment Captured",
+      "contentPath": "services/payment-service/events/payment-captured/versioned/1.0.0/index.mdx",
+      "contentHash": "sha256:6efa2010ccdb8b875cff034a091713c7522894abc018b0fce07b6e0681016665",
+      "resolvedFrom": {
+        "source": "team/payments",
+        "commit": "payments-fixture"
+      }
+    },
+    {
+      "type": "event",
+      "id": "payment-captured",
+      "version": "2.0.0",
+      "name": "Payment Captured",
+      "contentPath": "services/payment-service/events/payment-captured/index.mdx",
+      "contentHash": "sha256:f7d22f54b77b93244becb9abb8f7bfeac525ed75c876a5140ea2a5942fa9745d",
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:50f3452ea7d8d13c240bbf9ffa45485193eeacbc1f3c10358ddaa363442c8aa7"
+        }
+      ],
+      "resolvedFrom": {
+        "source": "team/payments",
+        "commit": "payments-fixture"
+      }
+    },
+    {
+      "type": "service",
+      "id": "payment-service",
+      "version": "1.0.0",
+      "name": "Payment Service",
+      "contentPath": "services/payment-service/index.mdx",
+      "contentHash": "sha256:0da186c10d170026e0bb10d5609733535bc6aa8c912bd1cbdd661be09be4b4cc",
+      "sidecars": [
+        {
+          "path": "services/payment-service/docs/runbook.mdx",
+          "hash": "sha256:e8b858a027227a93b55f118b8543d3028c21b69e545eb5e4a12a310e130aa7cf"
+        }
+      ],
+      "sends": [
+        {
+          "id": "payment-captured"
+        }
+      ],
+      "resolvedFrom": {
+        "source": "team/payments",
+        "commit": "payments-fixture"
+      }
+    },
+    {
+      "type": "flow",
+      "id": "payment-to-fulfilment",
+      "version": "1.0.0",
+      "name": "Payment to fulfilment",
+      "contentPath": "flows/payment-to-fulfilment/index.mdx",
+      "contentHash": "sha256:a3adc652d1bfd80b8f2842bee0a0653a361dc0174adbba4357829f9b1ebd5bf7",
+      "references": [
+        {
+          "kind": "service",
+          "id": "payment-service",
+          "version": "1.0.0"
+        },
+        {
+          "kind": "service",
+          "id": "fulfilment-service",
+          "version": "1.0.0"
+        }
+      ],
+      "resolvedFrom": {
+        "source": "central",
+        "commit": "central-fixture"
+      }
+    }
+  ],
+  "assets": [
+    {
+      "path": "public/icons/nodejs.svg",
+      "hash": "sha256:6fbbf52ad685cdad2380428b582e5c644b412e4c63f7a2a609270d4f9fd3b0ce",
+      "resolvedFrom": {
+        "source": "team/payments",
+        "commit": "payments-fixture"
+      }
+    }
+  ],
+  "edges": [
+    {
+      "from": "commerce",
+      "fromVersion": "1.0.0",
+      "fromResolvedFrom": {
+        "source": "central",
+        "commit": "central-fixture"
+      },
+      "to": "payment-service",
+      "direction": "contains",
+      "via": "services",
+      "pointer": null,
+      "resolved": "1.0.0",
+      "resolvedFrom": {
+        "source": "team/payments",
+        "commit": "payments-fixture"
+      },
+      "status": "resolved"
+    },
+    {
+      "from": "commerce",
+      "fromVersion": "1.0.0",
+      "fromResolvedFrom": {
+        "source": "central",
+        "commit": "central-fixture"
+      },
+      "to": "fulfilment-service",
+      "direction": "contains",
+      "via": "services",
+      "pointer": null,
+      "resolved": "1.0.0",
+      "resolvedFrom": {
+        "source": "team/fulfilment",
+        "commit": "fulfilment-fixture"
+      },
+      "status": "resolved"
+    },
+    {
+      "from": "federate-commerce-services",
+      "fromVersion": "1.0.0",
+      "fromResolvedFrom": {
+        "source": "central",
+        "commit": "central-fixture"
+      },
+      "to": "payment-service",
+      "direction": "appliesTo",
+      "pointer": null,
+      "resolved": "1.0.0",
+      "resolvedFrom": {
+        "source": "team/payments",
+        "commit": "payments-fixture"
+      },
+      "status": "resolved"
+    },
+    {
+      "from": "federate-commerce-services",
+      "fromVersion": "1.0.0",
+      "fromResolvedFrom": {
+        "source": "central",
+        "commit": "central-fixture"
+      },
+      "to": "fulfilment-service",
+      "direction": "appliesTo",
+      "pointer": null,
+      "resolved": "1.0.0",
+      "resolvedFrom": {
+        "source": "team/fulfilment",
+        "commit": "fulfilment-fixture"
+      },
+      "status": "resolved"
+    },
+    {
+      "from": "fulfilment-service",
+      "fromVersion": "1.0.0",
+      "fromResolvedFrom": {
+        "source": "team/fulfilment",
+        "commit": "fulfilment-fixture"
+      },
+      "to": "payment-captured",
+      "direction": "receives",
+      "pointer": "1.0.0",
+      "resolved": "1.0.0",
+      "resolvedFrom": {
+        "source": "team/payments",
+        "commit": "payments-fixture"
+      },
+      "status": "resolved"
+    },
+    {
+      "from": "fulfilment-service",
+      "fromVersion": "1.0.0",
+      "fromResolvedFrom": {
+        "source": "team/fulfilment",
+        "commit": "fulfilment-fixture"
+      },
+      "to": "shipment-dispatched",
+      "direction": "receives",
+      "pointer": null,
+      "resolved": null,
+      "status": "external"
+    },
+    {
+      "from": "payment-service",
+      "fromVersion": "1.0.0",
+      "fromResolvedFrom": {
+        "source": "team/payments",
+        "commit": "payments-fixture"
+      },
+      "to": "payment-captured",
+      "direction": "sends",
+      "pointer": null,
+      "resolved": "2.0.0",
+      "resolvedFrom": {
+        "source": "team/payments",
+        "commit": "payments-fixture"
+      },
+      "status": "resolved"
+    },
+    {
+      "from": "payment-to-fulfilment",
+      "fromVersion": "1.0.0",
+      "fromResolvedFrom": {
+        "source": "central",
+        "commit": "central-fixture"
+      },
+      "to": "payment-service",
+      "direction": "references",
+      "via": "steps",
+      "pointer": "1.0.0",
+      "resolved": "1.0.0",
+      "resolvedFrom": {
+        "source": "team/payments",
+        "commit": "payments-fixture"
+      },
+      "status": "resolved"
+    },
+    {
+      "from": "payment-to-fulfilment",
+      "fromVersion": "1.0.0",
+      "fromResolvedFrom": {
+        "source": "central",
+        "commit": "central-fixture"
+      },
+      "to": "fulfilment-service",
+      "direction": "references",
+      "via": "steps",
+      "pointer": "1.0.0",
+      "resolved": "1.0.0",
+      "resolvedFrom": {
+        "source": "team/fulfilment",
+        "commit": "fulfilment-fixture"
+      },
+      "status": "resolved"
+    }
+  ],
+  "conflicts": [],
+  "warnings": [],
+  "externals": [
+    {
+      "id": "shipment-dispatched",
+      "referencedBy": ["fulfilment-service"]
+    }
+  ]
+}


### PR DESCRIPTION
# PR: Add federation pipeline integration test with example catalogs

Follow-up to #2757 (federation pipeline in the SDK).

## What This PR Does

Adds an end-to-end integration test that exercises the full federation pipeline — `buildIndex`, `resolve`, and `hydrate` — against real catalogs on disk rather than hand-written in-memory fixtures. The catalogs live in `examples/federation` and model a realistic multi-team setup: a central catalog plus two team-owned catalogs. Committed snapshots of the resolved graph and hydrated file tree make any behavioural change in the pipeline visible in review as a diff.

## Changes Overview

### Key Changes

- New test `packages/sdk/src/test/federation-pipeline.integration.test.ts` (2 tests) covering index → resolve → hydrate.
- New example catalogs under `examples/federation`:
  - `central` — domain (`commerce`, with ubiquitous language), flow (`payment-to-fulfilment`), ADR (`federate-commerce-services`).
  - `team-payments` — `payment-service` with a versioned `payment-captured` event (1.0.0 and 2.0.0), a JSON schema, a docs sidecar, and a public icon asset.
  - `team-fulfilment` — `fulfilment-service`, including a reference to an event that no source provides.
- Committed snapshots:
  - `fixtures/resolve/federation-resolved-graph.json` — the full resolved graph.
  - `fixtures/hydrate/federation-hydrated-files.json` — the hydrated output file tree.
- Changeset (`@eventcatalog/sdk` patch).

## How It Works

Each fixture catalog is indexed via `buildIndex` with its own `source` and a fixed `commit` string, so results are deterministic. The three indexes are passed to `resolve`, and the resulting graph is asserted both against the committed snapshot and against targeted expectations.

Hydration runs through a `Fetcher` backed by the local filesystem. It resolves each requested artifact path against its fixture catalog root and rejects any path that escapes that root, so a path-traversal regression in the pipeline fails the test rather than reading outside the fixture. Output goes to a fresh `mkdtemp` directory per test, removed in `afterEach`.

The scenarios the fixtures deliberately cover:

- **Cross-source resolution** — `fulfilment-service` receives an event owned by `team/payments`.
- **Version resolution** — a pinned reference resolves to `1.0.0` while an unpinned one resolves to the latest `2.0.0`.
- **Externals** — `shipment-dispatched` is referenced but provided by no source, so it lands in `graph.externals` with an `external` edge rather than a hard failure.
- **Central resources** — domain, flow (with `steps` edges), and ADR (`appliesTo` edges) resolving onto team-owned services.
- **Sidecars and assets** — a docs sidecar, a JSON schema, and an SVG icon are all carried through hydration.
- **Stale-file removal** — a leftover file is written into the output directory beforehand and is expected to be gone afterwards.

`localSource: 'central'` is passed to `hydrate`, so central resources are referenced in place rather than fetched — reflected in the `{ fetched: 7, written: 7, referenced: 0 }` assertion.

## Breaking Changes

None. Test and fixture files only; no SDK source or public API changes.

## Additional Notes

- The snapshots are intentionally committed rather than generated with Vitest's `toMatchSnapshot`, so a change to the graph or file tree shows up as a reviewable diff in the PR itself.
- If the pipeline's output legitimately changes, both JSON snapshots need updating together.
- No corresponding change is needed in the `eventcatalog/eventcatalog-editor` repository — this adds test coverage only and does not alter any SDK behaviour or API surface.
