### PR TITLE
Fix dev command crashing on Windows with regex_error(error_escape)

### DIFF
--- a/.changeset/thick-donuts-shave.md
+++ b/.changeset/thick-donuts-shave.md
@@ -1,0 +1,11 @@
+---
+'@eventcatalog/core': patch
+---
+
+fix(core): dev command crashing on Windows with regex_error(error_escape)
+
+The file watcher interpolated raw Windows backslash paths into its ignore
+glob, which @parcel/watcher compiles with std::regex. Depending on the
+characters in the project path (e.g. a folder starting with `x` produced an
+invalid `\x` escape), this crashed `npm run dev` on startup. Paths are now
+normalized to forward slashes before building the glob.

--- a/packages/core/src/__tests__/watcher.spec.ts
+++ b/packages/core/src/__tests__/watcher.spec.ts
@@ -1,0 +1,45 @@
+import { expect, describe, it, beforeEach, vi } from 'vitest';
+import { watch } from '../watcher';
+
+const { subscribe } = vi.hoisted(() => ({
+  subscribe: vi.fn().mockResolvedValue({ unsubscribe: vi.fn() }),
+}));
+
+vi.mock('@parcel/watcher', () => ({
+  default: { subscribe },
+}));
+
+describe('watcher', () => {
+  beforeEach(() => {
+    subscribe.mockClear();
+  });
+
+  describe('watch', () => {
+    it('builds a forward-slash ignore glob from Windows-style paths', async () => {
+      // Backslash paths interpolated into the glob compile to invalid regex
+      // escapes (e.g. `\x...`) in @parcel/watcher's native matcher, crashing
+      // `dev` on startup with regex_error(error_escape).
+      const projectDir = 'C:\\Users\\bob\\source\\xyz-communications\\xyz-catalog';
+      const catalogDir = `${projectDir}\\node_modules\\@eventcatalog\\core`;
+
+      await watch(projectDir, catalogDir);
+
+      const options = subscribe.mock.calls[0][2];
+      expect(options.ignore).toEqual([
+        '**/C:/Users/bob/source/xyz-communications/xyz-catalog/node_modules/@eventcatalog/core/!(C:/Users/bob/source/xyz-communications/xyz-catalog)**',
+      ]);
+    });
+
+    it('leaves posix paths unchanged in the ignore glob', async () => {
+      const projectDir = '/Users/bob/source/my-catalog';
+      const catalogDir = `${projectDir}/node_modules/@eventcatalog/core`;
+
+      await watch(projectDir, catalogDir);
+
+      const options = subscribe.mock.calls[0][2];
+      expect(options.ignore).toEqual([
+        '**//Users/bob/source/my-catalog/node_modules/@eventcatalog/core/!(/Users/bob/source/my-catalog)**',
+      ]);
+    });
+  });
+});

--- a/packages/core/src/watcher.js
+++ b/packages/core/src/watcher.js
@@ -1,5 +1,11 @@
 import watcher from '@parcel/watcher';
 import fs from 'node:fs';
+
+// Globs always use forward slashes, even on Windows. Interpolating raw
+// backslash paths into the ignore glob crashes `dev` on startup:
+// @parcel/watcher compiles the glob with std::regex, which rejects escape
+// sequences like `\x...` with regex_error(error_escape).
+const toPosixPath = (p) => p.replace(/\\/g, '/');
 import { mapCatalogToAstro } from './map-catalog-to-astro.js';
 import { rimrafSync } from 'rimraf';
 
@@ -84,7 +90,7 @@ export async function watch(projectDirectory, catalogDirectory, callback = undef
       callback
     ),
     {
-      ignore: [`**/${catalogDirectory}/!(${projectDirectory})**`],
+      ignore: [`**/${toPosixPath(catalogDirectory)}/!(${toPosixPath(projectDirectory)})**`],
     }
   );
 


### PR DESCRIPTION
## What This PR Does

Fixes a Windows-only crash where `npm run dev` fails on startup with `Error: regex_error(error_escape): The expression contained an invalid escaped character, or a trailing escape.` thrown from `@parcel/watcher`. `npm run build` and `npm start` are unaffected because only the dev command starts the file watcher.

## Changes Overview

### Key Changes
- `packages/core/src/watcher.js`: adds a `toPosixPath` helper and normalizes backslashes to forward slashes in the paths interpolated into the watcher's `ignore` glob
- `packages/core/src/__tests__/watcher.spec.ts`: new regression test that mocks `@parcel/watcher` and asserts the exact ignore glob for Windows-style and posix paths
- `.changeset/thick-donuts-shave.md`: patch changeset for `@eventcatalog/core`

## How It Works

The watcher builds its ignore option by interpolating the project and catalog directories directly into a glob:

```js
ignore: [`**/${catalogDirectory}/!(${projectDirectory})**`]
```

On Windows those are absolute paths with backslashes. `@parcel/watcher` compiles glob ignores via `micromatch.makeRe()` and passes the regex source string to its native binding, which compiles it with C++ `std::regex` (ECMAScript grammar). The backslash sequences from the path survive into the regex source (`\Users`, `\core`, etc.). JavaScript's `RegExp` tolerates unknown escapes, but `std::regex` is strict — sequences like `\x` not followed by two hex digits throw `regex_error(error_escape)`.

Whether it crashes depends entirely on the characters in the user's directory names (e.g. a folder starting with `x` produces an invalid `\x` hex escape), which is why some installs work and others fail on the same machine.

Globs use forward slashes on every platform, so converting the paths to posix form before interpolation fixes the crash. Verified that the fixed glob compiles through micromatch with no letter-escape sequences left in the regex source.

## Breaking Changes

None

## Additional Notes

- The editor repository does not use `@parcel/watcher`, so no companion change is needed there.
- Interpolating absolute paths into an extglob remains fragile if a folder name contains glob-special characters like `(` — a follow-up could escape the interpolated paths, but that is a pre-existing edge case and out of scope here.