### PR TITLE
Clarify federation lock file log message

### DIFF
--- a/.changeset/silly-moons-tickle.md
+++ b/.changeset/silly-moons-tickle.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Clarify the federation lock file log message to reflect that it records resolved source state, not just pinned commits

--- a/packages/core/src/eventcatalog.ts
+++ b/packages/core/src/eventcatalog.ts
@@ -823,7 +823,7 @@ const reportFederationProgress = (event: FederationProgressEvent, verbose = fals
         `Federation complete: ${event.result.sources} sources, ${event.result.resources} remote resources, ${event.result.hydrate.written} files written (${event.result.hydrate.fetched} downloaded, ${event.result.hydrate.written - event.result.hydrate.fetched} cached)`,
         'federation'
       );
-      logger.info(`Pinned source commits in ${path.relative(dir, event.result.lockPath)}`, 'federation');
+      logger.info(`Recorded resolved source state in ${path.relative(dir, event.result.lockPath)}`, 'federation');
   }
 };
 


### PR DESCRIPTION
## What This PR Does

Updates the message logged after a successful federation run so it accurately describes what the lock file contains. Federation sources can now be local filesystem catalogs as well as GitHub repositories, so "Pinned source commits" is no longer accurate for every source type. The message now reads "Recorded resolved source state", which covers both cases.

## Changes Overview

### Key Changes
- `packages/core/src/eventcatalog.ts` — change the federation completion log line from `Pinned source commits in <lockPath>` to `Recorded resolved source state in <lockPath>`

## How It Works

The change is confined to `reportFederationProgress`, the helper that turns federation progress events into CLI log output. Only the human-readable string changes; the lock file path, log level, and `federation` log scope are untouched, and no federation behaviour is affected.

## Breaking Changes

None. This is a log message wording change only.

## Additional Notes

No editor changes are needed in `eventcatalog/eventcatalog-editor` — this only touches CLI log output in core.