### PR TITLE
Add the `eventcatalog federate` CLI command

### DIFF
--- a/.changeset/quiet-falcons-gather.md
+++ b/.changeset/quiet-falcons-gather.md
@@ -1,0 +1,6 @@
+---
+"@eventcatalog/core": patch
+"@eventcatalog/sdk": patch
+---
+
+Add the `eventcatalog federate` CLI command. Reads `federation.sources` from the catalog config, fetches and indexes each configured GitHub source, resolves the combined graph, then hydrates federated content and public assets into the local catalog. Includes a content-addressed cache (`--no-cache` to bypass), pinned source commits in a lockfile, and ownership conflict reporting.

--- a/packages/core/src/__tests__/content-cache.spec.ts
+++ b/packages/core/src/__tests__/content-cache.spec.ts
@@ -1,0 +1,56 @@
+import { createHash } from 'node:crypto';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createFederationContentCache } from '../federation/content-cache';
+
+const hash = (content: Buffer) => `sha256:${createHash('sha256').update(content).digest('hex')}`;
+
+describe('federation content cache', () => {
+  let projectDirectory: string;
+
+  beforeEach(async () => {
+    projectDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'eventcatalog-federation-cache-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(projectDirectory, { recursive: true, force: true });
+  });
+
+  it('stores and returns content by its verified hash', async () => {
+    const onHit = vi.fn();
+    const cache = createFederationContentCache(projectDirectory, { onHit });
+    const content = Buffer.from('# Payment service');
+    const key = hash(content);
+
+    await cache.set(key, content);
+
+    await expect(cache.get(key)).resolves.toEqual(content);
+    expect(onHit).toHaveBeenCalledWith(key);
+    await expect(
+      fs.readFile(path.join(projectDirectory, '.eventcatalog-cache', 'federation', 'content', encodeURIComponent(key)))
+    ).resolves.toEqual(content);
+  });
+
+  it('rejects and removes corrupt cached content', async () => {
+    const cache = createFederationContentCache(projectDirectory);
+    const content = Buffer.from('# Payment service');
+    const key = hash(content);
+    const cachePath = path.join(projectDirectory, '.eventcatalog-cache', 'federation', 'content', encodeURIComponent(key));
+    await fs.mkdir(path.dirname(cachePath), { recursive: true });
+    await fs.writeFile(cachePath, 'corrupt');
+
+    await expect(cache.get(key)).resolves.toBeUndefined();
+    await expect(fs.access(cachePath)).rejects.toThrow();
+  });
+
+  it('ignores unsupported cache keys', async () => {
+    const cache = createFederationContentCache(projectDirectory);
+
+    await cache.set('../unsafe', Buffer.from('content'));
+
+    await expect(cache.get('../unsafe')).resolves.toBeUndefined();
+    await expect(fs.access(path.join(projectDirectory, '.eventcatalog-cache'))).rejects.toThrow();
+  });
+});

