### PR TITLE
fix(core): index ubiquitous language terms

### DIFF
--- a/.changeset/green-cats-search.md
+++ b/.changeset/green-cats-search.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Fix indexed search so ubiquitous language terms are searchable.

--- a/packages/core/src/__tests__/search-indexer.spec.ts
+++ b/packages/core/src/__tests__/search-indexer.spec.ts
@@ -230,6 +230,7 @@ dictionary:
     name: Incoterm
     summary: Defines shipping responsibilities between buyers and sellers.
     description: International commercial terms used by the warehouse team.
+    icon: Mail
 ---
 `
     );
@@ -248,5 +249,6 @@ dictionary:
     expect(language?.content).toContain('Incoterm');
     expect(language?.content).toContain('Defines shipping responsibilities between buyers and sellers.');
     expect(language?.content).toContain('International commercial terms used by the warehouse team.');
+    expect(language?.content).not.toContain('Mail');
   });
 });

--- a/packages/core/src/__tests__/search-indexer.spec.ts
+++ b/packages/core/src/__tests__/search-indexer.spec.ts
@@ -207,4 +207,46 @@ Use this event to trigger fulfilment.
       version: '1.2.0',
     });
   });
+
+  it('indexes ubiquitous language terms and links to the domain language explorer', async () => {
+    const projectDir = await createTempCatalog();
+    await fs.mkdir(path.join(projectDir, 'domains', 'Warehouse'), { recursive: true });
+    await fs.writeFile(
+      path.join(projectDir, 'domains', 'Warehouse', 'index.mdx'),
+      `---
+id: Warehouse
+name: Warehouse
+version: 1.0.0
+---
+
+Warehouse overview.
+`
+    );
+    await fs.writeFile(
+      path.join(projectDir, 'domains', 'Warehouse', 'ubiquitous-language.mdx'),
+      `---
+dictionary:
+  - id: Incoterm
+    name: Incoterm
+    summary: Defines shipping responsibilities between buyers and sellers.
+    description: International commercial terms used by the warehouse team.
+---
+`
+    );
+
+    const records = await collectSearchRecords({ projectDir, config });
+    const language = records.find((record) => record.type === 'Language');
+
+    expect(language).toMatchObject({
+      url: '/docs/domains/Warehouse/language',
+      title: 'Warehouse ubiquitous language',
+      type: 'Language',
+      collection: 'language',
+      id: 'Warehouse',
+      version: '1.0.0',
+    });
+    expect(language?.content).toContain('Incoterm');
+    expect(language?.content).toContain('Defines shipping responsibilities between buyers and sellers.');
+    expect(language?.content).toContain('International commercial terms used by the warehouse team.');
+  });
 });

--- a/packages/core/src/search-indexer.ts
+++ b/packages/core/src/search-indexer.ts
@@ -327,6 +327,7 @@ export const collectSearchRecords = async ({
         decisionMakers: parsed.data.decisionMakers,
         appliesTo: parsed.data.appliesTo,
         badges: parsed.data.badges,
+        dictionary: parsed.data.dictionary,
       });
 
       const content = [frontmatterText, markdownToSearchText(parsed.content)].filter(Boolean).join('\n\n');

--- a/packages/core/src/search-indexer.ts
+++ b/packages/core/src/search-indexer.ts
@@ -82,6 +82,14 @@ const valueToSearchText = (value: unknown): string => {
   return '';
 };
 
+const getDictionarySearchFields = (dictionary: unknown) => {
+  if (!Array.isArray(dictionary)) return undefined;
+
+  return dictionary
+    .filter((entry): entry is Record<string, unknown> => typeof entry === 'object' && entry !== null)
+    .map(({ id, name, summary, description }) => ({ id, name, summary, description }));
+};
+
 export const markdownToSearchText = (content: string) => {
   return content
     .replace(/<!--[\s\S]*?-->/g, ' ')
@@ -327,7 +335,7 @@ export const collectSearchRecords = async ({
         decisionMakers: parsed.data.decisionMakers,
         appliesTo: parsed.data.appliesTo,
         badges: parsed.data.badges,
-        dictionary: parsed.data.dictionary,
+        dictionary: getDictionarySearchFields(parsed.data.dictionary),
       });
 
       const content = [frontmatterText, markdownToSearchText(parsed.content)].filter(Boolean).join('\n\n');


### PR DESCRIPTION
## Motivation

Indexed search records for ubiquitous language pages omitted the `dictionary` frontmatter, so searches for term names, summaries, and descriptions returned no results. Include the dictionary in the recursively flattened search content while continuing to link results to the domain language explorer.

Fixes #2797

## Verification

- Added a regression test covering an `Incoterm` dictionary entry and the expected domain language explorer URL.
- `pnpm --filter @eventcatalog/core exec vitest run src/__tests__/search-indexer.spec.ts`
- Prettier check and `git diff --check`
- Verified the default Ordering dictionary now indexes `Saga` and `compensating actions`.
