### PR TITLE
Fix linter resource discovery inside federated catalogs

### DIFF
--- a/.changeset/fix-federated-linter-discovery.md
+++ b/.changeset/fix-federated-linter-discovery.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/linter': patch
+---
+
+Fix resource discovery for federated domains, services, teams, and users so valid owner and decision-maker references are indexed correctly.

--- a/packages/linter/src/scanner/index.ts
+++ b/packages/linter/src/scanner/index.ts
@@ -17,13 +17,15 @@ const RESOURCE_DIRECTORY_NAMES: Partial<Record<ResourceType, string>> = {
   adr: 'adrs',
 };
 
+const withFederatedContent = (patterns: string[]) => [...patterns, ...patterns.map((pattern) => `federated/*/${pattern}`)];
+
 const RESOURCE_PATTERNS: Partial<Record<ResourceType, string[]>> = {
-  domain: [
+  domain: withFederatedContent([
     'domains/*/index.{md,mdx}',
     'domains/*/versioned/*/index.{md,mdx}',
     'domains/*/subdomains/*/index.{md,mdx}',
     'domains/*/subdomains/*/versioned/*/index.{md,mdx}',
-  ],
+  ]),
   system: [
     '**/systems/**/index.{md,mdx}',
     '**/systems/**/versioned/*/index.{md,mdx}',
@@ -42,14 +44,16 @@ const RESOURCE_PATTERNS: Partial<Record<ResourceType, string[]>> = {
     '!**/systems/**/docs/**',
   ],
   service: [
-    'domains/*/services/*/index.{md,mdx}',
-    'domains/*/services/*/versioned/*/index.{md,mdx}',
-    'domains/*/subdomains/*/services/*/index.{md,mdx}',
-    'domains/*/subdomains/*/services/*/versioned/*/index.{md,mdx}',
+    ...withFederatedContent([
+      'domains/*/services/*/index.{md,mdx}',
+      'domains/*/services/*/versioned/*/index.{md,mdx}',
+      'domains/*/subdomains/*/services/*/index.{md,mdx}',
+      'domains/*/subdomains/*/services/*/versioned/*/index.{md,mdx}',
+      'services/*/index.{md,mdx}',
+      'services/*/versioned/*/index.{md,mdx}',
+    ]),
     '**/systems/**/services/*/index.{md,mdx}',
     '**/systems/**/services/*/versioned/*/index.{md,mdx}',
-    'services/*/index.{md,mdx}',
-    'services/*/versioned/*/index.{md,mdx}',
   ],
   agent: ['**/agents/*/index.{md,mdx}', '**/agents/*/versioned/*/index.{md,mdx}'],
   adr: ['**/adrs/*/index.{md,mdx}', '**/adrs/*/versioned/*/index.{md,mdx}'],
@@ -62,8 +66,8 @@ const RESOURCE_PATTERNS: Partial<Record<ResourceType, string[]>> = {
   container: ['**/containers/**/index.{md,mdx}', '**/containers/**/versioned/*/index.{md,mdx}'],
   dataProduct: ['**/data-products/*/index.{md,mdx}', '**/data-products/*/versioned/*/index.{md,mdx}'],
   diagram: ['**/diagrams/**/index.{md,mdx}', '**/diagrams/**/versioned/*/index.{md,mdx}'],
-  user: ['users/*.{md,mdx}'],
-  team: ['teams/*.{md,mdx}'],
+  user: withFederatedContent(['users/*.{md,mdx}']),
+  team: withFederatedContent(['teams/*.{md,mdx}']),
 };
 
 export const extractResourceInfo = (filePath: string, resourceType: ResourceType): { id: string; version?: string } => {

--- a/packages/linter/tests/cli-integration.test.ts
+++ b/packages/linter/tests/cli-integration.test.ts
@@ -345,4 +345,42 @@ receives:
     expect(result.stdout).not.toContain('Referenced event/command/query');
     expect(result.stdout).toContain('2 files checked');
   });
+
+  it('resolves owners from federated catalogs', async () => {
+    const federatedRoot = path.join(tempDir, 'federated', 'event-catalog--payments--abc123');
+    const federatedServiceDir = path.join(federatedRoot, 'services', 'payment-service');
+    const federatedTeamsDir = path.join(federatedRoot, 'teams');
+
+    fs.mkdirSync(federatedServiceDir, { recursive: true });
+    fs.mkdirSync(federatedTeamsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(federatedServiceDir, 'index.mdx'),
+      `---
+id: payment-service
+name: Payment Service
+summary: Processes payments
+version: 1.0.0
+owners:
+  - payments-team
+---
+# Payment Service
+`
+    );
+    fs.writeFileSync(
+      path.join(federatedTeamsDir, 'payments-team.mdx'),
+      `---
+id: payments-team
+name: Payments Team
+summary: Owns payment services
+---
+# Payments Team
+`
+    );
+
+    const result = await runLinter();
+
+    expect(result.success).toBe(true);
+    expect(result.stdout).not.toContain('Referenced user/team');
+    expect(result.stdout).toContain('2 files checked');
+  });
 });

