### PR TITLE
Gate federation behind the Enterprise offline entitlement

### DIFF
--- a/.changeset/tidy-dragons-federate.md
+++ b/.changeset/tidy-dragons-federate.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Require the built-in Federation workflow to use the offline EventCatalog Enterprise entitlement instead of the Scale entitlement.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -66,7 +66,7 @@
     "@asyncapi/parser": "^3.6.0",
     "@asyncapi/react-component": "3.1.0",
     "@auth/core": "^0.41.3",
-    "@eventcatalog/license": "^0.0.7",
+    "@eventcatalog/license": "^0.0.8",
     "@eventcatalog/linter": "workspace:*",
     "@eventcatalog/sdk": "workspace:*",
     "@eventcatalog/visualiser": "workspace:^",

--- a/packages/core/src/__tests__/federation-entitlement.spec.ts
+++ b/packages/core/src/__tests__/federation-entitlement.spec.ts
@@ -1,0 +1,22 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const license = vi.hoisted(() => ({
+  isEventCatalogEnterpriseEnabled: vi.fn<() => Promise<boolean>>(),
+}));
+
+vi.mock('@eventcatalog/license', () => license);
+
+import { isFederationEnabled } from '../federation/entitlement';
+
+describe('federation entitlement', () => {
+  beforeEach(() => {
+    license.isEventCatalogEnterpriseEnabled.mockReset();
+  });
+
+  it('uses the EventCatalog Enterprise entitlement', async () => {
+    license.isEventCatalogEnterpriseEnabled.mockResolvedValueOnce(true);
+
+    await expect(isFederationEnabled()).resolves.toBe(true);
+    expect(license.isEventCatalogEnterpriseEnabled).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/core/src/eventcatalog.config.ts
+++ b/packages/core/src/eventcatalog.config.ts
@@ -442,6 +442,6 @@ export interface Config {
   integrations?: IntegrationsConfig;
   scalarConfiguration?: ScalarConfiguration;
   generators?: GeneratorConfig[];
-  /** Catalogs composed into this catalog by `eventcatalog federate`. */
+  /** Catalogs composed into this catalog by `eventcatalog federate`. Requires an offline EventCatalog Enterprise license. */
   federation?: FederationConfig;
 }

--- a/packages/core/src/federation/entitlement.ts
+++ b/packages/core/src/federation/entitlement.ts
@@ -3,11 +3,11 @@
  * See /packages/core/src/federation/LICENSE
  */
 
-import { isEventCatalogScaleEnabled } from '@eventcatalog/license';
+import { isEventCatalogEnterpriseEnabled } from '@eventcatalog/license';
 
 /**
- * Federation is currently enabled through the Scale entitlement. Keep callers
- * plan-agnostic so this can move to the Enterprise offline entitlement without
- * changing the federation workflow.
+ * Federation is enabled through the Enterprise offline entitlement. Keep
+ * callers plan-agnostic so licensing details remain isolated from the
+ * federation workflow.
  */
-export const isFederationEnabled = () => isEventCatalogScaleEnabled();
+export const isFederationEnabled = () => isEventCatalogEnterpriseEnabled();

--- a/packages/core/vitest.config.js
+++ b/packages/core/vitest.config.js
@@ -30,6 +30,7 @@ export default defineConfig({
       'astro:content': path.resolve(__dirname, './src/__mocks__/astro-content.ts'),
       '@config': path.resolve(__dirname, 'eventcatalog/eventcatalog.config.js'),
       '@eventcatalog/connectors': path.resolve(__dirname, 'node_modules/@eventcatalog/connectors/dist/index.mjs'),
+      '@eventcatalog/license': path.resolve(__dirname, 'node_modules/@eventcatalog/license/dist/index.js'),
       '@eventcatalog/sdk': path.resolve(__dirname, 'node_modules/@eventcatalog/sdk/dist/index.mjs'),
       '@eventcatalog': path.resolve(__dirname, 'eventcatalog/src/utils/eventcatalog-config/catalog.ts'),
       '@icons': path.resolve(__dirname, 'eventcatalog/src/icons'),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,8 +140,8 @@ importers:
         specifier: ^0.41.3
         version: 0.41.3
       '@eventcatalog/license':
-        specifier: ^0.0.7
-        version: 0.0.7
+        specifier: ^0.0.8
+        version: 0.0.8
       '@eventcatalog/linter':
         specifier: workspace:*
         version: link:../linter
@@ -1765,6 +1765,10 @@ packages:
 
   '@eventcatalog/license@0.0.7':
     resolution: {integrity: sha512-izSIn3Dfc6LTcPiA89EqZ4/l5WCitLxt0XVu2yilyaibMOioxW7ABRFZY8/Azocd6ULKseVA2lCcoeT35/GRcg==}
+    engines: {node: '>=16.0.0'}
+
+  '@eventcatalog/license@0.0.8':
+    resolution: {integrity: sha512-iMo2NiTo8MQVYONrrXe3WFo61i/T4oSz5OY4DSL9PwwdOYWtx0zZ1+ANcWyLI7ub6PFS8KJIWlxsM2JYOLYrjQ==}
     engines: {node: '>=16.0.0'}
 
   '@expressive-code/core@0.44.0':
@@ -9951,6 +9955,15 @@ snapshots:
     optional: true
 
   '@eventcatalog/license@0.0.7':
+    dependencies:
+      boxen: 8.0.1
+      chalk: 5.6.2
+      https-proxy-agent: 7.0.6
+      jose: 5.10.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eventcatalog/license@0.0.8':
     dependencies:
       boxen: 8.0.1
       chalk: 5.6.2


### PR DESCRIPTION
## What This PR Does

Federation was temporarily gated behind the Scale entitlement while the offline Enterprise entitlement was being finalised. This PR moves it to its intended home: `isFederationEnabled()` now delegates to `isEventCatalogEnterpriseEnabled()` from `@eventcatalog/license`.

The licensing detail stays isolated inside `federation/entitlement.ts`, so no federation workflow code changes — only the single entitlement check behind it.

## Changes Overview

### Key Changes
- `packages/core/src/federation/entitlement.ts` — swap `isEventCatalogScaleEnabled()` for `isEventCatalogEnterpriseEnabled()`
- `packages/core/package.json` / `pnpm-lock.yaml` — bump `@eventcatalog/license` from `^0.0.7` to `^0.0.8`, which exposes the Enterprise entitlement check
- `packages/core/src/eventcatalog.config.ts` — update the `federation` config JSDoc to state the Enterprise licence requirement
- `packages/core/vitest.config.js` — add an `@eventcatalog/license` alias so the package resolves under Vitest
- `packages/core/src/__tests__/federation-entitlement.spec.ts` — new test covering that federation reads the Enterprise entitlement

## How It Works

`isFederationEnabled()` remains the single choke point every federation caller goes through. Callers stay plan-agnostic, so this change is a one-line swap of which entitlement is consulted.

The new test mocks `@eventcatalog/license` and asserts `isFederationEnabled()` resolves through `isEventCatalogEnterpriseEnabled()`. The Vitest alias is required because the license package was not previously resolvable in the core test environment.

## Breaking Changes

Behavioural change for anyone relying on the interim gating: a Scale licence no longer unlocks `eventcatalog federate`. An offline Enterprise licence is now required. Federation has not been generally available under Scale, so impact is expected to be limited.

## Additional Notes

- No editor-repository (`eventcatalog/eventcatalog-editor`) change is needed — this is entirely a core licensing check.
- Docs referencing federation licence requirements may need a follow-up pass to say Enterprise rather than Scale.