### PR TITLE
Support local filesystem catalogs as federation sources

### DIFF
--- a/.changeset/federated-custom-components.md
+++ b/.changeset/federated-custom-components.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/core': patch
+---
+
+Make federated custom components available through `@catalog/components`, with local catalog components taking precedence.

--- a/.changeset/local-filesystem-federation.md
+++ b/.changeset/local-filesystem-federation.md
@@ -1,0 +1,8 @@
+---
+"@eventcatalog/core": patch
+"@eventcatalog/sdk": patch
+---
+
+Support local filesystem catalogs as federation sources using the `file:` protocol.
+
+Ignore generated `dist` and `.eventcatalog-core` resources when indexing catalogs.

--- a/packages/core/src/__tests__/custom-components.spec.ts
+++ b/packages/core/src/__tests__/custom-components.spec.ts
@@ -1,0 +1,86 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { catalogToAstro } from '../catalog-to-astro-content-directory';
+import { isCustomComponentPath } from '../custom-components';
+
+describe('custom component synchronization', () => {
+  let projectDirectory: string;
+  let catalogDirectory: string;
+  let destinationDirectory: string;
+
+  const writeProjectFile = async (relativePath: string, content: string) => {
+    const filePath = path.join(projectDirectory, relativePath);
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, content);
+    return filePath;
+  };
+
+  beforeEach(async () => {
+    projectDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'eventcatalog-components-project-'));
+    catalogDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'eventcatalog-components-core-'));
+    destinationDirectory = path.join(catalogDirectory, 'src', 'custom-defined-components');
+
+    await fs.mkdir(path.join(catalogDirectory, 'src'), { recursive: true });
+    await writeProjectFile('package.json', JSON.stringify({ type: 'module' }));
+    await writeProjectFile('eventcatalog.config.js', "export default { cId: 'component-test' };\n");
+  });
+
+  afterEach(async () => {
+    await fs.rm(projectDirectory, { recursive: true, force: true });
+    await fs.rm(catalogDirectory, { recursive: true, force: true });
+  });
+
+  it('combines federated components, applies local precedence, and removes stale output during catalog preparation', async () => {
+    await writeProjectFile('federated/components/remote-only.astro', 'remote only');
+    await writeProjectFile('federated/components/shared/card.astro', 'remote card');
+    await writeProjectFile('federated/components/shared/remote-helper.ts', 'export const remoteHelper = true;');
+    await writeProjectFile('federated/components/replaced-by-directory', 'remote file');
+    await writeProjectFile('federated/components/nested/helper.ts', 'export const helper = true;');
+    await writeProjectFile('components/local-only.mdx', '# Local only');
+    await writeProjectFile('components/shared/card.astro', 'local card');
+    await writeProjectFile('components/replaced-by-directory/index.astro', 'local directory');
+    await fs.mkdir(destinationDirectory, { recursive: true });
+    await fs.writeFile(path.join(destinationDirectory, 'stale.astro'), 'stale');
+
+    await catalogToAstro(projectDirectory, catalogDirectory);
+
+    await expect(fs.readFile(path.join(destinationDirectory, 'remote-only.astro'), 'utf8')).resolves.toBe('remote only');
+    await expect(fs.readFile(path.join(destinationDirectory, 'local-only.mdx'), 'utf8')).resolves.toBe('# Local only');
+    await expect(fs.readFile(path.join(destinationDirectory, 'shared', 'card.astro'), 'utf8')).resolves.toBe('local card');
+    await expect(fs.readFile(path.join(destinationDirectory, 'shared', 'remote-helper.ts'), 'utf8')).resolves.toBe(
+      'export const remoteHelper = true;'
+    );
+    await expect(fs.readFile(path.join(destinationDirectory, 'replaced-by-directory', 'index.astro'), 'utf8')).resolves.toBe(
+      'local directory'
+    );
+    await expect(fs.readFile(path.join(destinationDirectory, 'nested', 'helper.ts'), 'utf8')).resolves.toBe(
+      'export const helper = true;'
+    );
+    await expect(fs.access(path.join(destinationDirectory, 'stale.astro'))).rejects.toThrow();
+  });
+
+  it('removes components that disappear before the next catalog preparation', async () => {
+    const componentPath = await writeProjectFile('federated/components/temporary.astro', 'temporary');
+    await catalogToAstro(projectDirectory, catalogDirectory);
+    await fs.rm(componentPath);
+
+    await catalogToAstro(projectDirectory, catalogDirectory);
+
+    await expect(fs.access(path.join(destinationDirectory, 'temporary.astro'))).rejects.toThrow();
+  });
+
+  it('recognizes only the local and hydrated shared component directories', () => {
+    expect(isCustomComponentPath(projectDirectory, path.join(projectDirectory, 'components', 'card.astro'))).toBe(true);
+    expect(isCustomComponentPath(projectDirectory, path.join(projectDirectory, 'federated', 'components', 'card.astro'))).toBe(
+      true
+    );
+    expect(
+      isCustomComponentPath(projectDirectory, path.join(projectDirectory, 'federated', 'source', 'components', 'card.astro'))
+    ).toBe(false);
+    expect(isCustomComponentPath(projectDirectory, path.join(projectDirectory, 'services', 'components', 'card.astro'))).toBe(
+      false
+    );
+  });
+});

