### PR TITLE
Place federation under the EventCatalog Commercial License and enforce the Scale entitlement

### DIFF
--- a/.changeset/curly-pandas-federate.md
+++ b/.changeset/curly-pandas-federate.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Clarify that the built-in Federation workflow uses the EventCatalog Commercial License, ship the mixed-license terms with the core package, and enforce the existing Scale entitlement for every configured federation run.

--- a/LICENSE
+++ b/LICENSE
@@ -22,7 +22,10 @@ SOFTWARE.
 
 ---
 
-Note: Source code within `packages/core/eventcatalog/src/enterprise/` is
-licensed under the EventCatalog Commercial License and is NOT covered by the
-MIT License above. See `packages/core/eventcatalog/src/enterprise/LICENSE`
-for the full terms.
+Note: Source code within the following directories is licensed under the
+EventCatalog Commercial License and is NOT covered by the MIT License above:
+
+- `packages/core/eventcatalog/src/enterprise/`
+- `packages/core/src/federation/`
+
+See the `LICENSE` file in each directory for the full terms.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Document systems, domains, services, messages and schemas. Document your archite
 Customize your documentation to fit your workflow. Automate it, customize it, visualize it.
 
 [![main](https://github.com/event-catalog/eventcatalog/actions/workflows/verify-build.yml/badge.svg)](https://github.com/event-catalog/eventcatalog/actions/workflows/verify-build.yml)
-[![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/event-catalog/eventcatalog/blob/main/LICENSE)
+[![License](https://img.shields.io/badge/License-MIT%20%2B%20Commercial-blue.svg)](https://github.com/event-catalog/eventcatalog/blob/main/LICENSE)
 [![npm version](https://badge.fury.io/js/@eventcatalog%2Fcore.svg)](https://badge.fury.io/js/@eventcatalog/core)
 [![All Contributors](https://img.shields.io/badge/all_contributors-69-orange.svg?style=flat-square)](#contributors-)
 
@@ -271,4 +271,5 @@ This project follows the [all-contributors](https://github.com/all-contributors/
 
 ## License
 
-MIT.
+EventCatalog uses a mixed-license model. Most of the repository is licensed under MIT; paid feature directories identified
+in the root [LICENSE](LICENSE) use the EventCatalog Commercial License.

--- a/packages/core/LICENSE
+++ b/packages/core/LICENSE
@@ -1,0 +1,93 @@
+EventCatalog Core is distributed under a mixed-license model.
+
+The MIT License below applies to this package except for these commercially
+licensed paths and their compiled derivatives:
+
+- `eventcatalog/src/enterprise/`
+- `dist/federation/`
+
+The corresponding federation source is located at `src/federation/` in the
+EventCatalog repository. The EventCatalog Commercial License below applies to
+the listed commercial paths.
+
+MIT License
+
+Copyright (c) 2022-2026 boyney123
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+The EventCatalog Commercial License (the "Commercial License")
+Copyright (c) 2022-2026 EventCatalog Ltd
+
+With regard to the EventCatalog Software:
+
+This software and associated documentation files (the "Software") may only be
+used in production, if you (and any entity that you represent) have agreed to,
+and are in compliance with, the EventCatalog Terms of Service available
+at https://www.eventcatalog.dev/terms, or other agreements governing the use of
+the Software, as mutually agreed by you and EventCatalog Ltd ("EventCatalog"),
+and otherwise have a valid EventCatalog Starter, Scale, or Enterprise
+subscription ("Commercial Subscription").
+
+Subject to the foregoing sentence, you are free to modify this Software and
+publish patches to the Software. You agree that EventCatalog and/or its
+licensors (as applicable) retain all right, title and interest in and to all
+such modifications and/or patches, and all such modifications and/or patches
+may only be used, copied, modified, displayed, distributed, or otherwise
+exploited with a valid Commercial Subscription.
+
+A 14-day free trial of premium features is available at
+https://eventcatalog.cloud/ to help you evaluate the Software before purchasing
+a Commercial Subscription.
+
+Notwithstanding the foregoing, you may copy and modify the Software for
+development and testing purposes, without requiring a subscription. You agree
+that EventCatalog and/or its licensors (as applicable) retain all right, title
+and interest in and to all such modifications. You are not granted any other
+rights beyond what is expressly stated herein. Subject to the foregoing, it is
+forbidden to copy, merge, publish, distribute, sublicense, and/or sell the
+Software.
+
+You may not move, change, disable, or circumvent the license key functionality
+in the Software, and you may not remove or obscure any functionality in the
+Software that is protected by the license key.
+
+This Software is source-available for the purposes of transparency and
+auditability. Source availability does not constitute a grant of rights to use
+the Software in production without a valid Commercial Subscription.
+
+This Commercial License applies only to the part of this Software that is not
+distributed under the MIT license. Any part of this Software distributed under
+the MIT license is copyrighted under the MIT license. The full text of this
+Commercial License shall be included in all copies or substantial portions of
+the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+For all third party components incorporated into the EventCatalog Software,
+those components are licensed under the original license provided by the owner
+of the applicable component.

--- a/packages/core/LICENSE
+++ b/packages/core/LICENSE
@@ -1,14 +1,16 @@
 EventCatalog Core is distributed under a mixed-license model.
 
-The MIT License below applies to this package except for these commercially
-licensed paths and their compiled derivatives:
+The EventCatalog Commercial License below applies to these source paths:
 
-- `eventcatalog/src/enterprise/`
-- `dist/federation/`
+- `eventcatalog/src/enterprise/**`
+- `src/federation/**`
 
-The corresponding federation source is located at `src/federation/` in the
-EventCatalog repository. The EventCatalog Commercial License below applies to
-the listed commercial paths.
+The EventCatalog Commercial License also applies to any portion of a compiled,
+bundled, copied, minified, or otherwise generated artifact derived from those
+paths, regardless of its output location, including artifacts under `dist/**`
+and `bin/**`.
+
+The MIT License below applies to all remaining portions of this package.
 
 MIT License
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -35,7 +35,7 @@
 <div align="center">
 
 [![main](https://github.com/event-catalog/eventcatalog/actions/workflows/verify-build.yml/badge.svg)](https://github.com/event-catalog/eventcatalog/actions/workflows/verify-build.yml)
-[![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/event-catalog/eventcatalog/blob/main/LICENSE)
+[![License](https://img.shields.io/badge/License-MIT%20%2B%20Commercial-blue.svg)](./LICENSE)
 [![npm version](https://badge.fury.io/js/@eventcatalog%2Fcore.svg)](https://badge.fury.io/js/@eventcatalog/core)
 
 </div>
@@ -205,4 +205,5 @@ This project follows the [all-contributors](https://github.com/all-contributors/
 
 # License
 
-MIT.
+EventCatalog Core uses a mixed-license model. Most files are licensed under MIT; the Enterprise and Federation paths
+identified in [LICENSE](./LICENSE) use the EventCatalog Commercial License.

--- a/packages/core/src/__tests__/federate.spec.ts
+++ b/packages/core/src/__tests__/federate.spec.ts
@@ -13,6 +13,12 @@ import {
 } from '../federation/federate';
 import type { FederationSourceProvider } from '../federation/types';
 
+const federationEntitlement = vi.hoisted(() => ({
+  isFederationEnabled: vi.fn(async () => true),
+}));
+
+vi.mock('../federation/entitlement', () => federationEntitlement);
+
 const sourceIndex = (source: string, resourceId: string): Index => {
   const contentPath = `services/${resourceId}/index.mdx`;
   const content = Buffer.from(`# ${contentPath}\n`);
@@ -96,6 +102,8 @@ describe('federate catalog', () => {
   let projectDirectory: string;
 
   beforeEach(async () => {
+    federationEntitlement.isFederationEnabled.mockReset();
+    federationEntitlement.isFederationEnabled.mockResolvedValue(true);
     projectDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'eventcatalog-federate-'));
   });
 
@@ -689,9 +697,8 @@ describe('federate catalog', () => {
     );
 
     const progress: FederationProgressEvent[] = [];
-    const isFederationEnabled = vi.fn(async () => false);
+    federationEntitlement.isFederationEnabled.mockResolvedValueOnce(false);
     await federateCatalog(projectDirectory, {
-      isFederationEnabled,
       onProgress: (event) => progress.push(event),
     });
 
@@ -709,7 +716,7 @@ describe('federate catalog', () => {
       });
     if (lock) expect(lock).toMatchObject({ sources: [], publicFiles: {} });
     expect(progress).toContainEqual({ type: 'cleanup:complete', federated: true, publicFiles: 1, lock: true });
-    expect(isFederationEnabled).not.toHaveBeenCalled();
+    expect(federationEntitlement.isFederationEnabled).not.toHaveBeenCalled();
   });
 
   it('checks entitlement before resolving configured sources', async () => {
@@ -718,13 +725,13 @@ describe('federate catalog', () => {
       resolve: vi.fn(),
       fetchContent: vi.fn(),
     };
-    const isFederationEnabled = vi.fn(async () => false);
+    federationEntitlement.isFederationEnabled.mockResolvedValueOnce(false);
 
-    await expect(federateCatalog(projectDirectory, { provider, isFederationEnabled })).rejects.toThrow(
+    await expect(federateCatalog(projectDirectory, { provider })).rejects.toThrow(
       'EventCatalog federation is an Enterprise feature'
     );
 
-    expect(isFederationEnabled).toHaveBeenCalledOnce();
+    expect(federationEntitlement.isFederationEnabled).toHaveBeenCalledOnce();
     expect(provider.resolve).not.toHaveBeenCalled();
     expect(provider.fetchContent).not.toHaveBeenCalled();
   });
@@ -735,5 +742,6 @@ describe('federate catalog', () => {
 
     await expect(federateCatalog(projectDirectory, { onProgress: (event) => progress.push(event) })).resolves.toBeNull();
     expect(progress).toEqual([{ type: 'configured', sources: 0 }]);
+    expect(federationEntitlement.isFederationEnabled).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/__tests__/federation-license.spec.ts
+++ b/packages/core/src/__tests__/federation-license.spec.ts
@@ -1,0 +1,38 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const COMMERCIAL_HEADER = `/**
+ * Licensed under the EventCatalog Commercial License.
+ * See /packages/core/src/federation/LICENSE
+ */`;
+
+describe('federation license boundary', () => {
+  const federationDirectory = path.resolve(__dirname, '../federation');
+
+  it('marks every federation implementation file as commercially licensed', async () => {
+    const files = (await fs.readdir(federationDirectory)).filter((file) => file.endsWith('.ts'));
+
+    await Promise.all(
+      files.map(async (file) => {
+        const contents = await fs.readFile(path.join(federationDirectory, file), 'utf8');
+        expect(contents.startsWith(COMMERCIAL_HEADER), `${file} is missing the commercial license header`).toBe(true);
+      })
+    );
+  });
+
+  it('documents the source and package distribution boundaries', async () => {
+    const [rootLicense, packageLicense, federationLicense, sdkPackage] = await Promise.all([
+      fs.readFile(path.resolve(__dirname, '../../../../LICENSE'), 'utf8'),
+      fs.readFile(path.resolve(__dirname, '../../LICENSE'), 'utf8'),
+      fs.readFile(path.join(federationDirectory, 'LICENSE'), 'utf8'),
+      fs.readFile(path.resolve(__dirname, '../../../sdk/package.json'), 'utf8').then((contents) => JSON.parse(contents)),
+    ]);
+
+    expect(rootLicense).toContain('packages/core/src/federation/');
+    expect(packageLicense).toContain('dist/federation/');
+    expect(packageLicense).toContain('The EventCatalog Commercial License');
+    expect(federationLicense).toContain('The EventCatalog Commercial License');
+    expect(sdkPackage.license).toBe('MIT');
+  });
+});

--- a/packages/core/src/__tests__/federation-license.spec.ts
+++ b/packages/core/src/__tests__/federation-license.spec.ts
@@ -30,7 +30,10 @@ describe('federation license boundary', () => {
     ]);
 
     expect(rootLicense).toContain('packages/core/src/federation/');
-    expect(packageLicense).toContain('dist/federation/');
+    expect(packageLicense).toContain('src/federation/**');
+    expect(packageLicense).toContain('regardless of its output location');
+    expect(packageLicense).toContain('`dist/**`');
+    expect(packageLicense).toContain('`bin/**`');
     expect(packageLicense).toContain('The EventCatalog Commercial License');
     expect(federationLicense).toContain('The EventCatalog Commercial License');
     expect(sdkPackage.license).toBe('MIT');

--- a/packages/core/src/eventcatalog.ts
+++ b/packages/core/src/eventcatalog.ts
@@ -843,7 +843,6 @@ program
     let cleanedPreviousOutput = false;
     const result = await federateCatalog(dir, {
       useCache: commandOptions.cache,
-      isFederationEnabled: isEventCatalogScaleEnabled,
       onProgress: (event) => {
         if (event.type === 'cleanup:complete') cleanedPreviousOutput = true;
         reportFederationProgress(event, commandOptions.verbose);

--- a/packages/core/src/federation/LICENSE
+++ b/packages/core/src/federation/LICENSE
@@ -1,0 +1,57 @@
+The EventCatalog Commercial License (the "Commercial License")
+Copyright (c) 2022-2026 EventCatalog Ltd
+
+With regard to the EventCatalog Software:
+
+This software and associated documentation files (the "Software") may only be
+used in production, if you (and any entity that you represent) have agreed to,
+and are in compliance with, the EventCatalog Terms of Service available
+at https://www.eventcatalog.dev/terms, or other agreements governing the use of
+the Software, as mutually agreed by you and EventCatalog Ltd ("EventCatalog"),
+and otherwise have a valid EventCatalog Starter, Scale, or Enterprise
+subscription ("Commercial Subscription").
+
+Subject to the foregoing sentence, you are free to modify this Software and
+publish patches to the Software. You agree that EventCatalog and/or its
+licensors (as applicable) retain all right, title and interest in and to all
+such modifications and/or patches, and all such modifications and/or patches
+may only be used, copied, modified, displayed, distributed, or otherwise
+exploited with a valid Commercial Subscription.
+
+A 14-day free trial of premium features is available at
+https://eventcatalog.cloud/ to help you evaluate the Software before purchasing
+a Commercial Subscription.
+
+Notwithstanding the foregoing, you may copy and modify the Software for
+development and testing purposes, without requiring a subscription. You agree
+that EventCatalog and/or its licensors (as applicable) retain all right, title
+and interest in and to all such modifications. You are not granted any other
+rights beyond what is expressly stated herein. Subject to the foregoing, it is
+forbidden to copy, merge, publish, distribute, sublicense, and/or sell the
+Software.
+
+You may not move, change, disable, or circumvent the license key functionality
+in the Software, and you may not remove or obscure any functionality in the
+Software that is protected by the license key.
+
+This Software is source-available for the purposes of transparency and
+auditability. Source availability does not constitute a grant of rights to use
+the Software in production without a valid Commercial Subscription.
+
+This Commercial License applies only to the part of this Software that is not
+distributed under the MIT license. Any part of this Software distributed under
+the MIT license is copyrighted under the MIT license. The full text of this
+Commercial License shall be included in all copies or substantial portions of
+the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+For all third party components incorporated into the EventCatalog Software,
+those components are licensed under the original license provided by the owner
+of the applicable component.

--- a/packages/core/src/federation/content-cache.ts
+++ b/packages/core/src/federation/content-cache.ts
@@ -1,3 +1,8 @@
+/**
+ * Licensed under the EventCatalog Commercial License.
+ * See /packages/core/src/federation/LICENSE
+ */
+
 import { createHash, randomUUID } from 'node:crypto';
 import fs from 'node:fs/promises';
 import path from 'node:path';

--- a/packages/core/src/federation/diagnostics.ts
+++ b/packages/core/src/federation/diagnostics.ts
@@ -1,3 +1,8 @@
+/**
+ * Licensed under the EventCatalog Commercial License.
+ * See /packages/core/src/federation/LICENSE
+ */
+
 import type { Conflict, ResolvedGraph } from '@eventcatalog/sdk';
 import type { FederationRuleId, FederationRuleLevel, FederationRulesConfig } from '../eventcatalog.config';
 

--- a/packages/core/src/federation/entitlement.ts
+++ b/packages/core/src/federation/entitlement.ts
@@ -1,0 +1,13 @@
+/**
+ * Licensed under the EventCatalog Commercial License.
+ * See /packages/core/src/federation/LICENSE
+ */
+
+import { isEventCatalogScaleEnabled } from '@eventcatalog/license';
+
+/**
+ * Federation is currently enabled through the Scale entitlement. Keep callers
+ * plan-agnostic so this can move to the Enterprise offline entitlement without
+ * changing the federation workflow.
+ */
+export const isFederationEnabled = () => isEventCatalogScaleEnabled();

--- a/packages/core/src/federation/federate.ts
+++ b/packages/core/src/federation/federate.ts
@@ -1,3 +1,8 @@
+/**
+ * Licensed under the EventCatalog Commercial License.
+ * See /packages/core/src/federation/LICENSE
+ */
+
 import { createHash } from 'node:crypto';
 import fs from 'node:fs/promises';
 import path from 'node:path';
@@ -6,6 +11,7 @@ import type { FederationSourceConfig } from '../eventcatalog.config';
 import { getEventCatalogConfigFile } from '../eventcatalog-config-file-utils.js';
 import { createFederationContentCache } from './content-cache';
 import { getFederationDiagnostics, resolveFederationRules, type FederationDiagnostic } from './diagnostics';
+import { isFederationEnabled } from './entitlement';
 import { withFederationOutputTransaction } from './output-transaction';
 import { composePublicAssets, type FederatedPublicFiles, type PublicAssetCompositionResult } from './public-assets';
 import { createFederationSourceProvider } from './source-provider';
@@ -62,7 +68,6 @@ type FederateCatalogOptions = {
   onProgress?: (event: FederationProgressEvent) => void;
   now?: () => Date;
   useCache?: boolean;
-  isFederationEnabled?: () => Promise<boolean>;
 };
 
 export class FederationConflictError extends Error {
@@ -204,7 +209,7 @@ export const federateCatalog = async (
     await cleanupPreviousFederation(projectDirectory, options.onProgress);
     return null;
   }
-  if (options.isFederationEnabled && !(await options.isFederationEnabled())) {
+  if (!(await isFederationEnabled())) {
     throw new Error(
       'Cannot federate catalogs: EventCatalog federation is an Enterprise feature. Visit https://www.eventcatalog.dev/pricing to enable federation.'
     );

--- a/packages/core/src/federation/filesystem-source-provider.ts
+++ b/packages/core/src/federation/filesystem-source-provider.ts
@@ -1,3 +1,8 @@
+/**
+ * Licensed under the EventCatalog Commercial License.
+ * See /packages/core/src/federation/LICENSE
+ */
+
 import { createHash } from 'node:crypto';
 import fs from 'node:fs/promises';
 import path from 'node:path';

--- a/packages/core/src/federation/github-source-provider.ts
+++ b/packages/core/src/federation/github-source-provider.ts
@@ -1,3 +1,8 @@
+/**
+ * Licensed under the EventCatalog Commercial License.
+ * See /packages/core/src/federation/LICENSE
+ */
+
 import { execFile } from 'node:child_process';
 import fs from 'node:fs/promises';
 import os from 'node:os';

--- a/packages/core/src/federation/output-transaction.ts
+++ b/packages/core/src/federation/output-transaction.ts
@@ -1,3 +1,8 @@
+/**
+ * Licensed under the EventCatalog Commercial License.
+ * See /packages/core/src/federation/LICENSE
+ */
+
 import fs from 'node:fs/promises';
 import path from 'node:path';
 

--- a/packages/core/src/federation/public-assets.ts
+++ b/packages/core/src/federation/public-assets.ts
@@ -1,3 +1,8 @@
+/**
+ * Licensed under the EventCatalog Commercial License.
+ * See /packages/core/src/federation/LICENSE
+ */
+
 import { createHash } from 'node:crypto';
 import fs from 'node:fs/promises';
 import path from 'node:path';

--- a/packages/core/src/federation/source-provider.ts
+++ b/packages/core/src/federation/source-provider.ts
@@ -1,3 +1,8 @@
+/**
+ * Licensed under the EventCatalog Commercial License.
+ * See /packages/core/src/federation/LICENSE
+ */
+
 import type { FederationSourceConfig } from '../eventcatalog.config';
 import { createFileSystemSourceProvider } from './filesystem-source-provider';
 import { createGitHubSourceProvider } from './github-source-provider';

--- a/packages/core/src/federation/types.ts
+++ b/packages/core/src/federation/types.ts
@@ -1,3 +1,8 @@
+/**
+ * Licensed under the EventCatalog Commercial License.
+ * See /packages/core/src/federation/LICENSE
+ */
+
 import type { Index } from '@eventcatalog/sdk';
 import type { FederationSourceConfig } from '../eventcatalog.config';
 

--- a/packages/core/tsup.config.js
+++ b/packages/core/tsup.config.js
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/**', '!src/**/__tests__/**'],
+  entry: ['src/**', '!src/**/__tests__/**', '!src/**/LICENSE'],
   dts: true,
   outDir: 'dist/',
   format: ['esm', 'cjs'],


### PR DESCRIPTION
## What This PR Does

Clarifies that the built-in federation workflow is a paid feature by placing `packages/core/src/federation/` under the EventCatalog Commercial License, shipping the mixed-license terms with the `@eventcatalog/core` package, and enforcing the existing Scale entitlement inside the federation module for every configured run.

## Changes Overview

### Key Changes
- Add a Commercial License file at `packages/core/src/federation/LICENSE` and a license header to every source file in the federation module
- Update the root `LICENSE` and `README.md` to document the mixed-license model (MIT plus commercial directories), and add a package-level `packages/core/LICENSE` so the published npm package carries the full terms
- Add `packages/core/src/federation/entitlement.ts` exposing `isFederationEnabled()`, backed by the existing Scale entitlement (`isEventCatalogScaleEnabled` from `@eventcatalog/license`)
- Move the entitlement check from an injected `isFederationEnabled` option on `federateCatalog` into the federation module itself, so the CLI no longer wires it in and the check cannot be bypassed by omitting the option
- Exclude `LICENSE` files from the tsup build entry glob
- Add `federation-license.spec.ts` verifying every federation source file carries the license header and the LICENSE files exist, and update `federate.spec.ts` for the internal entitlement check
- Add a changeset (`curly-pandas-federate.md`) releasing `@eventcatalog/core` as a patch

## How It Works

`federateCatalog` now calls the module-internal `isFederationEnabled()` before running any configured federation, throwing the existing Enterprise-feature error when the entitlement is missing. The entitlement helper deliberately keeps callers plan-agnostic so federation can later move from the Scale entitlement to an Enterprise offline entitlement without touching the workflow. Cleanup of previous federation output still runs without an entitlement, so a catalog with no federation config is unaffected.

## Breaking Changes

None for MIT-licensed usage. Running `eventcatalog federate` with configured sources now always requires the Scale entitlement — previously the check depended on the caller passing it in (the CLI already did).

## Additional Notes

No corresponding change is needed in the editor repository — this only affects the core package's federation module and repository licensing docs.