--- a/packages/core/src/__tests__/federate.spec.ts
+++ b/packages/core/src/__tests__/federate.spec.ts
@@ -83,9 +83,9 @@ describe('federate catalog', () => {
       fetchContent: vi.fn(async ({ path: artifactPath }) => Buffer.from(`# ${artifactPath}\n`)),
     };
     const progress: FederationProgressEvent[] = [];
-    const centralResource = path.join(projectDirectory, 'services', 'payment-service', 'index.mdx');
+    const centralResource = path.join(projectDirectory, 'services', 'central-service', 'index.mdx');
     await fs.mkdir(path.dirname(centralResource), { recursive: true });
-    await fs.writeFile(centralResource, '---\nid: payment-service\nname: Central payment service\n---\n# Central');
+    await fs.writeFile(centralResource, '---\nid: central-service\nname: Central service\n---\n# Central');
     const previousOutput = path.join(projectDirectory, 'federated', 'old-source', 'services', 'payment-service', 'index.mdx');
     await fs.mkdir(path.dirname(previousOutput), { recursive: true });
     await fs.writeFile(previousOutput, '---\nid: payment-service\nname: Previously hydrated payment service\n---\n# Previous');
@@ -117,6 +117,8 @@ describe('federate catalog', () => {
       'source:complete',
       'source:start',
       'source:complete',
+      'local:start',
+      'local:complete',
       'resolving',
       'resolved',
       'hydrating',
@@ -125,6 +127,8 @@ describe('federate catalog', () => {
       'public:complete',
       'complete',
     ]);
+    expect(progress).toContainEqual({ type: 'local:complete', resources: 1 });
+    expect(progress).toContainEqual({ type: 'resolving', localResources: 1, resources: 2 });
   });
 
   it('composes public assets into the root with main ownership and last-source-wins semantics', async () => {
@@ -300,6 +304,32 @@ describe('federate catalog', () => {
     await expect(fs.readFile(previousOutput, 'utf8')).resolves.toBe('keep me');
     await expect(fs.access(path.join(projectDirectory, 'eventcatalog.lock'))).rejects.toThrow();
     expect(provider.fetchContent).not.toHaveBeenCalled();
+  });
+
+  it('stops before hydration when the main catalog and a source own the same resource', async () => {
+    await writeProject(projectDirectory, [{ id: 'acme/payments', source: 'github:acme/payments' }]);
+    const localResource = path.join(projectDirectory, 'services', 'payment-service', 'index.mdx');
+    await fs.mkdir(path.dirname(localResource), { recursive: true });
+    await fs.writeFile(localResource, '---\nid: payment-service\nname: Local payment service\n---\n# Local');
+
+    const index = sourceIndex('acme/payments', 'payment-service');
+    const provider: FederationSourceProvider = {
+      resolve: vi.fn(async () => ({ bytes: Buffer.from(JSON.stringify(index)), index, commit: index.commit, generated: true })),
+      fetchContent: vi.fn(async ({ path: artifactPath }) => Buffer.from(`# ${artifactPath}\n`)),
+    };
+
+    await expect(federateCatalog(projectDirectory, { provider })).rejects.toMatchObject({
+      conflicts: [
+        {
+          kind: 'duplicate-source',
+          id: 'payment-service',
+          sources: ['acme/payments', 'central-catalog'],
+        },
+      ],
+    });
+    expect(provider.fetchContent).not.toHaveBeenCalled();
+    await expect(fs.access(path.join(projectDirectory, 'federated'))).rejects.toThrow();
+    await expect(fs.access(path.join(projectDirectory, 'eventcatalog.lock'))).rejects.toThrow();
   });
 
   it('reuses unchanged content from the cache on later runs', async () => {

--- a/packages/core/src/__tests__/federate.spec.ts
+++ b/packages/core/src/__tests__/federate.spec.ts
@@ -223,6 +223,63 @@ describe('federate catalog', () => {
     await expect(fs.access(path.join(projectDirectory, 'federated/public'))).rejects.toThrow();
   });
 
+  it('removes resources, public assets, and lock entries when a configured source is removed', async () => {
+    const paymentsSource = { id: 'acme/payments', source: 'github:acme/payments' };
+    await writeProject(projectDirectory, [paymentsSource]);
+    const filesBySource: Record<string, Record<string, Buffer>> = {
+      'acme/payments': { 'public/payments.txt': Buffer.from('payments') },
+    };
+    const index = sourceIndexWithPublicFiles('acme/payments', 'payment-service', filesBySource['acme/payments']);
+    const provider: FederationSourceProvider = {
+      resolve: vi.fn(async () => ({ bytes: Buffer.from(JSON.stringify(index)), index, commit: index.commit, generated: true })),
+      fetchContent: vi.fn(async ({ source, path: artifactPath }) => {
+        if (artifactPath.startsWith('public/')) return filesBySource[source.id][artifactPath];
+        return Buffer.from(`# ${artifactPath}\n`);
+      }),
+    };
+    const removedSourceDirectory = path.join(projectDirectory, 'federated/acme-orders--874229ea429d');
+    await fs.mkdir(removedSourceDirectory, { recursive: true });
+    await fs.writeFile(path.join(removedSourceDirectory, 'old-resource.mdx'), '# Old resource');
+    await fs.mkdir(path.join(projectDirectory, 'public'), { recursive: true });
+    await fs.writeFile(path.join(projectDirectory, 'public/payments.txt'), 'payments');
+    await fs.writeFile(path.join(projectDirectory, 'public/orders.txt'), 'orders');
+    await fs.writeFile(
+      path.join(projectDirectory, 'eventcatalog.lock'),
+      JSON.stringify({
+        lockVersion: 1,
+        sources: [
+          { id: 'acme/orders', digest: hash('orders-index'), commit: 'orders-commit', resolvedAt: '2026-08-11T12:00:00.000Z' },
+          {
+            id: 'acme/payments',
+            digest: hash('payments-index'),
+            commit: 'payments-commit',
+            resolvedAt: '2026-08-11T12:00:00.000Z',
+          },
+        ],
+        publicFiles: {
+          'orders.txt': { source: 'acme/orders', hash: hash('orders') },
+          'payments.txt': { source: 'acme/payments', hash: hash('payments') },
+        },
+      })
+    );
+
+    const result = await federateCatalog(projectDirectory, { provider });
+
+    expect(result).toMatchObject({ sources: 1, resources: 1 });
+    await expect(
+      fs.readFile(path.join(projectDirectory, 'federated/acme-payments--bf264d5186bc/services/payment-service/index.mdx'), 'utf8')
+    ).resolves.toBe('# services/payment-service/index.mdx\n');
+    await expect(fs.access(path.join(projectDirectory, 'federated/acme-orders--874229ea429d'))).rejects.toThrow();
+    await expect(fs.readFile(path.join(projectDirectory, 'public/payments.txt'), 'utf8')).resolves.toBe('payments');
+    await expect(fs.access(path.join(projectDirectory, 'public/orders.txt'))).rejects.toThrow();
+
+    const lock = JSON.parse(await fs.readFile(path.join(projectDirectory, 'eventcatalog.lock'), 'utf8'));
+    expect(lock.sources.map((source: { id: string }) => source.id)).toEqual(['acme/payments']);
+    expect(lock.publicFiles).toEqual({
+      'payments.txt': { source: 'acme/payments', hash: hash('payments') },
+    });
+  });
+
   it('stops before hydration when two sources own the same resource', async () => {
     await writeProject(projectDirectory, [
       { id: 'acme/payments', source: 'github:acme/payments' },
@@ -287,6 +344,56 @@ describe('federate catalog', () => {
     expect(provider.fetchContent).toHaveBeenCalledTimes(2);
     expect(progress).toContainEqual({ type: 'cache:disabled' });
     expect(progress.some((event) => event.type === 'hydrate:cache')).toBe(false);
+  });
+
+  it('cleans previous federation output when the source list becomes empty', async () => {
+    await writeProject(projectDirectory, []);
+    const federatedResource = path.join(projectDirectory, 'federated', 'acme-payments', 'services', 'payments', 'index.mdx');
+    const managedPublicFile = path.join(projectDirectory, 'public', 'icons', 'managed.svg');
+    const editedPublicFile = path.join(projectDirectory, 'public', 'icons', 'edited.svg');
+    const centralPublicFile = path.join(projectDirectory, 'public', 'central.svg');
+    await fs.mkdir(path.dirname(federatedResource), { recursive: true });
+    await fs.mkdir(path.dirname(managedPublicFile), { recursive: true });
+    await fs.writeFile(federatedResource, '# Previously federated');
+    await fs.writeFile(managedPublicFile, 'managed');
+    await fs.writeFile(editedPublicFile, 'edited by the main catalog');
+    await fs.writeFile(centralPublicFile, 'central');
+    await fs.writeFile(
+      path.join(projectDirectory, 'eventcatalog.lock'),
+      JSON.stringify({
+        lockVersion: 1,
+        sources: [
+          {
+            id: 'acme/payments',
+            digest: hash('index'),
+            commit: 'abc123',
+            resolvedAt: '2026-08-11T12:00:00.000Z',
+          },
+        ],
+        publicFiles: {
+          'icons/managed.svg': { source: 'acme/payments', hash: hash('managed') },
+          'icons/edited.svg': { source: 'acme/payments', hash: hash('original generated content') },
+        },
+      })
+    );
+
+    const progress: FederationProgressEvent[] = [];
+    await federateCatalog(projectDirectory, { onProgress: (event) => progress.push(event) });
+
+    await expect(fs.access(path.join(projectDirectory, 'federated'))).rejects.toThrow();
+    await expect(fs.access(managedPublicFile)).rejects.toThrow();
+    await expect(fs.readFile(editedPublicFile, 'utf8')).resolves.toBe('edited by the main catalog');
+    await expect(fs.readFile(centralPublicFile, 'utf8')).resolves.toBe('central');
+
+    const lock = await fs
+      .readFile(path.join(projectDirectory, 'eventcatalog.lock'), 'utf8')
+      .then((contents) => JSON.parse(contents))
+      .catch((error: NodeJS.ErrnoException) => {
+        if (error.code === 'ENOENT') return undefined;
+        throw error;
+      });
+    if (lock) expect(lock).toMatchObject({ sources: [], publicFiles: {} });
+    expect(progress).toContainEqual({ type: 'cleanup:complete', federated: true, publicFiles: 1, lock: true });
   });
 
   it('does nothing when federation has no configured sources', async () => {

--- a/packages/core/src/__tests__/federate.spec.ts
+++ b/packages/core/src/__tests__/federate.spec.ts
@@ -1,0 +1,299 @@
+import { createHash } from 'node:crypto';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Index } from '@eventcatalog/sdk';
+import { federateCatalog, FederationConflictError, type FederationProgressEvent } from '../federation/federate';
+import type { FederationSourceProvider } from '../federation/types';
+
+const sourceIndex = (source: string, resourceId: string): Index => {
+  const contentPath = `services/${resourceId}/index.mdx`;
+  const content = Buffer.from(`# ${contentPath}\n`);
+  return {
+    indexVersion: 1,
+    source,
+    commit: `${source}-commit`,
+    resources: [
+      {
+        type: 'service',
+        id: resourceId,
+        name: resourceId,
+        contentPath,
+        contentHash: `sha256:${createHash('sha256').update(content).digest('hex')}`,
+      },
+    ],
+  };
+};
+
+const sourceIndexWithPublicFiles = (source: string, resourceId: string, files: Record<string, Buffer>): Index => ({
+  ...sourceIndex(source, resourceId),
+  assets: Object.entries(files).map(([assetPath, content]) => ({
+    path: assetPath,
+    hash: `sha256:${createHash('sha256').update(content).digest('hex')}`,
+  })),
+});
+
+const hash = (content: Buffer | string) => `sha256:${createHash('sha256').update(content).digest('hex')}`;
+
+const writeProject = async (projectDirectory: string, sources: unknown[]) => {
+  await fs.writeFile(path.join(projectDirectory, 'package.json'), JSON.stringify({ type: 'module' }));
+  await fs.writeFile(
+    path.join(projectDirectory, 'eventcatalog.config.js'),
+    `export default ${JSON.stringify({ cId: 'central-catalog', federation: { sources } }, null, 2)};\n`
+  );
+};
+
+const listFiles = async (directory: string, relativeDirectory = ''): Promise<string[]> => {
+  const entries = await fs.readdir(path.join(directory, relativeDirectory), { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const relativePath = path.join(relativeDirectory, entry.name);
+      return entry.isDirectory() ? listFiles(directory, relativePath) : [relativePath.split(path.sep).join('/')];
+    })
+  );
+  return files.flat().sort();
+};
+
+describe('federate catalog', () => {
+  let projectDirectory: string;
+
+  beforeEach(async () => {
+    projectDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'eventcatalog-federate-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(projectDirectory, { recursive: true, force: true });
+  });
+
+  it('resolves only configured sources, hydrates, locks, and reports progress', async () => {
+    await writeProject(projectDirectory, [
+      { id: 'acme/payments', source: 'github:acme/catalogs', path: 'payments', mode: 'hydrate' },
+      { id: 'acme/orders', source: 'github:acme/catalogs', path: 'orders', mode: 'hydrate' },
+    ]);
+    const indexes = {
+      'acme/payments': sourceIndex('acme/payments', 'payment-service'),
+      'acme/orders': sourceIndex('acme/orders', 'order-service'),
+    };
+    const provider: FederationSourceProvider = {
+      resolve: vi.fn(async (source) => {
+        const index = indexes[source.id as keyof typeof indexes];
+        return { bytes: Buffer.from(JSON.stringify(index)), index, commit: index.commit, generated: true };
+      }),
+      fetchContent: vi.fn(async ({ path: artifactPath }) => Buffer.from(`# ${artifactPath}\n`)),
+    };
+    const progress: FederationProgressEvent[] = [];
+    const centralResource = path.join(projectDirectory, 'services', 'payment-service', 'index.mdx');
+    await fs.mkdir(path.dirname(centralResource), { recursive: true });
+    await fs.writeFile(centralResource, '---\nid: payment-service\nname: Central payment service\n---\n# Central');
+    const previousOutput = path.join(projectDirectory, 'federated', 'old-source', 'services', 'payment-service', 'index.mdx');
+    await fs.mkdir(path.dirname(previousOutput), { recursive: true });
+    await fs.writeFile(previousOutput, '---\nid: payment-service\nname: Previously hydrated payment service\n---\n# Previous');
+
+    const result = await federateCatalog(projectDirectory, {
+      provider,
+      now: () => new Date('2026-08-11T12:00:00.000Z'),
+      onProgress: (event) => progress.push(event),
+    });
+
+    expect(result).toMatchObject({ sources: 2, resources: 2, hydrate: { fetched: 2, written: 2, referenced: 0 } });
+    expect(result?.graph.conflicts).toEqual([]);
+    expect(result?.graph.entities.map((entity) => entity.resolvedFrom.source).sort()).toEqual(['acme/orders', 'acme/payments']);
+    expect(await listFiles(path.join(projectDirectory, 'federated'))).toEqual([
+      'acme-orders--874229ea429d/services/order-service/index.mdx',
+      'acme-payments--bf264d5186bc/services/payment-service/index.mdx',
+    ]);
+    expect(JSON.parse(await fs.readFile(path.join(projectDirectory, 'eventcatalog.lock'), 'utf8'))).toEqual({
+      lockVersion: 1,
+      sources: [
+        expect.objectContaining({ id: 'acme/orders', commit: 'acme/orders-commit', resolvedAt: '2026-08-11T12:00:00.000Z' }),
+        expect.objectContaining({ id: 'acme/payments', commit: 'acme/payments-commit', resolvedAt: '2026-08-11T12:00:00.000Z' }),
+      ],
+      publicFiles: {},
+    });
+    expect(progress.map((event) => event.type)).toEqual([
+      'configured',
+      'source:start',
+      'source:complete',
+      'source:start',
+      'source:complete',
+      'resolving',
+      'resolved',
+      'hydrating',
+      'hydrate:file',
+      'hydrate:file',
+      'public:complete',
+      'complete',
+    ]);
+  });
+
+  it('composes public assets into the root with main ownership and last-source-wins semantics', async () => {
+    await writeProject(projectDirectory, [
+      { id: 'acme/first', source: 'github:acme/first' },
+      { id: 'acme/last', source: 'github:acme/last' },
+    ]);
+    const filesBySource: Record<string, Record<string, Buffer>> = {
+      'acme/first': {
+        'public/first.txt': Buffer.from('first source'),
+        'public/main.txt': Buffer.from('remote main'),
+        'public/shared.txt': Buffer.from('first shared'),
+      },
+      'acme/last': {
+        'public/last.txt': Buffer.from('last source'),
+        'public/shared.txt': Buffer.from('last shared'),
+      },
+    };
+    const indexes = {
+      'acme/first': sourceIndexWithPublicFiles('acme/first', 'first-service', filesBySource['acme/first']),
+      'acme/last': sourceIndexWithPublicFiles('acme/last', 'last-service', filesBySource['acme/last']),
+    };
+    const provider: FederationSourceProvider = {
+      resolve: vi.fn(async (source) => {
+        const index = indexes[source.id as keyof typeof indexes];
+        return { bytes: Buffer.from(JSON.stringify(index)), index, commit: index.commit, generated: true };
+      }),
+      fetchContent: vi.fn(async ({ source, path: artifactPath }) => {
+        if (artifactPath.startsWith('public/')) return filesBySource[source.id][artifactPath];
+        return Buffer.from(`# ${artifactPath}\n`);
+      }),
+    };
+    await fs.mkdir(path.join(projectDirectory, 'public'), { recursive: true });
+    await fs.writeFile(path.join(projectDirectory, 'public/main.txt'), 'main catalog');
+
+    const result = await federateCatalog(projectDirectory, { provider });
+
+    expect(result?.public).toEqual({ copied: 3, skipped: 1, overwritten: 1, removed: 0, files: expect.any(Object) });
+    await expect(fs.readFile(path.join(projectDirectory, 'public/main.txt'), 'utf8')).resolves.toBe('main catalog');
+    await expect(fs.readFile(path.join(projectDirectory, 'public/first.txt'), 'utf8')).resolves.toBe('first source');
+    await expect(fs.readFile(path.join(projectDirectory, 'public/last.txt'), 'utf8')).resolves.toBe('last source');
+    await expect(fs.readFile(path.join(projectDirectory, 'public/shared.txt'), 'utf8')).resolves.toBe('last shared');
+    await expect(fs.access(path.join(projectDirectory, 'federated/public'))).rejects.toThrow();
+    expect(result?.graph.warnings).toContainEqual({
+      kind: 'asset-collision',
+      path: 'public/shared.txt',
+      sources: ['acme/first', 'acme/last'],
+      winner: 'acme/last',
+    });
+
+    const lock = JSON.parse(await fs.readFile(path.join(projectDirectory, 'eventcatalog.lock'), 'utf8'));
+    expect(lock.publicFiles).toEqual({
+      'first.txt': { source: 'acme/first', hash: hash('first source') },
+      'last.txt': { source: 'acme/last', hash: hash('last source') },
+      'shared.txt': { source: 'acme/last', hash: hash('last shared') },
+    });
+  });
+
+  it('updates managed public assets, removes stale ones, and preserves manually edited files', async () => {
+    await writeProject(projectDirectory, [{ id: 'acme/payments', source: 'github:acme/payments' }]);
+    let files: Record<string, Buffer> = {
+      'public/manual.txt': Buffer.from('generated manual'),
+      'public/remove.txt': Buffer.from('remove me'),
+      'public/update.txt': Buffer.from('first version'),
+    };
+    let index = sourceIndexWithPublicFiles('acme/payments', 'payment-service', files);
+    const provider: FederationSourceProvider = {
+      resolve: vi.fn(async () => ({ bytes: Buffer.from(JSON.stringify(index)), index, commit: index.commit, generated: true })),
+      fetchContent: vi.fn(async ({ path: artifactPath }) =>
+        artifactPath.startsWith('public/') ? files[artifactPath] : Buffer.from(`# ${artifactPath}\n`)
+      ),
+    };
+
+    await federateCatalog(projectDirectory, { provider });
+    await fs.writeFile(path.join(projectDirectory, 'public/manual.txt'), 'main catalog edit');
+    files = {
+      'public/manual.txt': Buffer.from('new generated manual'),
+      'public/update.txt': Buffer.from('second version'),
+    };
+    index = sourceIndexWithPublicFiles('acme/payments', 'payment-service', files);
+
+    const result = await federateCatalog(projectDirectory, { provider });
+
+    expect(result?.public).toEqual({
+      copied: 1,
+      skipped: 1,
+      overwritten: 0,
+      removed: 1,
+      files: {
+        'update.txt': { source: 'acme/payments', hash: hash('second version') },
+      },
+    });
+    await expect(fs.readFile(path.join(projectDirectory, 'public/manual.txt'), 'utf8')).resolves.toBe('main catalog edit');
+    await expect(fs.readFile(path.join(projectDirectory, 'public/update.txt'), 'utf8')).resolves.toBe('second version');
+    await expect(fs.access(path.join(projectDirectory, 'public/remove.txt'))).rejects.toThrow();
+    await expect(fs.access(path.join(projectDirectory, 'federated/public'))).rejects.toThrow();
+  });
+
+  it('stops before hydration when two sources own the same resource', async () => {
+    await writeProject(projectDirectory, [
+      { id: 'acme/payments', source: 'github:acme/payments' },
+      { id: 'acme/orders', source: 'github:acme/orders' },
+    ]);
+    const provider: FederationSourceProvider = {
+      resolve: vi.fn(async (source) => {
+        const index = sourceIndex(source.id, 'shared-service');
+        return { bytes: Buffer.from(JSON.stringify(index)), index, commit: index.commit, generated: true };
+      }),
+      fetchContent: vi.fn(),
+    };
+    const previousOutput = path.join(projectDirectory, 'federated', 'previous.txt');
+    await fs.mkdir(path.dirname(previousOutput), { recursive: true });
+    await fs.writeFile(previousOutput, 'keep me');
+
+    await expect(federateCatalog(projectDirectory, { provider })).rejects.toBeInstanceOf(FederationConflictError);
+    await expect(fs.readFile(previousOutput, 'utf8')).resolves.toBe('keep me');
+    await expect(fs.access(path.join(projectDirectory, 'eventcatalog.lock'))).rejects.toThrow();
+    expect(provider.fetchContent).not.toHaveBeenCalled();
+  });
+
+  it('reuses unchanged content from the cache on later runs', async () => {
+    await writeProject(projectDirectory, [{ id: 'acme/payments', source: 'github:acme/payments' }]);
+    const index = sourceIndex('acme/payments', 'payment-service');
+    const provider: FederationSourceProvider = {
+      resolve: vi.fn(async () => ({ bytes: Buffer.from(JSON.stringify(index)), index, commit: index.commit, generated: true })),
+      fetchContent: vi.fn(async ({ path: artifactPath }) => Buffer.from(`# ${artifactPath}\n`)),
+    };
+
+    await expect(federateCatalog(projectDirectory, { provider })).resolves.toMatchObject({
+      hydrate: { fetched: 1, written: 1 },
+    });
+
+    const progress: FederationProgressEvent[] = [];
+    await expect(
+      federateCatalog(projectDirectory, { provider, onProgress: (event) => progress.push(event) })
+    ).resolves.toMatchObject({ hydrate: { fetched: 0, written: 1 } });
+
+    expect(provider.fetchContent).toHaveBeenCalledTimes(1);
+    expect(progress).toContainEqual({ type: 'hydrate:cache', files: 1 });
+  });
+
+  it('downloads and refreshes content when cache reads are disabled', async () => {
+    await writeProject(projectDirectory, [{ id: 'acme/payments', source: 'github:acme/payments' }]);
+    const index = sourceIndex('acme/payments', 'payment-service');
+    const provider: FederationSourceProvider = {
+      resolve: vi.fn(async () => ({ bytes: Buffer.from(JSON.stringify(index)), index, commit: index.commit, generated: true })),
+      fetchContent: vi.fn(async ({ path: artifactPath }) => Buffer.from(`# ${artifactPath}\n`)),
+    };
+    await federateCatalog(projectDirectory, { provider });
+    const progress: FederationProgressEvent[] = [];
+
+    await expect(
+      federateCatalog(projectDirectory, {
+        provider,
+        useCache: false,
+        onProgress: (event) => progress.push(event),
+      })
+    ).resolves.toMatchObject({ hydrate: { fetched: 1, written: 1 } });
+
+    expect(provider.fetchContent).toHaveBeenCalledTimes(2);
+    expect(progress).toContainEqual({ type: 'cache:disabled' });
+    expect(progress.some((event) => event.type === 'hydrate:cache')).toBe(false);
+  });
+
+  it('does nothing when federation has no configured sources', async () => {
+    await writeProject(projectDirectory, []);
+    const progress: FederationProgressEvent[] = [];
+
+    await expect(federateCatalog(projectDirectory, { onProgress: (event) => progress.push(event) })).resolves.toBeNull();
+    expect(progress).toEqual([{ type: 'configured', sources: 0 }]);
+  });
+});

--- a/packages/core/src/__tests__/federate.spec.ts
+++ b/packages/core/src/__tests__/federate.spec.ts
@@ -408,7 +408,11 @@ describe('federate catalog', () => {
     );
 
     const progress: FederationProgressEvent[] = [];
-    await federateCatalog(projectDirectory, { onProgress: (event) => progress.push(event) });
+    const isFederationEnabled = vi.fn(async () => false);
+    await federateCatalog(projectDirectory, {
+      isFederationEnabled,
+      onProgress: (event) => progress.push(event),
+    });
 
     await expect(fs.access(path.join(projectDirectory, 'federated'))).rejects.toThrow();
     await expect(fs.access(managedPublicFile)).rejects.toThrow();
@@ -424,6 +428,24 @@ describe('federate catalog', () => {
       });
     if (lock) expect(lock).toMatchObject({ sources: [], publicFiles: {} });
     expect(progress).toContainEqual({ type: 'cleanup:complete', federated: true, publicFiles: 1, lock: true });
+    expect(isFederationEnabled).not.toHaveBeenCalled();
+  });
+
+  it('checks entitlement before resolving configured sources', async () => {
+    await writeProject(projectDirectory, [{ id: 'acme/payments', source: 'github:acme/payments' }]);
+    const provider: FederationSourceProvider = {
+      resolve: vi.fn(),
+      fetchContent: vi.fn(),
+    };
+    const isFederationEnabled = vi.fn(async () => false);
+
+    await expect(federateCatalog(projectDirectory, { provider, isFederationEnabled })).rejects.toThrow(
+      'EventCatalog federation is an Enterprise feature'
+    );
+
+    expect(isFederationEnabled).toHaveBeenCalledOnce();
+    expect(provider.resolve).not.toHaveBeenCalled();
+    expect(provider.fetchContent).not.toHaveBeenCalled();
   });
 
   it('does nothing when federation has no configured sources', async () => {

--- a/packages/core/src/__tests__/github-source-provider.spec.ts
+++ b/packages/core/src/__tests__/github-source-provider.spec.ts
@@ -19,7 +19,7 @@ describe('GitHub federation source provider', () => {
     };
     const fetcher = vi.fn(async () => response(200, JSON.stringify(index)));
     const checkout = vi.fn();
-    const provider = createGitHubSourceProvider({ fetch: fetcher, checkout });
+    const provider = createGitHubSourceProvider({ fetch: fetcher, checkout, token: '' });
 
     await expect(
       provider.resolve({
@@ -38,7 +38,7 @@ describe('GitHub federation source provider', () => {
 
   it('fetches hydrated content from the pinned commit and catalog path', async () => {
     const fetcher = vi.fn(async () => response(200, '# Payment service'));
-    const provider = createGitHubSourceProvider({ fetch: fetcher });
+    const provider = createGitHubSourceProvider({ fetch: fetcher, token: '' });
 
     await expect(
       provider.fetchContent({
@@ -53,8 +53,90 @@ describe('GitHub federation source provider', () => {
     );
   });
 
+  it('uses an authenticated GitHub API request to load a private catalog index', async () => {
+    const index: Index = {
+      indexVersion: 1,
+      source: 'acme/payments',
+      commit: 'abc123',
+      resources: [],
+    };
+    const fetcher = vi.fn(async () => response(200, JSON.stringify(index)));
+    vi.stubEnv('EVENTCATALOG_GITHUB_TOKEN', 'github-token');
+
+    try {
+      const provider = createGitHubSourceProvider({ fetch: fetcher });
+
+      await provider.resolve({
+        id: 'acme/payments',
+        source: 'github:acme/catalogs',
+        path: 'teams/payments',
+        ref: 'production',
+      });
+
+      expect(fetcher).toHaveBeenCalledWith(
+        'https://api.github.com/repos/acme/catalogs/contents/teams/payments/catalog.index.json?ref=production',
+        {
+          headers: {
+            Accept: 'application/vnd.github.raw+json',
+            Authorization: 'Bearer github-token',
+            'X-GitHub-Api-Version': '2026-03-10',
+          },
+        }
+      );
+      expect(fetcher.mock.calls[0][0]).not.toContain('github-token');
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it('uses an authenticated GitHub API request to fetch private catalog content', async () => {
+    const fetcher = vi.fn(async () => response(200, '# Payment service'));
+    const provider = createGitHubSourceProvider({ fetch: fetcher, token: 'github-token' });
+
+    await provider.fetchContent({
+      source: { id: 'acme/payments', source: 'github:acme/catalogs', path: 'teams/payments' },
+      commit: 'abc123',
+      path: 'services/payment/index.mdx',
+    });
+
+    expect(fetcher).toHaveBeenCalledWith(
+      'https://api.github.com/repos/acme/catalogs/contents/teams/payments/services/payment/index.mdx?ref=abc123',
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer github-token' }),
+      })
+    );
+  });
+
+  it('authenticates the git checkout fallback without putting the token in the remote URL or arguments', async () => {
+    const fetcher = vi.fn(async () => response(404));
+    const executeFile = vi.fn(async (_file: string, args: string[]) => ({
+      stdout: args[0] === 'rev-parse' ? 'abc123\n' : '',
+      stderr: '',
+    }));
+    const provider = createGitHubSourceProvider({ fetch: fetcher, execFile: executeFile, token: 'github-token' });
+
+    await expect(provider.resolve({ id: 'acme/payments', source: 'github:acme/catalogs' })).resolves.toMatchObject({
+      commit: 'abc123',
+      generated: true,
+    });
+
+    const fetchCall = executeFile.mock.calls.find(([, args]) => args[0] === 'fetch');
+    const gitEnvironment = fetchCall?.[2].env;
+    const authConfigIndex = Number(gitEnvironment?.GIT_CONFIG_COUNT) - 1;
+    expect(gitEnvironment?.[`GIT_CONFIG_KEY_${authConfigIndex}`]).toBe('http.https://github.com/.extraheader');
+    expect(gitEnvironment?.[`GIT_CONFIG_VALUE_${authConfigIndex}`]).toBe(
+      `AUTHORIZATION: basic ${Buffer.from('x-access-token:github-token').toString('base64')}`
+    );
+    expect(executeFile.mock.calls.flatMap(([, args]) => args).join(' ')).not.toContain('github-token');
+    expect(executeFile).toHaveBeenCalledWith(
+      'git',
+      ['remote', 'add', 'origin', 'https://github.com/acme/catalogs.git'],
+      expect.any(Object)
+    );
+  });
+
   it('rejects catalog paths that escape the source repository', async () => {
-    const provider = createGitHubSourceProvider({ fetch: vi.fn() });
+    const provider = createGitHubSourceProvider({ fetch: vi.fn(), token: '' });
 
     await expect(provider.resolve({ id: 'acme/payments', source: 'github:acme/catalogs', path: '../payments' })).rejects.toThrow(
       'escapes source'

--- a/packages/core/src/__tests__/github-source-provider.spec.ts
+++ b/packages/core/src/__tests__/github-source-provider.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Index } from '@eventcatalog/sdk';
+import { createGitHubSourceProvider } from '../federation/github-source-provider';
+
+const response = (status: number, body = '') => ({
+  status,
+  statusText: status === 200 ? 'OK' : 'Not Found',
+  ok: status >= 200 && status < 300,
+  arrayBuffer: async () => Buffer.from(body),
+});
+
+describe('GitHub federation source provider', () => {
+  it('loads a published index from the configured catalog path', async () => {
+    const index: Index = {
+      indexVersion: 1,
+      source: 'acme/payments',
+      commit: 'abc123',
+      resources: [],
+    };
+    const fetcher = vi.fn(async () => response(200, JSON.stringify(index)));
+    const checkout = vi.fn();
+    const provider = createGitHubSourceProvider({ fetch: fetcher, checkout });
+
+    await expect(
+      provider.resolve({
+        id: 'acme/payments',
+        source: 'github:acme/catalogs',
+        path: 'teams/payments',
+        ref: 'production',
+      })
+    ).resolves.toMatchObject({ index, commit: 'abc123', generated: false });
+
+    expect(fetcher).toHaveBeenCalledWith(
+      'https://raw.githubusercontent.com/acme/catalogs/production/teams/payments/catalog.index.json'
+    );
+    expect(checkout).not.toHaveBeenCalled();
+  });
+
+  it('fetches hydrated content from the pinned commit and catalog path', async () => {
+    const fetcher = vi.fn(async () => response(200, '# Payment service'));
+    const provider = createGitHubSourceProvider({ fetch: fetcher });
+
+    await expect(
+      provider.fetchContent({
+        source: { id: 'acme/payments', source: 'github:acme/catalogs', path: 'teams/payments' },
+        commit: 'abc123',
+        path: 'services/payment/index.mdx',
+      })
+    ).resolves.toEqual(Buffer.from('# Payment service'));
+
+    expect(fetcher).toHaveBeenCalledWith(
+      'https://raw.githubusercontent.com/acme/catalogs/abc123/teams/payments/services/payment/index.mdx'
+    );
+  });
+
+  it('rejects catalog paths that escape the source repository', async () => {
+    const provider = createGitHubSourceProvider({ fetch: vi.fn() });
+
+    await expect(provider.resolve({ id: 'acme/payments', source: 'github:acme/catalogs', path: '../payments' })).rejects.toThrow(
+      'escapes source'
+    );
+  });
+});

--- a/packages/core/src/__tests__/github-source-provider.spec.ts
+++ b/packages/core/src/__tests__/github-source-provider.spec.ts
@@ -1,3 +1,5 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import type { Index } from '@eventcatalog/sdk';
 import { createGitHubSourceProvider } from '../federation/github-source-provider';
@@ -107,17 +109,22 @@ describe('GitHub federation source provider', () => {
     );
   });
 
-  it('authenticates the git checkout fallback without putting the token in the remote URL or arguments', async () => {
+  it('fully checks out a root catalog and authenticates without putting the token in the URL or arguments', async () => {
     const fetcher = vi.fn(async () => response(404));
-    const executeFile = vi.fn(async (_file: string, args: string[]) => ({
-      stdout: args[0] === 'rev-parse' ? 'abc123\n' : '',
-      stderr: '',
-    }));
+    const executeFile = vi.fn(async (_file: string, args: string[], options: { cwd: string }) => {
+      if (args[0] === 'checkout') {
+        const service = path.join(options.cwd, 'services/payment-service/index.mdx');
+        await fs.mkdir(path.dirname(service), { recursive: true });
+        await fs.writeFile(service, '---\nid: payment-service\nname: Payment service\n---\n# Payment service');
+      }
+      return { stdout: args[0] === 'rev-parse' ? 'abc123\n' : '', stderr: '' };
+    });
     const provider = createGitHubSourceProvider({ fetch: fetcher, execFile: executeFile, token: 'github-token' });
 
     await expect(provider.resolve({ id: 'acme/payments', source: 'github:acme/catalogs' })).resolves.toMatchObject({
       commit: 'abc123',
       generated: true,
+      index: { resources: [expect.objectContaining({ id: 'payment-service' })] },
     });
 
     const fetchCall = executeFile.mock.calls.find(([, args]) => args[0] === 'fetch');
@@ -133,6 +140,29 @@ describe('GitHub federation source provider', () => {
       ['remote', 'add', 'origin', 'https://github.com/acme/catalogs.git'],
       expect.any(Object)
     );
+    expect(executeFile.mock.calls.some(([, args]) => args[0] === 'sparse-checkout')).toBe(false);
+  });
+
+  it('uses sparse checkout when the catalog is in a repository subdirectory', async () => {
+    const fetcher = vi.fn(async () => response(404));
+    const executeFile = vi.fn(async (_file: string, args: string[], options: { cwd: string }) => {
+      if (args[0] === 'checkout') {
+        const service = path.join(options.cwd, 'catalogs/payments/services/payment-service/index.mdx');
+        await fs.mkdir(path.dirname(service), { recursive: true });
+        await fs.writeFile(service, '---\nid: payment-service\nname: Payment service\n---\n# Payment service');
+      }
+      return { stdout: args[0] === 'rev-parse' ? 'abc123\n' : '', stderr: '' };
+    });
+    const provider = createGitHubSourceProvider({ fetch: fetcher, execFile: executeFile, token: '' });
+
+    await expect(
+      provider.resolve({ id: 'acme/payments', source: 'github:acme/catalogs', path: 'catalogs/payments' })
+    ).resolves.toMatchObject({
+      index: { resources: [expect.objectContaining({ id: 'payment-service' })] },
+    });
+
+    expect(executeFile).toHaveBeenCalledWith('git', ['sparse-checkout', 'init', '--cone'], expect.any(Object));
+    expect(executeFile).toHaveBeenCalledWith('git', ['sparse-checkout', 'set', 'catalogs/payments'], expect.any(Object));
   });
 
   it('rejects catalog paths that escape the source repository', async () => {

--- a/packages/core/src/eventcatalog.config.ts
+++ b/packages/core/src/eventcatalog.config.ts
@@ -86,6 +86,23 @@ type VerticalNavigationGroupConfig = {
 
 type GeneratorConfig = string | Record<string, unknown> | [string, Record<string, unknown>];
 
+export type FederationSourceConfig = {
+  /** Stable source id used by the lockfile and federation graph. */
+  id: string;
+  /** Source locator, for example github:acme/payments. */
+  source: string;
+  /** Directory containing the source catalog. @default '.' */
+  path?: string;
+  /** Branch or tag to federate. @default 'main' */
+  ref?: string;
+  /** Materialize source files or retain graph references only. @default 'hydrate' */
+  mode?: 'hydrate' | 'reference';
+};
+
+type FederationConfig = {
+  sources: FederationSourceConfig[];
+};
+
 type DirectoryEntry = {
   id: string;
   markdown?: string;
@@ -409,4 +426,6 @@ export interface Config {
   integrations?: IntegrationsConfig;
   scalarConfiguration?: ScalarConfiguration;
   generators?: GeneratorConfig[];
+  /** Catalogs composed into this catalog by `eventcatalog federate`. */
+  federation?: FederationConfig;
 }

--- a/packages/core/src/eventcatalog.ts
+++ b/packages/core/src/eventcatalog.ts
@@ -744,8 +744,20 @@ const reportFederationProgress = (event: FederationProgressEvent) => {
         'federation'
       );
       return;
+    case 'local:start':
+      logger.info('Indexing central catalog ownership...', 'federation');
+      return;
+    case 'local:complete':
+      logger.success(
+        `Central catalog: ${event.resources} local resource${event.resources === 1 ? '' : 's'} found (excluding federated/)`,
+        'federation'
+      );
+      return;
     case 'resolving':
-      logger.info(`Resolving ${event.resources} resources across catalog boundaries...`, 'federation');
+      logger.info(
+        `Validating ownership across ${event.localResources} local resource${event.localResources === 1 ? '' : 's'} and ${event.resources} remote resource${event.resources === 1 ? '' : 's'}...`,
+        'federation'
+      );
       return;
     case 'resolved':
       if (event.graph.conflicts.length > 0) {
@@ -762,7 +774,7 @@ const reportFederationProgress = (event: FederationProgressEvent) => {
         return;
       }
       logger.success(
-        `Graph resolved: ${event.graph.entities.length} resources, ${event.graph.edges.length} relationships`,
+        `Graph resolved: ${event.graph.entities.length} remote resources, ${event.graph.edges.length} relationships`,
         'federation'
       );
       if (event.graph.warnings.length > 0) {

--- a/packages/core/src/eventcatalog.ts
+++ b/packages/core/src/eventcatalog.ts
@@ -836,15 +836,10 @@ program
     }
 
     logger.info('Starting federation...', 'federation');
-    if (!(await isEventCatalogScaleEnabled())) {
-      throw new Error(
-        'Cannot federate catalogs: EventCatalog federation is an Enterprise feature. Visit https://www.eventcatalog.dev/pricing to enable federation.'
-      );
-    }
-
     let cleanedPreviousOutput = false;
     const result = await federateCatalog(dir, {
       useCache: commandOptions.cache,
+      isFederationEnabled: isEventCatalogScaleEnabled,
       onProgress: (event) => {
         if (event.type === 'cleanup:complete') cleanedPreviousOutput = true;
         reportFederationProgress(event);

--- a/packages/core/src/eventcatalog.ts
+++ b/packages/core/src/eventcatalog.ts
@@ -22,6 +22,7 @@ import { buildFieldsIndex } from '../eventcatalog/src/enterprise/fields/field-in
 import { buildSearchIndex } from './search-indexer';
 import { linkCoreNodeModules, resolveInstalledCoreNodeModules } from './core-node-modules';
 import { createAstroDevLineFilter, createAstroLineFilter } from './astro-output';
+import { federateCatalog, FederationConflictError, type FederationProgressEvent } from './federation/federate';
 const currentDir = path.dirname(fileURLToPath(import.meta.url));
 const program = new Command().version(VERSION);
 
@@ -715,6 +716,119 @@ program
     await generate(dir);
   });
 
+const reportFederationProgress = (event: FederationProgressEvent) => {
+  switch (event.type) {
+    case 'configured':
+      if (event.sources > 0)
+        logger.info(`Found ${event.sources} configured source${event.sources === 1 ? '' : 's'}`, 'federation');
+      return;
+    case 'cache:disabled':
+      logger.info('Content cache disabled; all federated files will be downloaded.', 'federation');
+      return;
+    case 'source:start':
+      logger.info(`[${event.current}/${event.total}] Fetching and indexing ${event.source.id}...`, 'federation');
+      return;
+    case 'source:complete':
+      logger.success(
+        `[${event.current}/${event.total}] ${event.source.id}: ${event.resources} resources at ${event.commit.slice(0, 7)}${
+          event.generated ? ' (index generated)' : ' (published index)'
+        }`,
+        'federation'
+      );
+      return;
+    case 'resolving':
+      logger.info(`Resolving ${event.resources} resources across catalog boundaries...`, 'federation');
+      return;
+    case 'resolved':
+      if (event.graph.conflicts.length > 0) {
+        logger.error(
+          `${event.graph.conflicts.length} ownership conflict${event.graph.conflicts.length === 1 ? '' : 's'} found`,
+          'federation'
+        );
+        for (const conflict of event.graph.conflicts.slice(0, 10)) {
+          logger.error(`${conflict.id}: ${conflict.sources.join(', ')}`, 'federation');
+        }
+        if (event.graph.conflicts.length > 10) {
+          logger.error(`...and ${event.graph.conflicts.length - 10} more`, 'federation');
+        }
+        return;
+      }
+      logger.success(
+        `Graph resolved: ${event.graph.entities.length} resources, ${event.graph.edges.length} relationships`,
+        'federation'
+      );
+      if (event.graph.warnings.length > 0) {
+        logger.warning(
+          `${event.graph.warnings.length} federation warning${event.graph.warnings.length === 1 ? '' : 's'}`,
+          'federation'
+        );
+      }
+      if (event.graph.externals.length > 0) {
+        logger.warning(
+          `${event.graph.externals.length} reference${event.graph.externals.length === 1 ? '' : 's'} remain external`,
+          'federation'
+        );
+      }
+      return;
+    case 'hydrating':
+      logger.info(`Hydrating federated content into ${path.relative(dir, event.outDir)}/...`, 'federation');
+      return;
+    case 'hydrate:cache':
+      if (event.files === 1 || event.files % 25 === 0) {
+        logger.info(`Reused ${event.files} cached file${event.files === 1 ? '' : 's'}...`, 'federation');
+      }
+      return;
+    case 'hydrate:file':
+      if (event.files === 1 || event.files % 25 === 0) {
+        logger.info(`Fetched ${event.files} federated file${event.files === 1 ? '' : 's'}...`, 'federation');
+      }
+      return;
+    case 'public:complete':
+      logger.success(
+        `Public assets: ${event.result.copied} copied, ${event.result.skipped} preserved from the main catalog, ${event.result.removed} stale removed`,
+        'federation'
+      );
+      if (event.result.overwritten > 0) {
+        logger.warning(
+          `${event.result.overwritten} public asset conflict${event.result.overwritten === 1 ? '' : 's'} resolved using the last configured source`,
+          'federation'
+        );
+      }
+      return;
+    case 'complete':
+      logger.success(
+        `Federation complete: ${event.result.sources} sources, ${event.result.resources} remote resources, ${event.result.hydrate.written} files written (${event.result.hydrate.fetched} downloaded, ${event.result.hydrate.written - event.result.hydrate.fetched} cached)`,
+        'federation'
+      );
+      logger.info(`Pinned source commits in ${path.relative(dir, event.result.lockPath)}`, 'federation');
+  }
+};
+
+program
+  .command('federate')
+  .description('Fetch, resolve, and hydrate the catalogs configured in federation.sources.')
+  .option('--no-cache', 'Download all federation content and refresh the cache.')
+  .action(async (commandOptions: { cache: boolean }) => {
+    logger.welcome();
+
+    if (fs.existsSync(path.join(dir, '.env'))) {
+      dotenv.config({ path: path.join(dir, '.env') });
+    }
+
+    logger.info('Starting federation...', 'federation');
+    if (!(await isEventCatalogScaleEnabled())) {
+      throw new Error(
+        'Cannot federate catalogs: EventCatalog federation is an Enterprise feature. Visit https://www.eventcatalog.dev/pricing to enable federation.'
+      );
+    }
+
+    const result = await federateCatalog(dir, {
+      useCache: commandOptions.cache,
+      onProgress: reportFederationProgress,
+    });
+    if (!result) logger.warning('No federation sources configured; nothing to do.', 'federation');
+  });
+
 program.addHelpText(
   'after',
   `
@@ -728,6 +842,6 @@ program
   .parseAsync()
   .then(() => process.exit(0))
   .catch((err) => {
-    console.error(err);
+    if (!(err instanceof FederationConflictError)) console.error(err);
     process.exit(1);
   });

--- a/packages/core/src/eventcatalog.ts
+++ b/packages/core/src/eventcatalog.ts
@@ -722,6 +722,14 @@ const reportFederationProgress = (event: FederationProgressEvent) => {
       if (event.sources > 0)
         logger.info(`Found ${event.sources} configured source${event.sources === 1 ? '' : 's'}`, 'federation');
       return;
+    case 'cleanup:complete':
+      logger.success(
+        `No sources configured; removed previous federation output${
+          event.publicFiles > 0 ? ` and ${event.publicFiles} managed public file${event.publicFiles === 1 ? '' : 's'}` : ''
+        }.`,
+        'federation'
+      );
+      return;
     case 'cache:disabled':
       logger.info('Content cache disabled; all federated files will be downloaded.', 'federation');
       return;
@@ -822,11 +830,15 @@ program
       );
     }
 
+    let cleanedPreviousOutput = false;
     const result = await federateCatalog(dir, {
       useCache: commandOptions.cache,
-      onProgress: reportFederationProgress,
+      onProgress: (event) => {
+        if (event.type === 'cleanup:complete') cleanedPreviousOutput = true;
+        reportFederationProgress(event);
+      },
     });
-    if (!result) logger.warning('No federation sources configured; nothing to do.', 'federation');
+    if (!result && !cleanedPreviousOutput) logger.warning('No federation sources configured; nothing to do.', 'federation');
   });
 
 program.addHelpText(

--- a/packages/core/src/federation/content-cache.ts
+++ b/packages/core/src/federation/content-cache.ts
@@ -1,0 +1,51 @@
+import { createHash, randomUUID } from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import type { Cache } from '@eventcatalog/sdk';
+
+type FederationContentCacheOptions = {
+  read?: boolean;
+  onHit?: (key: string) => void;
+};
+
+const getContentHash = (content: Buffer) => `sha256:${createHash('sha256').update(content).digest('hex')}`;
+const isContentHash = (key: string) => /^sha256:[a-f0-9]{64}$/i.test(key);
+
+export const createFederationContentCache = (projectDirectory: string, options: FederationContentCacheOptions = {}): Cache => {
+  const cacheDirectory = path.join(projectDirectory, '.eventcatalog-cache', 'federation', 'content');
+  const getCachePath = (key: string) => path.join(cacheDirectory, encodeURIComponent(key));
+
+  return {
+    async get(key) {
+      if (options.read === false || !isContentHash(key)) return undefined;
+
+      const cachePath = getCachePath(key);
+      try {
+        const content = await fs.readFile(cachePath);
+        if (getContentHash(content) !== key) {
+          await fs.rm(cachePath, { force: true });
+          return undefined;
+        }
+        options.onHit?.(key);
+        return content;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+        throw error;
+      }
+    },
+
+    async set(key, content) {
+      if (!isContentHash(key) || getContentHash(content) !== key) return;
+
+      await fs.mkdir(cacheDirectory, { recursive: true });
+      const cachePath = getCachePath(key);
+      const temporaryPath = `${cachePath}.tmp-${process.pid}-${randomUUID()}`;
+      try {
+        await fs.writeFile(temporaryPath, content);
+        await fs.rename(temporaryPath, cachePath);
+      } finally {
+        await fs.rm(temporaryPath, { force: true });
+      }
+    },
+  };
+};

--- a/packages/core/src/federation/federate.ts
+++ b/packages/core/src/federation/federate.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto';
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { hydrate, resolve, type Conflict, type HydrateResult, type ResolvedGraph } from '@eventcatalog/sdk';
+import createSDK, { hydrate, resolve, type Conflict, type HydrateResult, type ResolvedGraph } from '@eventcatalog/sdk';
 import type { FederationSourceConfig } from '../eventcatalog.config';
 import { getEventCatalogConfigFile } from '../eventcatalog-config-file-utils.js';
 import { createFederationContentCache } from './content-cache';
@@ -23,7 +23,9 @@ export type FederationProgressEvent =
       resources: number;
       generated: boolean;
     }
-  | { type: 'resolving'; resources: number }
+  | { type: 'local:start' }
+  | { type: 'local:complete'; resources: number }
+  | { type: 'resolving'; resources: number; localResources: number }
   | { type: 'resolved'; graph: ResolvedGraph }
   | { type: 'hydrating'; outDir: string }
   | { type: 'hydrate:cache'; files: number }
@@ -175,10 +177,24 @@ export const federateCatalog = async (
   const lockPath = path.join(projectDirectory, 'eventcatalog.lock');
   const previousLock = await readLock(lockPath);
   const resources = resolvedSources.reduce((total, source) => total + source.resolved.index.resources.length, 0);
-  options.onProgress?.({ type: 'resolving', resources });
-  const graph = resolve(resolvedSources.map(({ resolved }) => resolved.index));
+  const remoteIndexes = resolvedSources.map(({ resolved }) => resolved.index);
+  options.onProgress?.({ type: 'local:start' });
+  const localIndex = await createSDK(projectDirectory).buildIndex({
+    source: config.cId,
+    commit: 'local',
+    hashContent: false,
+    includeFederated: false,
+  });
+  options.onProgress?.({ type: 'local:complete', resources: localIndex.resources.length });
+  options.onProgress?.({ type: 'resolving', resources, localResources: localIndex.resources.length });
+  const ownershipGraph = resolve([localIndex, ...remoteIndexes]);
+  if (ownershipGraph.conflicts.length > 0) {
+    options.onProgress?.({ type: 'resolved', graph: ownershipGraph });
+    throw new FederationConflictError(ownershipGraph.conflicts);
+  }
+
+  const graph = resolve(remoteIndexes);
   options.onProgress?.({ type: 'resolved', graph });
-  if (graph.conflicts.length > 0) throw new FederationConflictError(graph.conflicts);
 
   const sourcesById = new Map(sources.map((source) => [source.id, source]));
   options.onProgress?.({ type: 'hydrating', outDir });

--- a/packages/core/src/federation/federate.ts
+++ b/packages/core/src/federation/federate.ts
@@ -59,6 +59,7 @@ type FederateCatalogOptions = {
   onProgress?: (event: FederationProgressEvent) => void;
   now?: () => Date;
   useCache?: boolean;
+  isFederationEnabled?: () => Promise<boolean>;
 };
 
 export class FederationConflictError extends Error {
@@ -145,6 +146,11 @@ export const federateCatalog = async (
   if (sources.length === 0) {
     await cleanupPreviousFederation(projectDirectory, options.onProgress);
     return null;
+  }
+  if (options.isFederationEnabled && !(await options.isFederationEnabled())) {
+    throw new Error(
+      'Cannot federate catalogs: EventCatalog federation is an Enterprise feature. Visit https://www.eventcatalog.dev/pricing to enable federation.'
+    );
   }
   validateSources(sources);
   if (options.useCache === false) options.onProgress?.({ type: 'cache:disabled' });

--- a/packages/core/src/federation/federate.ts
+++ b/packages/core/src/federation/federate.ts
@@ -11,6 +11,7 @@ import type { FederationSourceProvider, ResolvedFederationSource } from './types
 
 export type FederationProgressEvent =
   | { type: 'configured'; sources: number }
+  | { type: 'cleanup:complete'; federated: boolean; publicFiles: number; lock: boolean }
   | { type: 'cache:disabled' }
   | { type: 'source:start'; source: FederationSourceConfig; current: number; total: number }
   | {
@@ -97,6 +98,41 @@ const readLock = async (lockPath: string): Promise<FederationLock | undefined> =
   }
 };
 
+const pathExists = async (filePath: string) => {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false;
+    throw error;
+  }
+};
+
+const cleanupPreviousFederation = async (projectDirectory: string, onProgress?: FederateCatalogOptions['onProgress']) => {
+  const outDir = path.join(projectDirectory, 'federated');
+  const lockPath = path.join(projectDirectory, 'eventcatalog.lock');
+  const previousLock = await readLock(lockPath);
+  const hadFederatedOutput = await pathExists(outDir);
+  const hadLock = previousLock !== undefined;
+
+  if (!hadFederatedOutput && !hadLock) return;
+
+  await fs.rm(outDir, { recursive: true, force: true });
+  const publicResult = await composePublicAssets({
+    projectDirectory,
+    federatedDirectory: outDir,
+    assets: [],
+    previousFiles: previousLock?.publicFiles,
+  });
+  await fs.rm(lockPath, { force: true });
+  onProgress?.({
+    type: 'cleanup:complete',
+    federated: hadFederatedOutput,
+    publicFiles: publicResult.removed,
+    lock: hadLock,
+  });
+};
+
 export const federateCatalog = async (
   projectDirectory: string,
   options: FederateCatalogOptions = {}
@@ -104,7 +140,10 @@ export const federateCatalog = async (
   const config = await getEventCatalogConfigFile(projectDirectory);
   const sources: FederationSourceConfig[] = config.federation?.sources ?? [];
   options.onProgress?.({ type: 'configured', sources: sources.length });
-  if (sources.length === 0) return null;
+  if (sources.length === 0) {
+    await cleanupPreviousFederation(projectDirectory, options.onProgress);
+    return null;
+  }
   validateSources(sources);
   if (options.useCache === false) options.onProgress?.({ type: 'cache:disabled' });
 

--- a/packages/core/src/federation/federate.ts
+++ b/packages/core/src/federation/federate.ts
@@ -1,0 +1,204 @@
+import { createHash } from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { hydrate, resolve, type Conflict, type HydrateResult, type ResolvedGraph } from '@eventcatalog/sdk';
+import type { FederationSourceConfig } from '../eventcatalog.config';
+import { getEventCatalogConfigFile } from '../eventcatalog-config-file-utils.js';
+import { createFederationContentCache } from './content-cache';
+import { createGitHubSourceProvider } from './github-source-provider';
+import { composePublicAssets, type FederatedPublicFiles, type PublicAssetCompositionResult } from './public-assets';
+import type { FederationSourceProvider, ResolvedFederationSource } from './types';
+
+export type FederationProgressEvent =
+  | { type: 'configured'; sources: number }
+  | { type: 'cache:disabled' }
+  | { type: 'source:start'; source: FederationSourceConfig; current: number; total: number }
+  | {
+      type: 'source:complete';
+      source: FederationSourceConfig;
+      current: number;
+      total: number;
+      commit: string;
+      resources: number;
+      generated: boolean;
+    }
+  | { type: 'resolving'; resources: number }
+  | { type: 'resolved'; graph: ResolvedGraph }
+  | { type: 'hydrating'; outDir: string }
+  | { type: 'hydrate:cache'; files: number }
+  | { type: 'hydrate:file'; files: number; source: string; path: string }
+  | { type: 'public:complete'; result: PublicAssetCompositionResult }
+  | { type: 'complete'; result: FederateCatalogResult };
+
+export type FederateCatalogResult = {
+  sources: number;
+  resources: number;
+  graph: ResolvedGraph;
+  hydrate: HydrateResult;
+  public: PublicAssetCompositionResult;
+  outDir: string;
+  lockPath: string;
+};
+
+type FederationLock = {
+  lockVersion: 1;
+  sources: {
+    id: string;
+    digest: string;
+    commit: string;
+    resolvedAt: string;
+  }[];
+  publicFiles?: FederatedPublicFiles;
+};
+
+type FederateCatalogOptions = {
+  provider?: FederationSourceProvider;
+  onProgress?: (event: FederationProgressEvent) => void;
+  now?: () => Date;
+  useCache?: boolean;
+};
+
+export class FederationConflictError extends Error {
+  conflicts: Conflict[];
+
+  constructor(conflicts: Conflict[]) {
+    const details = conflicts.map((conflict) => `${conflict.id}: ${conflict.sources.join(', ')}`).join('\n');
+    super(`Federation conflicts prevent hydration:\n${details}`);
+    this.name = 'FederationConflictError';
+    this.conflicts = conflicts;
+  }
+}
+
+const validateSources = (sources: FederationSourceConfig[]) => {
+  const ids = new Set<string>();
+  for (const source of sources) {
+    if (!source.id?.trim()) throw new Error('Every federation source requires a stable id.');
+    if (ids.has(source.id)) throw new Error(`Federation source id "${source.id}" is configured more than once.`);
+    ids.add(source.id);
+  }
+};
+
+const writeLock = async (lockPath: string, lock: FederationLock) => {
+  const temporaryPath = `${lockPath}.tmp-${process.pid}`;
+  try {
+    await fs.writeFile(temporaryPath, `${JSON.stringify(lock, null, 2)}\n`, 'utf8');
+    await fs.rename(temporaryPath, lockPath);
+  } finally {
+    await fs.rm(temporaryPath, { force: true });
+  }
+};
+
+const readLock = async (lockPath: string): Promise<FederationLock | undefined> => {
+  try {
+    return JSON.parse(await fs.readFile(lockPath, 'utf8')) as FederationLock;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+    throw new Error(`Cannot read federation lock at "${lockPath}"`, { cause: error });
+  }
+};
+
+export const federateCatalog = async (
+  projectDirectory: string,
+  options: FederateCatalogOptions = {}
+): Promise<FederateCatalogResult | null> => {
+  const config = await getEventCatalogConfigFile(projectDirectory);
+  const sources: FederationSourceConfig[] = config.federation?.sources ?? [];
+  options.onProgress?.({ type: 'configured', sources: sources.length });
+  if (sources.length === 0) return null;
+  validateSources(sources);
+  if (options.useCache === false) options.onProgress?.({ type: 'cache:disabled' });
+
+  const provider = options.provider ?? createGitHubSourceProvider();
+  const resolvedSources: { config: FederationSourceConfig; resolved: ResolvedFederationSource }[] = [];
+
+  for (const [index, source] of sources.entries()) {
+    const current = index + 1;
+    options.onProgress?.({ type: 'source:start', source, current, total: sources.length });
+    try {
+      const resolved = await provider.resolve(source);
+      resolvedSources.push({ config: source, resolved });
+      options.onProgress?.({
+        type: 'source:complete',
+        source,
+        current,
+        total: sources.length,
+        commit: resolved.commit,
+        resources: resolved.index.resources.length,
+        generated: resolved.generated,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Failed to federate source "${source.id}": ${message}`, { cause: error });
+    }
+  }
+
+  const outDir = path.join(projectDirectory, 'federated');
+  const lockPath = path.join(projectDirectory, 'eventcatalog.lock');
+  const previousLock = await readLock(lockPath);
+  const resources = resolvedSources.reduce((total, source) => total + source.resolved.index.resources.length, 0);
+  options.onProgress?.({ type: 'resolving', resources });
+  const graph = resolve(resolvedSources.map(({ resolved }) => resolved.index));
+  options.onProgress?.({ type: 'resolved', graph });
+  if (graph.conflicts.length > 0) throw new FederationConflictError(graph.conflicts);
+
+  const sourcesById = new Map(sources.map((source) => [source.id, source]));
+  options.onProgress?.({ type: 'hydrating', outDir });
+  let hydratedFiles = 0;
+  let cachedFiles = 0;
+  const hydrateResult = await hydrate(graph, {
+    outDir,
+    cache: createFederationContentCache(projectDirectory, {
+      read: options.useCache !== false,
+      onHit: () => {
+        cachedFiles += 1;
+        options.onProgress?.({ type: 'hydrate:cache', files: cachedFiles });
+      },
+    }),
+    modes: Object.fromEntries(sources.map((source) => [source.id, source.mode ?? 'hydrate'])),
+    fetch: async ({ source: sourceId, commit, path: artifactPath }) => {
+      const source = sourcesById.get(sourceId);
+      if (!source) throw new Error(`Cannot fetch content for unconfigured source "${sourceId}"`);
+      const content = await provider.fetchContent({ source, commit, path: artifactPath });
+      hydratedFiles += 1;
+      options.onProgress?.({ type: 'hydrate:file', files: hydratedFiles, source: sourceId, path: artifactPath });
+      return content;
+    },
+  });
+
+  const publicResult = await composePublicAssets({
+    projectDirectory,
+    federatedDirectory: outDir,
+    assets: graph.assets,
+    previousFiles: previousLock?.publicFiles,
+    collisionPaths: new Set(
+      graph.warnings.filter((warning) => warning.kind === 'asset-collision').map((warning) => warning.path)
+    ),
+  });
+  options.onProgress?.({ type: 'public:complete', result: publicResult });
+
+  const resolvedAt = (options.now ?? (() => new Date()))().toISOString();
+  await writeLock(lockPath, {
+    lockVersion: 1,
+    sources: resolvedSources
+      .map(({ config: source, resolved }) => ({
+        id: source.id,
+        digest: `sha256:${createHash('sha256').update(resolved.bytes).digest('hex')}`,
+        commit: resolved.commit,
+        resolvedAt,
+      }))
+      .sort((left, right) => left.id.localeCompare(right.id)),
+    publicFiles: publicResult.files,
+  });
+
+  const result = {
+    sources: sources.length,
+    resources,
+    graph,
+    hydrate: hydrateResult,
+    public: publicResult,
+    outDir,
+    lockPath,
+  };
+  options.onProgress?.({ type: 'complete', result });
+  return result;
+};

--- a/packages/core/src/federation/github-source-provider.ts
+++ b/packages/core/src/federation/github-source-provider.ts
@@ -1,0 +1,125 @@
+import { execFile } from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import createSDK, { parseIndex } from '@eventcatalog/sdk';
+import type { FederationSourceConfig } from '../eventcatalog.config';
+import type { FederationSourceProvider, ResolvedFederationSource } from './types';
+
+const execFileAsync = promisify(execFile);
+
+type FetchResponse = Pick<Response, 'status' | 'statusText' | 'ok' | 'arrayBuffer'>;
+type FetchFunction = (url: string) => Promise<FetchResponse>;
+type CheckoutFunction = <T>(
+  source: FederationSourceConfig,
+  ref: string,
+  callback: (directory: string) => Promise<T>
+) => Promise<T>;
+
+export type GitHubSourceProviderOptions = {
+  fetch?: FetchFunction;
+  checkout?: CheckoutFunction;
+};
+
+const parseGitHubSource = (source: FederationSourceConfig) => {
+  const match = /^github:([^/]+)\/(.+)$/.exec(source.source);
+  if (!match) throw new Error(`Unsupported federation source "${source.source}". Expected github:owner/repository.`);
+  return { owner: match[1], repository: match[2] };
+};
+
+const assertSafeCatalogPath = (source: FederationSourceConfig) => {
+  const catalogPath = source.path ?? '.';
+  const normalized = path.posix.normalize(catalogPath.replaceAll('\\', '/'));
+  if (catalogPath.includes('\\') || path.posix.isAbsolute(normalized) || normalized === '..' || normalized.startsWith('../')) {
+    throw new Error(`Catalog path "${catalogPath}" escapes source "${source.id}"`);
+  }
+};
+
+const encodePath = (value: string) => value.split('/').filter(Boolean).map(encodeURIComponent).join('/');
+
+const rawUrl = (source: FederationSourceConfig, ref: string, filePath: string) => {
+  const { owner, repository } = parseGitHubSource(source);
+  return `https://raw.githubusercontent.com/${encodeURIComponent(owner)}/${encodeURIComponent(repository)}/${encodeURIComponent(
+    ref
+  )}/${encodePath(filePath)}`;
+};
+
+const fetchBytes = async (url: string, fetcher: FetchFunction): Promise<Buffer | undefined> => {
+  const response = await fetcher(url);
+  if (response.status === 404) return undefined;
+  if (!response.ok) throw new Error(`Failed to fetch ${url}: ${response.status} ${response.statusText}`);
+  return Buffer.from(await response.arrayBuffer());
+};
+
+const withCheckout = async <T>(source: FederationSourceConfig, ref: string, callback: (directory: string) => Promise<T>) => {
+  const { owner, repository } = parseGitHubSource(source);
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'eventcatalog-federation-'));
+
+  try {
+    const git = (args: string[]) => execFileAsync('git', args, { cwd: directory });
+    await git(['init', '--quiet']);
+    await git(['remote', 'add', 'origin', `https://github.com/${owner}/${repository}.git`]);
+    await git(['sparse-checkout', 'init', '--cone']);
+    if ((source.path ?? '.') !== '.') await git(['sparse-checkout', 'set', source.path ?? '.']);
+    await git(['fetch', '--quiet', '--depth', '1', 'origin', ref]);
+    await git(['checkout', '--quiet', '--detach', 'FETCH_HEAD']);
+    return await callback(directory);
+  } finally {
+    await fs.rm(directory, { recursive: true, force: true });
+  }
+};
+
+const generateIndex = async (
+  source: FederationSourceConfig,
+  ref: string,
+  checkout: CheckoutFunction
+): Promise<ResolvedFederationSource> =>
+  checkout(source, ref, async (directory) => {
+    const { stdout } = await execFileAsync('git', ['rev-parse', 'HEAD'], { cwd: directory });
+    const commit = stdout.trim();
+    const catalogDirectory = path.resolve(directory, source.path ?? '.');
+    const relativeCatalogDirectory = path.relative(directory, catalogDirectory);
+    if (relativeCatalogDirectory.startsWith('..') || path.isAbsolute(relativeCatalogDirectory)) {
+      throw new Error(`Catalog path "${source.path}" escapes source "${source.id}"`);
+    }
+
+    const index = await createSDK(catalogDirectory).buildIndex({ source: source.id, commit });
+    return { bytes: Buffer.from(JSON.stringify(index)), index, commit, generated: true };
+  });
+
+const fetchPublishedIndex = async (
+  source: FederationSourceConfig,
+  ref: string,
+  fetcher: FetchFunction
+): Promise<ResolvedFederationSource | undefined> => {
+  const indexPath = path.posix.join(source.path ?? '.', 'catalog.index.json');
+  const bytes = await fetchBytes(rawUrl(source, ref, indexPath), fetcher);
+  if (!bytes) return undefined;
+  const index = parseIndex(JSON.parse(bytes.toString('utf8')));
+  if (index.source !== source.id) {
+    throw new Error(`Published index source "${index.source}" does not match configured id "${source.id}"`);
+  }
+  return { bytes, index, commit: index.commit, generated: false };
+};
+
+export const createGitHubSourceProvider = (options: GitHubSourceProviderOptions = {}): FederationSourceProvider => {
+  const fetcher: FetchFunction = options.fetch ?? ((url) => fetch(url));
+  const checkout = options.checkout ?? withCheckout;
+
+  return {
+    async resolve(source) {
+      assertSafeCatalogPath(source);
+      const ref = source.ref ?? 'main';
+      return (await fetchPublishedIndex(source, ref, fetcher)) ?? generateIndex(source, ref, checkout);
+    },
+
+    async fetchContent({ source, commit, path: artifactPath }) {
+      assertSafeCatalogPath(source);
+      const catalogPath = path.posix.join(source.path ?? '.', artifactPath);
+      const content = await fetchBytes(rawUrl(source, commit, catalogPath), fetcher);
+      if (!content) throw new Error(`Federated artifact not found for "${source.id}": ${artifactPath}`);
+      return content;
+    },
+  };
+};

--- a/packages/core/src/federation/github-source-provider.ts
+++ b/packages/core/src/federation/github-source-provider.ts
@@ -98,6 +98,7 @@ const createCheckout =
   (executeFile: ExecFileFunction, token?: string): CheckoutFunction =>
   async (source, ref, callback) => {
     const { owner, repository } = parseGitHubSource(source);
+    const catalogPath = path.posix.normalize(source.path ?? '.');
     const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'eventcatalog-federation-'));
     const env = getGitEnvironment(token);
 
@@ -105,8 +106,10 @@ const createCheckout =
       const git = (args: string[]) => executeFile('git', args, { cwd: directory, env, encoding: 'utf8' });
       await git(['init', '--quiet']);
       await git(['remote', 'add', 'origin', `https://github.com/${owner}/${repository}.git`]);
-      await git(['sparse-checkout', 'init', '--cone']);
-      if ((source.path ?? '.') !== '.') await git(['sparse-checkout', 'set', source.path ?? '.']);
+      if (catalogPath !== '.') {
+        await git(['sparse-checkout', 'init', '--cone']);
+        await git(['sparse-checkout', 'set', catalogPath]);
+      }
       await git(['fetch', '--quiet', '--depth', '1', 'origin', ref]);
       await git(['checkout', '--quiet', '--detach', 'FETCH_HEAD']);
       return await callback(directory);

--- a/packages/core/src/federation/github-source-provider.ts
+++ b/packages/core/src/federation/github-source-provider.ts
@@ -10,7 +10,12 @@ import type { FederationSourceProvider, ResolvedFederationSource } from './types
 const execFileAsync = promisify(execFile);
 
 type FetchResponse = Pick<Response, 'status' | 'statusText' | 'ok' | 'arrayBuffer'>;
-type FetchFunction = (url: string) => Promise<FetchResponse>;
+type FetchFunction = (url: string, init?: RequestInit) => Promise<FetchResponse>;
+type ExecFileFunction = (
+  file: string,
+  args: string[],
+  options: { cwd: string; env?: NodeJS.ProcessEnv; encoding: 'utf8' }
+) => Promise<{ stdout: string; stderr: string }>;
 type CheckoutFunction = <T>(
   source: FederationSourceConfig,
   ref: string,
@@ -20,6 +25,8 @@ type CheckoutFunction = <T>(
 export type GitHubSourceProviderOptions = {
   fetch?: FetchFunction;
   checkout?: CheckoutFunction;
+  execFile?: ExecFileFunction;
+  token?: string;
 };
 
 const parseGitHubSource = (source: FederationSourceConfig) => {
@@ -45,38 +52,77 @@ const rawUrl = (source: FederationSourceConfig, ref: string, filePath: string) =
   )}/${encodePath(filePath)}`;
 };
 
-const fetchBytes = async (url: string, fetcher: FetchFunction): Promise<Buffer | undefined> => {
-  const response = await fetcher(url);
+const contentsApiUrl = (source: FederationSourceConfig, ref: string, filePath: string) => {
+  const { owner, repository } = parseGitHubSource(source);
+  return `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repository)}/contents/${encodePath(
+    filePath
+  )}?ref=${encodeURIComponent(ref)}`;
+};
+
+const fetchBytes = async (
+  source: FederationSourceConfig,
+  ref: string,
+  filePath: string,
+  fetcher: FetchFunction,
+  token?: string
+): Promise<Buffer | undefined> => {
+  const url = token ? contentsApiUrl(source, ref, filePath) : rawUrl(source, ref, filePath);
+  const response = token
+    ? await fetcher(url, {
+        headers: {
+          Accept: 'application/vnd.github.raw+json',
+          Authorization: `Bearer ${token}`,
+          'X-GitHub-Api-Version': '2026-03-10',
+        },
+      })
+    : await fetcher(url);
   if (response.status === 404) return undefined;
   if (!response.ok) throw new Error(`Failed to fetch ${url}: ${response.status} ${response.statusText}`);
   return Buffer.from(await response.arrayBuffer());
 };
 
-const withCheckout = async <T>(source: FederationSourceConfig, ref: string, callback: (directory: string) => Promise<T>) => {
-  const { owner, repository } = parseGitHubSource(source);
-  const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'eventcatalog-federation-'));
+const getGitEnvironment = (token?: string) => {
+  if (!token) return process.env;
 
-  try {
-    const git = (args: string[]) => execFileAsync('git', args, { cwd: directory });
-    await git(['init', '--quiet']);
-    await git(['remote', 'add', 'origin', `https://github.com/${owner}/${repository}.git`]);
-    await git(['sparse-checkout', 'init', '--cone']);
-    if ((source.path ?? '.') !== '.') await git(['sparse-checkout', 'set', source.path ?? '.']);
-    await git(['fetch', '--quiet', '--depth', '1', 'origin', ref]);
-    await git(['checkout', '--quiet', '--detach', 'FETCH_HEAD']);
-    return await callback(directory);
-  } finally {
-    await fs.rm(directory, { recursive: true, force: true });
-  }
+  const inheritedCount = Number.parseInt(process.env.GIT_CONFIG_COUNT ?? '0', 10);
+  const configIndex = Number.isInteger(inheritedCount) && inheritedCount >= 0 ? inheritedCount : 0;
+  return {
+    ...process.env,
+    GIT_CONFIG_COUNT: String(configIndex + 1),
+    [`GIT_CONFIG_KEY_${configIndex}`]: 'http.https://github.com/.extraheader',
+    [`GIT_CONFIG_VALUE_${configIndex}`]: `AUTHORIZATION: basic ${Buffer.from(`x-access-token:${token}`).toString('base64')}`,
+  };
 };
+
+const createCheckout =
+  (executeFile: ExecFileFunction, token?: string): CheckoutFunction =>
+  async (source, ref, callback) => {
+    const { owner, repository } = parseGitHubSource(source);
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'eventcatalog-federation-'));
+    const env = getGitEnvironment(token);
+
+    try {
+      const git = (args: string[]) => executeFile('git', args, { cwd: directory, env, encoding: 'utf8' });
+      await git(['init', '--quiet']);
+      await git(['remote', 'add', 'origin', `https://github.com/${owner}/${repository}.git`]);
+      await git(['sparse-checkout', 'init', '--cone']);
+      if ((source.path ?? '.') !== '.') await git(['sparse-checkout', 'set', source.path ?? '.']);
+      await git(['fetch', '--quiet', '--depth', '1', 'origin', ref]);
+      await git(['checkout', '--quiet', '--detach', 'FETCH_HEAD']);
+      return await callback(directory);
+    } finally {
+      await fs.rm(directory, { recursive: true, force: true });
+    }
+  };
 
 const generateIndex = async (
   source: FederationSourceConfig,
   ref: string,
-  checkout: CheckoutFunction
+  checkout: CheckoutFunction,
+  executeFile: ExecFileFunction
 ): Promise<ResolvedFederationSource> =>
   checkout(source, ref, async (directory) => {
-    const { stdout } = await execFileAsync('git', ['rev-parse', 'HEAD'], { cwd: directory });
+    const { stdout } = await executeFile('git', ['rev-parse', 'HEAD'], { cwd: directory, encoding: 'utf8' });
     const commit = stdout.trim();
     const catalogDirectory = path.resolve(directory, source.path ?? '.');
     const relativeCatalogDirectory = path.relative(directory, catalogDirectory);
@@ -91,10 +137,11 @@ const generateIndex = async (
 const fetchPublishedIndex = async (
   source: FederationSourceConfig,
   ref: string,
-  fetcher: FetchFunction
+  fetcher: FetchFunction,
+  token?: string
 ): Promise<ResolvedFederationSource | undefined> => {
   const indexPath = path.posix.join(source.path ?? '.', 'catalog.index.json');
-  const bytes = await fetchBytes(rawUrl(source, ref, indexPath), fetcher);
+  const bytes = await fetchBytes(source, ref, indexPath, fetcher, token);
   if (!bytes) return undefined;
   const index = parseIndex(JSON.parse(bytes.toString('utf8')));
   if (index.source !== source.id) {
@@ -104,20 +151,23 @@ const fetchPublishedIndex = async (
 };
 
 export const createGitHubSourceProvider = (options: GitHubSourceProviderOptions = {}): FederationSourceProvider => {
-  const fetcher: FetchFunction = options.fetch ?? ((url) => fetch(url));
-  const checkout = options.checkout ?? withCheckout;
+  const fetcher: FetchFunction = options.fetch ?? ((url, init) => fetch(url, init));
+  const executeFile: ExecFileFunction = options.execFile ?? ((file, args, execOptions) => execFileAsync(file, args, execOptions));
+  const configuredToken = options.token ?? process.env.EVENTCATALOG_GITHUB_TOKEN ?? process.env.GITHUB_TOKEN;
+  const token = configuredToken?.trim() || undefined;
+  const checkout = options.checkout ?? createCheckout(executeFile, token);
 
   return {
     async resolve(source) {
       assertSafeCatalogPath(source);
       const ref = source.ref ?? 'main';
-      return (await fetchPublishedIndex(source, ref, fetcher)) ?? generateIndex(source, ref, checkout);
+      return (await fetchPublishedIndex(source, ref, fetcher, token)) ?? generateIndex(source, ref, checkout, executeFile);
     },
 
     async fetchContent({ source, commit, path: artifactPath }) {
       assertSafeCatalogPath(source);
       const catalogPath = path.posix.join(source.path ?? '.', artifactPath);
-      const content = await fetchBytes(rawUrl(source, commit, catalogPath), fetcher);
+      const content = await fetchBytes(source, commit, catalogPath, fetcher, token);
       if (!content) throw new Error(`Federated artifact not found for "${source.id}": ${artifactPath}`);
       return content;
     },

--- a/packages/core/src/federation/public-assets.ts
+++ b/packages/core/src/federation/public-assets.ts
@@ -1,0 +1,195 @@
+import { createHash } from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import type { ResolvedAsset } from '@eventcatalog/sdk';
+
+export type FederatedPublicFile = {
+  source: string;
+  hash: string;
+};
+
+export type FederatedPublicFiles = Record<string, FederatedPublicFile>;
+
+export type PublicAssetCompositionResult = {
+  files: FederatedPublicFiles;
+  copied: number;
+  skipped: number;
+  overwritten: number;
+  removed: number;
+};
+
+type ComposePublicAssetsOptions = {
+  projectDirectory: string;
+  federatedDirectory: string;
+  assets: ResolvedAsset[];
+  previousFiles?: FederatedPublicFiles;
+  collisionPaths?: Set<string>;
+};
+
+const getContentHash = (content: Buffer) => `sha256:${createHash('sha256').update(content).digest('hex')}`;
+
+const getFileHash = async (filePath: string) => {
+  try {
+    const stat = await fs.lstat(filePath);
+    return stat.isFile() ? getContentHash(await fs.readFile(filePath)) : undefined;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+    throw error;
+  }
+};
+
+const getSafePath = (directory: string, relativePath: string) => {
+  const normalizedPath = path.posix.normalize(relativePath);
+  const unsafe =
+    relativePath.length === 0 ||
+    relativePath.includes('\0') ||
+    relativePath.includes('\\') ||
+    path.posix.isAbsolute(relativePath) ||
+    /^[a-zA-Z]:\//.test(relativePath) ||
+    normalizedPath !== relativePath ||
+    normalizedPath === '..' ||
+    normalizedPath.startsWith('../');
+
+  if (unsafe) return undefined;
+
+  const resolvedDirectory = path.resolve(directory);
+  const resolvedPath = path.resolve(resolvedDirectory, relativePath);
+  const relativeResolvedPath = path.relative(resolvedDirectory, resolvedPath);
+
+  if (
+    relativeResolvedPath === '' ||
+    relativeResolvedPath === '..' ||
+    relativeResolvedPath.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relativeResolvedPath)
+  ) {
+    return undefined;
+  }
+
+  return resolvedPath;
+};
+
+const listFiles = async (directory: string, relativeDirectory = ''): Promise<string[]> => {
+  let entries;
+
+  try {
+    entries = await fs.readdir(path.join(directory, relativeDirectory), { withFileTypes: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw error;
+  }
+
+  const files = await Promise.all(
+    entries.map(async (entry): Promise<string[]> => {
+      const relativePath = path.join(relativeDirectory, entry.name);
+      if (entry.isDirectory()) return listFiles(directory, relativePath);
+      return entry.isFile() ? [relativePath.split(path.sep).join('/')] : [];
+    })
+  );
+
+  return files.flat().sort();
+};
+
+const pathExists = async (filePath: string) => {
+  try {
+    await fs.lstat(filePath);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false;
+    throw error;
+  }
+};
+
+const hasBlockingParent = async (publicDirectory: string, destinationPath: string) => {
+  let currentPath = path.dirname(destinationPath);
+
+  while (currentPath !== publicDirectory) {
+    try {
+      if (!(await fs.lstat(currentPath)).isDirectory()) return true;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    }
+    currentPath = path.dirname(currentPath);
+  }
+
+  return false;
+};
+
+const pruneEmptyDirectories = async (publicDirectory: string, filePath: string) => {
+  let currentPath = path.dirname(filePath);
+
+  while (currentPath !== publicDirectory) {
+    try {
+      await fs.rmdir(currentPath);
+    } catch (error) {
+      if (!['ENOENT', 'ENOTEMPTY'].includes((error as NodeJS.ErrnoException).code ?? '')) throw error;
+      if ((error as NodeJS.ErrnoException).code === 'ENOTEMPTY') return;
+    }
+    currentPath = path.dirname(currentPath);
+  }
+};
+
+export const composePublicAssets = async ({
+  projectDirectory,
+  federatedDirectory,
+  assets,
+  previousFiles = {},
+  collisionPaths = new Set(),
+}: ComposePublicAssetsOptions): Promise<PublicAssetCompositionResult> => {
+  const publicDirectory = path.resolve(projectDirectory, 'public');
+  const federatedPublicDirectory = path.resolve(federatedDirectory, 'public');
+  const sourceFiles = await listFiles(federatedPublicDirectory);
+  const sourceFileSet = new Set(sourceFiles);
+  const managedFiles = new Set<string>();
+
+  for (const [relativePath, previousFile] of Object.entries(previousFiles)) {
+    const destinationPath = getSafePath(publicDirectory, relativePath);
+    if (destinationPath && (await getFileHash(destinationPath)) === previousFile.hash) managedFiles.add(relativePath);
+  }
+
+  let removed = 0;
+  for (const relativePath of managedFiles) {
+    if (sourceFileSet.has(relativePath)) continue;
+    const destinationPath = getSafePath(publicDirectory, relativePath);
+    if (!destinationPath) continue;
+    await fs.rm(destinationPath, { force: true });
+    await pruneEmptyDirectories(publicDirectory, destinationPath);
+    removed += 1;
+  }
+
+  const publicAssetsByPath = new Map(
+    assets.filter((asset) => asset.path.startsWith('public/')).map((asset) => [asset.path.slice('public/'.length), asset])
+  );
+  const files: FederatedPublicFiles = {};
+  let copied = 0;
+  let skipped = 0;
+  let overwritten = 0;
+
+  for (const relativePath of sourceFiles) {
+    const sourcePath = getSafePath(federatedPublicDirectory, relativePath);
+    const destinationPath = getSafePath(publicDirectory, relativePath);
+    if (!sourcePath || !destinationPath) throw new Error(`Unsafe federated public asset path "${relativePath}"`);
+
+    const mainCatalogOwnsPath =
+      ((await pathExists(destinationPath)) && !managedFiles.has(relativePath)) ||
+      (await hasBlockingParent(publicDirectory, destinationPath));
+
+    if (mainCatalogOwnsPath) {
+      skipped += 1;
+      continue;
+    }
+
+    const asset = publicAssetsByPath.get(relativePath);
+    if (!asset) throw new Error(`Cannot identify the source of federated public asset "${relativePath}"`);
+
+    const content = await fs.readFile(sourcePath);
+    await fs.mkdir(path.dirname(destinationPath), { recursive: true });
+    await fs.writeFile(destinationPath, content);
+    files[relativePath] = { source: asset.resolvedFrom.source, hash: getContentHash(content) };
+    copied += 1;
+    if (collisionPaths.has(`public/${relativePath}`)) overwritten += 1;
+  }
+
+  await fs.rm(federatedPublicDirectory, { recursive: true, force: true });
+
+  return { files, copied, skipped, overwritten, removed };
+};

--- a/packages/core/src/federation/types.ts
+++ b/packages/core/src/federation/types.ts
@@ -1,0 +1,14 @@
+import type { Index } from '@eventcatalog/sdk';
+import type { FederationSourceConfig } from '../eventcatalog.config';
+
+export type ResolvedFederationSource = {
+  bytes: Buffer;
+  index: Index;
+  commit: string;
+  generated: boolean;
+};
+
+export type FederationSourceProvider = {
+  resolve(source: FederationSourceConfig): Promise<ResolvedFederationSource>;
+  fetchContent(request: { source: FederationSourceConfig; commit: string; path: string }): Promise<Buffer>;
+};

--- a/packages/sdk/src/build-index.ts
+++ b/packages/sdk/src/build-index.ts
@@ -16,7 +16,7 @@ import { getEntities } from './entities';
 import { getEvents } from './events';
 import { getFlows } from './flows';
 import type { Index, IndexAsset, IndexResource, IndexResourceType, IndexSidecar } from './index-types';
-import { getResourcePath } from './internal/resources';
+import { getResourcePath, getResourceSourcePath } from './internal/resources';
 import { getFiles } from './internal/utils';
 import { getQueries } from './queries';
 import { getServices } from './services';
@@ -46,6 +46,7 @@ type BuildIndexOptions = {
   source: string;
   commit: string;
   hashContent?: boolean;
+  includeFederated?: boolean;
 };
 
 type IndexableResource = {
@@ -150,6 +151,7 @@ const compareIndexResources = (
 ) => compareText(left.type, right.type) || compareText(left.id, right.id) || compareVersions(left.version, right.version);
 
 const toCatalogPath = (directory: string, filePath: string) => path.relative(directory, filePath).split(path.sep).join('/');
+const isFederatedPath = (directory: string, filePath: string) => toCatalogPath(directory, filePath).startsWith('federated/');
 
 const loadIgnoreRules = async (directory: string) => {
   try {
@@ -401,7 +403,7 @@ const toIndexResource = async (
 
 export const buildIndex =
   (directory: string) =>
-  async ({ source, commit, hashContent = true }: BuildIndexOptions): Promise<Index> => {
+  async ({ source, commit, hashContent = true, includeFederated = true }: BuildIndexOptions): Promise<Index> => {
     const ignoreRules = await loadIgnoreRules(directory);
     const [
       domains,
@@ -438,10 +440,12 @@ export const buildIndex =
       getUsers(directory)(),
       getDiagrams(directory)(),
     ]);
-    const federatedDirectoryResources = await Promise.all([
-      getFederatedDirectoryResources(directory, 'team', 'teams', ignoreRules),
-      getFederatedDirectoryResources(directory, 'user', 'users', ignoreRules),
-    ]);
+    const federatedDirectoryResources = includeFederated
+      ? await Promise.all([
+          getFederatedDirectoryResources(directory, 'team', 'teams', ignoreRules),
+          getFederatedDirectoryResources(directory, 'user', 'users', ignoreRules),
+        ])
+      : [];
     const indexableResources: IndexableResourceEntry[] = [
       ...(domains ?? []).map((resource) => ({ type: 'domain' as const, resource })),
       ...(channels ?? []).map((resource) => ({ type: 'channel' as const, resource })),
@@ -469,15 +473,20 @@ export const buildIndex =
       ...federatedDirectoryResources.flat(),
       ...(diagrams ?? []).map((resource) => ({ type: 'diagram' as const, resource })),
     ];
-    const locatedResources = await Promise.all(
-      indexableResources.map(async (entry) => {
-        const sourcePath =
-          entry.sourcePath ?? (await getResourcePath(directory, entry.resource.id, entry.resource.version))?.fullPath;
+    const locatedResources = (
+      await Promise.all(
+        indexableResources.map(async (entry) => {
+          const sourcePath =
+            entry.sourcePath ??
+            (includeFederated ? undefined : getResourceSourcePath(entry.resource)) ??
+            (await getResourcePath(directory, entry.resource.id, entry.resource.version))?.fullPath;
 
-        if (!sourcePath) throw new Error(`Cannot find ${entry.type} ${entry.resource.id} (${entry.resource.version})`);
-        return { ...entry, sourcePath };
-      })
-    );
+          if (!sourcePath) throw new Error(`Cannot find ${entry.type} ${entry.resource.id} (${entry.resource.version})`);
+          if (!includeFederated && isFederatedPath(directory, sourcePath)) return undefined;
+          return { ...entry, sourcePath };
+        })
+      )
+    ).filter((entry) => entry !== undefined);
     const resourceDirectories = new Set(
       locatedResources
         .filter(({ sourcePath }) => /^index\.mdx?$/i.test(path.basename(sourcePath)))

--- a/packages/sdk/src/build-index.ts
+++ b/packages/sdk/src/build-index.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto';
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import matter from 'gray-matter';
 import ignore from 'ignore';
 import { rcompare, valid } from 'semver';
 import { getAdrs } from './adrs';
@@ -16,6 +17,7 @@ import { getEvents } from './events';
 import { getFlows } from './flows';
 import type { Index, IndexAsset, IndexResource, IndexResourceType, IndexSidecar } from './index-types';
 import { getResourcePath } from './internal/resources';
+import { getFiles } from './internal/utils';
 import { getQueries } from './queries';
 import { getServices } from './services';
 import { getSystems } from './systems';
@@ -156,6 +158,26 @@ const loadIgnoreRules = async (directory: string) => {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
     throw error;
   }
+};
+
+const getFederatedDirectoryResources = async (
+  directory: string,
+  type: 'team' | 'user',
+  resourceDirectory: 'teams' | 'users',
+  ignoreRules?: ignore.Ignore
+): Promise<IndexableResourceEntry[]> => {
+  const files = await getFiles(path.join(directory, 'federated', '**', resourceDirectory, '*.{md,mdx}'));
+  const resourcePathPattern = new RegExp(`^(?:federated/[^/]+/)+${resourceDirectory}/[^/]+\\.mdx?$`, 'i');
+
+  return files
+    .filter((file) => {
+      const catalogPath = toCatalogPath(directory, file);
+      return resourcePathPattern.test(catalogPath) && !ignoreRules?.ignores(catalogPath);
+    })
+    .map((sourcePath) => {
+      const { data } = matter.read(sourcePath);
+      return { type, resource: data as IndexableResource, sourcePath };
+    });
 };
 
 const normalizeAssets = async (directory: string, hashContent: boolean, ignoreRules?: ignore.Ignore) => {
@@ -380,6 +402,7 @@ const toIndexResource = async (
 export const buildIndex =
   (directory: string) =>
   async ({ source, commit, hashContent = true }: BuildIndexOptions): Promise<Index> => {
+    const ignoreRules = await loadIgnoreRules(directory);
     const [
       domains,
       channels,
@@ -415,6 +438,10 @@ export const buildIndex =
       getUsers(directory)(),
       getDiagrams(directory)(),
     ]);
+    const federatedDirectoryResources = await Promise.all([
+      getFederatedDirectoryResources(directory, 'team', 'teams', ignoreRules),
+      getFederatedDirectoryResources(directory, 'user', 'users', ignoreRules),
+    ]);
     const indexableResources: IndexableResourceEntry[] = [
       ...(domains ?? []).map((resource) => ({ type: 'domain' as const, resource })),
       ...(channels ?? []).map((resource) => ({ type: 'channel' as const, resource })),
@@ -439,6 +466,7 @@ export const buildIndex =
         resource,
         sourcePath: path.join(directory, 'users', `${resource.id}.mdx`),
       })),
+      ...federatedDirectoryResources.flat(),
       ...(diagrams ?? []).map((resource) => ({ type: 'diagram' as const, resource })),
     ];
     const locatedResources = await Promise.all(
@@ -455,7 +483,6 @@ export const buildIndex =
         .filter(({ sourcePath }) => /^index\.mdx?$/i.test(path.basename(sourcePath)))
         .map(({ sourcePath }) => path.resolve(path.dirname(sourcePath)))
     );
-    const ignoreRules = await loadIgnoreRules(directory);
     const resources = await Promise.all(
       locatedResources.map(({ type, resource, sourcePath }) =>
         toIndexResource(directory, type, resource, hashContent, sourcePath, resourceDirectories, ignoreRules)

--- a/packages/sdk/src/hydrate.ts
+++ b/packages/sdk/src/hydrate.ts
@@ -12,7 +12,7 @@ export type Cache = {
 
 export type HydrateOptions = {
   outDir: string;
-  localSource: string;
+  localSource?: string;
   fetch: Fetcher;
   modes?: Record<string, 'hydrate' | 'reference'>;
   cache?: Cache;
@@ -99,7 +99,7 @@ export async function hydrate(graph: ResolvedGraph, options: HydrateOptions): Pr
 
   for (const entity of graph.entities) {
     const { source, commit } = entity.resolvedFrom;
-    if (source === options.localSource) continue;
+    if (options.localSource !== undefined && source === options.localSource) continue;
 
     if (options.modes?.[source] === 'reference') {
       result.referenced++;
@@ -136,7 +136,8 @@ export async function hydrate(graph: ResolvedGraph, options: HydrateOptions): Pr
 
   for (const asset of graph.assets) {
     const { source, commit } = asset.resolvedFrom;
-    if (source === options.localSource || options.modes?.[source] === 'reference') continue;
+    if ((options.localSource !== undefined && source === options.localSource) || options.modes?.[source] === 'reference')
+      continue;
 
     artifacts.push({
       source,

--- a/packages/sdk/src/hydrate.ts
+++ b/packages/sdk/src/hydrate.ts
@@ -41,6 +41,8 @@ const getSourceDirectory = (source: string) => {
 
 const getContentHash = (content: Buffer) => `sha256:${createHash('sha256').update(content).digest('hex')}`;
 
+const getHydrationTarget = (artifactPath: string) => artifactPath.replace(/^(?:federated\/[^/]+\/)+/, '');
+
 const getArtifactOutputPath = (artifact: Artifact, outDir: string) => {
   const allowedDirectory = path.resolve(artifact.shared ? outDir : path.join(outDir, getSourceDirectory(artifact.source)));
   const portableTarget = artifact.target.replaceAll('\\', '/');
@@ -113,7 +115,7 @@ export async function hydrate(graph: ResolvedGraph, options: HydrateOptions): Pr
       commit,
       path: entity.contentPath,
       hash: entity.contentHash,
-      target: entity.contentPath,
+      target: getHydrationTarget(entity.contentPath),
     });
 
     const entityDirectory = path.posix.dirname(entity.contentPath);
@@ -121,16 +123,28 @@ export async function hydrate(graph: ResolvedGraph, options: HydrateOptions): Pr
     for (const schema of entity.schemas ?? []) {
       if (!schema.path) continue;
       const artifactPath = path.posix.join(entityDirectory, schema.path);
-      artifacts.push({ source, commit, path: artifactPath, hash: schema.hash, target: artifactPath });
+      artifacts.push({ source, commit, path: artifactPath, hash: schema.hash, target: getHydrationTarget(artifactPath) });
     }
 
     for (const specification of entity.specifications ?? []) {
       const artifactPath = path.posix.join(entityDirectory, specification.path);
-      artifacts.push({ source, commit, path: artifactPath, hash: specification.hash, target: artifactPath });
+      artifacts.push({
+        source,
+        commit,
+        path: artifactPath,
+        hash: specification.hash,
+        target: getHydrationTarget(artifactPath),
+      });
     }
 
     for (const sidecar of entity.sidecars ?? []) {
-      artifacts.push({ source, commit, path: sidecar.path, hash: sidecar.hash, target: sidecar.path });
+      artifacts.push({
+        source,
+        commit,
+        path: sidecar.path,
+        hash: sidecar.hash,
+        target: getHydrationTarget(sidecar.path),
+      });
     }
   }
 
@@ -144,7 +158,7 @@ export async function hydrate(graph: ResolvedGraph, options: HydrateOptions): Pr
       commit,
       path: asset.path,
       hash: asset.hash,
-      target: asset.path,
+      target: getHydrationTarget(asset.path),
       shared: true,
     });
   }

--- a/packages/sdk/src/internal/resources.ts
+++ b/packages/sdk/src/internal/resources.ts
@@ -19,6 +19,9 @@ import { basename } from 'node:path';
 import path from 'node:path';
 
 type Resource = Service | Message | CustomDoc | Adr;
+const resourceSourcePaths = new WeakMap<object, string>();
+
+export const getResourceSourcePath = (resource: object) => resourceSourcePaths.get(resource);
 
 export const versionResource = async (catalogDir: string, id: string) => {
   // Find all the events in the directory
@@ -222,10 +225,12 @@ export const getResources = async (
         }
       }
     }
-    return {
+    const resource = {
       ...data,
       markdown: content.trim(),
     } as Resource;
+    resourceSourcePaths.set(resource, file);
+    return resource;
   });
 };
 

--- a/packages/sdk/src/resolve.ts
+++ b/packages/sdk/src/resolve.ts
@@ -99,12 +99,7 @@ export const resolve = (indexes: Index[]): ResolvedGraph => {
   const warnings: ResolutionWarning[] = [];
 
   for (const [assetPath, candidates] of assetCandidatesByPath) {
-    candidates.sort(
-      (left, right) =>
-        compareText(left.resolvedFrom.source, right.resolvedFrom.source) ||
-        compareText(left.resolvedFrom.commit, right.resolvedFrom.commit)
-    );
-    const [winner] = candidates;
+    const winner = candidates[candidates.length - 1];
     const sources = [...new Set(candidates.map((candidate) => candidate.resolvedFrom.source))].sort(compareText);
     const hashes = new Set(candidates.map((candidate) => candidate.hash));
     const hashesCanBeCompared = candidates.every((candidate) => candidate.hash !== undefined);

--- a/packages/sdk/src/test/build-index.test.ts
+++ b/packages/sdk/src/test/build-index.test.ts
@@ -54,6 +54,38 @@ describe('buildIndex', () => {
     ]);
   });
 
+  it('can exclude federated resources when indexing local catalog ownership', async () => {
+    const localService = path.join(CATALOG_PATH, 'services/payment-service/index.mdx');
+    const federatedService = path.join(CATALOG_PATH, 'federated/acme/services/payment-service/index.mdx');
+    const federatedOnlyService = path.join(CATALOG_PATH, 'federated/acme/services/order-service/index.mdx');
+    const federatedEventWithLocalServiceId = path.join(CATALOG_PATH, 'federated/acme/events/payment-service/index.mdx');
+    fs.mkdirSync(path.dirname(localService), { recursive: true });
+    fs.mkdirSync(path.dirname(federatedService), { recursive: true });
+    fs.mkdirSync(path.dirname(federatedOnlyService), { recursive: true });
+    fs.mkdirSync(path.dirname(federatedEventWithLocalServiceId), { recursive: true });
+    fs.writeFileSync(localService, '---\nid: payment-service\nname: Local payment service\n---\n# Local');
+    fs.writeFileSync(federatedService, '---\nid: payment-service\nname: Federated payment service\n---\n# Federated');
+    fs.writeFileSync(federatedOnlyService, '---\nid: order-service\nname: Federated order service\n---\n# Federated');
+    fs.writeFileSync(
+      federatedEventWithLocalServiceId,
+      '---\nid: payment-service\nname: Federated event with local service ID\n---\n# Federated'
+    );
+
+    const index = await sdk.buildIndex({
+      source: 'central-catalog',
+      commit: 'local',
+      includeFederated: false,
+    });
+
+    expect(index.resources).toEqual([
+      expect.objectContaining({
+        id: 'payment-service',
+        name: 'Local payment service',
+        contentPath: 'services/payment-service/index.mdx',
+      }),
+    ]);
+  });
+
   it('indexes teams and users from an already composed catalog using their federated paths', async () => {
     const federatedTeam = path.join(CATALOG_PATH, 'federated/acme/teams/payments-team.mdx');
     const federatedUser = path.join(CATALOG_PATH, 'federated/acme/users/alice.mdx');

--- a/packages/sdk/src/test/build-index.test.ts
+++ b/packages/sdk/src/test/build-index.test.ts
@@ -38,6 +38,46 @@ describe('buildIndex', () => {
     });
   });
 
+  it('indexes resources from an already composed catalog', async () => {
+    const federatedService = path.join(CATALOG_PATH, 'federated/acme/services/payment-service/index.mdx');
+    fs.mkdirSync(path.dirname(federatedService), { recursive: true });
+    fs.writeFileSync(federatedService, '---\nid: payment-service\nname: Payment service\n---\n# Federated');
+
+    const index = await sdk.buildIndex({ source: 'composed-catalog', commit: 'abc1234' });
+
+    expect(index.resources).toEqual([
+      expect.objectContaining({
+        id: 'payment-service',
+        name: 'Payment service',
+        contentPath: 'federated/acme/services/payment-service/index.mdx',
+      }),
+    ]);
+  });
+
+  it('indexes teams and users from an already composed catalog using their federated paths', async () => {
+    const federatedTeam = path.join(CATALOG_PATH, 'federated/acme/teams/payments-team.mdx');
+    const federatedUser = path.join(CATALOG_PATH, 'federated/acme/users/alice.mdx');
+    fs.mkdirSync(path.dirname(federatedTeam), { recursive: true });
+    fs.mkdirSync(path.dirname(federatedUser), { recursive: true });
+    fs.writeFileSync(federatedTeam, '---\nid: payments-team\nname: Payments team\nmembers:\n  - alice\n---\n# Team');
+    fs.writeFileSync(federatedUser, '---\nid: alice\nname: Alice\n---\n# User');
+
+    const index = await sdk.buildIndex({ source: 'composed-catalog', commit: 'abc1234' });
+
+    expect(index.resources).toEqual([
+      expect.objectContaining({
+        type: 'team',
+        id: 'payments-team',
+        contentPath: 'federated/acme/teams/payments-team.mdx',
+      }),
+      expect.objectContaining({
+        type: 'user',
+        id: 'alice',
+        contentPath: 'federated/acme/users/alice.mdx',
+      }),
+    ]);
+  });
+
   it('indexes public files and components as assets', async () => {
     fs.mkdirSync(path.join(CATALOG_PATH, 'public/icons/languages'), { recursive: true });
     fs.mkdirSync(path.join(CATALOG_PATH, 'components'), { recursive: true });

--- a/packages/sdk/src/test/hydrate.test.ts
+++ b/packages/sdk/src/test/hydrate.test.ts
@@ -106,6 +106,67 @@ describe('hydrate', () => {
     });
   });
 
+  it('flattens content from an already composed source instead of creating nested federation directories', async () => {
+    const files: Record<string, Buffer> = {
+      'federated/inner/teams/payments-team.mdx': Buffer.from('# Payments Team'),
+      'federated/inner/users/alice.mdx': Buffer.from('# Alice'),
+      'federated/inner/services/payment-service/index.mdx': Buffer.from('# Payment Service'),
+      'federated/inner/services/payment-service/schema.json': Buffer.from('{}'),
+      'federated/inner/services/payment-service/openapi.yaml': Buffer.from('openapi: 3.0.0'),
+      'federated/inner/services/payment-service/docs/runbook.mdx': Buffer.from('# Runbook'),
+    };
+    const fetch = vi.fn<Fetcher>().mockImplementation(async (request) => files[request.path]);
+    const graph: ResolvedGraph = {
+      entities: [
+        {
+          type: 'team',
+          id: 'payments-team',
+          name: 'Payments Team',
+          contentPath: 'federated/inner/teams/payments-team.mdx',
+          resolvedFrom: { source: 'acme/composed', commit: '4a1b7e2' },
+        },
+        {
+          type: 'user',
+          id: 'alice',
+          name: 'Alice',
+          contentPath: 'federated/inner/users/alice.mdx',
+          resolvedFrom: { source: 'acme/composed', commit: '4a1b7e2' },
+        },
+        {
+          type: 'service',
+          id: 'payment-service',
+          name: 'Payment Service',
+          contentPath: 'federated/inner/services/payment-service/index.mdx',
+          schemas: [{ path: 'schema.json' }],
+          specifications: [{ type: 'openapi', path: 'openapi.yaml' }],
+          sidecars: [{ path: 'federated/inner/services/payment-service/docs/runbook.mdx' }],
+          resolvedFrom: { source: 'acme/composed', commit: '4a1b7e2' },
+        },
+      ],
+      assets: [],
+      edges: [],
+      conflicts: [],
+      warnings: [],
+      externals: [],
+    };
+
+    await hydrate(graph, { outDir, fetch });
+
+    expect(fetch.mock.calls.map(([request]) => request.path)).toEqual(Object.keys(files));
+    const sourceDirectory = path.join(outDir, 'acme-composed--929126a0ee67');
+    await expect(
+      Promise.all([
+        fs.readFile(path.join(sourceDirectory, 'teams/payments-team.mdx')),
+        fs.readFile(path.join(sourceDirectory, 'users/alice.mdx')),
+        fs.readFile(path.join(sourceDirectory, 'services/payment-service/index.mdx')),
+        fs.readFile(path.join(sourceDirectory, 'services/payment-service/schema.json')),
+        fs.readFile(path.join(sourceDirectory, 'services/payment-service/openapi.yaml')),
+        fs.readFile(path.join(sourceDirectory, 'services/payment-service/docs/runbook.mdx')),
+      ])
+    ).resolves.toEqual(Object.values(files));
+    await expect(fs.access(path.join(sourceDirectory, 'federated'))).rejects.toThrow();
+  });
+
   it('fetches content for a federated channel', async () => {
     const content = Buffer.from('# Payments Events');
     const fetch = vi.fn<Fetcher>().mockResolvedValue(content);

--- a/packages/sdk/src/test/hydrate.test.ts
+++ b/packages/sdk/src/test/hydrate.test.ts
@@ -84,7 +84,6 @@ describe('hydrate', () => {
 
     const result = await hydrate(graph, {
       outDir,
-      localSource: 'acme/central',
       fetch,
     });
 

--- a/packages/sdk/src/test/resolve.test.ts
+++ b/packages/sdk/src/test/resolve.test.ts
@@ -368,7 +368,7 @@ describe('resolve', () => {
       });
     });
 
-    it('chooses a deterministic winner and warns when asset hashes differ', () => {
+    it('chooses the last source as the winner and warns when asset hashes differ', () => {
       const paymentsIndex = anIndex({
         source: 'acme/payments',
         commit: '4a1b7e2',
@@ -415,7 +415,27 @@ describe('resolve', () => {
       };
 
       expect(resolve([paymentsIndex, fulfilmentIndex])).toEqual(expected);
-      expect(resolve([fulfilmentIndex, paymentsIndex])).toEqual(expected);
+      expect(resolve([fulfilmentIndex, paymentsIndex])).toEqual({
+        ...expected,
+        assets: [
+          {
+            path: 'public/logo.svg',
+            hash: 'sha256:c81a4f',
+            resolvedFrom: {
+              source: 'acme/payments',
+              commit: '4a1b7e2',
+            },
+          },
+        ],
+        warnings: [
+          {
+            kind: 'asset-collision',
+            path: 'public/logo.svg',
+            sources: ['acme/fulfilment', 'acme/payments'],
+            winner: 'acme/payments',
+          },
+        ],
+      });
     });
   });
 


### PR DESCRIPTION
## What This PR Does

Adds the `eventcatalog federate` command, which composes remote catalogs into the local one. It reads `federation.sources` from `eventcatalog.config.ts`, fetches and indexes each configured GitHub source, resolves the combined graph across catalog boundaries, then hydrates the federated content and public assets into the local catalog directory.

This builds on the federation pipeline already added to the SDK (`build-index`, `resolve`, `hydrate`) in earlier PRs and wires it up behind a user-facing command. Federation is gated behind the Enterprise/Scale plan check.

## Changes Overview

### Key Changes

- **New `federate` command** (`packages/core/src/eventcatalog.ts`) — runs the full pipeline with progress reporting, a `--no-cache` flag, and `.env` loading. Exits quietly on ownership conflicts since those are already reported in detail.
- **Federation orchestrator** (`federation/federate.ts`) — drives fetch → index → resolve → hydrate, emits typed progress events, writes a lockfile pinning each source commit, and throws `FederationConflictError` when resources are owned by more than one source.
- **GitHub source provider** (`federation/github-source-provider.ts`) — resolves `github:owner/repo` locators. Prefers a published index from the source; falls back to a shallow checkout and generates one. Guards against catalog paths that escape the source directory.
- **Content cache** (`federation/content-cache.ts`) — content-addressed cache under `.eventcatalog-cache/federation/content`, keyed by `sha256:` hash and verified on read so corrupt entries are ignored rather than trusted.
- **Public asset composition** (`federation/public-assets.ts`) — copies federated public assets into the catalog, preserves local files over federated ones, and removes stale files from previous runs.
- **Config types** (`eventcatalog.config.ts`) — adds the `federation.sources` config with `id`, `source`, `path`, `ref`, and `mode` (`hydrate` or `reference`).

### SDK changes

- `build-index` now indexes teams and users found in `federated/**` directories, so federated non-versioned resources make it into the index.
- `hydrate` accepts an optional `localSource`, letting the graph hydrate when there is no local source to exclude.
- `resolve` picks the last asset candidate rather than sorting by source name, so the last configured source wins on asset collisions — consistent with how public asset conflicts resolve.

## How It Works

Each configured source is fetched and indexed independently. Where the source publishes its own index, that is used directly; otherwise the provider does a shallow checkout at the configured ref and generates one via the SDK. Every source resolves to a concrete commit SHA, which is written to the lockfile so runs are reproducible.

The indexes are then handed to the SDK's `resolve`, which stitches the catalogs into one graph and reports ownership conflicts, warnings, and unresolved external references. If any resource is claimed by more than one source, federation stops before writing anything.

Hydration streams file content through the content cache. Files already cached by hash are reused without a network call; the rest are downloaded and written into the federated directory. `--no-cache` skips reads and refreshes the cache from scratch.

## Breaking Changes

None. The `federation` config key is optional, and running `federate` without configured sources is a no-op with a warning.

## Additional Notes

- Tests cover the orchestrator, the content cache, and the GitHub provider (`packages/core/src/__tests__/`), plus updated SDK tests for the index/resolve/hydrate changes.
- The provider currently supports `github:owner/repository` only. Other locators throw a clear error and are the natural next thing to add.
- No corresponding change is needed in the `eventcatalog/eventcatalog-editor` repository — this is a CLI-only feature with no editor surface.