--- a/packages/core/src/__tests__/federate.spec.ts
+++ b/packages/core/src/__tests__/federate.spec.ts
@@ -44,6 +44,13 @@ const writeProject = async (projectDirectory: string, sources: unknown[]) => {
   );
 };
 
+const writeService = async (directory: string, id: string, markdown = `# ${id}`) => {
+  const filePath = path.join(directory, 'services', id, 'index.mdx');
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, `---\nid: ${id}\nname: ${id}\nversion: 1.0.0\n---\n${markdown}\n`);
+  return filePath;
+};
+
 const listFiles = async (directory: string, relativeDirectory = ''): Promise<string[]> => {
   const entries = await fs.readdir(path.join(directory, relativeDirectory), { withFileTypes: true });
   const files = await Promise.all(
@@ -129,6 +136,96 @@ describe('federate catalog', () => {
     ]);
     expect(progress).toContainEqual({ type: 'local:complete', resources: 1 });
     expect(progress).toContainEqual({ type: 'resolving', localResources: 1, resources: 2 });
+  });
+
+  it('indexes and hydrates local filesystem resources and assets through the default provider', async () => {
+    const sourceDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'eventcatalog-local-source-'));
+    try {
+      await writeService(sourceDirectory, 'payment-service');
+      await fs.mkdir(path.join(sourceDirectory, 'components'), { recursive: true });
+      await fs.writeFile(path.join(sourceDirectory, 'components', 'payment-card.astro'), '<aside>Payments</aside>');
+      await fs.mkdir(path.join(sourceDirectory, 'public'), { recursive: true });
+      await fs.writeFile(path.join(sourceDirectory, 'public', 'payment.txt'), 'payments');
+      await writeProject(projectDirectory, [
+        { id: 'acme/payments', source: `file:${path.relative(projectDirectory, sourceDirectory)}` },
+      ]);
+
+      const result = await federateCatalog(projectDirectory, { now: () => new Date('2026-08-19T12:00:00.000Z') });
+
+      expect(result).toMatchObject({
+        sources: 1,
+        resources: 1,
+        hydrate: { fetched: 3, written: 3, referenced: 0 },
+      });
+      expect(await listFiles(path.join(projectDirectory, 'federated'))).toEqual([
+        'acme-payments--bf264d5186bc/services/payment-service/index.mdx',
+        'components/payment-card.astro',
+      ]);
+      await expect(fs.readFile(path.join(projectDirectory, 'public', 'payment.txt'), 'utf8')).resolves.toBe('payments');
+      const lock = JSON.parse(await fs.readFile(path.join(projectDirectory, 'eventcatalog.lock'), 'utf8'));
+      expect(lock.sources).toEqual([
+        expect.objectContaining({
+          id: 'acme/payments',
+          commit: expect.stringMatching(/^local:[a-f0-9]{12}$/),
+          resolvedAt: '2026-08-19T12:00:00.000Z',
+        }),
+      ]);
+    } finally {
+      await fs.rm(sourceDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it('applies source conflict rules to filesystem catalogs before hydration', async () => {
+    const firstSource = await fs.mkdtemp(path.join(os.tmpdir(), 'eventcatalog-local-first-'));
+    const secondSource = await fs.mkdtemp(path.join(os.tmpdir(), 'eventcatalog-local-second-'));
+    try {
+      await writeService(firstSource, 'shared-service', '# First');
+      await writeService(secondSource, 'shared-service', '# Second');
+      await writeProject(projectDirectory, [
+        { id: 'acme/first', source: `file:${path.relative(projectDirectory, firstSource)}` },
+        { id: 'acme/second', source: `file:${path.relative(projectDirectory, secondSource)}` },
+      ]);
+
+      await expect(federateCatalog(projectDirectory)).rejects.toMatchObject({
+        conflicts: [
+          {
+            kind: 'duplicate-source',
+            id: 'shared-service',
+            sources: ['acme/first', 'acme/second'],
+          },
+        ],
+      });
+      await expect(fs.access(path.join(projectDirectory, 'federated'))).rejects.toThrow();
+    } finally {
+      await Promise.all([
+        fs.rm(firstSource, { recursive: true, force: true }),
+        fs.rm(secondSource, { recursive: true, force: true }),
+      ]);
+    }
+  });
+
+  it('applies central ownership conflicts to filesystem catalogs before hydration', async () => {
+    const sourceDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'eventcatalog-local-conflict-'));
+    try {
+      await writeService(sourceDirectory, 'shared-service', '# Source');
+      await writeService(projectDirectory, 'shared-service', '# Central');
+      await writeProject(projectDirectory, [
+        { id: 'acme/source', source: `file:${path.relative(projectDirectory, sourceDirectory)}` },
+      ]);
+
+      await expect(federateCatalog(projectDirectory)).rejects.toMatchObject({
+        conflicts: [
+          {
+            kind: 'duplicate-source',
+            id: 'shared-service',
+            sources: ['acme/source', 'central-catalog'],
+          },
+        ],
+      });
+      await expect(fs.access(path.join(projectDirectory, 'federated'))).rejects.toThrow();
+    } finally {
+      await fs.rm(sourceDirectory, { recursive: true, force: true });
+    }
   });
 
   it('composes public assets into the root with main ownership and last-source-wins semantics', async () => {

--- a/packages/core/src/__tests__/filesystem-source-provider.spec.ts
+++ b/packages/core/src/__tests__/filesystem-source-provider.spec.ts
@@ -1,0 +1,136 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createFileSystemSourceProvider } from '../federation/filesystem-source-provider';
+
+const writeFile = async (directory: string, relativePath: string, content: string) => {
+  const filePath = path.join(directory, relativePath);
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, content);
+  return filePath;
+};
+
+const service = (id: string, markdown = id) => `---
+id: ${id}
+name: ${id}
+version: 1.0.0
+---
+${markdown}
+`;
+
+describe('filesystem federation source provider', () => {
+  let workspaceDirectory: string;
+  let projectDirectory: string;
+  let sourceDirectory: string;
+
+  beforeEach(async () => {
+    workspaceDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'eventcatalog-filesystem-provider-'));
+    projectDirectory = path.join(workspaceDirectory, 'central-catalog');
+    sourceDirectory = path.join(workspaceDirectory, 'catalogs', 'payments');
+    await fs.mkdir(projectDirectory, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(workspaceDirectory, { recursive: true, force: true });
+  });
+
+  it('indexes and fetches a catalog relative to the central catalog directory', async () => {
+    await writeFile(sourceDirectory, 'services/payment-service/index.mdx', service('payment-service', '# Payments'));
+    await writeFile(sourceDirectory, 'components/payment-card.astro', '<aside>Payments</aside>');
+    await writeFile(sourceDirectory, 'public/payment.svg', '<svg></svg>');
+    await writeFile(sourceDirectory, 'federated/old/services/stale-service/index.mdx', service('stale-service'));
+    await writeFile(sourceDirectory, 'dist/generated/services/stale-dist-service/index.mdx', service('stale-dist-service'));
+    await writeFile(
+      sourceDirectory,
+      '.eventcatalog-core/src/content/services/stale-core-service/index.mdx',
+      service('stale-core-service')
+    );
+    const provider = createFileSystemSourceProvider(projectDirectory);
+    const source = {
+      id: 'acme/payments',
+      source: 'file:..',
+      path: 'catalogs/payments',
+    };
+
+    const resolved = await provider.resolve(source);
+
+    expect(resolved).toMatchObject({
+      generated: true,
+      commit: expect.stringMatching(/^local:[a-f0-9]{12}$/),
+      index: {
+        source: 'acme/payments',
+        commit: expect.stringMatching(/^local:[a-f0-9]{12}$/),
+        resources: [expect.objectContaining({ id: 'payment-service' })],
+        assets: expect.arrayContaining([
+          expect.objectContaining({ path: 'components/payment-card.astro' }),
+          expect.objectContaining({ path: 'public/payment.svg' }),
+        ]),
+      },
+    });
+    expect(resolved.index.resources.some((resource) => resource.id === 'stale-service')).toBe(false);
+    expect(resolved.index.resources.some((resource) => resource.id === 'stale-dist-service')).toBe(false);
+    expect(resolved.index.resources.some((resource) => resource.id === 'stale-core-service')).toBe(false);
+    await expect(
+      provider.fetchContent({
+        source,
+        commit: resolved.commit,
+        path: 'services/payment-service/index.mdx',
+      })
+    ).resolves.toEqual(Buffer.from(service('payment-service', '# Payments')));
+  });
+
+  it('changes the synthetic revision when indexed content changes', async () => {
+    const resourcePath = await writeFile(sourceDirectory, 'services/payment-service/index.mdx', service('payment-service'));
+    const provider = createFileSystemSourceProvider(projectDirectory);
+    const source = { id: 'acme/payments', source: 'file:../catalogs/payments' };
+
+    const first = await provider.resolve(source);
+    await fs.writeFile(resourcePath, service('payment-service', '# Updated'));
+    const second = await provider.resolve(source);
+
+    expect(second.commit).not.toBe(first.commit);
+    expect(second.index.resources[0].contentHash).not.toBe(first.index.resources[0].contentHash);
+  });
+
+  it('rejects catalog and artifact paths that escape their source', async () => {
+    await writeFile(sourceDirectory, 'services/payment-service/index.mdx', service('payment-service'));
+    const provider = createFileSystemSourceProvider(projectDirectory);
+
+    await expect(
+      provider.resolve({ id: 'acme/payments', source: 'file:../catalogs/payments', path: '../orders' })
+    ).rejects.toThrow('escapes its filesystem source');
+    await expect(
+      provider.fetchContent({
+        source: { id: 'acme/payments', source: 'file:../catalogs/payments' },
+        commit: 'local:test',
+        path: '../secret.txt',
+      })
+    ).rejects.toThrow('escapes its filesystem source');
+  });
+
+  it('reports missing sources and artifacts with the source id', async () => {
+    const provider = createFileSystemSourceProvider(projectDirectory);
+
+    await expect(provider.resolve({ id: 'acme/missing', source: 'file:../missing' })).rejects.toThrow(
+      'Filesystem federation source "acme/missing" does not exist'
+    );
+    await fs.mkdir(sourceDirectory, { recursive: true });
+    await expect(
+      provider.fetchContent({
+        source: { id: 'acme/payments', source: 'file:../catalogs/payments' },
+        commit: 'local:test',
+        path: 'missing.mdx',
+      })
+    ).rejects.toThrow('Federated artifact not found for "acme/payments": missing.mdx');
+  });
+
+  it('rejects Git refs because filesystem snapshots are content-derived', async () => {
+    await fs.mkdir(sourceDirectory, { recursive: true });
+    const provider = createFileSystemSourceProvider(projectDirectory);
+
+    await expect(provider.resolve({ id: 'acme/payments', source: 'file:../catalogs/payments', ref: 'main' })).rejects.toThrow(
+      'does not support "ref"'
+    );
+  });
+});

