### PR TITLE
fix(create-eventcatalog): stop npm audit flagging nested @auth/core

### DIFF
--- a/.changeset/auth-core-npm-audit.md
+++ b/.changeset/auth-core-npm-audit.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/create-eventcatalog": patch
+---
+
+Force generated catalogs to use patched `@auth/core` (>=0.41.3) so npm does not nest the vulnerable 0.37.x copy pulled in by auth-astro.

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   },
   "pnpm": {
     "overrides": {
-      "prismjs": ">=1.30.0"
+      "prismjs": ">=1.30.0",
+      "@auth/core": ">=0.41.3"
     }
   },
   "packageManager": "pnpm@10.23.0+sha512.21c4e5698002ade97e4efe8b8b4a89a8de3c85a37919f957e7a0f30f38fbc5bbdd05980ffe29179b2fb6e6e691242e098d945d1601772cad0fef5fb6411e2a4b",

--- a/packages/create-eventcatalog/templates/index.ts
+++ b/packages/create-eventcatalog/templates/index.ts
@@ -40,8 +40,15 @@ export const installTemplate = async ({
   organizationName,
 }: InstallTemplateArgs) => {
   /**
-   * Create a package.json for the new project
+   * Create a package.json for the new project.
+   *
+   * auth-astro@4.2.0 peerDepends on @auth/core@^0.37.3, which does not include
+   * the patched 0.41.3+ releases (GHSA-7rqj-j65f-68wh, GHSA-xmf8-cvqr-rfgj,
+   * GHSA-x445-f3h2-j279). npm therefore nests a vulnerable 0.37.x copy under
+   * auth-astro even though @eventcatalog/core already depends on @auth/core@^0.41.3.
+   * Force a patched version for npm, pnpm, and yarn generated catalogs.
    */
+  const authCoreOverride = '>=0.41.3';
   const packageJson = {
     name: appName,
     version: '0.1.0',
@@ -57,6 +64,17 @@ export const installTemplate = async ({
       export: 'eventcatalog export',
       lint: 'eventcatalog-linter',
       test: 'echo "Error: no test specified" && exit 1',
+    },
+    overrides: {
+      '@auth/core': authCoreOverride,
+    },
+    pnpm: {
+      overrides: {
+        '@auth/core': authCoreOverride,
+      },
+    },
+    resolutions: {
+      '@auth/core': authCoreOverride,
     },
   };
   /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   prismjs: '>=1.30.0'
+  '@auth/core': '>=0.41.3'
 
 importers:
 
@@ -137,7 +138,7 @@ importers:
         specifier: 3.1.0
         version: 3.1.0(postcss@8.5.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@auth/core':
-        specifier: ^0.41.3
+        specifier: '>=0.41.3'
         version: 0.41.3
       '@eventcatalog/license':
         specifier: ^0.0.8
@@ -4072,7 +4073,7 @@ packages:
     resolution: {integrity: sha512-Jx0dFAvwJ5UJ6E/2J6rqPNhXzTX6Fj18sIq12U7n+J15TV7etpXSHFPPcQdAmfDmX3RCURp253Vxe4l/keNW1g==}
     engines: {node: '>=17.4'}
     peerDependencies:
-      '@auth/core': ^0.37.3
+      '@auth/core': '>=0.41.3'
       astro: '>=4.0.0'
 
   available-typed-arrays@1.0.7:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Motivation

Dave asked to scaffold a real catalog with `create-eventcatalog`, run `npm audit`, and open a PR with any obvious fixes.

A freshly generated catalog (`npx @eventcatalog/create-eventcatalog@latest`, org name Acme, npm, skills skipped) currently fails `npm audit` because `auth-astro` nests a vulnerable `@auth/core@0.37.4` even though `@eventcatalog/core` already depends on the patched `^0.41.3`.

This PR does **not** commit a generated catalog or `node_modules`, and it does **not** run `npm audit fix --force` (that would install `@eventcatalog/core@2.42.10`, a major downgrade).

## npm audit (generated catalog, `@eventcatalog/core@4.7.12`)

**Command:** `printf 'n\n' | npx --yes @eventcatalog/create-eventcatalog@latest audit-catalog --organization-name Acme --use-npm` then `npm audit` / `npm audit --json` from the generated catalog.

### Summary

| Severity | Count |
| --- | --- |
| info | 0 |
| low | 0 |
| moderate | 0 |
| high | 0 |
| critical | 3 |
| **total** | **3** |

npm rolls the three `@auth/core` advisories up as **3 critical** because the package’s highest advisory is critical. The individual GHSA ratings are critical / high / moderate.

### Human-readable `npm audit`

```
# npm audit report

@auth/core  <=0.41.2
Severity: critical
Auth.js: Email normalizer validates the address before Unicode normalization, allowing a homoglyph @ bypass - https://github.com/advisories/GHSA-7rqj-j65f-68wh
Auth.js: getToken() throws an uncaught exception on malformed Bearer authorization headers - https://github.com/advisories/GHSA-xmf8-cvqr-rfgj
Auth.js: OAuth state, nonce, and PKCE check cookies are not bound to the provider that created them - https://github.com/advisories/GHSA-x445-f3h2-j279
fix available via `npm audit fix --force`
Will install @eventcatalog/core@2.42.10, which is a breaking change
node_modules/@auth/core
  auth-astro  *
  Depends on vulnerable versions of @auth/core
  node_modules/auth-astro
    @eventcatalog/core  >=2.43.0
    Depends on vulnerable versions of auth-astro
    node_modules/@eventcatalog/core

3 critical severity vulnerabilities
```

### Advisories

| Advisory | Severity | Vulnerable range | Patched |
| --- | --- | --- | --- |
| [GHSA-7rqj-j65f-68wh](https://github.com/advisories/GHSA-7rqj-j65f-68wh) Email homoglyph `@` bypass | critical | `>=0.1.0 <0.41.3` | `0.41.3` |
| [GHSA-xmf8-cvqr-rfgj](https://github.com/advisories/GHSA-xmf8-cvqr-rfgj) `getToken()` uncaught exception on malformed Bearer headers | high | `>=0.1.0 <0.41.3` | `0.41.3` |
| [GHSA-x445-f3h2-j279](https://github.com/advisories/GHSA-x445-f3h2-j279) OAuth state/nonce/PKCE cookies not bound to provider | moderate | `<=0.41.2` | `0.41.3` |

### Where it sits in the tree

Generated catalog `package.json` only has:

- `@eventcatalog/core@4.7.12` (direct)
- `@eventcatalog/linter@1.1.14` (direct)

Installed tree:

```
audit-catalog
└─ @eventcatalog/core@4.7.12          ← direct dep of the generated catalog
   ├─ @auth/core@0.41.3               ← already patched (core’s own dependency)
   └─ auth-astro@4.2.0                ← dep of @eventcatalog/core
      └─ @auth/core@0.37.4            ← VULNERABLE nested copy (peer ^0.37.3)
```

- Not a direct dep of the generated catalog.
- `auth-astro@4.2.0` is the latest release; its peer is still `@auth/core@^0.37.3`, which does **not** include `0.41.3`.
- npm therefore nests `0.37.4`. This repo’s pnpm install already hoists `0.41.3` with `auth-astro`, which is why the monorepo itself was clean.

## What changed vs what we skipped

**Changed (obvious, low-risk):**

- `create-eventcatalog` now writes npm `overrides`, pnpm `overrides`, and yarn `resolutions` so new catalogs force `@auth/core` to `>=0.41.3`.
- Root `pnpm.overrides` gets the same floor so this monorepo cannot pick up an older copy later.

Verified against a throwaway catalog: after adding the override, `npm ls @auth/core` shows only `0.41.3` (overridden / deduped) and `npm audit` reports **0 vulnerabilities**.

**Skipped:**

- No `npm audit fix --force` (would downgrade to `@eventcatalog/core@2.42.10`).
- No major upgrades (Astro, React, etc.).
- Did not fork or replace `auth-astro` (latest is 4.2.0; bumping its peer range is upstream).
- Did not put `overrides` on published `@eventcatalog/core` — npm only applies overrides from the **root** package, so they would not help consumers.
- Existing catalogs that already ran `create-eventcatalog` still need to add the override themselves (see below). Re-scaffolding is not required.

**Existing catalogs** can add this to their root `package.json` and reinstall:

```json
{
  "overrides": {
    "@auth/core": ">=0.41.3"
  },
  "pnpm": {
    "overrides": {
      "@auth/core": ">=0.41.3"
    }
  },
  "resolutions": {
    "@auth/core": ">=0.41.3"
  }
}
```

## Additional notes

- Changeset included for `@eventcatalog/create-eventcatalog` (patch).
- No EventCatalog Editor change is needed; this is scaffold/install metadata only.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-85db86bf-13ef-4c4d-985e-67a43430dffb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-85db86bf-13ef-4c4d-985e-67a43430dffb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

