### PR TITLE
fix(core): point container visualiser context menus at /containers/…

### DIFF
--- a/.changeset/container-visualiser-context-menu.md
+++ b/.changeset/container-visualiser-context-menu.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/core': patch
+---
+
+Fix service and agent visualiser context menus linking container nodes to /entities/… instead of /containers/….

--- a/packages/core/eventcatalog/src/utils/__tests__/agents/node-graph.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/agents/node-graph.spec.ts
@@ -125,4 +125,25 @@ describe('Agents NodeGraph', () => {
     expect(nodes).toEqual([]);
     expect(edges).toEqual([]);
   });
+
+  it('links container context menus to /containers/… rather than /entities/… (issue #2804)', async () => {
+    const { nodes } = await getNodesAndEdges({ id: 'OrderSupportAgent', version: '1.0.0' });
+
+    const expectedContainerContextMenu = (id: string) => [
+      { label: 'Read documentation', href: `/docs/containers/${id}/1.0.0` },
+      { label: 'Focus node', href: `/visualiser/containers/${id}/1.0.0` },
+      {
+        label: 'Read changelog',
+        href: `/docs/containers/${id}/1.0.0/changelog`,
+        external: true,
+        separator: true,
+      },
+    ];
+
+    const writesToNode = nodes.find((node) => node.id === 'OrderDatabase-1.0.0');
+    const readsFromNode = nodes.find((node) => node.id === 'PaymentDatabase-1.0.0');
+
+    expect(writesToNode?.data.contextMenu).toEqual(expectedContainerContextMenu('OrderDatabase'));
+    expect(readsFromNode?.data.contextMenu).toEqual(expectedContainerContextMenu('PaymentDatabase'));
+  });
 });

--- a/packages/core/eventcatalog/src/utils/__tests__/services/node-graph.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/services/node-graph.spec.ts
@@ -420,6 +420,27 @@ describe('Services NodeGraph', () => {
       expect(hasContainers).toBe(true);
     });
 
+    it('links container context menus to /containers/… rather than /entities/… (issue #2804)', async () => {
+      const { nodes } = await getNodesAndEdges({ id: 'OrderService', version: '1.0.0' });
+
+      const expectedContainerContextMenu = (id: string) => [
+        { label: 'Read documentation', href: `/docs/containers/${id}/1.0.0` },
+        { label: 'Focus node', href: `/visualiser/containers/${id}/1.0.0` },
+        {
+          label: 'Read changelog',
+          href: `/docs/containers/${id}/1.0.0/changelog`,
+          external: true,
+          separator: true,
+        },
+      ];
+
+      const writesToNode = nodes.find((node) => node.id === 'OrderDatabase-1.0.0');
+      const readsFromNode = nodes.find((node) => node.id === 'PaymentDatabase-1.0.0');
+
+      expect(writesToNode?.data.contextMenu).toEqual(expectedContainerContextMenu('OrderDatabase'));
+      expect(readsFromNode?.data.contextMenu).toEqual(expectedContainerContextMenu('PaymentDatabase'));
+    });
+
     describe('message grouping', () => {
       it('should collapse grouped sends into messageGroup nodes', async () => {
         vi.mocked(getCollection).mockImplementation(((key: any) => {

--- a/packages/core/eventcatalog/src/utils/node-graphs/services-node-graph.ts
+++ b/packages/core/eventcatalog/src/utils/node-graphs/services-node-graph.ts
@@ -363,7 +363,11 @@ export const getNodesAndEdges = async ({
       data: {
         mode,
         data: { ...writeTo.data },
-        contextMenu: buildContextMenuForResource({ collection: 'entities', id: writeTo.data.id, version: writeTo.data.version }),
+        contextMenu: buildContextMenuForResource({
+          collection: 'containers',
+          id: writeTo.data.id,
+          version: writeTo.data.version,
+        }),
       },
       type: 'data',
     });
@@ -449,7 +453,7 @@ export const getNodesAndEdges = async ({
         mode,
         data: { ...readFrom.data },
         contextMenu: buildContextMenuForResource({
-          collection: 'entities',
+          collection: 'containers',
           id: readFrom.data.id,
           version: readFrom.data.version,
         }),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://www.eventcatalog.dev/docs/contributing/overview

Happy contributing!

-->

## Motivation

Fixes #2804.

On service (and agent) visualiser pages, right-clicking a container node that the resource `readsFrom` / `writesTo` produced 404s. The graph builder hydrated those nodes from the `containers` collection, then called `buildContextMenuForResource` with `collection: 'entities'`, so Focus node / Read documentation / Read changelog pointed at `/entities/…` instead of `/containers/…`.

The container's own visualiser already passed `collection: 'containers'`, which is why those pages worked. Nodes, edges, and sidebar links were already correct.

## Changes

- Pass `collection: 'containers'` for `writesTo` / `readsFrom` nodes in `services-node-graph.ts` (shared by agent visualisers).
- Assert context-menu hrefs in the service and agent node-graph unit tests.

No EventCatalog Editor change is needed; this is catalog graph-builder URL generation only.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-200eadc3-caf8-48f3-a86b-2d4aafd1eb99?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-200eadc3-caf8-48f3-a86b-2d4aafd1eb99&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