--- a/packages/linter/tests/scanner.test.ts
+++ b/packages/linter/tests/scanner.test.ts
@@ -136,4 +136,34 @@ describe('extractResourceInfo', () => {
     expect(catalogFiles.some((file) => file.resourceType === 'service' && file.resourceId === 'customer-api')).toBe(true);
     expect(catalogFiles.some((file) => file.resourceType === 'container' && file.resourceId === 'customer-db')).toBe(true);
   });
+
+  it('should scan root-scoped resources inside federated catalogs', async () => {
+    const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), 'eventcatalog-linter-scanner-'));
+    const sourceDir = 'federated/event-catalog--payments--abc123';
+    const files = [
+      `${sourceDir}/domains/payments/index.mdx`,
+      `${sourceDir}/domains/payments/services/payment-service/index.mdx`,
+      `${sourceDir}/services/fraud-service/index.mdx`,
+      `${sourceDir}/teams/payments-team.mdx`,
+      `${sourceDir}/users/jane-doe.mdx`,
+    ];
+
+    await Promise.all(
+      files.map(async (file) => {
+        const filePath = path.join(rootDir, file);
+        await fs.mkdir(path.dirname(filePath), { recursive: true });
+        await fs.writeFile(filePath, '---\nid: test\nname: Test\nversion: 1.0.0\n---\n');
+      })
+    );
+
+    const catalogFiles = await scanCatalogFiles(rootDir);
+
+    expect(catalogFiles.map((file) => `${file.resourceType}:${file.resourceId}`).sort()).toEqual([
+      'domain:payments',
+      'service:fraud-service',
+      'service:payment-service',
+      'team:payments-team',
+      'user:jane-doe',
+    ]);
+  });
 });


### PR DESCRIPTION
## What This PR Does

The linter's file scanner did not look inside `federated/*/` directories for root-scoped resources, so domains, services, teams, and users pulled in via `eventcatalog federate` were never indexed. Because they were missing from the index, valid references to them (owners, decision makers) were reported as broken. This PR extends the scanner's glob patterns so federated copies of those resources are discovered alongside local ones.

## Changes Overview

### Key Changes

- Add a `withFederatedContent` helper in `packages/linter/src/scanner/index.ts` that mirrors a set of glob patterns under `federated/*/`.
- Apply it to the `domain`, `service`, `user`, and `team` resource patterns.
- Move the root-scoped `services/*/index.{md,mdx}` patterns into the federated-aware set so `federated/*/services/*` is matched.
- Add a scanner unit test covering root-scoped resources inside a federated catalog.
- Add a CLI integration test asserting owner references resolve to a team defined in a federated catalog.

## How It Works

Most resource patterns already begin with `**/`, so they match at any depth and pick up federated content for free. The ones that were anchored to the catalog root — `domains/*`, `services/*`, `teams/*.mdx`, `users/*.mdx` — did not. `withFederatedContent(patterns)` returns the original patterns plus a `federated/*/`-prefixed copy of each, which keeps the anchoring intent (one level of nesting for the federated source directory) without loosening the patterns to `**/`.

## Breaking Changes

None. This only widens what the linter discovers; no existing behaviour changes for non-federated catalogs.

## Additional Notes

- All 174 tests in `@eventcatalog/linter` pass.
- Includes a `patch` changeset for `@eventcatalog/linter`.
- No corresponding change is needed in the `eventcatalog/eventcatalog-editor` repository — this is scanner-internal to the linter package.