### PR TITLE
Bundle the auth-astro server import so production SSR deployments boot

### DIFF
--- a/.changeset/calm-cats-build.md
+++ b/.changeset/calm-cats-build.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/core': patch
+---
+
+Bundle the Auth Astro server dependency used by the login page so production SSR deployments can resolve it at runtime.

--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -72,12 +72,24 @@ jobs:
             visualiser-package.tgz
 
   build-eventcatalog:
-    name: Build EventCatalog
+    name: Build EventCatalog (${{ matrix.label }})
     timeout-minutes: 10
     needs: build-and-test
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        include:
+          - label: static, Linux
+            os: ubuntu-latest
+            catalog: default
+            output: static
+          - label: static, Windows
+            os: windows-latest
+            catalog: default
+            output: static
+          - label: SSR, Linux
+            os: ubuntu-latest
+            catalog: ssr
+            output: server
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -89,20 +101,23 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.npm
-          key: npm-${{ runner.os }}-${{ hashFiles('examples/default/package-lock.json') }}
-          restore-keys: npm-${{ runner.os }}-
+          key: npm-${{ runner.os }}-${{ matrix.catalog }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: npm-${{ runner.os }}-${{ matrix.catalog }}-
       - name: Download package artifacts
         uses: actions/download-artifact@v4
         with:
           name: eventcatalog-packages-artifact
       - name: Install @eventcatalog packages
-        working-directory: examples/default/
+        working-directory: examples/${{ matrix.catalog }}/
         run: npm install ../../sdk-package.tgz ../../core-package.tgz ../../linter-package.tgz ../../connectors-package.tgz ../../visualiser-package.tgz
       - name: Build EventCatalog
-        working-directory: examples/default/
+        working-directory: examples/${{ matrix.catalog }}/
         run: npx eventcatalog build
+      - name: Smoke test SSR artifact
+        if: matrix.output == 'server'
+        run: node packages/core/scripts/ci/smoke-ssr.mjs examples/${{ matrix.catalog }}
       - name: Check build size
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest' && matrix.output == 'static'
         run: node packages/core/scripts/check-build-size.js
         env:
           SIZE_THRESHOLD: 5

--- a/examples/ssr/eventcatalog.config.js
+++ b/examples/ssr/eventcatalog.config.js
@@ -2,7 +2,7 @@ export default {
   cId: '3de53164-f865-4bdb-9a9f-6e73fb39a7de',
   title: 'SSR Test Catalog',
   tagline: 'A minimal catalog used to verify production SSR deployments.',
-  organizationName: 'EventCatalog',
+  organizationName: 'SSR Test Catalog',
   homepageLink: 'https://eventcatalog.dev',
   editUrl: 'https://github.com/event-catalog/eventcatalog',
   base: '/',

--- a/examples/ssr/eventcatalog.config.js
+++ b/examples/ssr/eventcatalog.config.js
@@ -1,0 +1,18 @@
+export default {
+  cId: '3de53164-f865-4bdb-9a9f-6e73fb39a7de',
+  title: 'SSR Test Catalog',
+  tagline: 'A minimal catalog used to verify production SSR deployments.',
+  organizationName: 'EventCatalog',
+  homepageLink: 'https://eventcatalog.dev',
+  editUrl: 'https://github.com/event-catalog/eventcatalog',
+  base: '/',
+  trailingSlash: false,
+  output: 'server',
+  outDir: 'dist',
+  search: {
+    type: 'resource',
+  },
+  llmsTxt: {
+    enabled: false,
+  },
+};

--- a/examples/ssr/eventcatalog.styles.css
+++ b/examples/ssr/eventcatalog.styles.css
@@ -1,0 +1,1 @@
+/* Intentionally empty: this fixture exercises the default SSR theme. */

--- a/examples/ssr/events/OrderCreated/index.mdx
+++ b/examples/ssr/events/OrderCreated/index.mdx
@@ -1,0 +1,8 @@
+---
+id: order-created
+name: Order Created
+version: 1.0.0
+summary: Published when an order is created.
+---
+
+This event keeps the SSR test catalog deliberately small while exercising a generated resource page.

--- a/examples/ssr/package.json
+++ b/examples/ssr/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "eventcatalog-ssr-test-catalog",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@eventcatalog/connectors": "workspace:*",
+    "@eventcatalog/core": "workspace:*"
+  }
+}