--- a/packages/core/src/__tests__/source-provider.spec.ts
+++ b/packages/core/src/__tests__/source-provider.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createFederationSourceProvider } from '../federation/source-provider';
+import type { FederationSourceProvider } from '../federation/types';
+
+const provider = (name: string): FederationSourceProvider => ({
+  resolve: vi.fn(async (source) => {
+    const index = { indexVersion: 1 as const, source: source.id, commit: name, resources: [] };
+    return { bytes: Buffer.from(name), index, commit: name, generated: true };
+  }),
+  fetchContent: vi.fn(async () => Buffer.from(name)),
+});
+
+describe('federation source provider', () => {
+  it('routes GitHub and filesystem sources by protocol', async () => {
+    const github = provider('github');
+    const filesystem = provider('filesystem');
+    const sourceProvider = createFederationSourceProvider('/catalog', { github, filesystem });
+    const githubSource = { id: 'acme/github', source: 'github:acme/catalog' };
+    const filesystemSource = { id: 'acme/filesystem', source: 'file:../catalog' };
+
+    await expect(sourceProvider.resolve(githubSource)).resolves.toMatchObject({ commit: 'github' });
+    await expect(sourceProvider.resolve(filesystemSource)).resolves.toMatchObject({ commit: 'filesystem' });
+    await expect(sourceProvider.fetchContent({ source: githubSource, commit: 'github', path: 'service.mdx' })).resolves.toEqual(
+      Buffer.from('github')
+    );
+    await expect(
+      sourceProvider.fetchContent({ source: filesystemSource, commit: 'filesystem', path: 'service.mdx' })
+    ).resolves.toEqual(Buffer.from('filesystem'));
+  });
+
+  it('rejects unsupported source protocols before resolving or fetching', async () => {
+    const github = provider('github');
+    const filesystem = provider('filesystem');
+    const sourceProvider = createFederationSourceProvider('/catalog', { github, filesystem });
+    const source = { id: 'acme/gitlab', source: 'gitlab:acme/catalog' };
+
+    await expect(sourceProvider.resolve(source)).rejects.toThrow('Supported protocols: github:, file:');
+    await expect(sourceProvider.fetchContent({ source, commit: 'test', path: 'service.mdx' })).rejects.toThrow(
+      'Supported protocols: github:, file:'
+    );
+  });
+});

