### PR TITLE
Restore the previous federation output when a run fails

### DIFF
--- a/.changeset/quiet-otters-repair.md
+++ b/.changeset/quiet-otters-repair.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Federation now restores the previous output when a run fails part way through. The federated resources directory, managed public assets, and `eventcatalog.lock` are snapshotted before the update and rolled back if hydration, public asset composition, or lock writing throws, so a failed federate no longer leaves the catalog in a half-written state.

--- a/packages/core/src/__tests__/federate.spec.ts
+++ b/packages/core/src/__tests__/federate.spec.ts
@@ -354,6 +354,52 @@ describe('federate catalog', () => {
     await expect(fs.access(path.join(projectDirectory, 'federated/public'))).rejects.toThrow();
   });
 
+  it('restores the previous federation output when public asset composition fails', async () => {
+    await writeProject(projectDirectory, [{ id: 'acme/payments', source: 'github:acme/payments' }]);
+    let files: Record<string, Buffer> = {
+      'public/remove.txt': Buffer.from('remove me'),
+      'public/update.txt': Buffer.from('first version'),
+    };
+    let index = sourceIndexWithPublicFiles('acme/payments', 'payment-service', files);
+    const provider: FederationSourceProvider = {
+      resolve: vi.fn(async () => ({ bytes: Buffer.from(JSON.stringify(index)), index, commit: index.commit, generated: true })),
+      fetchContent: vi.fn(async ({ path: artifactPath }) =>
+        artifactPath.startsWith('public/') ? files[artifactPath] : Buffer.from(`# ${artifactPath}\n`)
+      ),
+    };
+
+    await federateCatalog(projectDirectory, { provider });
+    const previousOutput = path.join(projectDirectory, 'federated', 'previous-only.txt');
+    const lockPath = path.join(projectDirectory, 'eventcatalog.lock');
+    await fs.writeFile(previousOutput, 'previous output');
+    const previousLock = await fs.readFile(lockPath, 'utf8');
+
+    files = {
+      'public/new.txt': Buffer.from('new file'),
+      'public/update.txt': Buffer.from('second version'),
+    };
+    index = sourceIndexWithPublicFiles('acme/payments', 'payment-service', files);
+
+    const failedDestination = path.join(projectDirectory, 'public', 'update.txt');
+    const writeFile = fs.writeFile.bind(fs);
+    const writeFileSpy = vi.spyOn(fs, 'writeFile').mockImplementation(async (filePath, ...args) => {
+      if (filePath === failedDestination) throw new Error('Simulated public asset write failure');
+      return writeFile(filePath, ...args);
+    });
+
+    try {
+      await expect(federateCatalog(projectDirectory, { provider })).rejects.toThrow('Simulated public asset write failure');
+    } finally {
+      writeFileSpy.mockRestore();
+    }
+
+    await expect(fs.readFile(previousOutput, 'utf8')).resolves.toBe('previous output');
+    await expect(fs.readFile(path.join(projectDirectory, 'public/remove.txt'), 'utf8')).resolves.toBe('remove me');
+    await expect(fs.readFile(path.join(projectDirectory, 'public/update.txt'), 'utf8')).resolves.toBe('first version');
+    await expect(fs.access(path.join(projectDirectory, 'public/new.txt'))).rejects.toThrow();
+    await expect(fs.readFile(lockPath, 'utf8')).resolves.toBe(previousLock);
+  });
+
   it('removes resources, public assets, and lock entries when a configured source is removed', async () => {
     const paymentsSource = { id: 'acme/payments', source: 'github:acme/payments' };
     await writeProject(projectDirectory, [paymentsSource]);

--- a/packages/core/src/federation/federate.ts
+++ b/packages/core/src/federation/federate.ts
@@ -6,6 +6,7 @@ import type { FederationSourceConfig } from '../eventcatalog.config';
 import { getEventCatalogConfigFile } from '../eventcatalog-config-file-utils.js';
 import { createFederationContentCache } from './content-cache';
 import { getFederationDiagnostics, resolveFederationRules, type FederationDiagnostic } from './diagnostics';
+import { withFederationOutputTransaction } from './output-transaction';
 import { composePublicAssets, type FederatedPublicFiles, type PublicAssetCompositionResult } from './public-assets';
 import { createFederationSourceProvider } from './source-provider';
 import type { FederationSourceProvider, ResolvedFederationSource } from './types';
@@ -168,14 +169,22 @@ const cleanupPreviousFederation = async (projectDirectory: string, onProgress?: 
 
   if (!hadFederatedOutput && !hadLock) return;
 
-  await fs.rm(outDir, { recursive: true, force: true });
-  const publicResult = await composePublicAssets({
+  const publicResult = await withFederationOutputTransaction(
     projectDirectory,
-    federatedDirectory: outDir,
-    assets: [],
-    previousFiles: previousLock?.publicFiles,
-  });
-  await fs.rm(lockPath, { force: true });
+    outDir,
+    Object.keys(previousLock?.publicFiles ?? {}),
+    async () => {
+      const result = await composePublicAssets({
+        projectDirectory,
+        federatedDirectory: outDir,
+        assets: [],
+        previousFiles: previousLock?.publicFiles,
+      });
+      await fs.rm(lockPath, { force: true });
+      return result;
+    }
+  );
+
   onProgress?.({
     type: 'cleanup:complete',
     federated: hadFederatedOutput,
@@ -259,53 +268,65 @@ export const federateCatalog = async (
   const blockingDiagnostics = diagnostics.filter((diagnostic) => diagnostic.severity === 'error');
   if (blockingDiagnostics.length > 0) throw new FederationDiagnosticError(blockingDiagnostics);
 
-  const sourcesById = new Map(sources.map((source) => [source.id, source]));
-  options.onProgress?.({ type: 'hydrating', outDir });
-  let hydratedFiles = 0;
-  let cachedFiles = 0;
-  const hydrateResult = await hydrate(graph, {
-    outDir,
-    cache: createFederationContentCache(projectDirectory, {
-      read: options.useCache !== false,
-      onHit: () => {
-        cachedFiles += 1;
-        options.onProgress?.({ type: 'hydrate:cache', files: cachedFiles });
-      },
-    }),
-    fetch: async ({ source: sourceId, commit, path: artifactPath }) => {
-      const source = sourcesById.get(sourceId);
-      if (!source) throw new Error(`Cannot fetch content for unconfigured source "${sourceId}"`);
-      const content = await provider.fetchContent({ source, commit, path: artifactPath });
-      hydratedFiles += 1;
-      options.onProgress?.({ type: 'hydrate:file', files: hydratedFiles, source: sourceId, path: artifactPath });
-      return content;
-    },
-  });
-
-  const publicResult = await composePublicAssets({
+  const publicPaths = [
+    ...Object.keys(previousLock?.publicFiles ?? {}),
+    ...graph.assets.filter((asset) => asset.path.startsWith('public/')).map((asset) => asset.path.slice('public/'.length)),
+  ];
+  const { hydrateResult, publicResult } = await withFederationOutputTransaction(
     projectDirectory,
-    federatedDirectory: outDir,
-    assets: graph.assets,
-    previousFiles: previousLock?.publicFiles,
-    collisionPaths: new Set(
-      graph.warnings.filter((warning) => warning.kind === 'asset-collision').map((warning) => warning.path)
-    ),
-  });
-  options.onProgress?.({ type: 'public:complete', result: publicResult });
+    outDir,
+    publicPaths,
+    async () => {
+      const sourcesById = new Map(sources.map((source) => [source.id, source]));
+      options.onProgress?.({ type: 'hydrating', outDir });
+      let hydratedFiles = 0;
+      let cachedFiles = 0;
+      const hydrateResult = await hydrate(graph, {
+        outDir,
+        cache: createFederationContentCache(projectDirectory, {
+          read: options.useCache !== false,
+          onHit: () => {
+            cachedFiles += 1;
+            options.onProgress?.({ type: 'hydrate:cache', files: cachedFiles });
+          },
+        }),
+        fetch: async ({ source: sourceId, commit, path: artifactPath }) => {
+          const source = sourcesById.get(sourceId);
+          if (!source) throw new Error(`Cannot fetch content for unconfigured source "${sourceId}"`);
+          const content = await provider.fetchContent({ source, commit, path: artifactPath });
+          hydratedFiles += 1;
+          options.onProgress?.({ type: 'hydrate:file', files: hydratedFiles, source: sourceId, path: artifactPath });
+          return content;
+        },
+      });
 
-  const resolvedAt = (options.now ?? (() => new Date()))().toISOString();
-  await writeLock(lockPath, {
-    lockVersion: 1,
-    sources: resolvedSources
-      .map(({ config: source, resolved }) => ({
-        id: source.id,
-        digest: `sha256:${createHash('sha256').update(resolved.bytes).digest('hex')}`,
-        commit: resolved.commit,
-        resolvedAt,
-      }))
-      .sort((left, right) => left.id.localeCompare(right.id)),
-    publicFiles: publicResult.files,
-  });
+      const publicResult = await composePublicAssets({
+        projectDirectory,
+        federatedDirectory: outDir,
+        assets: graph.assets,
+        previousFiles: previousLock?.publicFiles,
+        collisionPaths: new Set(
+          graph.warnings.filter((warning) => warning.kind === 'asset-collision').map((warning) => warning.path)
+        ),
+      });
+      options.onProgress?.({ type: 'public:complete', result: publicResult });
+
+      const resolvedAt = (options.now ?? (() => new Date()))().toISOString();
+      await writeLock(lockPath, {
+        lockVersion: 1,
+        sources: resolvedSources
+          .map(({ config: source, resolved }) => ({
+            id: source.id,
+            digest: `sha256:${createHash('sha256').update(resolved.bytes).digest('hex')}`,
+            commit: resolved.commit,
+            resolvedAt,
+          }))
+          .sort((left, right) => left.id.localeCompare(right.id)),
+        publicFiles: publicResult.files,
+      });
+      return { hydrateResult, publicResult };
+    }
+  );
 
   const result = {
     sources: sources.length,

--- a/packages/core/src/federation/output-transaction.ts
+++ b/packages/core/src/federation/output-transaction.ts
@@ -1,0 +1,157 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+type PublicPathSnapshot =
+  | { destinationPath: string; state: 'missing' }
+  | { backupPath: string; destinationPath: string; state: 'file' };
+
+const getSafePublicPath = (publicDirectory: string, relativePath: string) => {
+  const normalizedPath = path.posix.normalize(relativePath);
+  const unsafe =
+    relativePath.length === 0 ||
+    relativePath.includes('\0') ||
+    relativePath.includes('\\') ||
+    path.posix.isAbsolute(relativePath) ||
+    /^[a-zA-Z]:\//.test(relativePath) ||
+    normalizedPath !== relativePath ||
+    normalizedPath === '..' ||
+    normalizedPath.startsWith('../');
+
+  if (unsafe) return undefined;
+
+  const destinationPath = path.resolve(publicDirectory, relativePath);
+  const relativeDestinationPath = path.relative(publicDirectory, destinationPath);
+  return relativeDestinationPath !== '' &&
+    relativeDestinationPath !== '..' &&
+    !relativeDestinationPath.startsWith(`..${path.sep}`) &&
+    !path.isAbsolute(relativeDestinationPath)
+    ? destinationPath
+    : undefined;
+};
+
+const beginFederationOutputTransaction = async (
+  projectDirectory: string,
+  outDir: string,
+  relativePublicPaths: Iterable<string>
+) => {
+  const transactionDirectory = await fs.mkdtemp(path.join(projectDirectory, '.eventcatalog-federation-transaction-'));
+  const previousOutDir = path.join(transactionDirectory, 'federated');
+  const publicBackupDirectory = path.join(transactionDirectory, 'public');
+  const publicDirectory = path.resolve(projectDirectory, 'public');
+  const publicSnapshots: PublicPathSnapshot[] = [];
+  const missingPublicDirectories = new Set<string>();
+  let hadPreviousOutDir = false;
+
+  try {
+    for (const relativePath of new Set(relativePublicPaths)) {
+      const destinationPath = getSafePublicPath(publicDirectory, relativePath);
+      if (!destinationPath) continue;
+
+      try {
+        const stat = await fs.lstat(destinationPath);
+        if (!stat.isFile()) continue;
+
+        const backupPath = path.join(publicBackupDirectory, `${publicSnapshots.length}`);
+        await fs.mkdir(path.dirname(backupPath), { recursive: true });
+        await fs.copyFile(destinationPath, backupPath);
+        publicSnapshots.push({ backupPath, destinationPath, state: 'file' });
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException).code;
+        if (code === 'ENOTDIR') continue;
+        if (code !== 'ENOENT') throw error;
+
+        publicSnapshots.push({ destinationPath, state: 'missing' });
+        let directory = path.dirname(destinationPath);
+        while (directory !== publicDirectory) {
+          try {
+            await fs.lstat(directory);
+            break;
+          } catch (directoryError) {
+            const directoryCode = (directoryError as NodeJS.ErrnoException).code;
+            if (directoryCode === 'ENOTDIR') break;
+            if (directoryCode !== 'ENOENT') throw directoryError;
+            missingPublicDirectories.add(directory);
+            directory = path.dirname(directory);
+          }
+        }
+      }
+    }
+
+    try {
+      await fs.rename(outDir, previousOutDir);
+      hadPreviousOutDir = true;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    }
+  } catch (error) {
+    await fs.rm(transactionDirectory, { recursive: true, force: true });
+    throw error;
+  }
+
+  return {
+    commit: async () => {
+      // The new output and lock are already installed. A failed backup cleanup must not turn a successful run into a rollback.
+      await fs.rm(transactionDirectory, { recursive: true, force: true }).catch(() => undefined);
+    },
+    rollback: async () => {
+      const rollbackErrors: unknown[] = [];
+      const attempt = async (operation: () => Promise<unknown>) => {
+        try {
+          await operation();
+        } catch (error) {
+          rollbackErrors.push(error);
+        }
+      };
+
+      await attempt(() => fs.rm(outDir, { recursive: true, force: true }));
+      if (hadPreviousOutDir) await attempt(() => fs.rename(previousOutDir, outDir));
+
+      for (const snapshot of publicSnapshots) {
+        if (snapshot.state === 'missing') {
+          await attempt(() => fs.rm(snapshot.destinationPath, { force: true }));
+          continue;
+        }
+
+        await attempt(async () => {
+          await fs.mkdir(path.dirname(snapshot.destinationPath), { recursive: true });
+          await fs.copyFile(snapshot.backupPath, snapshot.destinationPath);
+        });
+      }
+
+      for (const directory of [...missingPublicDirectories].sort((left, right) => right.length - left.length)) {
+        await attempt(async () => {
+          try {
+            await fs.rmdir(directory);
+          } catch (error) {
+            if (!['ENOENT', 'ENOTEMPTY'].includes((error as NodeJS.ErrnoException).code ?? '')) throw error;
+          }
+        });
+      }
+
+      await attempt(() => fs.rm(transactionDirectory, { recursive: true, force: true }));
+      if (rollbackErrors.length > 0) throw new AggregateError(rollbackErrors, 'Failed to restore the previous federation output');
+    },
+  };
+};
+
+export const withFederationOutputTransaction = async <Result>(
+  projectDirectory: string,
+  outDir: string,
+  relativePublicPaths: Iterable<string>,
+  update: () => Promise<Result>
+) => {
+  const transaction = await beginFederationOutputTransaction(projectDirectory, outDir, relativePublicPaths);
+
+  try {
+    const result = await update();
+    await transaction.commit();
+    return result;
+  } catch (error) {
+    try {
+      await transaction.rollback();
+    } catch (rollbackError) {
+      throw new AggregateError([error, rollbackError], 'Federation failed and the previous output could not be restored');
+    }
+    throw error;
+  }
+};


### PR DESCRIPTION
## What This PR Does

Federation used to delete the existing federated output before writing the new one. If any step after that deletion failed — content hydration, public asset composition, or writing the lock file — the catalog was left in a half-written state with resources missing, public assets partially overwritten, and a lock file that no longer matched what was on disk.

This PR makes a federation run atomic from the caller's point of view. The previous output is snapshotted before anything is modified, and restored if the update throws.

## Changes Overview

### Key Changes

- Add `packages/core/src/federation/output-transaction.ts`, which snapshots the federated directory and the managed public assets before an update and rolls them back on failure.
- Wrap both federation write paths in `federate.ts` with the new transaction: the full `federateCatalog` update and the `cleanupPreviousFederation` path used when sources are removed.
- Add a regression test that simulates a public asset write failure mid-run and asserts the federated directory, public assets, and `eventcatalog.lock` are all left exactly as they were.
- Add a changeset (patch).

## How It Works

`withFederationOutputTransaction(projectDirectory, outDir, relativePublicPaths, update)` wraps the update callback:

**Begin.** A temp directory is created inside the project. For every public path the run may touch (the previous lock's managed files plus the incoming `public/` assets), the current state is recorded as either `file` (copied into the backup directory) or `missing`. For missing paths it also walks up and records which parent directories don't exist yet, so they can be removed again on rollback rather than left behind as empty directories. The existing federated directory is then moved aside with `rename` instead of being deleted, which makes the rollback a cheap move back.

**Commit.** On success the new output and lock are already in place, so commit only removes the backup. That cleanup is deliberately non-fatal — a failure to delete a temp directory must not turn a successful run into a rollback.

**Rollback.** On failure the new output directory is removed, the previous one is renamed back, and each public snapshot is restored: `file` snapshots are copied back, `missing` snapshots are deleted. Newly created parent directories are then removed deepest-first, tolerating `ENOENT`/`ENOTEMPTY`. Every rollback step runs through an `attempt` helper that collects errors rather than aborting, so one failed step doesn't prevent the rest of the restore. Any collected errors are thrown as an `AggregateError`.

If the update fails *and* rollback also fails, both errors are surfaced together in an `AggregateError` so the original cause isn't hidden by the cleanup failure.

Public paths are validated by `getSafePublicPath` before use, which rejects absolute paths, traversal (`..`), backslashes, null bytes, Windows drive prefixes, and any path that doesn't normalize to itself, then double-checks the resolved path is still inside `public/`. Only regular files are backed up — symlinks and directories are skipped via `lstat`.

## Breaking Changes

None. This is purely a failure-path change; a successful federation run produces exactly the same output as before.

## Additional Notes

- Branched off the latest `main`, which already includes the configurable federation diagnostics work from #2790. The changeset for that PR is untouched; this PR adds its own.
- The new test spies on `fs.writeFile` to force a mid-run failure at a specific public asset destination, then asserts full restoration including byte-for-byte lock file equality.
- No editor repository change is needed for this — it is internal to the core federation write path and does not alter any config surface or output format.