### PR TITLE
Add federate script and federation ignores to new catalog templates

### DIFF
--- a/.changeset/bright-tools-federate.md
+++ b/.changeset/bright-tools-federate.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/create-eventcatalog': patch
+---
+
+Add a federate script and ignore generated federation files in new catalogs.

--- a/packages/create-eventcatalog/templates/amazon-api-gateway/gitignore
+++ b/packages/create-eventcatalog/templates/amazon-api-gateway/gitignore
@@ -22,6 +22,8 @@ yarn-debug.log*
 yarn-error.log*
 
 .eventcatalog-core
+.eventcatalog-cache/
+federated/
 
 .env
 .env-*

--- a/packages/create-eventcatalog/templates/asyncapi/gitignore
+++ b/packages/create-eventcatalog/templates/asyncapi/gitignore
@@ -22,6 +22,8 @@ yarn-debug.log*
 yarn-error.log*
 
 .eventcatalog-core
+.eventcatalog-cache/
+federated/
 
 .env
 .env-*

--- a/packages/create-eventcatalog/templates/confluent/gitignore
+++ b/packages/create-eventcatalog/templates/confluent/gitignore
@@ -22,6 +22,8 @@ yarn-debug.log*
 yarn-error.log*
 
 .eventcatalog-core
+.eventcatalog-cache/
+federated/
 
 .env
 .env-*

--- a/packages/create-eventcatalog/templates/default/gitignore
+++ b/packages/create-eventcatalog/templates/default/gitignore
@@ -22,6 +22,8 @@ yarn-debug.log*
 yarn-error.log*
 
 .eventcatalog-core
+.eventcatalog-cache/
+federated/
 
 .env
 .env-*

--- a/packages/create-eventcatalog/templates/empty/gitignore
+++ b/packages/create-eventcatalog/templates/empty/gitignore
@@ -22,6 +22,8 @@ yarn-debug.log*
 yarn-error.log*
 
 .eventcatalog-core
+.eventcatalog-cache/
+federated/
 
 .env
 .env-*

--- a/packages/create-eventcatalog/templates/eventbridge/gitignore
+++ b/packages/create-eventcatalog/templates/eventbridge/gitignore
@@ -22,6 +22,8 @@ yarn-debug.log*
 yarn-error.log*
 
 .eventcatalog-core
+.eventcatalog-cache/
+federated/
 
 .env
 .env-*

--- a/packages/create-eventcatalog/templates/graphql/gitignore
+++ b/packages/create-eventcatalog/templates/graphql/gitignore
@@ -22,6 +22,8 @@ yarn-debug.log*
 yarn-error.log*
 
 .eventcatalog-core
+.eventcatalog-cache/
+federated/
 
 .env
 .env-*

--- a/packages/create-eventcatalog/templates/index.ts
+++ b/packages/create-eventcatalog/templates/index.ts
@@ -53,6 +53,7 @@ export const installTemplate = async ({
       start: 'eventcatalog start',
       preview: 'eventcatalog preview',
       generate: 'eventcatalog generate',
+      federate: 'eventcatalog federate',
       export: 'eventcatalog export',
       lint: 'eventcatalog-linter',
       test: 'echo "Error: no test specified" && exit 1',

--- a/packages/create-eventcatalog/templates/openapi/gitignore
+++ b/packages/create-eventcatalog/templates/openapi/gitignore
@@ -22,6 +22,8 @@ yarn-debug.log*
 yarn-error.log*
 
 .eventcatalog-core
+.eventcatalog-cache/
+federated/
 
 .env
 .env-*

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -148,7 +148,6 @@
 - 8f724a7: feat: add `externalSystem` flag to services for modelling third-party integrations
 
   Services can now set `externalSystem: true` in their frontmatter to be rendered as external systems. This changes their presentation without changing their capabilities — they still send and receive messages, have owners, and support specifications like any other service.
-
   - Visualiser: external services render purple with a Globe icon and an "External System" badge
   - Sidebar (root): a dedicated "External Systems" section lists externals; the regular "Services" section excludes them
   - Sidebar (domain): externals appear under a new "External Integrations" group, separate from "Services In Domain"


### PR DESCRIPTION
## What This PR Does

Updates the `create-eventcatalog` project templates so new catalogs are ready for federation out of the box. Every scaffolded catalog now includes a `federate` npm script and ignores the files that federation runs generate.

## Changes Overview

### Key Changes
- Add a `federate: eventcatalog federate` script to the `package.json` generated for new catalogs (`templates/index.ts`)
- Ignore `.eventcatalog-cache/` and `federated/` in the `gitignore` shipped with every template (default, empty, asyncapi, openapi, confluent, eventbridge, graphql, amazon-api-gateway)
- Fix a missing trailing newline in those template gitignore files
- Add a changeset (`bright-tools-federate.md`) releasing `@eventcatalog/create-eventcatalog` as a patch

## How It Works

`create-eventcatalog` copies the template directory for the chosen template and generates the project's `package.json` from `templates/index.ts`. Adding the script and gitignore entries at the template level means every newly scaffolded catalog can run `npm run federate` immediately, and the federation cache and pulled `federated/` output stay out of version control by default.

## Breaking Changes

None

## Additional Notes

Existing catalogs are unaffected — users who want the same setup can add the script and gitignore entries manually. No corresponding change is needed in the editor repository.