--- a/packages/core/src/catalog-to-astro-content-directory.js
+++ b/packages/core/src/catalog-to-astro-content-directory.js
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'url';
 import os from 'node:os';
 import { verifyRequiredFieldsAreInCatalogConfigFile } from './eventcatalog-config-file-utils.js';
 import { mapCatalogToAstro } from './map-catalog-to-astro.js';
+import { isCustomComponentPath, syncCustomComponents } from './custom-components.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const rootPkg = path.resolve(path.dirname(__filename), '../');
@@ -32,6 +33,10 @@ const copyFiles = async (source, target) => {
   }
 
   for (const file of files) {
+    // Custom components are composed in one deterministic pass so local files
+    // always override federated files and stale generated files are removed.
+    if (isCustomComponentPath(source, file)) continue;
+
     mapCatalogToAstro({
       filePath: file,
       astroDir: target,
@@ -90,5 +95,6 @@ export const catalogToAstro = async (source, astroDir) => {
 
   await clearCustomPages(astroDir);
   await removeGeneratedLikeC4Sources(astroDir);
+  await syncCustomComponents(source, astroDir);
   await copyFiles(source, astroDir);
 };

--- a/packages/core/src/custom-components.js
+++ b/packages/core/src/custom-components.js
@@ -1,0 +1,60 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+export const isCustomComponentPath = (projectDirectory, filePath) => {
+  const [rootDirectory, childDirectory] = path.relative(projectDirectory, filePath).split(path.sep);
+  return rootDirectory === 'components' || (rootDirectory === 'federated' && childDirectory === 'components');
+};
+
+const readDirectory = async (directory) => {
+  try {
+    return await fs.readdir(directory, { withFileTypes: true });
+  } catch (error) {
+    if (error.code === 'ENOENT') return [];
+    throw error;
+  }
+};
+
+const mergeDirectory = async (sourceDirectory, destinationDirectory) => {
+  for (const entry of await readDirectory(sourceDirectory)) {
+    const sourcePath = path.join(sourceDirectory, entry.name);
+    const destinationPath = path.join(destinationDirectory, entry.name);
+
+    if (entry.isDirectory()) {
+      const destinationEntry = await fs.stat(destinationPath).catch((error) => {
+        if (error.code === 'ENOENT') return undefined;
+        throw error;
+      });
+      if (destinationEntry && !destinationEntry.isDirectory()) {
+        await fs.rm(destinationPath, { recursive: true, force: true });
+      }
+      await fs.mkdir(destinationPath, { recursive: true });
+      await mergeDirectory(sourcePath, destinationPath);
+      continue;
+    }
+
+    await fs.rm(destinationPath, { recursive: true, force: true });
+    await fs.copyFile(sourcePath, destinationPath);
+  }
+};
+
+/**
+ * Builds the component directory consumed by the @catalog/components/* alias.
+ * Federated components form the base layer and local catalog components always win.
+ */
+export const syncCustomComponents = async (projectDirectory, catalogDirectory) => {
+  const destinationDirectory = path.join(catalogDirectory, 'src', 'custom-defined-components');
+  const destinationParent = path.dirname(destinationDirectory);
+  await fs.mkdir(destinationParent, { recursive: true });
+
+  const stagingDirectory = await fs.mkdtemp(path.join(destinationParent, '.custom-defined-components.staging-'));
+
+  try {
+    await mergeDirectory(path.join(projectDirectory, 'federated', 'components'), stagingDirectory);
+    await mergeDirectory(path.join(projectDirectory, 'components'), stagingDirectory);
+    await fs.rm(destinationDirectory, { recursive: true, force: true });
+    await fs.rename(stagingDirectory, destinationDirectory);
+  } finally {
+    await fs.rm(stagingDirectory, { recursive: true, force: true });
+  }
+};

--- a/packages/core/src/eventcatalog.config.ts
+++ b/packages/core/src/eventcatalog.config.ts
@@ -89,11 +89,11 @@ type GeneratorConfig = string | Record<string, unknown> | [string, Record<string
 export type FederationSourceConfig = {
   /** Stable source id used by the lockfile and federation graph. */
   id: string;
-  /** Source locator, for example github:acme/payments. */
+  /** Source locator, for example github:acme/payments or file:../payments. */
   source: string;
-  /** Directory containing the source catalog. @default '.' */
+  /** Directory containing the source catalog, relative to the GitHub repository or filesystem source. @default '.' */
   path?: string;
-  /** Branch or tag to federate. @default 'main' */
+  /** Branch or tag to federate from a GitHub source. Not supported for filesystem sources. @default 'main' */
   ref?: string;
   /** Materialize source files or retain graph references only. @default 'hydrate' */
   mode?: 'hydrate' | 'reference';

--- a/packages/core/src/federation/federate.ts
+++ b/packages/core/src/federation/federate.ts
@@ -5,8 +5,8 @@ import createSDK, { hydrate, resolve, type Conflict, type HydrateResult, type Re
 import type { FederationSourceConfig } from '../eventcatalog.config';
 import { getEventCatalogConfigFile } from '../eventcatalog-config-file-utils.js';
 import { createFederationContentCache } from './content-cache';
-import { createGitHubSourceProvider } from './github-source-provider';
 import { composePublicAssets, type FederatedPublicFiles, type PublicAssetCompositionResult } from './public-assets';
+import { createFederationSourceProvider } from './source-provider';
 import type { FederationSourceProvider, ResolvedFederationSource } from './types';
 
 export type FederationProgressEvent =
@@ -155,7 +155,7 @@ export const federateCatalog = async (
   validateSources(sources);
   if (options.useCache === false) options.onProgress?.({ type: 'cache:disabled' });
 
-  const provider = options.provider ?? createGitHubSourceProvider();
+  const provider = options.provider ?? createFederationSourceProvider(projectDirectory);
   const resolvedSources: { config: FederationSourceConfig; resolved: ResolvedFederationSource }[] = [];
 
   for (const [index, source] of sources.entries()) {

--- a/packages/core/src/federation/filesystem-source-provider.ts
+++ b/packages/core/src/federation/filesystem-source-provider.ts
@@ -1,0 +1,109 @@
+import { createHash } from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import createSDK from '@eventcatalog/sdk';
+import type { FederationSourceConfig } from '../eventcatalog.config';
+import type { FederationSourceProvider } from './types';
+
+const FILESYSTEM_SOURCE_PREFIX = 'file:';
+
+const isWithinDirectory = (directory: string, target: string) => {
+  const relativePath = path.relative(directory, target);
+  return (
+    relativePath === '' || (!relativePath.startsWith(`..${path.sep}`) && relativePath !== '..' && !path.isAbsolute(relativePath))
+  );
+};
+
+const assertPortableRelativePath = (filePath: string, label: string, allowRoot = true) => {
+  const portablePath = filePath.replaceAll('\\', '/');
+  const normalizedPath = path.posix.normalize(portablePath);
+  const isUnsafe =
+    filePath.includes('\\') ||
+    filePath.includes('\0') ||
+    path.posix.isAbsolute(normalizedPath) ||
+    /^[a-zA-Z]:\//.test(normalizedPath) ||
+    normalizedPath === '..' ||
+    normalizedPath.startsWith('../') ||
+    (!allowRoot && (normalizedPath === '.' || normalizedPath === ''));
+
+  if (isUnsafe) throw new Error(`${label} "${filePath}" escapes its filesystem source`);
+  return normalizedPath;
+};
+
+const getSourceRoot = (projectDirectory: string, source: FederationSourceConfig) => {
+  if (!source.source.startsWith(FILESYSTEM_SOURCE_PREFIX)) {
+    throw new Error(`Unsupported federation source "${source.source}". Expected file:path/to/catalog.`);
+  }
+
+  const locator = source.source.slice(FILESYSTEM_SOURCE_PREFIX.length);
+  if (!locator.trim()) throw new Error(`Filesystem federation source "${source.id}" requires a path after "file:".`);
+  return path.resolve(projectDirectory, locator);
+};
+
+const getCatalogDirectory = async (projectDirectory: string, source: FederationSourceConfig) => {
+  if (source.ref) throw new Error(`Filesystem federation source "${source.id}" does not support "ref".`);
+
+  const sourceRoot = getSourceRoot(projectDirectory, source);
+  const catalogPath = assertPortableRelativePath(source.path ?? '.', 'Catalog path');
+  const catalogDirectory = path.resolve(sourceRoot, ...catalogPath.split('/'));
+  if (!isWithinDirectory(sourceRoot, catalogDirectory)) {
+    throw new Error(`Catalog path "${source.path}" escapes source "${source.id}"`);
+  }
+
+  try {
+    const [realSourceRoot, realCatalogDirectory] = await Promise.all([fs.realpath(sourceRoot), fs.realpath(catalogDirectory)]);
+    if (!isWithinDirectory(realSourceRoot, realCatalogDirectory)) {
+      throw new Error(`Catalog path "${source.path}" escapes source "${source.id}"`);
+    }
+    if (!(await fs.stat(realCatalogDirectory)).isDirectory()) {
+      throw new Error(`Filesystem federation source "${source.id}" is not a directory: ${catalogDirectory}`);
+    }
+    return realCatalogDirectory;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new Error(`Filesystem federation source "${source.id}" does not exist: ${catalogDirectory}`, { cause: error });
+    }
+    throw error;
+  }
+};
+
+const getArtifactPath = async (catalogDirectory: string, source: FederationSourceConfig, artifactPath: string) => {
+  const normalizedPath = assertPortableRelativePath(artifactPath, 'Federated artifact path', false);
+  const filePath = path.resolve(catalogDirectory, ...normalizedPath.split('/'));
+  if (!isWithinDirectory(catalogDirectory, filePath)) {
+    throw new Error(`Federated artifact path "${artifactPath}" escapes source "${source.id}"`);
+  }
+
+  try {
+    const realFilePath = await fs.realpath(filePath);
+    if (!isWithinDirectory(catalogDirectory, realFilePath)) {
+      throw new Error(`Federated artifact path "${artifactPath}" escapes source "${source.id}"`);
+    }
+    return realFilePath;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new Error(`Federated artifact not found for "${source.id}": ${artifactPath}`, { cause: error });
+    }
+    throw error;
+  }
+};
+
+export const createFileSystemSourceProvider = (projectDirectory: string): FederationSourceProvider => ({
+  async resolve(source) {
+    const catalogDirectory = await getCatalogDirectory(projectDirectory, source);
+    const localIndex = await createSDK(catalogDirectory).buildIndex({
+      source: source.id,
+      commit: 'local',
+      includeFederated: false,
+    });
+    const snapshot = createHash('sha256').update(JSON.stringify(localIndex)).digest('hex').slice(0, 12);
+    const index = { ...localIndex, commit: `local:${snapshot}` };
+    const bytes = Buffer.from(JSON.stringify(index));
+    return { bytes, index, commit: index.commit, generated: true };
+  },
+
+  async fetchContent({ source, path: artifactPath }) {
+    const catalogDirectory = await getCatalogDirectory(projectDirectory, source);
+    return fs.readFile(await getArtifactPath(catalogDirectory, source, artifactPath));
+  },
+});

--- a/packages/core/src/federation/source-provider.ts
+++ b/packages/core/src/federation/source-provider.ts
@@ -1,0 +1,32 @@
+import type { FederationSourceConfig } from '../eventcatalog.config';
+import { createFileSystemSourceProvider } from './filesystem-source-provider';
+import { createGitHubSourceProvider } from './github-source-provider';
+import type { FederationSourceProvider } from './types';
+
+type FederationSourceProviders = {
+  github?: FederationSourceProvider;
+  filesystem?: FederationSourceProvider;
+};
+
+export const createFederationSourceProvider = (
+  projectDirectory: string,
+  providers: FederationSourceProviders = {}
+): FederationSourceProvider => {
+  const github = providers.github ?? createGitHubSourceProvider();
+  const filesystem = providers.filesystem ?? createFileSystemSourceProvider(projectDirectory);
+
+  const getProvider = (source: FederationSourceConfig) => {
+    if (source.source.startsWith('github:')) return github;
+    if (source.source.startsWith('file:')) return filesystem;
+    throw new Error(`Unsupported federation source "${source.source}" for "${source.id}". Supported protocols: github:, file:.`);
+  };
+
+  return {
+    async resolve(source) {
+      return getProvider(source).resolve(source);
+    },
+    async fetchContent(request) {
+      return getProvider(request.source).fetchContent(request);
+    },
+  };
+};

--- a/packages/sdk/src/internal/utils.ts
+++ b/packages/sdk/src/internal/utils.ts
@@ -28,7 +28,7 @@ function buildFileCache(catalogDir: string): void {
   const canonicalCatalogDir = toCanonicalPath(catalogDir);
   const files = globSync('**/index.{md,mdx}', {
     cwd: canonicalCatalogDir,
-    ignore: ['node_modules/**'],
+    ignore: ['node_modules/**', 'dist/**', '.eventcatalog-core/**'],
     absolute: true,
     nodir: true,
   }).map(normalize);
@@ -234,7 +234,7 @@ export const getFiles = async (pattern: string, ignore: string | string[] = '') 
 
     const files = globSync(relativePattern, {
       cwd: absoluteBaseDir,
-      ignore: ['node_modules/**', ...ignoreList],
+      ignore: ['node_modules/**', 'dist/**', '.eventcatalog-core/**', ...ignoreList],
       absolute: true,
       nodir: true,
     });

--- a/packages/sdk/src/test/build-index.test.ts
+++ b/packages/sdk/src/test/build-index.test.ts
@@ -86,6 +86,27 @@ describe('buildIndex', () => {
     ]);
   });
 
+  it('excludes generated catalog resources', async () => {
+    const localService = path.join(CATALOG_PATH, 'services/payment-service/index.mdx');
+    const distService = path.join(CATALOG_PATH, 'dist/services/generated-service/index.mdx');
+    const coreService = path.join(CATALOG_PATH, '.eventcatalog-core/services/cached-service/index.mdx');
+    fs.mkdirSync(path.dirname(localService), { recursive: true });
+    fs.mkdirSync(path.dirname(distService), { recursive: true });
+    fs.mkdirSync(path.dirname(coreService), { recursive: true });
+    fs.writeFileSync(localService, '---\nid: payment-service\nname: Payment service\n---\n# Local');
+    fs.writeFileSync(distService, '---\nid: generated-service\nname: Generated service\n---\n# Generated');
+    fs.writeFileSync(coreService, '---\nid: cached-service\nname: Cached service\n---\n# Cached');
+
+    const index = await sdk.buildIndex({ source: 'acme/payments', commit: 'local' });
+
+    expect(index.resources).toEqual([
+      expect.objectContaining({
+        id: 'payment-service',
+        contentPath: 'services/payment-service/index.mdx',
+      }),
+    ]);
+  });
+
   it('indexes teams and users from an already composed catalog using their federated paths', async () => {
     const federatedTeam = path.join(CATALOG_PATH, 'federated/acme/teams/payments-team.mdx');
     const federatedUser = path.join(CATALOG_PATH, 'federated/acme/users/alice.mdx');


### PR DESCRIPTION
## What This PR Does

Adds a `file:` protocol to EventCatalog federation so a catalog can federate from another catalog on the local filesystem, not just from GitHub. This makes local development and monorepo setups possible without pushing sources to a remote first. It also merges federated custom components into the catalog's own components directory, and stops the SDK from indexing generated `dist` and `.eventcatalog-core` output as real catalog resources.

## Changes Overview

### Key Changes

- New `file:` federation source protocol — `{ id: 'acme/payments', source: 'file:../payments' }` in `eventcatalog.config`.
- New `createFileSystemSourceProvider` (`packages/core/src/federation/filesystem-source-provider.ts`) that indexes and reads a catalog directly from disk.
- New `createFederationSourceProvider` (`packages/core/src/federation/source-provider.ts`) that routes each source to the right provider by protocol and errors clearly on unsupported ones.
- `federateCatalog` now defaults to the routing provider instead of the GitHub provider directly.
- Federated custom components are merged into the catalog components directory during the Astro content build.
- SDK indexing now ignores `dist/**` and `.eventcatalog-core/**`, so generated output no longer shows up as duplicate resources.
- Config JSDoc updated to document `file:` and to note `ref` is GitHub-only.

## How It Works

`createFederationSourceProvider(projectDirectory)` inspects each source's locator prefix. `github:` sources continue to go through the existing GitHub provider; `file:` sources go to the new filesystem provider. Anything else throws with the list of supported protocols.

The filesystem provider resolves the locator relative to the project directory, then builds an index with the SDK's `buildIndex` (with `includeFederated: false`, so a source catalog's own federated content isn't re-federated). Because there's no git commit to pin against, it derives a synthetic commit of the form `local:<sha256-prefix>` from a hash of the index — so the lockfile still changes whenever source content changes, and caching stays correct.

Path handling is deliberately strict. Both the configured `path` and every requested artifact path are normalized, rejected if they're absolute, Windows-drive-prefixed, contain backslashes or null bytes, or traverse upward. After that, `fs.realpath` is applied and the containment check is repeated, so symlinks can't be used to read outside the source root. `ref` is rejected on filesystem sources since there's no branch or tag to check out.

Conflict detection runs unchanged: filesystem sources go through the same resolve step as GitHub sources, so duplicate resource ids — whether between two filesystem sources or between a source and the central catalog — still fail before anything is written to `federated/`.

## Breaking Changes

None. Existing `github:` sources behave exactly as before; the new provider only adds a branch for `file:` locators.

## Additional Notes

- Test coverage: 21 core tests across `source-provider.spec.ts`, `filesystem-source-provider.spec.ts`, and `federate.spec.ts` (indexing/hydration, public asset composition, both conflict paths), plus 38 SDK `build-index` tests covering the new ignore rules. All passing.
- Reviewer note: the path-escape checks in `filesystem-source-provider.ts` are the security-sensitive part and are worth a close read — they run both before and after `realpath` resolution.
- This branch also carries the earlier custom-components merge commit (`bf0c04cf`), which wasn't pushed separately.
- No change needed in the `eventcatalog/eventcatalog-editor` repository — this is build-time federation behavior with no editor-facing surface.