### PR TITLE
Load Astro content collections from federated directories

### DIFF
--- a/.changeset/quiet-pandas-federate.md
+++ b/.changeset/quiet-pandas-federate.md
@@ -1,0 +1,10 @@
+---
+'@eventcatalog/core': minor
+---
+
+feat(core): load catalog content from federated source directories
+
+Astro content collections now also scan `federated/*/` so resources pulled in from
+federated catalog sources (services, domains, subdomains, resource docs and doc
+categories, ubiquitous language, users and teams) are picked up alongside the
+local catalog.

--- a/packages/core/eventcatalog/src/content.config.ts
+++ b/packages/core/eventcatalog/src/content.config.ts
@@ -9,7 +9,7 @@ import path from 'path';
 import { userTeamDirectoryLoader } from './enterprise/directory/user-team-directory';
 import config from '@config';
 import { schemaLoader } from './utils/collections/schema-loader';
-import { globWithSafeWatcher, withIgnoredBuildArtifacts } from './utils/collections/glob-loader';
+import { globWithSafeWatcher, withFederatedContent, withIgnoredBuildArtifacts } from './utils/collections/glob-loader';
 import { withExtensionProperties } from './utils/collections/extension-properties';
 
 // Enterprise Collections
@@ -494,24 +494,26 @@ const dataProducts = defineCollection({
 
 const services = defineCollection({
   loader: globWithSafeWatcher({
-    pattern: withIgnoredBuildArtifacts([
-      'domains/*/services/*/index.(md|mdx)',
-      'domains/*/services/*/versioned/*/index.(md|mdx)',
+    pattern: withIgnoredBuildArtifacts(
+      withFederatedContent([
+        'domains/*/services/*/index.(md|mdx)',
+        'domains/*/services/*/versioned/*/index.(md|mdx)',
 
-      // Capture subdomain folders
-      'domains/*/subdomains/*/services/*/index.(md|mdx)',
-      'domains/*/subdomains/*/services/*/versioned/*/index.(md|mdx)',
+        // Capture subdomain folders
+        'domains/*/subdomains/*/services/*/index.(md|mdx)',
+        'domains/*/subdomains/*/services/*/versioned/*/index.(md|mdx)',
 
-      // Capture services inside systems
-      'systems/*/services/*/index.(md|mdx)',
-      'systems/*/services/*/versioned/*/index.(md|mdx)',
-      'domains/*/systems/*/services/*/index.(md|mdx)',
-      'domains/*/systems/*/services/*/versioned/*/index.(md|mdx)',
+        // Capture services inside systems
+        'systems/*/services/*/index.(md|mdx)',
+        'systems/*/services/*/versioned/*/index.(md|mdx)',
+        'domains/*/systems/*/services/*/index.(md|mdx)',
+        'domains/*/systems/*/services/*/versioned/*/index.(md|mdx)',
 
-      // Capture services in the root
-      'services/*/index.(md|mdx)', // ✅ Capture only services markdown files
-      'services/*/versioned/*/index.(md|mdx)', // ✅ Capture versioned files inside services
-    ]),
+        // Capture services in the root
+        'services/*/index.(md|mdx)', // ✅ Capture only services markdown files
+        'services/*/versioned/*/index.(md|mdx)', // ✅ Capture versioned files inside services
+      ])
+    ),
     base: projectDirBase,
     generateId: ({ data, ...rest }) => {
       return `${data.id}-${data.version}`;
@@ -730,14 +732,16 @@ const resourceDocs = defineCollection({
   loader: globWithSafeWatcher({
     // Resource-level docs are restricted to known resource paths.
     // This avoids scanning external docs such as node_modules/**/docs.
-    pattern: withIgnoredBuildArtifacts([
-      '{agents,events,commands,queries,services,flows,containers,channels,entities,data-products,systems}/**/docs/**/*.@(md|mdx)',
-      '{agents,events,commands,queries,services,flows,containers,channels,entities,data-products,systems}/**/docs/*.@(md|mdx)',
-      '{agents,events,commands,queries,services,flows,containers,channels,entities,data-products,systems}/**/versioned/*/docs/**/*.@(md|mdx)',
-      '{agents,events,commands,queries,services,flows,containers,channels,entities,data-products,systems}/**/versioned/*/docs/*.@(md|mdx)',
-      'domains/**/docs/**/*.@(md|mdx)',
-      'domains/**/docs/*.@(md|mdx)',
-    ]),
+    pattern: withIgnoredBuildArtifacts(
+      withFederatedContent([
+        '{agents,events,commands,queries,services,flows,containers,channels,entities,data-products,systems}/**/docs/**/*.@(md|mdx)',
+        '{agents,events,commands,queries,services,flows,containers,channels,entities,data-products,systems}/**/docs/*.@(md|mdx)',
+        '{agents,events,commands,queries,services,flows,containers,channels,entities,data-products,systems}/**/versioned/*/docs/**/*.@(md|mdx)',
+        '{agents,events,commands,queries,services,flows,containers,channels,entities,data-products,systems}/**/versioned/*/docs/*.@(md|mdx)',
+        'domains/**/docs/**/*.@(md|mdx)',
+        'domains/**/docs/*.@(md|mdx)',
+      ])
+    ),
     base: projectDirBase,
   }),
   schema: resourceDocsSchema,
@@ -745,16 +749,18 @@ const resourceDocs = defineCollection({
 
 const resourceDocCategories = defineCollection({
   loader: globWithSafeWatcher({
-    pattern: withIgnoredBuildArtifacts([
-      '{agents,events,commands,queries,services,flows,containers,channels,entities,data-products,systems}/**/docs/**/category.json',
-      '{agents,events,commands,queries,services,flows,containers,channels,entities,data-products,systems}/**/docs/**/_category_.json',
-      '{agents,events,commands,queries,services,flows,containers,channels,entities,data-products,systems}/**/versioned/*/docs/**/category.json',
-      '{agents,events,commands,queries,services,flows,containers,channels,entities,data-products,systems}/**/versioned/*/docs/**/_category_.json',
-      'domains/**/docs/**/category.json',
-      'domains/**/docs/**/_category_.json',
-      'domains/**/docs/category.json',
-      'domains/**/docs/_category_.json',
-    ]),
+    pattern: withIgnoredBuildArtifacts(
+      withFederatedContent([
+        '{agents,events,commands,queries,services,flows,containers,channels,entities,data-products,systems}/**/docs/**/category.json',
+        '{agents,events,commands,queries,services,flows,containers,channels,entities,data-products,systems}/**/docs/**/_category_.json',
+        '{agents,events,commands,queries,services,flows,containers,channels,entities,data-products,systems}/**/versioned/*/docs/**/category.json',
+        '{agents,events,commands,queries,services,flows,containers,channels,entities,data-products,systems}/**/versioned/*/docs/**/_category_.json',
+        'domains/**/docs/**/category.json',
+        'domains/**/docs/**/_category_.json',
+        'domains/**/docs/category.json',
+        'domains/**/docs/_category_.json',
+      ])
+    ),
     base: projectDirBase,
   }),
   schema: resourceDocCategoriesSchema,
@@ -762,15 +768,17 @@ const resourceDocCategories = defineCollection({
 
 const domains = defineCollection({
   loader: globWithSafeWatcher({
-    pattern: withIgnoredBuildArtifacts([
-      // ✅ Strictly include only index.md at the expected levels
-      'domains/*/index.(md|mdx)',
-      'domains/*/versioned/*/index.(md|mdx)',
+    pattern: withIgnoredBuildArtifacts(
+      withFederatedContent([
+        // ✅ Strictly include only index.md at the expected levels
+        'domains/*/index.(md|mdx)',
+        'domains/*/versioned/*/index.(md|mdx)',
 
-      // Capture subdomain folders
-      'domains/*/subdomains/*/index.(md|mdx)',
-      'domains/*/subdomains/*/versioned/*/index.(md|mdx)',
-    ]),
+        // Capture subdomain folders
+        'domains/*/subdomains/*/index.(md|mdx)',
+        'domains/*/subdomains/*/versioned/*/index.(md|mdx)',
+      ])
+    ),
     base: projectDirBase,
     generateId: ({ data, ...rest }) => {
       return `${data.id}-${data.version}`;
@@ -938,10 +946,9 @@ const channels = defineCollection({
 
 const ubiquitousLanguages = defineCollection({
   loader: globWithSafeWatcher({
-    pattern: withIgnoredBuildArtifacts([
-      'domains/*/ubiquitous-language.(md|mdx)',
-      'domains/*/subdomains/*/ubiquitous-language.(md|mdx)',
-    ]),
+    pattern: withIgnoredBuildArtifacts(
+      withFederatedContent(['domains/*/ubiquitous-language.(md|mdx)', 'domains/*/subdomains/*/ubiquitous-language.(md|mdx)'])
+    ),
     base: projectDirBase,
     generateId: ({ data }) => {
       // File has no id, so we need to generate one
@@ -1039,7 +1046,7 @@ const users = defineCollection({
     sources: config.directory?.sources,
     conflictStrategy: config.directory?.conflictStrategy,
     local: {
-      pattern: withIgnoredBuildArtifacts('users/*.(md|mdx)'),
+      pattern: withIgnoredBuildArtifacts(withFederatedContent('users/*.(md|mdx)')),
       base: projectDirBase,
       generateId: ({ data }) => data.id as string,
     },
@@ -1071,7 +1078,7 @@ const teams = defineCollection({
     sources: config.directory?.sources,
     conflictStrategy: config.directory?.conflictStrategy,
     local: {
-      pattern: withIgnoredBuildArtifacts('teams/*.(md|mdx)'),
+      pattern: withIgnoredBuildArtifacts(withFederatedContent('teams/*.(md|mdx)')),
       base: projectDirBase,
       generateId: ({ data }) => data.id as string,
     },

--- a/packages/core/eventcatalog/src/utils/collections/glob-loader.spec.ts
+++ b/packages/core/eventcatalog/src/utils/collections/glob-loader.spec.ts
@@ -1,0 +1,20 @@
+import picomatch from 'picomatch';
+import { describe, expect, it } from 'vitest';
+import { withFederatedContent } from './glob-loader';
+
+describe('withFederatedContent', () => {
+  it('loads root catalog content from every federated source directory', () => {
+    const patterns = withFederatedContent(['services/*/index.(md|mdx)', 'domains/*/index.(md|mdx)', '!domains/*/services/**']);
+
+    expect(patterns).toEqual([
+      'services/*/index.(md|mdx)',
+      'domains/*/index.(md|mdx)',
+      '!domains/*/services/**',
+      'federated/*/services/*/index.(md|mdx)',
+      'federated/*/domains/*/index.(md|mdx)',
+      '!federated/*/domains/*/services/**',
+    ]);
+    expect(picomatch.isMatch('federated/team-payments--abc123/services/payment-service/index.mdx', patterns)).toBe(true);
+    expect(picomatch.isMatch('federated/team-payments--abc123/domains/payments/index.mdx', patterns)).toBe(true);
+  });
+});

--- a/packages/core/eventcatalog/src/utils/collections/glob-loader.ts
+++ b/packages/core/eventcatalog/src/utils/collections/glob-loader.ts
@@ -15,6 +15,17 @@ export const withIgnoredBuildArtifacts = (patterns: string | string[]) => {
 
 const toPatterns = (patterns: string | string[]) => (Array.isArray(patterns) ? patterns : [patterns]);
 
+export const withFederatedContent = (patterns: string | string[]) => {
+  const patternList = toPatterns(patterns);
+  const federatedPatterns = patternList.map((pattern) => {
+    const isNegative = pattern.startsWith('!');
+    const catalogPattern = isNegative ? pattern.slice(1) : pattern;
+    return `${isNegative ? '!' : ''}federated/*/${catalogPattern}`;
+  });
+
+  return [...patternList, ...federatedPatterns];
+};
+
 const matchesGlobPattern = (entry: string, patterns: string | string[]) => {
   const patternList = toPatterns(patterns);
   const positivePatterns = patternList.filter((pattern) => !pattern.startsWith('!'));


### PR DESCRIPTION
## What This PR Does

Federated catalogs are hydrated into a `federated/<source>/` directory inside the project, but Astro's content collections only globbed the root catalog paths, so none of that content was ever loaded. This PR adds a `withFederatedContent` helper that mirrors every catalog glob pattern under `federated/*/`, and applies it to the collections that federated sources can contribute to.

## Changes Overview

### Key Changes

- Add `withFederatedContent(patterns)` to `packages/core/eventcatalog/src/utils/collections/glob-loader.ts` — takes a pattern (or list) and returns the originals plus a `federated/*/`-prefixed copy of each, preserving `!` negations.
- Apply it in `packages/core/eventcatalog/src/content.config.ts` to the `services`, `resourceDocs`, `resourceDocCategories`, `domains`, `ubiquitousLanguages`, `users`, and `teams` collections.
- Add `packages/core/eventcatalog/src/utils/collections/glob-loader.spec.ts` covering the expanded pattern list and verifying real federated paths match via `picomatch`.

## How It Works

Each collection's glob list is wrapped with `withFederatedContent(...)` before being passed to `withIgnoredBuildArtifacts(...)`, so build-artifact ignores still apply to both the local and federated patterns.

For a pattern like `services/*/index.(md|mdx)`, the helper emits both the original and `federated/*/services/*/index.(md|mdx)`. The single `*` segment matches one federated source directory (e.g. `federated/team-payments--abc123/`), so federated resources land in the same collections as local ones and flow through the existing schemas, ID generation, and utilities unchanged.

Negated patterns are handled explicitly: the leading `!` is stripped, the prefix applied, and the `!` re-attached — so an exclusion in the root catalog stays an exclusion inside federated sources rather than accidentally becoming an include.

## Breaking Changes

None. Catalogs without a `federated/` directory match nothing extra and behave exactly as before.

## Additional Notes

- Collections not touched here (events, commands, queries, flows, channels, entities, etc.) still only glob the root catalog — worth confirming whether federated sources are expected to contribute those too, or whether they're picked up through another path.
- The new spec runs under the existing core Vitest setup; `pnpm run format` is clean.