### PR TITLE
Make federated custom components available through @catalog/components

### DIFF
--- a/.changeset/federated-custom-components.md
+++ b/.changeset/federated-custom-components.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/core': patch
+---
+
+Make federated custom components available through `@catalog/components`, with local catalog components taking precedence.

--- a/packages/core/src/__tests__/custom-components.spec.ts
+++ b/packages/core/src/__tests__/custom-components.spec.ts
@@ -1,0 +1,86 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { catalogToAstro } from '../catalog-to-astro-content-directory';
+import { isCustomComponentPath } from '../custom-components';
+
+describe('custom component synchronization', () => {
+  let projectDirectory: string;
+  let catalogDirectory: string;
+  let destinationDirectory: string;
+
+  const writeProjectFile = async (relativePath: string, content: string) => {
+    const filePath = path.join(projectDirectory, relativePath);
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, content);
+    return filePath;
+  };
+
+  beforeEach(async () => {
+    projectDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'eventcatalog-components-project-'));
+    catalogDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'eventcatalog-components-core-'));
+    destinationDirectory = path.join(catalogDirectory, 'src', 'custom-defined-components');
+
+    await fs.mkdir(path.join(catalogDirectory, 'src'), { recursive: true });
+    await writeProjectFile('package.json', JSON.stringify({ type: 'module' }));
+    await writeProjectFile('eventcatalog.config.js', "export default { cId: 'component-test' };\n");
+  });
+
+  afterEach(async () => {
+    await fs.rm(projectDirectory, { recursive: true, force: true });
+    await fs.rm(catalogDirectory, { recursive: true, force: true });
+  });
+
+  it('combines federated components, applies local precedence, and removes stale output during catalog preparation', async () => {
+    await writeProjectFile('federated/components/remote-only.astro', 'remote only');
+    await writeProjectFile('federated/components/shared/card.astro', 'remote card');
+    await writeProjectFile('federated/components/shared/remote-helper.ts', 'export const remoteHelper = true;');
+    await writeProjectFile('federated/components/replaced-by-directory', 'remote file');
+    await writeProjectFile('federated/components/nested/helper.ts', 'export const helper = true;');
+    await writeProjectFile('components/local-only.mdx', '# Local only');
+    await writeProjectFile('components/shared/card.astro', 'local card');
+    await writeProjectFile('components/replaced-by-directory/index.astro', 'local directory');
+    await fs.mkdir(destinationDirectory, { recursive: true });
+    await fs.writeFile(path.join(destinationDirectory, 'stale.astro'), 'stale');
+
+    await catalogToAstro(projectDirectory, catalogDirectory);
+
+    await expect(fs.readFile(path.join(destinationDirectory, 'remote-only.astro'), 'utf8')).resolves.toBe('remote only');
+    await expect(fs.readFile(path.join(destinationDirectory, 'local-only.mdx'), 'utf8')).resolves.toBe('# Local only');
+    await expect(fs.readFile(path.join(destinationDirectory, 'shared', 'card.astro'), 'utf8')).resolves.toBe('local card');
+    await expect(fs.readFile(path.join(destinationDirectory, 'shared', 'remote-helper.ts'), 'utf8')).resolves.toBe(
+      'export const remoteHelper = true;'
+    );
+    await expect(fs.readFile(path.join(destinationDirectory, 'replaced-by-directory', 'index.astro'), 'utf8')).resolves.toBe(
+      'local directory'
+    );
+    await expect(fs.readFile(path.join(destinationDirectory, 'nested', 'helper.ts'), 'utf8')).resolves.toBe(
+      'export const helper = true;'
+    );
+    await expect(fs.access(path.join(destinationDirectory, 'stale.astro'))).rejects.toThrow();
+  });
+
+  it('removes components that disappear before the next catalog preparation', async () => {
+    const componentPath = await writeProjectFile('federated/components/temporary.astro', 'temporary');
+    await catalogToAstro(projectDirectory, catalogDirectory);
+    await fs.rm(componentPath);
+
+    await catalogToAstro(projectDirectory, catalogDirectory);
+
+    await expect(fs.access(path.join(destinationDirectory, 'temporary.astro'))).rejects.toThrow();
+  });
+
+  it('recognizes only the local and hydrated shared component directories', () => {
+    expect(isCustomComponentPath(projectDirectory, path.join(projectDirectory, 'components', 'card.astro'))).toBe(true);
+    expect(isCustomComponentPath(projectDirectory, path.join(projectDirectory, 'federated', 'components', 'card.astro'))).toBe(
+      true
+    );
+    expect(
+      isCustomComponentPath(projectDirectory, path.join(projectDirectory, 'federated', 'source', 'components', 'card.astro'))
+    ).toBe(false);
+    expect(isCustomComponentPath(projectDirectory, path.join(projectDirectory, 'services', 'components', 'card.astro'))).toBe(
+      false
+    );
+  });
+});

--- a/packages/core/src/catalog-to-astro-content-directory.js
+++ b/packages/core/src/catalog-to-astro-content-directory.js
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'url';
 import os from 'node:os';
 import { verifyRequiredFieldsAreInCatalogConfigFile } from './eventcatalog-config-file-utils.js';
 import { mapCatalogToAstro } from './map-catalog-to-astro.js';
