### PR TITLE
Show all direct resources on domain resources pages

### DIFF
--- a/.changeset/quiet-pandas-listen.md
+++ b/.changeset/quiet-pandas-listen.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Resources pages now list every resource directly attached to a domain (subdomains, systems, agents and data products alongside services, flows, entities and messages), and the sidebar Resources link appears whenever any of those exist. Service sidebar links are versioned again, and sidebar icons render at a consistent size.

--- a/.changeset/tidy-moons-gather.md
+++ b/.changeset/tidy-moons-gather.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/create-eventcatalog": patch
+---
+
+Default template now enables the visualiser and architecture graph, adds top-level diagrams to the navigation, and drops the duplicate component map from the Catalog domain page.

--- a/examples/default/domains/Catalog/index.mdx
+++ b/examples/default/domains/Catalog/index.mdx
@@ -55,11 +55,3 @@ The **Catalog** domain is responsible for the lifecycle of every product Acme In
 The **Product Catalog System** is the authoritative source of product data. Whenever a product is created, updated or deleted it publishes a domain event. The **Search System** subscribes to those events, keeps its search index in sync, and exposes a search API so other teams never have to query the catalog database directly.
 
 The diagram below shows the domain's systems, how they relate, and the people who interact with them.
-
-<ContextDiagram />
-
-## Component map
-
-These are the components that are part of this domain (parts of the systems in this domain)
-
-<NodeGraph />

