### PR TITLE
ESLint-style federation diagnostics with configurable rule levels

### DIFF
--- a/.changeset/silver-pandas-listen.md
+++ b/.changeset/silver-pandas-listen.md
@@ -2,4 +2,4 @@
 "@eventcatalog/core": patch
 ---
 
-Federation diagnostics are now configurable per rule. Set `federation.rules` in `eventcatalog.config.js` to `off`, `warn`, or `error` for any `federation/*` rule, and add a new `federation/unresolved-version` warning when a resource references a version that does not exist.
+Federation diagnostics are now configurable per rule. Set `federation.rules` in `eventcatalog.config.js` to `off`, `warn`, or `error` for any `federation/*` rule, and add a new `federation/unresolved-version` warning when a resource references a version that does not exist. Remote references are resolved against resources owned by the central catalog before diagnostics are applied, and warning counts remain visible when errors coexist.

--- a/.changeset/silver-pandas-listen.md
+++ b/.changeset/silver-pandas-listen.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Federation diagnostics are now configurable per rule. Set `federation.rules` in `eventcatalog.config.js` to `off`, `warn`, or `error` for any `federation/*` rule, and add a new `federation/unresolved-version` warning when a resource references a version that does not exist.

--- a/packages/core/src/__tests__/federate.spec.ts
+++ b/packages/core/src/__tests__/federate.spec.ts
@@ -4,7 +4,13 @@ import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Index } from '@eventcatalog/sdk';
-import { federateCatalog, FederationConflictError, type FederationProgressEvent } from '../federation/federate';
+import type { FederationRulesConfig } from '../eventcatalog.config';
+import {
+  federateCatalog,
+  FederationConflictError,
+  FederationDiagnosticError,
+  type FederationProgressEvent,
+} from '../federation/federate';
 import type { FederationSourceProvider } from '../federation/types';
 
 const sourceIndex = (source: string, resourceId: string): Index => {
@@ -36,11 +42,15 @@ const sourceIndexWithPublicFiles = (source: string, resourceId: string, files: R
 
 const hash = (content: Buffer | string) => `sha256:${createHash('sha256').update(content).digest('hex')}`;
 
-const writeProject = async (projectDirectory: string, sources: unknown[]) => {
+const writeProject = async (projectDirectory: string, sources: unknown[], rules?: FederationRulesConfig) => {
   await fs.writeFile(path.join(projectDirectory, 'package.json'), JSON.stringify({ type: 'module' }));
   await fs.writeFile(
     path.join(projectDirectory, 'eventcatalog.config.js'),
-    `export default ${JSON.stringify({ cId: 'central-catalog', federation: { sources } }, null, 2)};\n`
+    `export default ${JSON.stringify(
+      { cId: 'central-catalog', federation: { sources, ...(rules === undefined ? {} : { rules }) } },
+      null,
+      2
+    )};\n`
   );
 };
 
@@ -401,6 +411,75 @@ describe('federate catalog', () => {
     await expect(fs.readFile(previousOutput, 'utf8')).resolves.toBe('keep me');
     await expect(fs.access(path.join(projectDirectory, 'eventcatalog.lock'))).rejects.toThrow();
     expect(provider.fetchContent).not.toHaveBeenCalled();
+  });
+
+  it('continues hydration when a conflict rule is configured as a warning', async () => {
+    await writeProject(
+      projectDirectory,
+      [
+        { id: 'acme/payments', source: 'github:acme/payments' },
+        { id: 'acme/orders', source: 'github:acme/orders' },
+      ],
+      { 'federation/duplicate-source': 'warn' }
+    );
+    const provider: FederationSourceProvider = {
+      resolve: vi.fn(async (source) => {
+        const index = sourceIndex(source.id, 'shared-service');
+        return { bytes: Buffer.from(JSON.stringify(index)), index, commit: index.commit, generated: true };
+      }),
+      fetchContent: vi.fn(async ({ path: artifactPath }) => Buffer.from(`# ${artifactPath}\n`)),
+    };
+
+    const result = await federateCatalog(projectDirectory, { provider });
+
+    expect(result).toMatchObject({ hydrate: { fetched: 1, written: 2 } });
+    expect(result?.diagnostics).toEqual([
+      expect.objectContaining({
+        severity: 'warning',
+        rule: 'federation/duplicate-source',
+      }),
+    ]);
+    expect(provider.fetchContent).toHaveBeenCalledOnce();
+  });
+
+  it('stops before hydration when a warning rule is configured as an error', async () => {
+    await writeProject(
+      projectDirectory,
+      [
+        { id: 'acme/payments', source: 'github:acme/payments' },
+        { id: 'acme/orders', source: 'github:acme/orders' },
+      ],
+      { 'federation/asset-collision': 'error' }
+    );
+    const indexes = {
+      'acme/payments': sourceIndexWithPublicFiles('acme/payments', 'payment-service', {
+        'public/shared.svg': Buffer.from('payments'),
+      }),
+      'acme/orders': sourceIndexWithPublicFiles('acme/orders', 'order-service', {
+        'public/shared.svg': Buffer.from('orders'),
+      }),
+    };
+    const provider: FederationSourceProvider = {
+      resolve: vi.fn(async (source) => {
+        const index = indexes[source.id as keyof typeof indexes];
+        return { bytes: Buffer.from(JSON.stringify(index)), index, commit: index.commit, generated: true };
+      }),
+      fetchContent: vi.fn(),
+    };
+
+    const federation = federateCatalog(projectDirectory, { provider });
+    await expect(federation).rejects.toMatchObject({
+      name: 'FederationDiagnosticError',
+      diagnostics: [
+        expect.objectContaining({
+          severity: 'error',
+          rule: 'federation/asset-collision',
+        }),
+      ],
+    });
+    await expect(federation).rejects.toBeInstanceOf(FederationDiagnosticError);
+    expect(provider.fetchContent).not.toHaveBeenCalled();
+    await expect(fs.access(path.join(projectDirectory, 'federated'))).rejects.toThrow();
   });
 
   it('stops before hydration when the main catalog and a source own the same resource', async () => {

--- a/packages/core/src/__tests__/federate.spec.ts
+++ b/packages/core/src/__tests__/federate.spec.ts
@@ -32,6 +32,26 @@ const sourceIndex = (source: string, resourceId: string): Index => {
   };
 };
 
+const sourceSystemIndex = (source: string, resourceId: string, services: { id: string; version?: string }[]): Index => {
+  const contentPath = `systems/${resourceId}/index.mdx`;
+  const content = Buffer.from(`# ${contentPath}\n`);
+  return {
+    indexVersion: 1,
+    source,
+    commit: `${source}-commit`,
+    resources: [
+      {
+        type: 'system',
+        id: resourceId,
+        name: resourceId,
+        services,
+        contentPath,
+        contentHash: `sha256:${createHash('sha256').update(content).digest('hex')}`,
+      },
+    ],
+  };
+};
+
 const sourceIndexWithPublicFiles = (source: string, resourceId: string, files: Record<string, Buffer>): Index => ({
   ...sourceIndex(source, resourceId),
   assets: Object.entries(files).map(([assetPath, content]) => ({
@@ -480,6 +500,45 @@ describe('federate catalog', () => {
     await expect(federation).rejects.toBeInstanceOf(FederationDiagnosticError);
     expect(provider.fetchContent).not.toHaveBeenCalled();
     await expect(fs.access(path.join(projectDirectory, 'federated'))).rejects.toThrow();
+  });
+
+  it('resolves remote references to resources owned by the central catalog before applying diagnostic rules', async () => {
+    await writeProject(projectDirectory, [{ id: 'acme/orders', source: 'github:acme/orders' }], {
+      'federation/missing-resource': 'error',
+    });
+    await writeService(projectDirectory, 'central-audit-service');
+    const index = sourceSystemIndex('acme/orders', 'order-system', [{ id: 'central-audit-service' }]);
+    const provider: FederationSourceProvider = {
+      resolve: vi.fn(async () => ({ bytes: Buffer.from(JSON.stringify(index)), index, commit: index.commit, generated: true })),
+      fetchContent: vi.fn(async ({ path: artifactPath }) => Buffer.from(`# ${artifactPath}\n`)),
+    };
+
+    const result = await federateCatalog(projectDirectory, { provider });
+
+    expect(result?.diagnostics).toEqual([]);
+    expect(result).toMatchObject({ hydrate: { fetched: 1, written: 1 } });
+  });
+
+  it('does not apply federation diagnostics to references originating in the central catalog', async () => {
+    await writeProject(projectDirectory, [{ id: 'acme/orders', source: 'github:acme/orders' }], {
+      'federation/missing-resource': 'error',
+    });
+    const localSystem = path.join(projectDirectory, 'systems', 'central-system', 'index.mdx');
+    await fs.mkdir(path.dirname(localSystem), { recursive: true });
+    await fs.writeFile(
+      localSystem,
+      '---\nid: central-system\nname: Central System\nservices:\n  - id: missing-local-service\n---\n# Central System\n'
+    );
+    const index = sourceIndex('acme/orders', 'order-service');
+    const provider: FederationSourceProvider = {
+      resolve: vi.fn(async () => ({ bytes: Buffer.from(JSON.stringify(index)), index, commit: index.commit, generated: true })),
+      fetchContent: vi.fn(async ({ path: artifactPath }) => Buffer.from(`# ${artifactPath}\n`)),
+    };
+
+    const result = await federateCatalog(projectDirectory, { provider });
+
+    expect(result?.diagnostics).toEqual([]);
+    expect(result).toMatchObject({ hydrate: { fetched: 1, written: 1 } });
   });
 
   it('stops before hydration when the main catalog and a source own the same resource', async () => {

--- a/packages/core/src/__tests__/federation-diagnostics.spec.ts
+++ b/packages/core/src/__tests__/federation-diagnostics.spec.ts
@@ -4,6 +4,7 @@ import {
   federationRuleDefaults,
   getFederationDiagnosticCounts,
   getFederationDiagnostics,
+  getVisibleFederationDiagnostics,
   resolveFederationRules,
 } from '../federation/diagnostics';
 
@@ -263,6 +264,8 @@ describe('federation diagnostics', () => {
       { rule: 'federation/duplicate-source', severity: 'warning' },
     ]);
     expect(getFederationDiagnosticCounts(diagnostics)).toEqual({ errors: 1, warnings: 1 });
+    expect(getVisibleFederationDiagnostics(diagnostics, false)).toEqual([diagnostics[0]]);
+    expect(getVisibleFederationDiagnostics(diagnostics, true)).toEqual(diagnostics);
   });
 
   it('rejects unknown rule ids and invalid rule levels', () => {

--- a/packages/core/src/__tests__/federation-diagnostics.spec.ts
+++ b/packages/core/src/__tests__/federation-diagnostics.spec.ts
@@ -1,6 +1,11 @@
 import type { ResolvedGraph } from '@eventcatalog/sdk';
 import { describe, expect, it } from 'vitest';
-import { getFederationDiagnosticCounts, getFederationDiagnostics } from '../federation/diagnostics';
+import {
+  federationRuleDefaults,
+  getFederationDiagnosticCounts,
+  getFederationDiagnostics,
+  resolveFederationRules,
+} from '../federation/diagnostics';
 
 const graph = (overrides: Partial<ResolvedGraph>): ResolvedGraph => ({
   entities: [],
@@ -55,6 +60,70 @@ describe('federation diagnostics', () => {
         ],
       },
     ]);
+  });
+
+  it.each([
+    { requestedVersion: '1.0.0', description: 'an unavailable exact version' },
+    { requestedVersion: '^1.0.0', description: 'an unsatisfied version range' },
+  ])('describes $description and lists the available versions', ({ requestedVersion }) => {
+    const resolvedGraph = graph({
+      entities: [
+        {
+          type: 'event',
+          id: 'payment-captured',
+          version: '2.0.0',
+          name: 'Payment Captured',
+          contentPath: 'events/payment-captured/2.0.0/index.mdx',
+          resolvedFrom: { source: 'event-catalog/payments', commit: 'abc123' },
+        },
+        {
+          type: 'event',
+          id: 'payment-captured',
+          version: '2.1.0',
+          name: 'Payment Captured',
+          contentPath: 'events/payment-captured/2.1.0/index.mdx',
+          resolvedFrom: { source: 'event-catalog/payments', commit: 'def456' },
+        },
+        {
+          type: 'service',
+          id: 'shipping-service',
+          version: '1.0.0',
+          name: 'Shipping Service',
+          contentPath: 'services/shipping-service/index.mdx',
+          resolvedFrom: { source: 'event-catalog/fulfillment', commit: 'ghi789' },
+        },
+      ],
+      edges: [
+        {
+          from: 'shipping-service',
+          fromVersion: '1.0.0',
+          fromResolvedFrom: { source: 'event-catalog/fulfillment', commit: 'ghi789' },
+          to: 'payment-captured',
+          direction: 'receives',
+          pointer: requestedVersion,
+          resolved: null,
+          status: 'unresolved',
+        },
+      ],
+    });
+
+    const diagnostics = getFederationDiagnostics(resolvedGraph);
+
+    expect(diagnostics).toEqual([
+      {
+        severity: 'warning',
+        message: 'Referenced EventCatalog resource version does not exist',
+        rule: 'federation/unresolved-version',
+        attributes: [
+          { label: 'source catalog', value: 'event-catalog/fulfillment' },
+          { label: 'referenced by', value: 'shipping-service@1.0.0' },
+          { label: 'resource', value: 'payment-captured' },
+          { label: 'requested version', value: requestedVersion },
+          { label: 'available versions', value: '2.0.0, 2.1.0' },
+        ],
+      },
+    ]);
+    expect(getFederationDiagnosticCounts(diagnostics)).toEqual({ errors: 0, warnings: 1 });
   });
 
   it('formats asset collisions with their sources and winner', () => {
@@ -114,7 +183,9 @@ describe('federation diagnostics', () => {
       externals: [{ id: 'missing-ledger', referencedBy: ['payment-captured'] }],
     });
 
-    expect(getFederationDiagnostics(resolvedGraph)).toEqual([
+    const diagnostics = getFederationDiagnostics(resolvedGraph);
+
+    expect(diagnostics).toEqual([
       {
         severity: 'error',
         message: 'Resource ID has conflicting types',
@@ -136,6 +207,70 @@ describe('federation diagnostics', () => {
         ],
       },
     ]);
-    expect(getFederationDiagnosticCounts(resolvedGraph)).toEqual({ errors: 1, warnings: 1 });
+    expect(getFederationDiagnosticCounts(diagnostics)).toEqual({ errors: 1, warnings: 1 });
+  });
+
+  it('keeps the existing rule levels as defaults', () => {
+    expect(federationRuleDefaults).toEqual({
+      'federation/duplicate-source': 'error',
+      'federation/type-collision': 'error',
+      'federation/pointer-type-mismatch': 'error',
+      'federation/facet-disagreement': 'error',
+      'federation/asset-collision': 'warn',
+      'federation/missing-resource': 'warn',
+      'federation/unresolved-version': 'warn',
+    });
+  });
+
+  it('applies off, warn, and error rule overrides before reporting and counting diagnostics', () => {
+    const resolvedGraph = graph({
+      entities: [
+        {
+          type: 'service',
+          id: 'checkout-api',
+          version: '1.0.0',
+          name: 'Checkout API',
+          contentPath: 'services/checkout-api/index.mdx',
+          resolvedFrom: { source: 'event-catalog/checkout', commit: 'abc123' },
+        },
+      ],
+      conflicts: [
+        {
+          kind: 'duplicate-source',
+          id: 'checkout-api',
+          sources: ['event-catalog/checkout', 'event-catalog/storefront'],
+        },
+      ],
+      externals: [{ id: 'payment-authorized', referencedBy: ['checkout-api'] }],
+      warnings: [
+        {
+          kind: 'asset-collision',
+          path: 'public/logo.svg',
+          sources: ['event-catalog/checkout', 'event-catalog/storefront'],
+          winner: 'event-catalog/storefront',
+        },
+      ],
+    });
+
+    const diagnostics = getFederationDiagnostics(resolvedGraph, {
+      'federation/duplicate-source': 'warn',
+      'federation/missing-resource': 'error',
+      'federation/asset-collision': 'off',
+    });
+
+    expect(diagnostics.map(({ rule, severity }) => ({ rule, severity }))).toEqual([
+      { rule: 'federation/missing-resource', severity: 'error' },
+      { rule: 'federation/duplicate-source', severity: 'warning' },
+    ]);
+    expect(getFederationDiagnosticCounts(diagnostics)).toEqual({ errors: 1, warnings: 1 });
+  });
+
+  it('rejects unknown rule ids and invalid rule levels', () => {
+    expect(() => resolveFederationRules({ 'federation/not-a-rule': 'warn' } as never)).toThrow(
+      'Unknown federation rule "federation/not-a-rule".'
+    );
+    expect(() => resolveFederationRules({ 'federation/missing-resource': 'fatal' } as never)).toThrow(
+      'Invalid level "fatal" for federation rule "federation/missing-resource". Expected off, warn, or error.'
+    );
   });
 });

--- a/packages/core/src/eventcatalog.config.ts
+++ b/packages/core/src/eventcatalog.config.ts
@@ -97,8 +97,26 @@ export type FederationSourceConfig = {
   ref?: string;
 };
 
+export type FederationRuleId =
+  | 'federation/duplicate-source'
+  | 'federation/type-collision'
+  | 'federation/pointer-type-mismatch'
+  | 'federation/facet-disagreement'
+  | 'federation/asset-collision'
+  | 'federation/missing-resource'
+  | 'federation/unresolved-version';
+
+export type FederationRuleLevel = 'off' | 'warn' | 'error';
+
+export type FederationRulesConfig = Partial<Record<FederationRuleId, FederationRuleLevel>>;
+
 type FederationConfig = {
   sources: FederationSourceConfig[];
+  /**
+   * Override federation validation rule levels. Unconfigured rules keep their defaults.
+   * `off` hides the diagnostic, `warn` reports and continues, and `error` stops before hydration.
+   */
+  rules?: FederationRulesConfig;
 };
 
 type DirectoryEntry = {

--- a/packages/core/src/eventcatalog.ts
+++ b/packages/core/src/eventcatalog.ts
@@ -28,7 +28,7 @@ import {
   FederationDiagnosticError,
   type FederationProgressEvent,
 } from './federation/federate';
-import { getFederationDiagnosticCounts } from './federation/diagnostics';
+import { getFederationDiagnosticCounts, getVisibleFederationDiagnostics } from './federation/diagnostics';
 const currentDir = path.dirname(fileURLToPath(import.meta.url));
 const program = new Command().version(VERSION);
 
@@ -766,8 +766,7 @@ const reportFederationProgress = (event: FederationProgressEvent, verbose = fals
       );
       return;
     case 'resolved':
-      const graphCounts = getFederationDiagnosticCounts(event.diagnostics);
-      const counts = graphCounts.errors > 0 ? { errors: graphCounts.errors, warnings: 0 } : graphCounts;
+      const counts = getFederationDiagnosticCounts(event.diagnostics);
       const showDiagnosticDetails = verbose || counts.errors > 0;
 
       if (counts.errors === 0) {
@@ -780,9 +779,7 @@ const reportFederationProgress = (event: FederationProgressEvent, verbose = fals
       if (counts.errors + counts.warnings === 0) return;
 
       if (showDiagnosticDetails) {
-        const diagnostics = event.diagnostics.filter((diagnostic) =>
-          counts.errors > 0 ? diagnostic.severity === 'error' : verbose
-        );
+        const diagnostics = getVisibleFederationDiagnostics(event.diagnostics, verbose);
 
         logger.info('Federation diagnostics', 'federation');
         logger.line();

--- a/packages/core/src/eventcatalog.ts
+++ b/packages/core/src/eventcatalog.ts
@@ -22,8 +22,13 @@ import { buildFieldsIndex } from '../eventcatalog/src/enterprise/fields/field-in
 import { buildSearchIndex } from './search-indexer';
 import { linkCoreNodeModules, resolveInstalledCoreNodeModules } from './core-node-modules';
 import { createAstroDevLineFilter, createAstroLineFilter } from './astro-output';
-import { federateCatalog, FederationConflictError, type FederationProgressEvent } from './federation/federate';
-import { getFederationDiagnosticCounts, getFederationDiagnostics } from './federation/diagnostics';
+import {
+  federateCatalog,
+  FederationConflictError,
+  FederationDiagnosticError,
+  type FederationProgressEvent,
+} from './federation/federate';
+import { getFederationDiagnosticCounts } from './federation/diagnostics';
 const currentDir = path.dirname(fileURLToPath(import.meta.url));
 const program = new Command().version(VERSION);
 
@@ -761,7 +766,7 @@ const reportFederationProgress = (event: FederationProgressEvent, verbose = fals
       );
       return;
     case 'resolved':
-      const graphCounts = getFederationDiagnosticCounts(event.graph);
+      const graphCounts = getFederationDiagnosticCounts(event.diagnostics);
       const counts = graphCounts.errors > 0 ? { errors: graphCounts.errors, warnings: 0 } : graphCounts;
       const showDiagnosticDetails = verbose || counts.errors > 0;
 
@@ -775,7 +780,7 @@ const reportFederationProgress = (event: FederationProgressEvent, verbose = fals
       if (counts.errors + counts.warnings === 0) return;
 
       if (showDiagnosticDetails) {
-        const diagnostics = getFederationDiagnostics(event.graph).filter((diagnostic) =>
+        const diagnostics = event.diagnostics.filter((diagnostic) =>
           counts.errors > 0 ? diagnostic.severity === 'error' : verbose
         );
 
@@ -863,6 +868,6 @@ program
   .parseAsync()
   .then(() => process.exit(0))
   .catch((err) => {
-    if (!(err instanceof FederationConflictError)) console.error(err);
+    if (!(err instanceof FederationConflictError) && !(err instanceof FederationDiagnosticError)) console.error(err);
     process.exit(1);
   });

--- a/packages/core/src/federation/diagnostics.ts
+++ b/packages/core/src/federation/diagnostics.ts
@@ -189,3 +189,6 @@ export const getFederationDiagnosticCounts = (diagnostics: FederationDiagnostic[
     }),
     { errors: 0, warnings: 0 }
   );
+
+export const getVisibleFederationDiagnostics = (diagnostics: FederationDiagnostic[], verbose: boolean) =>
+  diagnostics.filter((diagnostic) => verbose || diagnostic.severity === 'error');

--- a/packages/core/src/federation/diagnostics.ts
+++ b/packages/core/src/federation/diagnostics.ts
@@ -1,14 +1,40 @@
 import type { Conflict, ResolvedGraph } from '@eventcatalog/sdk';
+import type { FederationRuleId, FederationRuleLevel, FederationRulesConfig } from '../eventcatalog.config';
 
 export type FederationDiagnostic = {
   severity: 'error' | 'warning';
   message: string;
-  rule: `federation/${string}`;
+  rule: FederationRuleId;
   attributes: { label: string; value: string }[];
+};
+
+export const federationRuleDefaults: Record<FederationRuleId, FederationRuleLevel> = {
+  'federation/duplicate-source': 'error',
+  'federation/type-collision': 'error',
+  'federation/pointer-type-mismatch': 'error',
+  'federation/facet-disagreement': 'error',
+  'federation/asset-collision': 'warn',
+  'federation/missing-resource': 'warn',
+  'federation/unresolved-version': 'warn',
+};
+
+export type ResolvedFederationRules = Record<FederationRuleId, FederationRuleLevel>;
+
+export const resolveFederationRules = (rules: FederationRulesConfig = {}): ResolvedFederationRules => {
+  for (const [rule, level] of Object.entries(rules)) {
+    if (!Object.hasOwn(federationRuleDefaults, rule)) throw new Error(`Unknown federation rule "${rule}".`);
+    if (level !== 'off' && level !== 'warn' && level !== 'error') {
+      throw new Error(`Invalid level "${String(level)}" for federation rule "${rule}". Expected off, warn, or error.`);
+    }
+  }
+
+  return { ...federationRuleDefaults, ...rules };
 };
 
 const getExternalResource = (external: ResolvedGraph['externals'][number]) =>
   `${external.id}${external.version === undefined ? '' : `@${external.version}`}`;
+
+const getVersionedResource = (id: string, version: string | null | undefined) => `${id}${version == null ? '' : `@${version}`}`;
 
 const getDocumentedResourceType = (type: ResolvedGraph['entities'][number]['type']) => {
   const usesAn = type === 'adr' || type === 'agent' || type === 'entity' || type === 'event';
@@ -86,7 +112,8 @@ const getConflictDiagnostic = (conflict: Conflict, graph: ResolvedGraph): Federa
   }
 };
 
-export const getFederationDiagnostics = (graph: ResolvedGraph): FederationDiagnostic[] => {
+export const getFederationDiagnostics = (graph: ResolvedGraph, rules: FederationRulesConfig = {}): FederationDiagnostic[] => {
+  const resolvedRules = resolveFederationRules(rules);
   const diagnostics = graph.conflicts.map((conflict) => getConflictDiagnostic(conflict, graph));
 
   for (const external of graph.externals) {
@@ -107,6 +134,25 @@ export const getFederationDiagnostics = (graph: ResolvedGraph): FederationDiagno
     }
   }
 
+  for (const edge of graph.edges.filter((edge) => edge.status === 'unresolved')) {
+    const availableVersions = [
+      ...new Set(graph.entities.filter((entity) => entity.id === edge.to).map((entity) => entity.version ?? 'unversioned')),
+    ].sort((left, right) => left.localeCompare(right, undefined, { numeric: true }));
+
+    diagnostics.push({
+      severity: 'warning',
+      message: 'Referenced EventCatalog resource version does not exist',
+      rule: 'federation/unresolved-version',
+      attributes: [
+        { label: 'source catalog', value: edge.fromResolvedFrom.source },
+        { label: 'referenced by', value: getVersionedResource(edge.from, edge.fromVersion) },
+        { label: 'resource', value: edge.to },
+        { label: 'requested version', value: edge.pointer ?? 'unspecified' },
+        { label: 'available versions', value: availableVersions.join(', ') },
+      ],
+    });
+  }
+
   for (const warning of graph.warnings) {
     diagnostics.push({
       severity: 'warning',
@@ -121,15 +167,25 @@ export const getFederationDiagnostics = (graph: ResolvedGraph): FederationDiagno
     });
   }
 
-  return diagnostics.sort(
-    (left, right) =>
-      (left.severity === right.severity ? 0 : left.severity === 'error' ? -1 : 1) ||
-      left.rule.localeCompare(right.rule) ||
-      (left.attributes[0]?.value ?? '').localeCompare(right.attributes[0]?.value ?? '')
-  );
+  return diagnostics
+    .flatMap((diagnostic) => {
+      const level = resolvedRules[diagnostic.rule];
+      if (level === 'off') return [];
+      return [{ ...diagnostic, severity: level === 'error' ? ('error' as const) : ('warning' as const) }];
+    })
+    .sort(
+      (left, right) =>
+        (left.severity === right.severity ? 0 : left.severity === 'error' ? -1 : 1) ||
+        left.rule.localeCompare(right.rule) ||
+        (left.attributes[0]?.value ?? '').localeCompare(right.attributes[0]?.value ?? '')
+    );
 };
 
-export const getFederationDiagnosticCounts = (graph: ResolvedGraph) => ({
-  errors: graph.conflicts.length,
-  warnings: graph.warnings.length + graph.externals.length,
-});
+export const getFederationDiagnosticCounts = (diagnostics: FederationDiagnostic[]) =>
+  diagnostics.reduce(
+    (counts, diagnostic) => ({
+      errors: counts.errors + (diagnostic.severity === 'error' ? 1 : 0),
+      warnings: counts.warnings + (diagnostic.severity === 'warning' ? 1 : 0),
+    }),
+    { errors: 0, warnings: 0 }
+  );

--- a/packages/core/src/federation/federate.ts
+++ b/packages/core/src/federation/federate.ts
@@ -5,6 +5,7 @@ import createSDK, { hydrate, resolve, type Conflict, type HydrateResult, type Re
 import type { FederationSourceConfig } from '../eventcatalog.config';
 import { getEventCatalogConfigFile } from '../eventcatalog-config-file-utils.js';
 import { createFederationContentCache } from './content-cache';
+import { getFederationDiagnostics, resolveFederationRules, type FederationDiagnostic } from './diagnostics';
 import { composePublicAssets, type FederatedPublicFiles, type PublicAssetCompositionResult } from './public-assets';
 import { createFederationSourceProvider } from './source-provider';
 import type { FederationSourceProvider, ResolvedFederationSource } from './types';
@@ -26,7 +27,7 @@ export type FederationProgressEvent =
   | { type: 'local:start' }
   | { type: 'local:complete'; resources: number }
   | { type: 'resolving'; resources: number; localResources: number }
-  | { type: 'resolved'; graph: ResolvedGraph }
+  | { type: 'resolved'; graph: ResolvedGraph; diagnostics: FederationDiagnostic[] }
   | { type: 'hydrating'; outDir: string }
   | { type: 'hydrate:cache'; files: number }
   | { type: 'hydrate:file'; files: number; source: string; path: string }
@@ -37,6 +38,7 @@ export type FederateCatalogResult = {
   sources: number;
   resources: number;
   graph: ResolvedGraph;
+  diagnostics: FederationDiagnostic[];
   hydrate: HydrateResult;
   public: PublicAssetCompositionResult;
   outDir: string;
@@ -70,6 +72,17 @@ export class FederationConflictError extends Error {
     super(`Federation conflicts prevent hydration:\n${details}`);
     this.name = 'FederationConflictError';
     this.conflicts = conflicts;
+  }
+}
+
+export class FederationDiagnosticError extends Error {
+  diagnostics: FederationDiagnostic[];
+
+  constructor(diagnostics: FederationDiagnostic[]) {
+    const details = diagnostics.map((diagnostic) => `${diagnostic.rule}: ${diagnostic.message}`).join('\n');
+    super(`Federation diagnostics prevent hydration:\n${details}`);
+    this.name = 'FederationDiagnosticError';
+    this.diagnostics = diagnostics;
   }
 }
 
@@ -153,6 +166,7 @@ export const federateCatalog = async (
     );
   }
   validateSources(sources);
+  const rules = resolveFederationRules(config.federation?.rules);
   if (options.useCache === false) options.onProgress?.({ type: 'cache:disabled' });
 
   const provider = options.provider ?? createFederationSourceProvider(projectDirectory);
@@ -194,13 +208,18 @@ export const federateCatalog = async (
   options.onProgress?.({ type: 'local:complete', resources: localIndex.resources.length });
   options.onProgress?.({ type: 'resolving', resources, localResources: localIndex.resources.length });
   const ownershipGraph = resolve([localIndex, ...remoteIndexes]);
-  if (ownershipGraph.conflicts.length > 0) {
-    options.onProgress?.({ type: 'resolved', graph: ownershipGraph });
-    throw new FederationConflictError(ownershipGraph.conflicts);
-  }
-
   const graph = resolve(remoteIndexes);
-  options.onProgress?.({ type: 'resolved', graph });
+  const diagnostics = getFederationDiagnostics(
+    { ...graph, entities: ownershipGraph.entities, conflicts: ownershipGraph.conflicts },
+    rules
+  );
+  options.onProgress?.({ type: 'resolved', graph, diagnostics });
+
+  const blockingConflicts = ownershipGraph.conflicts.filter((conflict) => rules[`federation/${conflict.kind}`] === 'error');
+  if (blockingConflicts.length > 0) throw new FederationConflictError(blockingConflicts);
+
+  const blockingDiagnostics = diagnostics.filter((diagnostic) => diagnostic.severity === 'error');
+  if (blockingDiagnostics.length > 0) throw new FederationDiagnosticError(blockingDiagnostics);
 
   const sourcesById = new Map(sources.map((source) => [source.id, source]));
   options.onProgress?.({ type: 'hydrating', outDir });
@@ -254,6 +273,7 @@ export const federateCatalog = async (
     sources: sources.length,
     resources,
     graph,
+    diagnostics,
     hydrate: hydrateResult,
     public: publicResult,
     outDir,

--- a/packages/core/src/federation/federate.ts
+++ b/packages/core/src/federation/federate.ts
@@ -95,6 +95,41 @@ const validateSources = (sources: FederationSourceConfig[]) => {
   }
 };
 
+const createDiagnosticGraph = (
+  graph: ResolvedGraph,
+  ownershipGraph: ResolvedGraph,
+  remoteSourceIds: Set<string>,
+  localSourceId: string
+): ResolvedGraph => {
+  const edges = ownershipGraph.edges.filter((edge) => remoteSourceIds.has(edge.fromResolvedFrom.source));
+  const externalsByPointer = new Map<string, ResolvedGraph['externals'][number]>();
+
+  for (const edge of edges.filter((edge) => edge.status === 'external')) {
+    const version = edge.pointer ?? undefined;
+    const key = `${edge.to}@${version ?? ''}`;
+    const external = externalsByPointer.get(key) ?? {
+      id: edge.to,
+      ...(version === undefined ? {} : { version }),
+      referencedBy: [],
+    };
+    if (!external.referencedBy.includes(edge.from)) external.referencedBy.push(edge.from);
+    externalsByPointer.set(key, external);
+  }
+
+  return {
+    ...graph,
+    entities: [
+      ...graph.entities,
+      ...ownershipGraph.entities.filter(
+        (entity) => entity.resolvedFrom.source === localSourceId && entity.resolvedFrom.commit === 'local'
+      ),
+    ],
+    edges,
+    conflicts: ownershipGraph.conflicts,
+    externals: [...externalsByPointer.values()],
+  };
+};
+
 const writeLock = async (lockPath: string, lock: FederationLock) => {
   const temporaryPath = `${lockPath}.tmp-${process.pid}`;
   try {
@@ -209,10 +244,13 @@ export const federateCatalog = async (
   options.onProgress?.({ type: 'resolving', resources, localResources: localIndex.resources.length });
   const ownershipGraph = resolve([localIndex, ...remoteIndexes]);
   const graph = resolve(remoteIndexes);
-  const diagnostics = getFederationDiagnostics(
-    { ...graph, entities: ownershipGraph.entities, conflicts: ownershipGraph.conflicts },
-    rules
+  const diagnosticGraph = createDiagnosticGraph(
+    graph,
+    ownershipGraph,
+    new Set(remoteIndexes.map((index) => index.source)),
+    localIndex.source
   );
+  const diagnostics = getFederationDiagnostics(diagnosticGraph, rules);
   options.onProgress?.({ type: 'resolved', graph, diagnostics });
 
   const blockingConflicts = ownershipGraph.conflicts.filter((conflict) => rules[`federation/${conflict.kind}`] === 'error');


### PR DESCRIPTION

## What This PR Does

Reworks how federation problems are surfaced when building a federated catalog. Instead of failing on the first conflict with a bare error, the CLI now collects every federation problem into a set of ESLint-style diagnostics — each with a severity, a message, a `federation/*` rule ID, and structured attributes — and prints them as a grouped report with a problem summary.

Each rule's severity is configurable. Teams can set any `federation/*` rule to `off`, `warn`, or `error` in `eventcatalog.config.js`, so a catalog can downgrade a blocking conflict to a warning while it is being resolved, or promote a warning to a hard failure in CI.

It also adds a new `federation/unresolved-version` rule that catches references to resource versions that do not exist, and removes the incomplete federation `reference` mode from the SDK so all configured sources hydrate consistently.

## Changes Overview

### Key Changes

- **New diagnostics module** (`packages/core/src/federation/diagnostics.ts`) — turns graph conflicts, externals, unresolved edges, and warnings into a single sorted `FederationDiagnostic[]`, with errors first, then rule ID, then subject.
- **Configurable rule levels** — `federation.rules` in `eventcatalog.config.js` maps any of the seven `federation/*` rule IDs to `off`, `warn`, or `error`. Unconfigured rules keep their defaults; unknown rule IDs and invalid levels throw at config-resolution time.
- **New `federation/unresolved-version` rule** — warns when a resource points at a version that does not exist, listing the requested version alongside the versions that are actually available.
- **New `FederationDiagnosticError`** — thrown when any diagnostic resolves to `error` severity, so non-conflict rules promoted to `error` can also block hydration.
- **CLI reporting** (`packages/core/src/utils/cli-logger.ts`) — adds `logger.diagnostic` and `logger.diagnosticSummary` for the ESLint-style output: colored severity, right-aligned gray rule ID, indented attribute lines, and an `✖ N problems (N errors, N warnings)` footer.
- **`--verbose` flag** — warnings are only itemised under `--verbose`; errors are always shown in full.
- **SDK cleanup** — removes the unused `modes: Record<string, 'hydrate' | 'reference'>` hydrate option and the `referenced` counter from `HydrateResult`.

### Rule defaults

| Rule | Default |
|---|---|
| `federation/duplicate-source` | `error` |
| `federation/type-collision` | `error` |
| `federation/pointer-type-mismatch` | `error` |
| `federation/facet-disagreement` | `error` |
| `federation/asset-collision` | `warn` |
| `federation/missing-resource` | `warn` |
| `federation/unresolved-version` | `warn` |

## How It Works

`resolveFederationRules` merges any user-supplied `federation.rules` over `federationRuleDefaults`, validating rule IDs and levels up front so a typo fails fast with a clear message rather than silently doing nothing.

`getFederationDiagnostics` builds the raw diagnostic list from the resolved graph, then applies the rule levels as a final pass: `off` drops the diagnostic entirely, and `warn`/`error` rewrite its severity. Because filtering happens after generation, counts and output always agree with the configured levels — `getFederationDiagnosticCounts` now derives its totals from the diagnostic list itself rather than re-counting raw graph fields, which previously could disagree with what was printed.

In `federateCatalog`, diagnostics are computed against a graph that combines the remote-only resolution with the ownership graph's entities and conflicts, so version-resolution warnings can see local resources too. The progress event now carries the finished `diagnostics` array, so the CLI reporter no longer recomputes them. Hydration is blocked in two places: conflicts whose rule resolves to `error` throw `FederationConflictError`, and any remaining `error`-severity diagnostic throws `FederationDiagnosticError`. Both are caught at the top level and exit without a stack trace, since the diagnostic report has already been printed.

### Example config

```js
export default {
  federation: {
    sources: [/* ... */],
    rules: {
      'federation/asset-collision': 'off',
      'federation/missing-resource': 'error',
    },
  },
};
```

## Breaking Changes

Two internal API signatures changed. Neither is part of a documented public surface, but both will break direct callers:

- `getFederationDiagnosticCounts(graph)` → `getFederationDiagnosticCounts(diagnostics)`. It now takes the diagnostic array rather than the resolved graph.
- SDK `hydrate()` no longer accepts `options.modes`, and `HydrateResult` no longer includes `referenced`. The `reference` mode was incomplete, so all configured sources now hydrate.

There are no changes to catalog content, generated output, or the `eventcatalog.config.js` contract — `federation.rules` is optional and existing configs behave exactly as before.

## Additional Notes

- Both changesets are `patch` for `@eventcatalog/core` (the first also patches `@eventcatalog/sdk`).
- Test coverage: 8 tests in `federation-diagnostics.spec.ts` and 16 in `federate.spec.ts`, all passing. The removed `reference` mode also took ~94 lines of now-dead assertions out of the SDK's `hydrate.test.ts`.
- **Docs follow-up needed** — `federation.rules` and the rule ID table are not documented on the website yet.
- No corresponding change is needed in the `eventcatalog/eventcatalog-editor` repository; this is CLI/build-time behaviour only and does not touch the editor's surface.