+import { isCustomComponentPath, syncCustomComponents } from './custom-components.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const rootPkg = path.resolve(path.dirname(__filename), '../');
@@ -32,6 +33,10 @@ const copyFiles = async (source, target) => {
   }
 
   for (const file of files) {
+    // Custom components are composed in one deterministic pass so local files
+    // always override federated files and stale generated files are removed.
+    if (isCustomComponentPath(source, file)) continue;
+
     mapCatalogToAstro({
       filePath: file,
       astroDir: target,
@@ -90,5 +95,6 @@ export const catalogToAstro = async (source, astroDir) => {
 
   await clearCustomPages(astroDir);
   await removeGeneratedLikeC4Sources(astroDir);
+  await syncCustomComponents(source, astroDir);
   await copyFiles(source, astroDir);
 };

--- a/packages/core/src/custom-components.js
+++ b/packages/core/src/custom-components.js
@@ -1,0 +1,60 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+export const isCustomComponentPath = (projectDirectory, filePath) => {
+  const [rootDirectory, childDirectory] = path.relative(projectDirectory, filePath).split(path.sep);
+  return rootDirectory === 'components' || (rootDirectory === 'federated' && childDirectory === 'components');
+};
+
+const readDirectory = async (directory) => {
+  try {
+    return await fs.readdir(directory, { withFileTypes: true });
+  } catch (error) {
+    if (error.code === 'ENOENT') return [];
+    throw error;
+  }
+};
+
+const mergeDirectory = async (sourceDirectory, destinationDirectory) => {
+  for (const entry of await readDirectory(sourceDirectory)) {
+    const sourcePath = path.join(sourceDirectory, entry.name);
+    const destinationPath = path.join(destinationDirectory, entry.name);
+
+    if (entry.isDirectory()) {
+      const destinationEntry = await fs.stat(destinationPath).catch((error) => {
+        if (error.code === 'ENOENT') return undefined;
+        throw error;
+      });
+      if (destinationEntry && !destinationEntry.isDirectory()) {
+        await fs.rm(destinationPath, { recursive: true, force: true });
+      }
+      await fs.mkdir(destinationPath, { recursive: true });
+      await mergeDirectory(sourcePath, destinationPath);
+      continue;
+    }
+
+    await fs.rm(destinationPath, { recursive: true, force: true });
+    await fs.copyFile(sourcePath, destinationPath);
+  }
+};
+
+/**
+ * Builds the component directory consumed by the @catalog/components/* alias.
+ * Federated components form the base layer and local catalog components always win.
+ */
+export const syncCustomComponents = async (projectDirectory, catalogDirectory) => {
+  const destinationDirectory = path.join(catalogDirectory, 'src', 'custom-defined-components');
+  const destinationParent = path.dirname(destinationDirectory);
+  await fs.mkdir(destinationParent, { recursive: true });
+
+  const stagingDirectory = await fs.mkdtemp(path.join(destinationParent, '.custom-defined-components.staging-'));
+
+  try {
+    await mergeDirectory(path.join(projectDirectory, 'federated', 'components'), stagingDirectory);
+    await mergeDirectory(path.join(projectDirectory, 'components'), stagingDirectory);
+    await fs.rm(destinationDirectory, { recursive: true, force: true });
+    await fs.rename(stagingDirectory, destinationDirectory);
+  } finally {
+    await fs.rm(stagingDirectory, { recursive: true, force: true });
+  }
+};


### PR DESCRIPTION
## What This PR Does

Components shipped in a federated catalog were not reachable through the `@catalog/components` alias — only the local catalog's `components/` directory resolved, so federated components silently failed to import.

This PR merges custom components from federated catalogs into the generated component directory, with local catalog components taking precedence on a name collision.

## Changes Overview

### Key Changes

- `packages/core/src/custom-components.js` — new module that composes the component directory consumed by `@catalog/components/*`.
- `packages/core/src/catalog-to-astro-content-directory.js` — skips component files during the generic copy pass and delegates to `syncCustomComponents()` instead.
- `packages/core/src/__tests__/custom-components.spec.ts` — tests covering precedence, nested directories, and stale-file removal.

## How It Works

`syncCustomComponents()` builds the merged directory in one deterministic pass into a staging directory: federated components (`federated/*/components`) are laid down first as the base layer, then local `components/` is merged over the top, so a local file always wins on a name collision.

The staging directory is then swapped into place over `src/custom-defined-components`, which removes stale generated files left by previous runs. `isCustomComponentPath()` lets the generic copy loop skip these files so the two mechanisms don't race.

## Breaking Changes

None. The change is additive — catalogs without a `federated/` directory behave exactly as before.

## Additional Notes

- One changeset, `patch`, for `@eventcatalog/core`.
- The merge is last-write-wins per file, not a deep merge of file contents — a local component fully replaces a federated one at the same path.
- This branch previously also carried the linter federated-discovery fix; that shipped separately in #2779 (released as `@eventcatalog/linter@1.1.12`) and has been rebased out.