### PR TITLE
fix(core): show consumers for historical messages

### DIFF
--- a/.changeset/fuzzy-spiders-smile.md
+++ b/.changeset/fuzzy-spiders-smile.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/core': patch
+---
+
+Show version-specific producers and consumers in the sidebar for historical messages.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,8 @@ const event = await getEntry('events', 'OrderCreated-1.0.0');
 
 Most resources are versioned. Entry IDs follow the pattern: `{id}-{version}` (e.g., `OrderCreated-1.0.0`).
 
+Historical Astro message entries are identified by a top-level `filePath` containing `versioned`; test fixtures must preserve this field outside `data`.
+
 When you need to get specific version or latest version you need to use the `getItemsFromCollectionByIdAndSemverOrLatest` utility function.
 
 ```typescript

--- a/packages/core/eventcatalog/src/pages/api/search-index.json.ts
+++ b/packages/core/eventcatalog/src/pages/api/search-index.json.ts
@@ -1,5 +1,6 @@
 import type { APIRoute } from 'astro';
 import { getNestedSideBarData } from '@stores/sidebar-store/state';
+import { getSearchIndexNodeEntries } from '@stores/sidebar-store/search-index';
 
 const isDev = import.meta.env.DEV;
 
@@ -18,7 +19,7 @@ const SKIPPED_PREFIXES = ['list:'];
 export const GET: APIRoute = async () => {
   const sidebarData = await getNestedSideBarData();
 
-  const items = Object.entries(sidebarData.nodes).reduce<SearchIndexItemCompact[]>((acc, [key, node]) => {
+  const items = getSearchIndexNodeEntries(sidebarData.nodes).reduce<SearchIndexItemCompact[]>((acc, [key, node]) => {
     if (typeof node === 'string') return acc;
     if (SKIPPED_PREFIXES.some((prefix) => key.startsWith(prefix))) return acc;
     if (!node.title) return acc;

--- a/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/search-index.spec.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/search-index.spec.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { getSearchIndexNodeEntries } from '../search-index';
+import type { NavigationData } from '../state';
+
+describe('getSearchIndexNodeEntries', () => {
+  it('keeps only current message targets while preserving other versioned resources', () => {
+    const nodes: NavigationData['nodes'] = {
+      'event:PaymentProcessed': 'event:PaymentProcessed:3.1.0',
+      'event:PaymentProcessed:2.18.0': { type: 'item', title: 'Payment Processed' },
+      'event:PaymentProcessed:3.1.0': { type: 'item', title: 'Payment Processed' },
+      'service:PaymentService:1.0.0': { type: 'item', title: 'Payment Service' },
+    };
+
+    expect(getSearchIndexNodeEntries(nodes).map(([key]) => key)).toEqual([
+      'event:PaymentProcessed:3.1.0',
+      'service:PaymentService:1.0.0',
+    ]);
+  });
+});

--- a/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/sidebar-builder.spec.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/sidebar-builder.spec.ts
@@ -13,6 +13,7 @@ const mockSystems: any[] = [];
 const mockResourceDocs: any[] = [];
 const mockResourceDocCategories: any[] = [];
 const mockAgents: any[] = [];
+const mockEvents: any[] = [];
 const mockSchemas: any[] = [];
 const mockUbiquitousLanguages: any[] = [];
 
@@ -73,7 +74,10 @@ vi.mock('astro:content', async (importOriginal) => {
         case 'events':
           const { getEvents } = utils(CATALOG_FOLDER);
           const events = (await getEvents()) ?? [];
-          return Promise.resolve(events.map((event) => toAstroCollection(event, 'events')));
+          return Promise.resolve([
+            ...events.map((event) => toAstroCollection(event, 'events')),
+            ...mockEvents.map(({ filePath, ...event }) => ({ ...toAstroCollection(event, 'events'), filePath })),
+          ]);
         case 'commands':
           const { getCommands } = utils(CATALOG_FOLDER);
           const commands = (await getCommands()) ?? [];
@@ -190,6 +194,7 @@ describe('getNestedSideBarData', () => {
     mockResourceDocs.length = 0;
     mockResourceDocCategories.length = 0;
     mockAgents.length = 0;
+    mockEvents.length = 0;
     mockSchemas.length = 0;
     mockUbiquitousLanguages.length = 0;
     fs.rmSync(CATALOG_FOLDER, { recursive: true, force: true });
@@ -2748,6 +2753,46 @@ describe('getNestedSideBarData', () => {
   });
 
   describe('message navigation items', () => {
+    it('builds historical message nodes with version-specific consumers without listing them in Browse', async () => {
+      const { writeService } = utils(CATALOG_FOLDER);
+
+      mockEvents.push(
+        {
+          id: 'PaymentProcessed',
+          name: 'Payment Processed',
+          version: '2.18.0',
+          markdown: 'Payment Processed 2.18.0',
+          filePath: 'events/PaymentProcessed/versioned/2.18.0/index.mdx',
+        },
+        {
+          id: 'PaymentProcessed',
+          name: 'Payment Processed',
+          version: '3.1.0',
+          markdown: 'Payment Processed 3.1.0',
+          filePath: 'events/PaymentProcessed/index.mdx',
+        }
+      );
+      await writeService({
+        id: 'PaymentService',
+        name: 'Payment Service',
+        version: '1.0.0',
+        markdown: 'Payment Service',
+        receives: [{ id: 'PaymentProcessed', version: '2.18.0' }],
+      });
+
+      const navigationData = await getNestedSideBarData();
+      const historicalNode = getNavigationConfigurationByKey('event:PaymentProcessed:2.18.0', navigationData);
+      const latestNode = getNavigationConfigurationByKey('event:PaymentProcessed:3.1.0', navigationData);
+      const historicalConsumers = getChildNodeByTitle('Consumers', historicalNode.pages ?? []);
+      const latestConsumers = getChildNodeByTitle('Consumers', latestNode.pages ?? []);
+      const eventsList = getNavigationConfigurationByKey('list:events', navigationData);
+
+      expect(historicalNode).toBeDefined();
+      expect(historicalConsumers.pages).toEqual(['service:PaymentService:1.0.0']);
+      expect(latestConsumers).toBeUndefined();
+      expect(eventsList.pages).toEqual(['event:PaymentProcessed:3.1.0']);
+    });
+
     it('users can reference the latest version of a resource without passing in the version', async () => {
       const { writeEvent } = utils(CATALOG_FOLDER);
       await writeEvent({

--- a/packages/core/eventcatalog/src/stores/sidebar-store/search-index.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/search-index.ts
@@ -1,0 +1,17 @@
+import type { NavigationData, NavNode } from './builders/shared';
+
+const MESSAGE_NODE_PREFIXES = ['event:', 'command:', 'query:'];
+
+export const getSearchIndexNodeEntries = (nodes: NavigationData['nodes']): [string, NavNode | string][] => {
+  const currentMessageTargets = new Set(
+    Object.entries(nodes).flatMap(([key, node]) => {
+      const isMessageAlias = MESSAGE_NODE_PREFIXES.some((prefix) => key.startsWith(prefix));
+      return typeof node === 'string' && isMessageAlias && node.startsWith(`${key}:`) ? [node] : [];
+    })
+  );
+
+  return Object.entries(nodes).filter(([key]) => {
+    const isMessageNode = MESSAGE_NODE_PREFIXES.some((prefix) => key.startsWith(prefix));
+    return !isMessageNode || currentMessageTargets.has(key);
+  });
+};

--- a/packages/core/eventcatalog/src/stores/sidebar-store/state.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/state.ts
@@ -281,7 +281,7 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
     systems,
     agents,
     services,
-    { events, commands, queries },
+    { events: allEvents, commands: allCommands, queries: allQueries },
     containers,
     flows,
     users,
@@ -301,7 +301,7 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
     getSystems({ getAllVersions: false }),
     getAgents({ getAllVersions: false }),
     getServices({ getAllVersions: false }),
-    getMessages({ getAllVersions: false }),
+    getMessages({ getAllVersions: true }),
     getContainers({ getAllVersions: false }),
     getFlows({ getAllVersions: false }),
     getUsers(),
@@ -322,7 +322,10 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
   const allSubDomainIds = new Set(domains.flatMap((d) => (d.data.domains || []).map((sd: any) => sd.data.id)));
   const rootDomains = domains.filter((d) => !allSubDomainIds.has(d.data.id));
 
-  const messages = [...events, ...commands, ...queries];
+  const events = allEvents.filter((event) => event.data.version === event.data.latestVersion);
+  const commands = allCommands.filter((command) => command.data.version === command.data.latestVersion);
+  const queries = allQueries.filter((query) => query.data.version === query.data.latestVersion);
+  const messages = [...allEvents, ...allCommands, ...allQueries];
 
   const context = {
     agents,
@@ -595,7 +598,12 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
     }
   }
 
-  const flowRefsByMessage = buildFlowReferencesByMessage({ flows, events, commands, queries });
+  const flowRefsByMessage = buildFlowReferencesByMessage({
+    flows,
+    events: allEvents,
+    commands: allCommands,
+    queries: allQueries,
+  });
 
   const messageNodes = messagesWithOwners.reduce(
     (acc, { message, owners }) => {


### PR DESCRIPTION
## Motivation

Consumers and producers pinned to a historical message version were missing from that version's sidebar because sidebar data only included current message versions. The route lookup consequently fell back to the latest message node and displayed the wrong relationships.

This change builds sidebar nodes and version-specific relationships for every event, command, and query version while keeping Browse and search results limited to current versions.

Closes #2787.

## Verification

- `pnpm --filter @eventcatalog/core test:ci` (1,301 tests passed)
- `pnpm verify-build:catalog` (933 pages built, 0 Astro errors)
- Reproduced against the reported PayFit catalog fixture