### PR TITLE
Local filesystem federation sources and ESLint-style federation diagnostics

### DIFF
--- a/.changeset/local-filesystem-federation.md
+++ b/.changeset/local-filesystem-federation.md
@@ -1,0 +1,8 @@
+---
+"@eventcatalog/core": patch
+"@eventcatalog/sdk": patch
+---
+
+Add ESLint-style `--verbose` federation diagnostics for asset collisions and missing-resource references, with structured attributes, gray rule IDs, and consolidated problem counts.
+
+Remove the incomplete federation reference mode so all configured sources are consistently hydrated.

--- a/packages/core/src/__tests__/federate.spec.ts
+++ b/packages/core/src/__tests__/federate.spec.ts
@@ -75,8 +75,8 @@ describe('federate catalog', () => {
 
   it('resolves only configured sources, hydrates, locks, and reports progress', async () => {
     await writeProject(projectDirectory, [
-      { id: 'acme/payments', source: 'github:acme/catalogs', path: 'payments', mode: 'hydrate' },
-      { id: 'acme/orders', source: 'github:acme/catalogs', path: 'orders', mode: 'hydrate' },
+      { id: 'acme/payments', source: 'github:acme/catalogs', path: 'payments' },
+      { id: 'acme/orders', source: 'github:acme/catalogs', path: 'orders' },
     ]);
     const indexes = {
       'acme/payments': sourceIndex('acme/payments', 'payment-service'),
@@ -103,7 +103,7 @@ describe('federate catalog', () => {
       onProgress: (event) => progress.push(event),
     });
 
-    expect(result).toMatchObject({ sources: 2, resources: 2, hydrate: { fetched: 2, written: 2, referenced: 0 } });
+    expect(result).toMatchObject({ sources: 2, resources: 2, hydrate: { fetched: 2, written: 2 } });
     expect(result?.graph.conflicts).toEqual([]);
     expect(result?.graph.entities.map((entity) => entity.resolvedFrom.source).sort()).toEqual(['acme/orders', 'acme/payments']);
     expect(await listFiles(path.join(projectDirectory, 'federated'))).toEqual([
@@ -155,7 +155,7 @@ describe('federate catalog', () => {
       expect(result).toMatchObject({
         sources: 1,
         resources: 1,
-        hydrate: { fetched: 3, written: 3, referenced: 0 },
+        hydrate: { fetched: 3, written: 3 },
       });
       expect(await listFiles(path.join(projectDirectory, 'federated'))).toEqual([
         'acme-payments--bf264d5186bc/services/payment-service/index.mdx',

--- a/packages/core/src/__tests__/federation-diagnostics.spec.ts
+++ b/packages/core/src/__tests__/federation-diagnostics.spec.ts
@@ -1,0 +1,141 @@
+import type { ResolvedGraph } from '@eventcatalog/sdk';
+import { describe, expect, it } from 'vitest';
+import { getFederationDiagnosticCounts, getFederationDiagnostics } from '../federation/diagnostics';
+
+const graph = (overrides: Partial<ResolvedGraph>): ResolvedGraph => ({
+  entities: [],
+  assets: [],
+  edges: [],
+  conflicts: [],
+  warnings: [],
+  externals: [],
+  ...overrides,
+});
+
+describe('federation diagnostics', () => {
+  it('describes missing resources with the catalog and resource that references them', () => {
+    const result = getFederationDiagnostics(
+      graph({
+        entities: [
+          {
+            type: 'service',
+            id: 'checkout-api',
+            version: '1.0.0',
+            name: 'Checkout API',
+            contentPath: 'services/checkout-api/index.mdx',
+            resolvedFrom: { source: 'event-catalog/checkout', commit: 'abc123' },
+          },
+        ],
+        externals: [
+          { id: 'payment-authorized', version: '1.0.0', referencedBy: ['checkout-api'] },
+          { id: 'missing-service', referencedBy: ['checkout-api'] },
+        ],
+      })
+    );
+
+    expect(result).toEqual([
+      {
+        severity: 'warning',
+        message: 'Referenced EventCatalog resource does not exist',
+        rule: 'federation/missing-resource',
+        attributes: [
+          { label: 'source catalog', value: 'event-catalog/checkout' },
+          { label: 'referenced by', value: 'checkout-api' },
+          { label: 'missing resource', value: 'payment-authorized@1.0.0' },
+        ],
+      },
+      {
+        severity: 'warning',
+        message: 'Referenced EventCatalog resource does not exist',
+        rule: 'federation/missing-resource',
+        attributes: [
+          { label: 'source catalog', value: 'event-catalog/checkout' },
+          { label: 'referenced by', value: 'checkout-api' },
+          { label: 'missing resource', value: 'missing-service' },
+        ],
+      },
+    ]);
+  });
+
+  it('formats asset collisions with their sources and winner', () => {
+    expect(
+      getFederationDiagnostics(
+        graph({
+          warnings: [
+            {
+              kind: 'asset-collision',
+              path: 'public/federation-warning.svg',
+              sources: ['event-catalog/orders', 'event-catalog/payments'],
+              winner: 'event-catalog/payments',
+            },
+          ],
+        })
+      )
+    ).toEqual([
+      {
+        severity: 'warning',
+        message: 'Asset collision',
+        rule: 'federation/asset-collision',
+        attributes: [
+          { label: 'asset', value: 'public/federation-warning.svg' },
+          { label: 'sources', value: 'event-catalog/orders, event-catalog/payments' },
+          { label: 'winner', value: 'event-catalog/payments' },
+          { label: 'resolution', value: 'last configured source wins' },
+        ],
+      },
+    ]);
+  });
+
+  it('formats conflicts and reports consolidated counts', () => {
+    const resolvedGraph = graph({
+      entities: [
+        {
+          type: 'event',
+          id: 'payment-captured',
+          name: 'Payment Captured',
+          contentPath: 'events/payment-captured/index.mdx',
+          resolvedFrom: { source: 'event-catalog/payments', commit: 'abc123' },
+        },
+        {
+          type: 'command',
+          id: 'payment-captured',
+          name: 'Payment Captured',
+          contentPath: 'commands/payment-captured/index.mdx',
+          resolvedFrom: { source: 'event-catalog/legacy-billing', commit: 'def456' },
+        },
+      ],
+      conflicts: [
+        {
+          kind: 'type-collision',
+          id: 'payment-captured',
+          sources: ['event-catalog/legacy-billing', 'event-catalog/payments'],
+        },
+      ],
+      externals: [{ id: 'missing-ledger', referencedBy: ['payment-captured'] }],
+    });
+
+    expect(getFederationDiagnostics(resolvedGraph)).toEqual([
+      {
+        severity: 'error',
+        message: 'Resource ID has conflicting types',
+        rule: 'federation/type-collision',
+        attributes: [
+          { label: 'resource', value: 'payment-captured' },
+          { label: 'event-catalog/payments', value: 'documented as an event' },
+          { label: 'event-catalog/legacy-billing', value: 'documented as a command' },
+        ],
+      },
+      {
+        severity: 'warning',
+        message: 'Referenced EventCatalog resource does not exist',
+        rule: 'federation/missing-resource',
+        attributes: [
+          { label: 'source catalog', value: 'event-catalog/payments' },
+          { label: 'referenced by', value: 'payment-captured' },
+          { label: 'missing resource', value: 'missing-ledger' },
+        ],
+      },
+    ]);
+    expect(getFederationDiagnosticCounts(resolvedGraph)).toEqual({ errors: 1, warnings: 1 });
+  });
+});

--- a/packages/core/src/eventcatalog.config.ts
+++ b/packages/core/src/eventcatalog.config.ts
@@ -95,8 +95,6 @@ export type FederationSourceConfig = {
   path?: string;
   /** Branch or tag to federate from a GitHub source. Not supported for filesystem sources. @default 'main' */
   ref?: string;
-  /** Materialize source files or retain graph references only. @default 'hydrate' */
-  mode?: 'hydrate' | 'reference';
 };
 
 type FederationConfig = {

--- a/packages/core/src/eventcatalog.ts
+++ b/packages/core/src/eventcatalog.ts
@@ -23,6 +23,7 @@ import { buildSearchIndex } from './search-indexer';
 import { linkCoreNodeModules, resolveInstalledCoreNodeModules } from './core-node-modules';
 import { createAstroDevLineFilter, createAstroLineFilter } from './astro-output';
 import { federateCatalog, FederationConflictError, type FederationProgressEvent } from './federation/federate';
+import { getFederationDiagnosticCounts, getFederationDiagnostics } from './federation/diagnostics';
 const currentDir = path.dirname(fileURLToPath(import.meta.url));
 const program = new Command().version(VERSION);
 
@@ -716,7 +717,7 @@ program
     await generate(dir);
   });
 
-const reportFederationProgress = (event: FederationProgressEvent) => {
+const reportFederationProgress = (event: FederationProgressEvent, verbose = false) => {
   switch (event.type) {
     case 'configured':
       if (event.sources > 0)
@@ -760,34 +761,40 @@ const reportFederationProgress = (event: FederationProgressEvent) => {
       );
       return;
     case 'resolved':
-      if (event.graph.conflicts.length > 0) {
-        logger.error(
-          `${event.graph.conflicts.length} ownership conflict${event.graph.conflicts.length === 1 ? '' : 's'} found`,
-          'federation'
-        );
-        for (const conflict of event.graph.conflicts.slice(0, 10)) {
-          logger.error(`${conflict.id}: ${conflict.sources.join(', ')}`, 'federation');
-        }
-        if (event.graph.conflicts.length > 10) {
-          logger.error(`...and ${event.graph.conflicts.length - 10} more`, 'federation');
-        }
-        return;
-      }
-      logger.success(
-        `Graph resolved: ${event.graph.entities.length} remote resources, ${event.graph.edges.length} relationships`,
-        'federation'
-      );
-      if (event.graph.warnings.length > 0) {
-        logger.warning(
-          `${event.graph.warnings.length} federation warning${event.graph.warnings.length === 1 ? '' : 's'}`,
+      const graphCounts = getFederationDiagnosticCounts(event.graph);
+      const counts = graphCounts.errors > 0 ? { errors: graphCounts.errors, warnings: 0 } : graphCounts;
+      const showDiagnosticDetails = verbose || counts.errors > 0;
+
+      if (counts.errors === 0) {
+        logger.success(
+          `Graph resolved: ${event.graph.entities.length} remote resources, ${event.graph.edges.length} relationships`,
           'federation'
         );
       }
-      if (event.graph.externals.length > 0) {
+
+      if (counts.errors + counts.warnings === 0) return;
+
+      if (showDiagnosticDetails) {
+        const diagnostics = getFederationDiagnostics(event.graph).filter((diagnostic) =>
+          counts.errors > 0 ? diagnostic.severity === 'error' : verbose
+        );
+
+        logger.info('Federation diagnostics', 'federation');
+        logger.line();
+        for (const diagnostic of diagnostics) {
+          logger.diagnostic(diagnostic.severity, diagnostic.message, diagnostic.rule, diagnostic.attributes);
+          logger.line();
+        }
+        logger.diagnosticSummary(counts.errors, counts.warnings);
+      } else {
         logger.warning(
-          `${event.graph.externals.length} reference${event.graph.externals.length === 1 ? '' : 's'} remain external`,
+          `${counts.warnings} problem${counts.warnings === 1 ? '' : 's'} (0 errors, ${counts.warnings} warning${counts.warnings === 1 ? '' : 's'})`,
           'federation'
         );
+      }
+
+      if (!verbose && counts.warnings > 0) {
+        logger.info('Run with --verbose to see warning details.', 'federation');
       }
       return;
     case 'hydrating':
@@ -808,12 +815,6 @@ const reportFederationProgress = (event: FederationProgressEvent) => {
         `Public assets: ${event.result.copied} copied, ${event.result.skipped} preserved from the main catalog, ${event.result.removed} stale removed`,
         'federation'
       );
-      if (event.result.overwritten > 0) {
-        logger.warning(
-          `${event.result.overwritten} public asset conflict${event.result.overwritten === 1 ? '' : 's'} resolved using the last configured source`,
-          'federation'
-        );
-      }
       return;
     case 'complete':
       logger.success(
@@ -828,7 +829,8 @@ program
   .command('federate')
   .description('Fetch, resolve, and hydrate the catalogs configured in federation.sources.')
   .option('--no-cache', 'Download all federation content and refresh the cache.')
-  .action(async (commandOptions: { cache: boolean }) => {
+  .option('-v, --verbose', 'Show detailed federation diagnostics.')
+  .action(async (commandOptions: { cache: boolean; verbose: boolean }) => {
     logger.welcome();
 
     if (fs.existsSync(path.join(dir, '.env'))) {
@@ -842,7 +844,7 @@ program
       isFederationEnabled: isEventCatalogScaleEnabled,
       onProgress: (event) => {
         if (event.type === 'cleanup:complete') cleanedPreviousOutput = true;
-        reportFederationProgress(event);
+        reportFederationProgress(event, commandOptions.verbose);
       },
     });
     if (!result && !cleanedPreviousOutput) logger.warning('No federation sources configured; nothing to do.', 'federation');

--- a/packages/core/src/federation/diagnostics.ts
+++ b/packages/core/src/federation/diagnostics.ts
@@ -1,0 +1,135 @@
+import type { Conflict, ResolvedGraph } from '@eventcatalog/sdk';
+
+export type FederationDiagnostic = {
+  severity: 'error' | 'warning';
+  message: string;
+  rule: `federation/${string}`;
+  attributes: { label: string; value: string }[];
+};
+
+const getExternalResource = (external: ResolvedGraph['externals'][number]) =>
+  `${external.id}${external.version === undefined ? '' : `@${external.version}`}`;
+
+const getDocumentedResourceType = (type: ResolvedGraph['entities'][number]['type']) => {
+  const usesAn = type === 'adr' || type === 'agent' || type === 'entity' || type === 'event';
+  return `documented as ${usesAn ? 'an' : 'a'} ${type}`;
+};
+
+const getConflictDiagnostic = (conflict: Conflict, graph: ResolvedGraph): FederationDiagnostic => {
+  const catalogs = { label: 'catalogs', value: conflict.sources.join(', ') };
+
+  switch (conflict.kind) {
+    case 'duplicate-source':
+      return {
+        severity: 'error',
+        message: 'Resource has multiple owners',
+        rule: 'federation/duplicate-source',
+        attributes: [
+          { label: 'resource', value: conflict.id },
+          catalogs,
+          { label: 'resolution', value: 'assign a single owning catalog' },
+        ],
+      };
+    case 'type-collision': {
+      const types = [
+        ...new Map(
+          graph.entities
+            .filter((entity) => entity.id === conflict.id)
+            .map(
+              (entity) =>
+                [
+                  `${entity.resolvedFrom.source}:${entity.type}`,
+                  { label: entity.resolvedFrom.source, value: getDocumentedResourceType(entity.type) },
+                ] as const
+            )
+        ).values(),
+      ];
+
+      return {
+        severity: 'error',
+        message: 'Resource ID has conflicting types',
+        rule: 'federation/type-collision',
+        attributes: [{ label: 'resource', value: conflict.id }, ...(types.length > 0 ? types : [catalogs])],
+      };
+    }
+    case 'pointer-type-mismatch': {
+      const typeMismatch = /^Expected (.+) but found (.+)$/.exec(conflict.detail ?? '');
+      return {
+        severity: 'error',
+        message: 'Reference type does not match resource',
+        rule: 'federation/pointer-type-mismatch',
+        attributes: [
+          { label: 'resource', value: conflict.id },
+          ...(typeMismatch
+            ? [
+                { label: 'expected type', value: typeMismatch[1] },
+                { label: 'actual type', value: typeMismatch[2] },
+              ]
+            : conflict.detail
+              ? [{ label: 'detail', value: conflict.detail }]
+              : []),
+          catalogs,
+        ],
+      };
+    }
+    case 'facet-disagreement':
+      return {
+        severity: 'error',
+        message: 'Catalogs disagree about this resource',
+        rule: 'federation/facet-disagreement',
+        attributes: [
+          { label: 'resource', value: conflict.id },
+          ...(conflict.detail ? [{ label: 'detail', value: conflict.detail }] : []),
+          catalogs,
+        ],
+      };
+  }
+};
+
+export const getFederationDiagnostics = (graph: ResolvedGraph): FederationDiagnostic[] => {
+  const diagnostics = graph.conflicts.map((conflict) => getConflictDiagnostic(conflict, graph));
+
+  for (const external of graph.externals) {
+    const resource = getExternalResource(external);
+
+    for (const referencedBy of external.referencedBy) {
+      const referrer = graph.entities.find((entity) => entity.id === referencedBy);
+      diagnostics.push({
+        severity: 'warning',
+        message: 'Referenced EventCatalog resource does not exist',
+        rule: 'federation/missing-resource',
+        attributes: [
+          { label: 'source catalog', value: referrer?.resolvedFrom.source ?? 'unknown' },
+          { label: 'referenced by', value: referencedBy },
+          { label: 'missing resource', value: resource },
+        ],
+      });
+    }
+  }
+
+  for (const warning of graph.warnings) {
+    diagnostics.push({
+      severity: 'warning',
+      message: 'Asset collision',
+      rule: 'federation/asset-collision',
+      attributes: [
+        { label: 'asset', value: warning.path },
+        { label: 'sources', value: warning.sources.join(', ') },
+        { label: 'winner', value: warning.winner },
+        { label: 'resolution', value: 'last configured source wins' },
+      ],
+    });
+  }
+
+  return diagnostics.sort(
+    (left, right) =>
+      (left.severity === right.severity ? 0 : left.severity === 'error' ? -1 : 1) ||
+      left.rule.localeCompare(right.rule) ||
+      (left.attributes[0]?.value ?? '').localeCompare(right.attributes[0]?.value ?? '')
+  );
+};
+
+export const getFederationDiagnosticCounts = (graph: ResolvedGraph) => ({
+  errors: graph.conflicts.length,
+  warnings: graph.warnings.length + graph.externals.length,
+});

--- a/packages/core/src/federation/federate.ts
+++ b/packages/core/src/federation/federate.ts
@@ -215,7 +215,6 @@ export const federateCatalog = async (
         options.onProgress?.({ type: 'hydrate:cache', files: cachedFiles });
       },
     }),
-    modes: Object.fromEntries(sources.map((source) => [source.id, source.mode ?? 'hydrate'])),
     fetch: async ({ source: sourceId, commit, path: artifactPath }) => {
       const source = sourcesById.get(sourceId);
       if (!source) throw new Error(`Cannot fetch content for unconfigured source "${sourceId}"`);

--- a/packages/core/src/utils/cli-logger.ts
+++ b/packages/core/src/utils/cli-logger.ts
@@ -38,6 +38,34 @@ export const logger = {
   warning: (message: string, tag: string = 'warn') => {
     console.log(formatMessage(tag, message, pc.yellow));
   },
+  line: (message = '') => {
+    console.log(message);
+  },
+  diagnostic: (
+    severity: 'error' | 'warning',
+    message: string,
+    rule: string,
+    attributes: { label: string; value: string }[] = []
+  ) => {
+    const isError = severity === 'error';
+    const color = isError ? pc.red : pc.yellow;
+    const icon = isError ? '✖' : '⚠';
+    const label = `${icon} ${severity.padEnd(7)} ${message}`;
+    const ruleSpacing = ' '.repeat(Math.max(2, 72 - label.length));
+    console.log(`  ${color(icon)} ${color(severity.padEnd(7))} ${message}${ruleSpacing}${pc.gray(rule)}`);
+    for (const attribute of attributes) {
+      console.log(`             - ${pc.dim(`${attribute.label}:`)} ${attribute.value}`);
+    }
+  },
+  diagnosticSummary: (errors: number, warnings: number) => {
+    const total = errors + warnings;
+    const color = errors > 0 ? pc.red : pc.yellow;
+    const icon = errors > 0 ? '✖' : '⚠';
+    const problems = `${total} problem${total === 1 ? '' : 's'}`;
+    const errorCount = `${errors} error${errors === 1 ? '' : 's'}`;
+    const warningCount = `${warnings} warning${warnings === 1 ? '' : 's'}`;
+    console.log(color(`${icon} ${problems} (${errorCount}, ${warningCount})`));
+  },
   dim: (message: string) => {
     console.log(pc.dim(message));
   },

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -140,7 +140,6 @@
 - 8f724a7: feat: add `externalSystem` flag to services for modelling third-party integrations
 
   Services can now set `externalSystem: true` in their frontmatter to be rendered as external systems. This changes their presentation without changing their capabilities — they still send and receive messages, have owners, and support specifications like any other service.
-
   - Visualiser: external services render purple with a Globe icon and an "External System" badge
   - Sidebar (root): a dedicated "External Systems" section lists externals; the regular "Services" section excludes them
   - Sidebar (domain): externals appear under a new "External Integrations" group, separate from "Services In Domain"

--- a/packages/sdk/src/hydrate.ts
+++ b/packages/sdk/src/hydrate.ts
@@ -14,14 +14,12 @@ export type HydrateOptions = {
   outDir: string;
   localSource?: string;
   fetch: Fetcher;
-  modes?: Record<string, 'hydrate' | 'reference'>;
   cache?: Cache;
 };
 
 export type HydrateResult = {
   fetched: number;
   written: number;
-  referenced: number;
 };
 
 type Artifact = {
@@ -95,18 +93,12 @@ export async function hydrate(graph: ResolvedGraph, options: HydrateOptions): Pr
   const result: HydrateResult = {
     fetched: 0,
     written: 0,
-    referenced: 0,
   };
   const artifacts: Artifact[] = [];
 
   for (const entity of graph.entities) {
     const { source, commit } = entity.resolvedFrom;
     if (options.localSource !== undefined && source === options.localSource) continue;
-
-    if (options.modes?.[source] === 'reference') {
-      result.referenced++;
-      continue;
-    }
 
     if (!entity.contentPath) continue;
 
@@ -150,8 +142,7 @@ export async function hydrate(graph: ResolvedGraph, options: HydrateOptions): Pr
 
   for (const asset of graph.assets) {
     const { source, commit } = asset.resolvedFrom;
-    if ((options.localSource !== undefined && source === options.localSource) || options.modes?.[source] === 'reference')
-      continue;
+    if (options.localSource !== undefined && source === options.localSource) continue;
 
     artifacts.push({
       source,

--- a/packages/sdk/src/test/federation-pipeline.integration.test.ts
+++ b/packages/sdk/src/test/federation-pipeline.integration.test.ts
@@ -186,7 +186,6 @@ describe('federation pipeline integration', () => {
     ).resolves.toEqual({
       fetched: 7,
       written: 7,
-      referenced: 0,
     });
 
     const hydratedTreeSnapshot = JSON.parse(await fs.readFile(HYDRATED_TREE_SNAPSHOT_PATH, 'utf8'));

--- a/packages/sdk/src/test/hydrate.test.ts
+++ b/packages/sdk/src/test/hydrate.test.ts
@@ -51,7 +51,6 @@ describe('hydrate', () => {
     ).resolves.toEqual({
       fetched: 0,
       written: 0,
-      referenced: 0,
     });
     expect(fetch).not.toHaveBeenCalled();
     await expect(fs.access(outDir)).rejects.toThrow();
@@ -102,7 +101,6 @@ describe('hydrate', () => {
     expect(result).toEqual({
       fetched: 1,
       written: 1,
-      referenced: 0,
     });
   });
 
@@ -215,7 +213,6 @@ describe('hydrate', () => {
     expect(result).toEqual({
       fetched: 1,
       written: 1,
-      referenced: 0,
     });
   });
 
@@ -266,7 +263,6 @@ describe('hydrate', () => {
     expect(result).toEqual({
       fetched: 0,
       written: 1,
-      referenced: 0,
     });
   });
 
@@ -323,7 +319,6 @@ describe('hydrate', () => {
     expect(result).toEqual({
       fetched: 1,
       written: 1,
-      referenced: 0,
     });
   });
 
@@ -383,7 +378,6 @@ describe('hydrate', () => {
     expect(result).toEqual({
       fetched: 1,
       written: 1,
-      referenced: 0,
     });
   });
 
@@ -632,7 +626,6 @@ describe('hydrate', () => {
     expect(result).toEqual({
       fetched: 3,
       written: 3,
-      referenced: 0,
     });
   });
 
@@ -718,7 +711,6 @@ describe('hydrate', () => {
     expect(result).toEqual({
       fetched: 3,
       written: 3,
-      referenced: 0,
     });
   });
 
@@ -787,7 +779,6 @@ describe('hydrate', () => {
     expect(result).toEqual({
       fetched: 4,
       written: 4,
-      referenced: 0,
     });
   });
 
@@ -845,46 +836,7 @@ describe('hydrate', () => {
       expect(result).toEqual({
         fetched: 2,
         written: 2,
-        referenced: 0,
       });
-    });
-
-    it('does not fetch assets from a source in reference mode', async () => {
-      const fetch = vi.fn<Fetcher>();
-      const graph: ResolvedGraph = {
-        entities: [],
-        assets: [
-          {
-            path: 'public/icons/payments.svg',
-            hash: 'sha256:4c22e5bcafd94c0d64a92f4d0f45853c2ea14d5e76b0e3c7806ef59fa45b9817',
-            resolvedFrom: {
-              source: 'acme/payments',
-              commit: '4a1b7e2',
-            },
-          },
-        ],
-        edges: [],
-        conflicts: [],
-        warnings: [],
-        externals: [],
-      };
-
-      await expect(
-        hydrate(graph, {
-          outDir,
-          localSource: 'acme/central',
-          fetch,
-          modes: {
-            'acme/payments': 'reference',
-          },
-        })
-      ).resolves.toEqual({
-        fetched: 0,
-        written: 0,
-        referenced: 0,
-      });
-      expect(fetch).not.toHaveBeenCalled();
-      await expect(fs.access(outDir)).rejects.toThrow();
     });
 
     it('hydrates the selected asset when a collision warning is present', async () => {
@@ -924,7 +876,6 @@ describe('hydrate', () => {
       ).resolves.toEqual({
         fetched: 1,
         written: 1,
-        referenced: 0,
       });
       expect(fetch.mock.calls).toEqual([
         [
@@ -937,48 +888,6 @@ describe('hydrate', () => {
       ]);
       await expect(fs.readFile(path.join(outDir, 'public/logo.svg'))).resolves.toEqual(content);
     });
-  });
-
-  it('does not fetch content for a source in reference mode', async () => {
-    const fetch = vi.fn<Fetcher>().mockResolvedValue(Buffer.from('# Payment Service'));
-    const graph: ResolvedGraph = {
-      entities: [
-        {
-          type: 'service',
-          id: 'payment-service',
-          version: '1.0.0',
-          name: 'Payment Service',
-          contentPath: 'services/payment-service/index.mdx',
-          contentHash: 'sha256:3e63897b7cc3a92411599289d00d686f1b1fc8e336927efa46101c8943410c70',
-          resolvedFrom: {
-            source: 'acme/payments',
-            commit: '4a1b7e2',
-          },
-        },
-      ],
-      assets: [],
-      edges: [],
-      conflicts: [],
-      warnings: [],
-      externals: [],
-    };
-
-    await expect(
-      hydrate(graph, {
-        outDir,
-        localSource: 'acme/central',
-        fetch,
-        modes: {
-          'acme/payments': 'reference',
-        },
-      })
-    ).resolves.toEqual({
-      fetched: 0,
-      written: 0,
-      referenced: 1,
-    });
-    expect(fetch.mock.calls).toEqual([]);
-    await expect(fs.access(outDir)).rejects.toThrow();
   });
 
   it('removes files from a previous hydrate that are no longer in the graph', async () => {
@@ -1020,7 +929,6 @@ describe('hydrate', () => {
     ).resolves.toEqual({
       fetched: 1,
       written: 1,
-      referenced: 0,
     });
     await expect(fs.access(stalePath)).rejects.toThrow();
     await expect(fs.readFile(currentPath)).resolves.toEqual(content);
@@ -1053,7 +961,6 @@ describe('hydrate', () => {
     ).resolves.toEqual({
       fetched: 0,
       written: 0,
-      referenced: 0,
     });
     expect(fetch.mock.calls).toEqual([]);
     await expect(fs.readFile(localPath, 'utf8')).resolves.toBe('# Local Service');
@@ -1100,7 +1007,6 @@ describe('hydrate', () => {
     ).resolves.toEqual({
       fetched: 1,
       written: 1,
-      referenced: 0,
     });
     await expect(fs.access(departedSourceDirectory)).rejects.toThrow();
     await expect(fs.readFile(currentPath)).resolves.toEqual(content);


### PR DESCRIPTION
## What This PR Does

Adds support for federating from local filesystem catalogs using the `file:` protocol, so teams can compose catalogs that live on disk without pushing them to GitHub first. It also replaces the previous ad-hoc federation warning output with structured, ESLint-style diagnostics behind a new `--verbose` flag, making it clear which catalog caused a problem and how to fix it. Along the way it fixes linter resource discovery inside federated catalogs and merges federated custom components into the host catalog.

## Changes Overview

### Key Changes

- **Filesystem federation sources** — new `filesystem-source-provider.ts` resolves `file:` sources, alongside a shared `source-provider.ts` that dispatches between GitHub and filesystem providers.
- **Federation diagnostics** — new `federation/diagnostics.ts` turns graph conflicts, warnings, and unresolved externals into typed diagnostics with a severity, a human-readable message, a `federation/*` rule ID, and structured attributes.
- **`eventcatalog federate --verbose`** — new flag that prints full diagnostic details. Errors always print; warnings are summarised by default with a hint to re-run with `--verbose`.
- **CLI logger additions** — `logger.diagnostic()`, `logger.diagnosticSummary()`, and `logger.line()` render the ESLint-style output (coloured icon, padded severity, right-aligned gray rule ID, indented attributes).
- **Removed federation `reference` mode** — the `mode: 'hydrate' | 'reference'` source option was incomplete, so all configured sources now hydrate consistently. `HydrateResult.referenced` is gone.
- **Linter fix** — the scanner now ignores generated `dist` and `.eventcatalog-core` directories when indexing catalogs.
- **Custom components** — federated custom components are merged into the host catalog's components.

## How It Works

`getFederationDiagnostics(graph)` maps each conflict kind (`duplicate-source`, `type-collision`, `pointer-type-mismatch`, `facet-disagreement`) plus graph warnings and externals onto a `FederationDiagnostic`. Each diagnostic carries attributes such as the resource ID, the owning catalogs, and a suggested resolution, which the CLI renders as indented `label: value` lines under the message.

The `resolved` progress event in `eventcatalog.ts` uses `getFederationDiagnosticCounts()` to decide what to print. When there are errors, only errors are shown (warnings are suppressed as noise) and the command reports failure. When there are only warnings, the default output is a one-line problem count, and `--verbose` expands to the full listing followed by a `N problems (E errors, W warnings)` summary.

Filesystem sources resolve a local directory to the same source-index shape as the GitHub provider, so the resolve/hydrate pipeline downstream is unchanged. The `ref` option is not supported for filesystem sources.

## Breaking Changes

The federation `mode: 'reference'` source option has been removed from `FederationSourceConfig`. Any catalog configuring `mode: 'reference'` will now hydrate that source instead of keeping it as a graph reference only. `HydrateResult` no longer includes a `referenced` count. This mode was incomplete and not documented as supported, so impact should be minimal.

## Additional Notes

- Tests: 3 new diagnostics specs, expanded `federate.spec.ts`, new filesystem-source-provider and source-provider specs, plus linter scanner and CLI integration coverage. All federation and hydrate suites pass locally.
- Changesets included for `@eventcatalog/core`, `@eventcatalog/sdk`, and `@eventcatalog/linter`.
- No corresponding change appears to be needed in the `eventcatalog/eventcatalog-editor` repository — this is CLI and federation-pipeline work with no editor-facing surface.