### PR TITLE
fix(core): resolve likec4:plugin virtual modules in Vite dev

### DIFF
--- a/.changeset/fix-likec4-plugin-virtual-module.md
+++ b/.changeset/fix-likec4-plugin-virtual-module.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/core': patch
+---
+
+Fix LikeC4 diagrams in Vite dev by resolving `likec4:plugin/` virtual modules without a `\0` prefix.

--- a/packages/core/eventcatalog/src/plugins/__tests__/likec4.test.ts
+++ b/packages/core/eventcatalog/src/plugins/__tests__/likec4.test.ts
@@ -51,4 +51,13 @@ describe('eventCatalogLikeC4', () => {
       'eventcatalog-likec4',
     ]);
   });
+
+  it('returns likec4:plugin virtual module ids without a null-byte prefix', async () => {
+    const plugins = await eventCatalogLikeC4(testProjectDirectory);
+    const resolver = plugins.find((plugin) => plugin.name === 'eventcatalog-likec4-dependency-resolver');
+    const resolveId = resolver?.resolveId as ((id: string) => string | undefined) | undefined;
+
+    expect(resolveId?.('likec4:plugin/react.js')).toBe('likec4:plugin/react.js');
+    expect(resolveId?.('likec4:plugin/react/payments.js')).toBe('likec4:plugin/react/payments.js');
+  });
 });

--- a/packages/core/eventcatalog/src/plugins/likec4.ts
+++ b/packages/core/eventcatalog/src/plugins/likec4.ts
@@ -72,6 +72,10 @@ const likeC4DependencyResolver = (resolveLikeC4Dependency: (id: string) => strin
   enforce: 'pre',
 
   resolveId(id) {
+    if (id.startsWith('likec4:plugin/')) {
+      return id;
+    }
+
     if (!id.startsWith('likec4/')) {
       return;
     }

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -160,7 +160,6 @@
 - 8f724a7: feat: add `externalSystem` flag to services for modelling third-party integrations
 
   Services can now set `externalSystem: true` in their frontmatter to be rendered as external systems. This changes their presentation without changing their capabilities — they still send and receive messages, have owners, and support specifications like any other service.
-
   - Visualiser: external services render purple with a Globe icon and an "External System" badge
   - Sidebar (root): a dedicated "External Systems" section lists externals; the regular "Services" section excludes them
   - Sidebar (domain): externals appear under a new "External Integrations" group, separate from "Services In Domain"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Motivation

LikeC4 diagrams fail to render during `npm run dev` because Vite Fast Refresh re-imports `likec4:plugin/react.js`, and LikeC4's own `resolveId` only handles `likec4:react`. Production `npm run build` / `npm start` already works.

This was reproduced on EventCatalog 4.7.9 with `likec4@1.55.1`.

The EventCatalog Vite plugin now claims `likec4:plugin/` ids in `resolveId` and returns them as-is (no `\0` prefix). LikeC4 1.55 `load()` matches the virtual id exactly, so prefixing would break the loader.

## Changes

- Claim `likec4:plugin/` virtual module ids in `likeC4DependencyResolver.resolveId` before the `likec4/` package-subpath check
- Return the id unchanged so named-project ids such as `likec4:plugin/react/payments.js` also round-trip
- Add unit coverage for the default and named-project virtual ids
- Patch changeset for `@eventcatalog/core`
- Rebase onto latest `main` and format `packages/sdk/CHANGELOG.md` so `pnpm run format:diff` passes (CI lint was failing on an extra blank line from the version-packages changelog)

No `eventcatalog-editor` change is needed; this is EventCatalog's Vite plugin only.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-19e72522-7386-44f5-9d00-51b4cfa8cb4d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-19e72522-7386-44f5-9d00-51b4cfa8cb4d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