--- a/packages/core/eventcatalog/src/__tests__/server-runtime-imports.spec.ts
+++ b/packages/core/eventcatalog/src/__tests__/server-runtime-imports.spec.ts
@@ -1,0 +1,60 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const sourceDirectory = path.resolve(import.meta.dirname, '..');
+const sourceExtensions = new Set(['.astro', '.js', '.mjs', '.ts', '.tsx']);
+const ignoredDirectories = new Set(['.astro', '__tests__', 'dist', 'node_modules']);
+
+const findSourceFiles = async (directory: string): Promise<string[]> => {
+  const entries = await fs.readdir(directory, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const entryPath = path.join(directory, entry.name);
+
+      if (entry.isDirectory()) {
+        return ignoredDirectories.has(entry.name) ? [] : findSourceFiles(entryPath);
+      }
+
+      return sourceExtensions.has(path.extname(entry.name)) ? [entryPath] : [];
+    })
+  );
+
+  return files.flat();
+};
+
+const isBarePackageSpecifier = (specifier: string) =>
+  !specifier.startsWith('.') && !specifier.startsWith('/') && !specifier.startsWith('file:') && !specifier.startsWith('node:');
+
+const findIgnoredBarePackageImports = (source: string) => {
+  const ignoredImport = /import\s*\(\s*\/\*\s*@vite-ignore\s*\*\/\s*(['"])([^'"]+)\1\s*\)/g;
+
+  return [...source.matchAll(ignoredImport)]
+    .filter((match) => isBarePackageSpecifier(match[2]))
+    .map((match) => ({ index: match.index, specifier: match[2] }));
+};
+
+describe('server runtime imports', () => {
+  it('detects ignored imports that leave package resolution to production Node', () => {
+    const source = `await import(/* @vite-ignore */ 'auth-astro/server');`;
+
+    expect(findIgnoredBarePackageImports(source)).toEqual([{ index: 6, specifier: 'auth-astro/server' }]);
+  });
+
+  it('does not bypass Vite bundling for bare package specifiers', async () => {
+    const sourceFiles = await findSourceFiles(sourceDirectory);
+    const offenders: string[] = [];
+
+    await Promise.all(
+      sourceFiles.map(async (file) => {
+        const source = await fs.readFile(file, 'utf8');
+
+        for (const ignoredImport of findIgnoredBarePackageImports(source)) {
+          const line = source.slice(0, ignoredImport.index).split('\n').length;
+          offenders.push(`${path.relative(sourceDirectory, file)}:${line} imports ${ignoredImport.specifier}`);
+        }
+      })
+    );
+
+    expect(offenders.sort()).toEqual([]);
+  });
+});

--- a/packages/core/eventcatalog/src/enterprise/auth/login.astro
+++ b/packages/core/eventcatalog/src/enterprise/auth/login.astro
@@ -5,6 +5,7 @@ const { title, logo } = config;
 import { join } from 'node:path';
 import { isAuthEnabled, isSSR } from '@utils/feature';
 import { buildUrl } from '@utils/url-builder';
+import { getSession } from 'auth-astro/server';
 
 const catalogDirectory = process.env.PROJECT_DIR || process.cwd();
 
@@ -32,7 +33,6 @@ if (!isSSR() || !isAuthEnabled()) {
 
 // If we are in SSR mode, check if the user is already logged in
 if (isSSR() && isAuthEnabled()) {
-  const { getSession } = await import(/* @vite-ignore */ 'auth-astro/server');
   const session = await getSession(Astro.request);
   if (session) {
     return Astro.redirect('/');

--- a/packages/core/scripts/ci/smoke-ssr.mjs
+++ b/packages/core/scripts/ci/smoke-ssr.mjs
@@ -41,6 +41,7 @@ const server = spawn(process.execPath, [serverEntry], {
   },
   stdio: ['ignore', 'pipe', 'pipe'],
 });
+const serverExit = once(server, 'exit');
 
 let output = '';
 const captureOutput = (chunk) => {
@@ -51,14 +52,17 @@ server.stdout.on('data', captureOutput);
 server.stderr.on('data', captureOutput);
 
 const stopServer = async () => {
-  if (server.exitCode !== null) return;
+  if (server.exitCode !== null || server.signalCode !== null) {
+    await serverExit;
+    return;
+  }
 
   server.kill('SIGTERM');
-  await Promise.race([once(server, 'exit'), delay(5_000)]);
+  const exited = await Promise.race([serverExit.then(() => true), delay(5_000, false, { ref: false })]);
 
-  if (server.exitCode === null) {
+  if (!exited) {
     server.kill('SIGKILL');
-    await once(server, 'exit');
+    await serverExit;
   }
 };
 

--- a/packages/core/scripts/ci/smoke-ssr.mjs
+++ b/packages/core/scripts/ci/smoke-ssr.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import fs from 'node:fs';
+import net from 'node:net';
+import path from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+
+const projectDirectory = path.resolve(process.argv[2] || 'examples/ssr');
+const serverEntry = path.join(projectDirectory, 'dist', 'server', 'entry.mjs');
+
+if (!fs.existsSync(serverEntry)) {
+  throw new Error(`SSR server entry was not found at ${serverEntry}`);
+}
+
+const getAvailablePort = async () => {
+  const server = net.createServer();
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    server.close();
+    throw new Error('Could not allocate a port for the SSR smoke test');
+  }
+
+  const { port } = address;
+  server.close();
+  await once(server, 'close');
+  return port;
+};
+
+const port = await getAvailablePort();
+const server = spawn(process.execPath, [serverEntry], {
+  cwd: projectDirectory,
+  env: {
+    ...process.env,
+    HOST: '127.0.0.1',
+    PORT: String(port),
+  },
+  stdio: ['ignore', 'pipe', 'pipe'],
+});
+
+let output = '';
+const captureOutput = (chunk) => {
+  output = `${output}${chunk}`.slice(-20_000);
+};
+
+server.stdout.on('data', captureOutput);
+server.stderr.on('data', captureOutput);
+
+const stopServer = async () => {
+  if (server.exitCode !== null) return;
+
+  server.kill('SIGTERM');
+  await Promise.race([once(server, 'exit'), delay(5_000)]);
+
+  if (server.exitCode === null) {
+    server.kill('SIGKILL');
+    await once(server, 'exit');
+  }
+};
+
+try {
+  const deadline = Date.now() + 60_000;
+  let lastError;
+
+  while (Date.now() < deadline) {
+    if (server.exitCode !== null) {
+      throw new Error(`SSR server exited with code ${server.exitCode}\n${output}`);
+    }
+
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/`, {
+        signal: AbortSignal.timeout(2_000),
+      });
+      const body = await response.text();
+
+      if (!response.ok) {
+        throw new Error(`GET / returned ${response.status}`);
+      }
+      if (!body.includes('SSR Test Catalog')) {
+        throw new Error('GET / did not render the SSR test catalog');
+      }
+
+      console.log(`SSR smoke test passed on port ${port}`);
+      lastError = undefined;
+      break;
+    } catch (error) {
+      lastError = error;
+      await delay(500);
+    }
+  }
+
+  if (lastError) {
+    throw new Error(`SSR server did not become ready: ${lastError.message}\n${output}`);
+  }
+} finally {
+  await stopServer();
+}


### PR DESCRIPTION
## What This PR Does

The login page loaded `auth-astro/server` through a dynamic `import(/* @vite-ignore */ ...)`, which told Vite to leave the specifier alone and defer resolution to Node at runtime. That works locally where `auth-astro` sits in `node_modules`, but production SSR deployments that ship only the build output have nothing to resolve, so the login route fails at runtime.

This changes the import to a normal static import so Vite bundles the dependency into the server output. It also adds a regression test that fails if any source file reintroduces a `@vite-ignore`d bare package import, plus a minimal SSR example catalog and a CI smoke test that boots the built server and asserts it serves a page.

## Changes Overview

### Key Changes

- `packages/core/eventcatalog/src/enterprise/auth/login.astro` — replace the `@vite-ignore` dynamic import of `auth-astro/server` with a static top-level import so it gets bundled.
- `packages/core/eventcatalog/src/__tests__/server-runtime-imports.spec.ts` — new test that walks the core source tree and fails on any `import(/* @vite-ignore */ 'bare-package')`.
- `examples/ssr/` — new minimal catalog fixture (`output: 'server'`, one event) used to exercise a real SSR build.
- `packages/core/scripts/ci/smoke-ssr.mjs` — new script that boots `dist/server/entry.mjs`, polls `GET /` until it responds, and asserts the rendered page contains the catalog title.
- `.github/workflows/verify-build.yml` — convert the build matrix from a plain OS list to explicit `include` entries (static/Linux, static/Windows, SSR/Linux) and run the SSR smoke test on the server build.

## How It Works

`@vite-ignore` on a dynamic import is an instruction to skip bundling — the specifier survives verbatim into the output and is resolved by Node at request time. For a bare package specifier that only holds when the package is installed alongside the build. Making it a static import puts `auth-astro/server` back under Vite's control, so it lands in the server bundle.

The rest is guardrails. The unit test greps the source tree for the pattern that caused the bug and asserts no offenders remain, so the same mistake surfaces in tests rather than in a production deploy. The CI matrix now also builds the new `examples/ssr` catalog in server mode; the smoke script picks a free port, spawns the built entry, retries `GET /` for up to 60s (bailing early if the process exits), checks the response contains `SSR Test Catalog`, and terminates the server via SIGTERM with a SIGKILL fallback. The build-size check stays scoped to the static Linux build, and the npm cache key now includes the catalog name so the two catalogs don't share an entry.

## Breaking Changes

None.

## Additional Notes

- The `auth-astro` import is now unconditional at module scope, while the `getSession` call remains guarded by `isSSR() && isAuthEnabled()`. Worth a reviewer eye on whether pulling the module into static builds is acceptable — the login page early-returns in that case, but the import is no longer lazy.
- The SSR smoke test only asserts that `/` renders. It is a boot check, not coverage of the auth flow itself.
- No corresponding change is needed in the `eventcatalog/eventcatalog-editor` repository.