--- a/examples/default/eventcatalog.config.js
+++ b/examples/default/eventcatalog.config.js
@@ -65,6 +65,10 @@ export default {
   //   ],
   // },
 
+  navigation: {
+    pages: ["list:top-level-domains", "list:top-level-diagrams", "list:all"],
+  },
+
   customDocs: {
     sidebar: [
       {
@@ -95,6 +99,7 @@ export default {
   },
 
   visualiser: {
+    enabled: true,
     channels: {
       renderMode: "flat",
     },

--- a/packages/core/eventcatalog/src/components/SideNav/NestedSideBar/index.tsx
+++ b/packages/core/eventcatalog/src/components/SideNav/NestedSideBar/index.tsx
@@ -866,12 +866,6 @@ export default function NestedSideBar() {
     // a custom icon (item.leftIcon) is always still shown.
     const IconComponent =
       item.icon && !suppressDefaultIcon ? (LucideIcons as unknown as Record<string, LucideIcons.LucideIcon>)[item.icon] : null;
-    // Some glyphs fill their box more than others, so they read larger at the shared
-    // item size. Render these ~25% smaller (matching the ADR icon) to visually balance:
-    // ClipboardList (ADRs) and the message glyphs (events/commands/queries).
-    const smallerIcons = ['ClipboardList', 'Zap', 'MessageSquare', 'Search', 'Mail'];
-    const iconSizeClass = item.icon && smallerIcons.includes(item.icon) ? 'w-3 h-3' : 'w-4 h-4';
-
     const handleStarClick = (e: React.MouseEvent) => {
       e.preventDefault();
       e.stopPropagation();
@@ -888,7 +882,7 @@ export default function NestedSideBar() {
                 isActive ? 'text-[rgb(var(--ec-accent-text))]' : 'text-[rgb(var(--ec-content-text-muted))]'
               )}
             >
-              <IconComponent className={iconSizeClass} />
+              <IconComponent className="w-4 h-4" />
             </span>
           )}
           {item.leftIcon && <img src={resolveIconUrl(item.leftIcon)} alt="" loading="lazy" className="w-4 h-4 flex-shrink-0" />}

--- a/packages/core/eventcatalog/src/components/Tables/SystemResources/SystemResourcesTable.tsx
+++ b/packages/core/eventcatalog/src/components/Tables/SystemResources/SystemResourcesTable.tsx
@@ -12,7 +12,18 @@ import { getColorAndIconForCollection } from '@utils/collections/icons';
 import { getCollectionTextColorClass } from '@utils/collection-colors';
 import { isIconPath, resolveIconUrl } from '@utils/icon';
 
-export type SystemResourceCollection = 'services' | 'flows' | 'entities' | 'containers' | 'events' | 'commands' | 'queries';
+export type SystemResourceCollection =
+  | 'domains'
+  | 'systems'
+  | 'agents'
+  | 'services'
+  | 'flows'
+  | 'entities'
+  | 'data-products'
+  | 'containers'
+  | 'events'
+  | 'commands'
+  | 'queries';
 
 export interface SystemResourceItem {
   collection: SystemResourceCollection;
@@ -29,9 +40,13 @@ interface SystemResourcesTableProps {
 }
 
 const TYPE_LABELS: Record<SystemResourceCollection, string> = {
+  domains: 'Subdomains',
+  systems: 'Systems',
+  agents: 'Agents',
   services: 'Services',
   flows: 'Flows',
   entities: 'Entities',
+  'data-products': 'Data Products',
   containers: 'Data Stores',
   events: 'Events',
   commands: 'Commands',
@@ -39,7 +54,19 @@ const TYPE_LABELS: Record<SystemResourceCollection, string> = {
 };
 
 // Order the type filter pills follow on the page.
-const TYPE_ORDER: SystemResourceCollection[] = ['services', 'flows', 'entities', 'containers', 'events', 'commands', 'queries'];
+const TYPE_ORDER: SystemResourceCollection[] = [
+  'domains',
+  'systems',
+  'agents',
+  'services',
+  'flows',
+  'entities',
+  'data-products',
+  'containers',
+  'events',
+  'commands',
+  'queries',
+];
 
 // Small icon for a collection type (used in filter pills and the type column).
 const CollectionTypeIcon = ({ collection, className }: { collection: SystemResourceCollection; className?: string }) => {

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/resources/_index.data.spec.ts
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/resources/_index.data.spec.ts
@@ -1,0 +1,28 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { loadResourceOwner } from './_index.data';
+
+const collectionMocks = vi.hoisted(() => ({
+  getDomains: vi.fn(() => Promise.resolve([])),
+  getSystems: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock('@utils/collections/domains', () => ({ getDomains: collectionMocks.getDomains }));
+vi.mock('@utils/collections/systems', () => ({ getSystems: collectionMocks.getSystems }));
+
+describe('Resources page owner loader', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('loads domains without flattening child-subdomain services and agents', async () => {
+    await loadResourceOwner('domains');
+
+    expect(collectionMocks.getDomains).toHaveBeenCalledWith({ includeServicesInSubdomains: false });
+  });
+
+  it('keeps the system loader unchanged', async () => {
+    await loadResourceOwner('systems');
+
+    expect(collectionMocks.getSystems).toHaveBeenCalledWith();
+  });
+});

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/resources/_index.data.ts
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/resources/_index.data.ts
@@ -1,9 +1,9 @@
 import { isSSR } from '@utils/feature';
 import { HybridPage } from '@utils/page-loaders/hybrid-page';
+import { hasResources } from './_resources';
 
-// The Resources page lists the top-level resources (services, flows, entities and
-// data stores) attached to a single system or domain. It is only available for
-// systems and domains — every other resource type 404s.
+// The Resources page lists the resources directly attached to a single system or
+// domain. It is only available for systems and domains — every other resource type 404s.
 const SUPPORTED_TYPES = ['systems', 'domains'] as const;
 type SupportedType = (typeof SUPPORTED_TYPES)[number];
 
@@ -16,21 +16,6 @@ const loadResourceOwner = async (type: SupportedType) => {
   }
   const { getDomains } = await import('@utils/collections/domains');
   return getDomains();
-};
-
-// A system/domain only gets a Resources page when it actually has resources attached.
-// Mirrors what the page renders: services, flows, entities, data stores and (domains
-// only) the domain's own messages.
-const hasResources = (owner: any): boolean => {
-  const data = owner?.data ?? {};
-  return (
-    (data.services || []).length > 0 ||
-    (data.flows || []).length > 0 ||
-    (data.entities || []).length > 0 ||
-    (data.containers || []).length > 0 ||
-    (data.sends || []).length > 0 ||
-    (data.receives || []).length > 0
-  );
 };
 
 export class Page extends HybridPage {
@@ -47,7 +32,7 @@ export class Page extends HybridPage {
 
     return SUPPORTED_TYPES.flatMap((type, index) =>
       owners[index]
-        .filter((owner) => hasResources(owner))
+        .filter((owner) => hasResources(owner, type))
         .map((owner) => ({
           params: {
             type,
@@ -71,7 +56,7 @@ export class Page extends HybridPage {
     const owners = await loadResourceOwner(type);
     const owner = owners.find((o) => o.data.id === id && o.data.version === version);
 
-    if (!owner || !hasResources(owner)) {
+    if (!owner || !hasResources(owner, type)) {
       return null;
     }
 

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/resources/_index.data.ts
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/resources/_index.data.ts
@@ -9,13 +9,13 @@ type SupportedType = (typeof SUPPORTED_TYPES)[number];
 
 const isSupportedType = (type: string): type is SupportedType => SUPPORTED_TYPES.includes(type as SupportedType);
 
-const loadResourceOwner = async (type: SupportedType) => {
+export const loadResourceOwner = async (type: SupportedType) => {
   if (type === 'systems') {
     const { getSystems } = await import('@utils/collections/systems');
     return getSystems();
   }
   const { getDomains } = await import('@utils/collections/domains');
-  return getDomains();
+  return getDomains({ includeServicesInSubdomains: false });
 };
 
 export class Page extends HybridPage {

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/resources/_resources.spec.ts
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/resources/_resources.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { getResourceGroups, hasResources } from './_resources';
+
+const resource = (id: string, version = '1.0.0') => ({ data: { id, name: id, version } });
+const message = (collection: 'events' | 'commands' | 'queries', id: string, version = '1.0.0') => ({
+  collection,
+  data: { id, name: id, version },
+});
+
+describe('resource page groups', () => {
+  it('includes every resource directly attached to a domain', () => {
+    const sharedEvent = message('events', 'OrderPlaced');
+    const groups = getResourceGroups(
+      {
+        domains: [resource('Fulfilment')],
+        systems: [resource('OrderingSystem')],
+        agents: [resource('OrderAgent')],
+        'data-products': [resource('OrderAnalytics')],
+        services: [resource('OrdersService')],
+        flows: [resource('PlaceOrder')],
+        entities: [resource('Order')],
+        sends: [sharedEvent, message('commands', 'PlaceOrder')],
+        receives: [sharedEvent, message('queries', 'GetOrder')],
+      },
+      'domains'
+    );
+
+    expect(Object.fromEntries(groups.map(({ collection, items }) => [collection, items.map((item) => item.data.id)]))).toEqual({
+      domains: ['Fulfilment'],
+      systems: ['OrderingSystem'],
+      agents: ['OrderAgent'],
+      'data-products': ['OrderAnalytics'],
+      services: ['OrdersService'],
+      flows: ['PlaceOrder'],
+      entities: ['Order'],
+      containers: [],
+      events: ['OrderPlaced'],
+      commands: ['PlaceOrder'],
+      queries: ['GetOrder'],
+    });
+  });
+
+  it('keeps domain-only resources off system resource pages', () => {
+    const collections = getResourceGroups(
+      {
+        domains: [resource('Fulfilment')],
+        systems: [resource('OrderingSystem')],
+        agents: [resource('OrderAgent')],
+        'data-products': [resource('OrderAnalytics')],
+        services: [resource('OrdersService')],
+        containers: [resource('OrdersDatabase')],
+      },
+      'systems'
+    ).map(({ collection }) => collection);
+
+    expect(collections).toEqual(['services', 'flows', 'entities', 'containers', 'events', 'commands', 'queries']);
+  });
+
+  it.each(['domains', 'systems', 'agents', 'data-products'] as const)(
+    'makes a domain with only %s eligible for a Resources page',
+    (collection) => {
+      expect(hasResources({ data: { [collection]: [resource('direct-resource')] } }, 'domains')).toBe(true);
+    }
+  );
+});

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/resources/_resources.ts
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/resources/_resources.ts
@@ -1,0 +1,46 @@
+import type { SystemResourceCollection } from '@components/Tables/SystemResources/SystemResourcesTable';
+
+export type ResourceOwnerCollection = 'systems' | 'domains';
+
+export interface ResourceGroup {
+  collection: SystemResourceCollection;
+  items: any[];
+}
+
+const getDomainMessages = (data: any) => {
+  const seen = new Map<string, any>();
+
+  for (const message of [...(data.sends || []), ...(data.receives || [])]) {
+    if (!message?.data?.id || !message?.collection) continue;
+    seen.set(`${message.collection}:${message.data.id}:${message.data.version}`, message);
+  }
+
+  return Array.from(seen.values());
+};
+
+export const getResourceGroups = (data: any, ownerCollection: ResourceOwnerCollection): ResourceGroup[] => {
+  const domainMessages = ownerCollection === 'domains' ? getDomainMessages(data) : [];
+  const domainOnlyGroups: ResourceGroup[] =
+    ownerCollection === 'domains'
+      ? [
+          { collection: 'domains', items: data.domains || [] },
+          { collection: 'systems', items: data.systems || [] },
+          { collection: 'agents', items: data.agents || [] },
+          { collection: 'data-products', items: data['data-products'] || [] },
+        ]
+      : [];
+
+  return [
+    ...domainOnlyGroups,
+    { collection: 'services', items: data.services || [] },
+    { collection: 'flows', items: data.flows || [] },
+    { collection: 'entities', items: data.entities || [] },
+    { collection: 'containers', items: data.containers || [] },
+    { collection: 'events', items: domainMessages.filter((message) => message.collection === 'events') },
+    { collection: 'commands', items: domainMessages.filter((message) => message.collection === 'commands') },
+    { collection: 'queries', items: domainMessages.filter((message) => message.collection === 'queries') },
+  ];
+};
+
+export const hasResources = (owner: any, ownerCollection: ResourceOwnerCollection): boolean =>
+  getResourceGroups(owner?.data ?? {}, ownerCollection).some(({ items }) => items.length > 0);

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/resources/index.astro
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/resources/index.astro
@@ -7,6 +7,7 @@ import {
   type SystemResourceItem,
   type SystemResourceCollection,
 } from '@components/Tables/SystemResources/SystemResourcesTable';
+import { getResourceGroups, type ResourceOwnerCollection } from './_resources';
 
 import { Page } from './_index.data';
 
@@ -15,35 +16,11 @@ export const getStaticPaths = Page.getStaticPaths;
 
 const resourceOwner = await Page.getData(Astro);
 const { data } = resourceOwner;
-const ownerCollection = resourceOwner.collection as 'systems' | 'domains';
+const ownerCollection = resourceOwner.collection as ResourceOwnerCollection;
 
-// Domain-level messages come from the domain's own `sends` (Domain Events) and
-// `receives` (External Events). Each resolved entry already carries its own
-// collection (events / commands / queries). Dedupe across sends + receives.
-const messageEntries = (() => {
-  const seen = new Map<string, any>();
-  for (const message of [...(data.sends || []), ...(data.receives || [])]) {
-    if (!message?.data?.id || !message?.collection) continue;
-    seen.set(`${message.collection}:${message.data.id}:${message.data.version}`, message);
-  }
-  return Array.from(seen.values());
-})();
-
-const messagesByCollection = (collection: SystemResourceCollection) =>
-  messageEntries.filter((message: any) => message.collection === collection);
-
-// Only show resources that are directly attached to the system/domain — not resources
-// nested further downstream. Domains can't hold containers directly, so a domain's
-// Resources page shows services, flows, entities and its own messages.
-const resourceGroups: Array<{ collection: SystemResourceCollection; items: any[] }> = [
-  { collection: 'services', items: data.services || [] },
-  { collection: 'flows', items: data.flows || [] },
-  { collection: 'entities', items: data.entities || [] },
-  { collection: 'containers', items: data.containers || [] },
-  { collection: 'events', items: messagesByCollection('events') },
-  { collection: 'commands', items: messagesByCollection('commands') },
-  { collection: 'queries', items: messagesByCollection('queries') },
-];
+// Only show resources directly attached to this system/domain. Domain child resources
+// are not flattened, so services inside a child system remain on that system's page.
+const resourceGroups = getResourceGroups(data, ownerCollection);
 
 const hrefForResource = (collection: SystemResourceCollection, id: string, version: string) => {
   if (collection === 'entities') {
@@ -72,7 +49,8 @@ const resources: SystemResourceItem[] = resourceGroups.flatMap(({ collection, it
         <div class="border-b border-[rgb(var(--ec-page-border))] pb-4">
           <h2 class="text-2xl md:text-4xl font-bold text-[rgb(var(--ec-page-text))]">{data.name} Resources</h2>
           <h2 class="text-lg pt-2 text-[rgb(var(--ec-page-text-muted))] font-light">
-            A group of resources that are mapped to the {data.name} {ownerCollection === 'domains' ? 'domain' : 'system'}.
+            A group of resources that are mapped to the {data.name}{' '}
+            {ownerCollection === 'domains' ? 'domain' : 'system'}.
           </h2>
         </div>
 

--- a/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/sidebar-builder.spec.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/sidebar-builder.spec.ts
@@ -1972,7 +1972,7 @@ describe('getNestedSideBarData', () => {
         expect(serviceNode).toHaveNavigationLink({
           type: 'item',
           title: 'Overview',
-          href: '/docs/services/ShippingService',
+          href: '/docs/services/ShippingService/0.0.1',
         });
       });
 
@@ -1990,7 +1990,7 @@ describe('getNestedSideBarData', () => {
         expect(serviceNode).toHaveNavigationLink({
           type: 'item',
           title: 'Changelog',
-          href: '/docs/services/ShippingService/changelog',
+          href: '/docs/services/ShippingService/0.0.1/changelog',
         });
         config.changelog = { enabled: false };
       });
@@ -2009,7 +2009,7 @@ describe('getNestedSideBarData', () => {
         expect(serviceNode).not.toHaveNavigationLink({
           type: 'item',
           title: 'Changelog',
-          href: '/docs/services/ShippingService/changelog',
+          href: '/docs/services/ShippingService/0.0.1/changelog',
         });
       });
 
@@ -2032,7 +2032,7 @@ describe('getNestedSideBarData', () => {
         expect(serviceNode).not.toHaveNavigationLink({
           type: 'item',
           title: 'Changelog',
-          href: '/docs/services/ShippingService/changelog',
+          href: '/docs/services/ShippingService/0.0.1/changelog',
         });
         config.changelog = { enabled: false };
       });
@@ -2182,24 +2182,24 @@ describe('getNestedSideBarData', () => {
             type: 'item',
             title: 'OpenAPI',
             leftIcon: '/icons/openapi-black.svg',
-            href: '/docs/services/ShippingService/spec/openapi',
+            href: '/docs/services/ShippingService/0.0.1/spec/openapi',
           },
           {
             type: 'item',
             title: 'AsyncAPI',
             leftIcon: '/icons/asyncapi-black.svg',
-            href: '/docs/services/ShippingService/asyncapi/asyncapi',
+            href: '/docs/services/ShippingService/0.0.1/asyncapi/asyncapi',
           },
           {
             type: 'item',
             title: 'GraphQL',
             leftIcon: '/icons/graphql-black.svg',
-            href: '/docs/services/ShippingService/graphql/graphql',
+            href: '/docs/services/ShippingService/0.0.1/graphql/graphql',
           },
         ]);
       });
 
-      it('keeps specification links versioned for historical service versions', async () => {
+      it('keeps specification links versioned for every service version', async () => {
         const { writeService } = utils(CATALOG_FOLDER);
         const specifications = [{ type: 'asyncapi' as const, path: 'asyncapi.yaml', name: 'AsyncAPI' }];
 
@@ -2233,7 +2233,7 @@ describe('getNestedSideBarData', () => {
         expect(latestServiceNode).toHaveNavigationLink({
           type: 'item',
           title: 'AsyncAPI',
-          href: '/docs/services/ShippingService/asyncapi/asyncapi',
+          href: '/docs/services/ShippingService/2.0.0/asyncapi/asyncapi',
         });
       });
     });
@@ -4753,7 +4753,7 @@ describe('getNestedSideBarData', () => {
           {
             type: 'item',
             title: 'Service Boundary ADR',
-            href: '/docs/services/ShippingService/adrs/service-boundary',
+            href: '/docs/services/ShippingService/0.0.1/adrs/service-boundary',
           },
         ]);
 

--- a/packages/core/eventcatalog/src/stores/sidebar-store/builders/__tests__/domain-builder.spec.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/builders/__tests__/domain-builder.spec.ts
@@ -1,0 +1,73 @@
+import type { CollectionEntry } from 'astro:content';
+import { describe, expect, it, vi } from 'vitest';
+import { buildDomainNode } from '../domain';
+
+vi.mock('@utils/feature', () => ({
+  isVisualiserEnabled: () => true,
+  isChangelogEnabled: () => false,
+}));
+
+vi.mock('@utils/url-builder', () => ({
+  buildUrl: (path: string) => path,
+}));
+
+vi.mock('@utils/collections/domains', () => ({
+  getSpecificationsForDomain: () => [],
+  hasUbiquitousLanguageTermsWithSubdomainsInCollection: () => false,
+}));
+
+const resource = (id: string) => ({ data: { id, name: id, version: '1.0.0' } });
+
+const createDomain = (overrides: Record<string, unknown> = {}): CollectionEntry<'domains'> =>
+  ({
+    id: 'domains/Ordering/index.mdx',
+    slug: 'domains/Ordering',
+    collection: 'domains',
+    data: {
+      id: 'Ordering',
+      name: 'Ordering',
+      version: '1.0.0',
+      owners: [],
+      ...overrides,
+    },
+  }) as unknown as CollectionEntry<'domains'>;
+
+const emptyContext = {
+  services: [],
+  domains: [],
+  events: [],
+  commands: [],
+  queries: [],
+  flows: [],
+  containers: [],
+  dataProducts: [],
+  diagrams: [],
+  adrs: [],
+  resourceDocs: [],
+  resourceDocCategories: [],
+} as any;
+
+const getQuickReferenceLinks = (domain: CollectionEntry<'domains'>) => {
+  const node = buildDomainNode(domain, [], emptyContext);
+  const quickReference = node.pages?.find((page) => typeof page !== 'string' && page.title === 'Quick Reference');
+  return quickReference && typeof quickReference !== 'string' ? quickReference.pages : [];
+};
+
+describe('buildDomainNode', () => {
+  it.each([
+    ['subdomains', { domains: [resource('Fulfilment')] }],
+    ['systems', { systems: [resource('OrderingSystem')] }],
+    ['agents', { agents: [resource('OrderAgent')] }],
+    ['data products', { 'data-products': [resource('OrderAnalytics')] }],
+  ])('links to Domain Resources when the domain only contains %s', (_type, overrides) => {
+    expect(getQuickReferenceLinks(createDomain(overrides))).toContainEqual({
+      type: 'item',
+      title: 'Domain Resources',
+      href: '/docs/domains/Ordering/1.0.0/resources',
+    });
+  });
+
+  it('does not link to Domain Resources when the domain has no direct resources', () => {
+    expect(getQuickReferenceLinks(createDomain())).not.toContainEqual(expect.objectContaining({ title: 'Domain Resources' }));
+  });
+});

--- a/packages/core/eventcatalog/src/stores/sidebar-store/builders/__tests__/service-builder.spec.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/builders/__tests__/service-builder.spec.ts
@@ -1,0 +1,57 @@
+import type { CollectionEntry } from 'astro:content';
+import { describe, expect, it, vi } from 'vitest';
+import { buildServiceNode } from '../service';
+
+vi.mock('@utils/feature', () => ({
+  isVisualiserEnabled: () => true,
+  isChangelogEnabled: () => false,
+}));
+
+vi.mock('@utils/url-builder', () => ({
+  buildUrl: (path: string) => path,
+}));
+
+vi.mock('@utils/collections/services', () => ({
+  getSpecificationsForService: () => [],
+}));
+
+const service = {
+  id: 'services/ProductApi/index.mdx',
+  slug: 'services/ProductApi',
+  collection: 'services',
+  data: {
+    id: 'ProductApi',
+    name: 'Product API',
+    version: '1.0.0',
+    latestVersion: '1.0.0',
+    owners: [],
+  },
+} as unknown as CollectionEntry<'services'>;
+
+const emptyContext = {
+  services: [],
+  domains: [],
+  events: [],
+  commands: [],
+  queries: [],
+  flows: [],
+  containers: [],
+  dataProducts: [],
+  diagrams: [],
+  adrs: [],
+  resourceDocs: [],
+  resourceDocCategories: [],
+} as any;
+
+describe('buildServiceNode', () => {
+  it('links directly to the resolved service version from Quick Reference', () => {
+    const node = buildServiceNode(service, [], emptyContext);
+    const quickReference = node.pages?.find((page) => typeof page !== 'string' && page.title === 'Quick Reference');
+
+    expect(quickReference && typeof quickReference !== 'string' ? quickReference.pages : []).toContainEqual({
+      type: 'item',
+      title: 'Overview',
+      href: '/docs/services/ProductApi/1.0.0',
+    });
+  });
+});

--- a/packages/core/eventcatalog/src/stores/sidebar-store/builders/domain.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/builders/domain.ts
@@ -81,10 +81,14 @@ export const buildDomainNode = (domain: CollectionEntry<'domains'>, owners: any[
   const sortedReceivesMessages = [...receivesMessages].sort(byResourceName);
   const renderMessages = shouldRenderSideBarSection(domain, 'messages');
 
-  // The Resources page/link only makes sense when the domain actually has resources
-  // attached (services, flows, entities or its own messages). Mirrors what the page renders.
+  // The Resources page/link only makes sense when the domain has direct resources.
+  // Keep this aligned with the resource groups rendered by the page.
   const hasResources =
-    servicesInDomain.length > 0 ||
+    subDomains.length > 0 ||
+    systemsInDomain.length > 0 ||
+    agentsInDomain.length > 0 ||
+    dataProductsInDomain.length > 0 ||
+    allServicesInDomain.length > 0 ||
     domainFlows.length > 0 ||
     entitiesInDomain.length > 0 ||
     sendsMessages.length > 0 ||

--- a/packages/core/eventcatalog/src/stores/sidebar-store/builders/service.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/builders/service.ts
@@ -58,15 +58,13 @@ export const buildServiceNode = (
   const renderEntities = serviceEntities.length > 0 && shouldRenderSideBarSection(service, 'entities');
   const renderOwners = owners.length > 0 && shouldRenderSideBarSection(service, 'owners');
   const renderRepository = service.data.repository && shouldRenderSideBarSection(service, 'repository');
-  const isLatestVersion = service.data.version === service.data.latestVersion;
-  const docsBasePath = `/docs/services/${service.data.id}${isLatestVersion ? '' : `/${service.data.version}`}`;
+  const docsBasePath = `/docs/services/${service.data.id}/${service.data.version}`;
   const docsSection = buildResourceDocsSection(
     'services',
     service.data.id,
     service.data.version,
     context.resourceDocs,
-    context.resourceDocCategories,
-    { includeVersionInUrl: !isLatestVersion }
+    context.resourceDocCategories
   );
 
   // Diagrams

--- a/packages/core/eventcatalog/src/utils/__tests__/domains/domains.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/domains/domains.spec.ts
@@ -8,6 +8,7 @@ import {
   mockUbiquitousLanguages,
   mockDataProducts,
   mockSystems,
+  mockAgents,
 } from './mocks';
 import {
   domainHasEntities,
@@ -38,6 +39,8 @@ vi.mock('astro:content', async (importOriginal) => {
           return Promise.resolve(mockDataProducts);
         case 'systems':
           return Promise.resolve(mockSystems);
+        case 'agents':
+          return Promise.resolve(mockAgents);
         case 'ubiquitousLanguages':
           let result = mockUbiquitousLanguages;
           if (filter) {
@@ -84,6 +87,17 @@ describe('Domains', () => {
       expect(systems[0].data.services).toEqual([
         expect.objectContaining({ data: expect.objectContaining({ id: 'LocationService' }) }),
       ]);
+    });
+
+    it('can keep child-subdomain services and agents off the parent domain', async () => {
+      const domains = await getDomains({ includeServicesInSubdomains: false });
+      const shipping = domains.find((domain) => domain.data.id === 'Shipping');
+      const checkout = (shipping?.data.domains as any[])?.find((domain) => domain.data.id === 'Checkout');
+
+      expect((shipping?.data.services as any[]).map((service) => service.data.id)).toEqual(['LocationService']);
+      expect(shipping?.data.agents).toEqual([]);
+      expect(checkout.data.services.map((service: any) => service.data.id)).toEqual(['OrderService', 'PaymentService']);
+      expect(checkout.data.agents.map((agent: any) => agent.data.id)).toEqual(['FraudReviewAgent']);
     });
   });
 

--- a/packages/core/eventcatalog/src/utils/__tests__/domains/mocks.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/domains/mocks.ts
@@ -24,6 +24,7 @@ export const mockDomains = [
       name: 'Checkout',
       version: '0.0.1',
       services: [{ id: 'OrderService' /* version: latest */ }, { id: 'PaymentService', version: '0.0.1' }],
+      agents: [{ id: 'FraudReviewAgent', version: '1.0.0' }],
       'data-products': [{ id: 'CheckoutAnalytics', version: '1.0.0' }],
     },
   },

--- a/packages/core/eventcatalog/src/utils/__tests__/domains/node-graph.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/domains/node-graph.spec.ts
@@ -126,8 +126,8 @@ describe('Domains NodeGraph', () => {
 
       // 9 original nodes + 2 from data product (ShippingAnalytics + ShippingMetricsCalculated) + agent consumer + agent tool
       expect(nodes.length).toEqual(15);
-      // 8 original edges + 2 from data product (input edge + output edge) + agent consumer edge + agent → tool edge
-      expect(edges.length).toEqual(14);
+      // Attaching the agent directly to the Checkout subdomain adds its remaining relationship edge.
+      expect(edges.length).toEqual(15);
     });
 
     it('does not pull a referenced system (or its services) into the domain resource graph', async () => {

--- a/packages/create-eventcatalog/templates/default/domains/Catalog/index.mdx
+++ b/packages/create-eventcatalog/templates/default/domains/Catalog/index.mdx
@@ -57,9 +57,3 @@ The **Product Catalog System** is the authoritative source of product data. When
 The diagram below shows the domain's systems, how they relate, and the people who interact with them.
 
 <ContextDiagram />
-
-## Component map
-
-These are the components that are part of this domain (parts of the systems in this domain)
-
-<NodeGraph />

--- a/packages/create-eventcatalog/templates/default/eventcatalog.config.js
+++ b/packages/create-eventcatalog/templates/default/eventcatalog.config.js
@@ -23,7 +23,7 @@ export default {
   // Customize the navigation for your docs sidebar.
   // read more at https://eventcatalog.dev/docs/development/customization/customize-sidebars/documentation-sidebar
   navigation: {
-    pages: ['list:top-level-domains', 'list:all'],
+    pages: ['list:top-level-domains', 'list:top-level-diagrams', 'list:all'],
   },
   mermaid: {
     enableSupportForElkLayout: true,
@@ -34,8 +34,12 @@ export default {
     limit: 15,
   },
   visualiser: {
+    enabled: true,
     channels: {
       renderMode: 'flat',
+    },
+    architectureGraph: {
+      enabled: true,
     },
   },
   // Customize the logo, add your logo to public/ folder

--- a/packages/sdk/src/test/fixtures/build-index/default-catalog-index.json
+++ b/packages/sdk/src/test/fixtures/build-index/default-catalog-index.json
@@ -542,7 +542,7 @@
       "version": "1.0.0",
       "name": "Catalog",
       "contentPath": "domains/Catalog/index.mdx",
-      "contentHash": "sha256:73da6896ccad4dc201c8199a89e103cba2e71a2bd2bfc8d16c86d403586fa5f9",
+      "contentHash": "sha256:1cb8e8ddd496e775dcc6d0e0a4eac85cc28066d248599a363d38c44f6c3a5801",
       "owners": ["product-platform"],
       "sidecars": [
         {


### PR DESCRIPTION

## What This PR Does

The Resources page for a domain only listed services, flows, entities, data stores and messages. Domains that hold subdomains, systems, agents or data products showed an incomplete page — or no Resources link at all when those were the only resources attached.

This PR extends the Resources page to cover every resource type that can be directly attached to a domain, and moves the resource-grouping logic into a shared module so the page and the sidebar link agree on when a Resources page exists. It also restores versioned service URLs in the sidebar and evens out sidebar icon sizing.

## Changes Overview

### Key Changes

- Extract resource grouping into `resources/_resources.ts`, shared by the page and its static-path loader.
- Domain resources pages now include subdomains, systems, agents and data products, on top of the existing services, flows, entities, data stores and messages.
- `hasResources` is now derived from the same resource groups the page renders, so the sidebar Resources link and the page can't drift apart.
- `SystemResourcesTable` gains `domains`, `systems`, `agents` and `data-products` types, with labels and filter-pill ordering.
- Sidebar domain builder counts the new resource types when deciding whether to show the Resources link.
- Service sidebar links always include the version again (Overview, Changelog, specs, ADRs, docs).
- Sidebar icons all render at `w-4 h-4`; the per-glyph shrink list is removed.
- Default example catalog and `create-eventcatalog` template: enable the visualiser and architecture graph, add `list:top-level-diagrams` to navigation, drop the duplicate component map from the Catalog domain page.

## How It Works

`getResourceGroups(data, ownerCollection)` returns an ordered list of `{ collection, items }` groups. Domain-only groups (subdomains, systems, agents, data products) are prepended when the owner is a domain; systems get the common groups only. Domain messages are still deduped across `sends` and `receives` by `collection:id:version`.

`hasResources(owner, ownerCollection)` is now just "do any of those groups have items", which is what makes the page and the sidebar link consistent by construction. Both `_index.data.ts` (static paths + SSR lookup) and `index.astro` call into the same functions.

Resources are still only those *directly* attached — a service inside a child system stays on that system's page rather than being flattened up into the parent domain.

## Breaking Changes

None.

## Testing

New unit tests cover the resource grouping and the sidebar builders:

- `resources/_resources.spec.ts` — 6 tests
- `builders/__tests__/domain-builder.spec.ts` — 5 tests
- `builders/__tests__/service-builder.spec.ts` — 1 test

All 41 tests in the affected suites pass.

## Additional Notes

- `sidebar-builder.spec.ts` has ~170 failures on `main` that are unrelated to this PR — verified by stashing these changes and re-running against a clean tree. Worth a separate fix.
- Those failures also require a fresh `@eventcatalog/sdk` build to surface properly; a stale `packages/sdk/dist` makes them appear as `getAdrs is not a function`.
- `buildResourceDocsSection`'s `includeVersionInUrl` option in `builders/shared.ts` no longer has any caller passing it now that service links are always versioned. Left in place; could be removed in a follow-up.
- No corresponding change needed in the `eventcatalog/eventcatalog-editor` repository.