### PR TITLE
fix(core): update js-yaml to 4.3.1

### DIFF
--- a/.changeset/secure-yaks-parse.md
+++ b/.changeset/secure-yaks-parse.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/core': patch
+---
+
+fix(core): update js-yaml to patch denial-of-service vulnerabilities

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -109,7 +109,7 @@
     "gray-matter": "^4.0.3",
     "hono": "4.12.27",
     "html-to-image": "^1.11.11",
-    "js-yaml": "^4.3.0",
+    "js-yaml": "^4.3.1",
     "jsonpath-plus": "^10.4.0",
     "jsonwebtoken": "^9.0.2",
     "lodash.debounce": "^4.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -269,8 +269,8 @@ importers:
         specifier: ^1.11.11
         version: 1.11.13
       js-yaml:
-        specifier: ^4.3.0
-        version: 4.3.0
+        specifier: ^4.3.1
+        version: 4.3.1
       jsonpath-plus:
         specifier: ^10.4.0
         version: 10.4.0
@@ -5809,8 +5809,8 @@ packages:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdom@27.0.0:
@@ -9023,7 +9023,7 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       picomatch: 4.0.4
       retext-smartypants: 6.2.0
       shiki: 4.0.2
@@ -9230,7 +9230,7 @@ snapshots:
       ajv-errors: 3.0.0(ajv@8.17.1)
       ajv-formats: 2.1.1(ajv@8.17.1)
       avsc: 5.7.9
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       jsonpath-plus: 10.4.0
       node-fetch: 2.6.7
     transitivePeerDependencies:
@@ -9548,7 +9548,7 @@ snapshots:
   '@changesets/parse@0.4.2':
     dependencies:
       '@changesets/types': 6.1.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
 
   '@changesets/pre@2.0.2':
     dependencies:
@@ -12631,7 +12631,7 @@ snapshots:
       github-slugger: 2.0.0
       html-escaper: 3.0.3
       http-cache-semantics: 4.2.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       jsonc-parser: 3.3.1
       magic-string: 1.1.0
       magicast: 0.5.2
@@ -14738,7 +14738,7 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
## Motivation

Supersedes #2742 and #2759 with one complete dependency update. `@auth/core` is already at the patched `0.41.3` release on `main`, while `js-yaml` still needed to move from `4.3.0` to the first patched 4.x release, `4.3.1`.

Keeping `js-yaml` on 4.x avoids the breaking CommonJS/ESM migration introduced by 5.x while addressing GHSA-5p4m-2wfm-xmqj.

## Changes

- update `js-yaml` from `^4.3.0` to `^4.3.1`
- regenerate `pnpm-lock.yaml`
- add a patch changeset for `@eventcatalog/core`

## Validation

- `pnpm install --frozen-lockfile --filter @eventcatalog/core`
- `pnpm --filter @eventcatalog/core test --run` — 1,228 tests passed
- `js-yaml 4.3.1` load smoke test
- Prettier and `git diff --check`

`pnpm --filter @eventcatalog/core check` currently reaches an existing generated default-catalog entry and fails because `FraudDetected-0.0.1` contains an unsupported `tags` property. This is unrelated to the dependency update.