### PR TITLE
fix(core): match domain entities by catalog id in the entity map

### DIFF
--- a/.changeset/rich-pumas-shave.md
+++ b/.changeset/rich-pumas-shave.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/core': patch
+---
+
+fix(core): stop treating entities owned by a domain as external in the entity map

--- a/packages/core/eventcatalog/src/utils/__tests__/domains/domain-entity-map.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/domains/domain-entity-map.spec.ts
@@ -254,6 +254,68 @@ const mockEntities = [
       ],
     },
   },
+  // Shop entities use the Astro id format generated in production (`${id}-${version}`)
+  {
+    id: 'ShopOrder-1.0.0',
+    slug: 'entities/ShopOrder',
+    collection: 'entities',
+    data: {
+      id: 'ShopOrder',
+      name: 'ShopOrder',
+      version: '1.0.0',
+      identifier: 'orderId',
+      properties: [
+        {
+          name: 'orderId',
+          type: 'UUID',
+          required: true,
+        },
+        {
+          name: 'customer_id',
+          type: 'UUID',
+          required: true,
+          references: 'ShopCustomer',
+          relationType: 'hasOne',
+        },
+      ],
+    },
+  },
+  {
+    id: 'ShopCustomer-1.0.0',
+    slug: 'entities/ShopCustomer',
+    collection: 'entities',
+    data: {
+      id: 'ShopCustomer',
+      name: 'ShopCustomer',
+      version: '1.0.0',
+      identifier: 'customerId',
+      properties: [
+        {
+          name: 'customerId',
+          type: 'UUID',
+          required: true,
+        },
+      ],
+    },
+  },
+  {
+    id: 'ShopCustomer-2.0.0',
+    slug: 'entities/ShopCustomer',
+    collection: 'entities',
+    data: {
+      id: 'ShopCustomer',
+      name: 'ShopCustomer',
+      version: '2.0.0',
+      identifier: 'customerId',
+      properties: [
+        {
+          name: 'customerId',
+          type: 'UUID',
+          required: true,
+        },
+      ],
+    },
+  },
   // Versioned Order entity
   {
     id: 'entities/Order/versioned/200/index.mdx',
@@ -340,6 +402,33 @@ const mockDomains = [
       ],
     },
   },
+  // Domain that owns both sides of a reference
+  {
+    id: 'domains/Shop-1.0.0',
+    slug: 'domains/Shop',
+    collection: 'domains',
+    data: {
+      id: 'Shop',
+      name: 'Shop',
+      version: '1.0.0',
+      entities: [{ id: 'ShopOrder' }, { id: 'ShopCustomer' }],
+    },
+  },
+  // Same as Shop, but pinned to an older version of the referenced entity
+  {
+    id: 'domains/ShopLegacy-1.0.0',
+    slug: 'domains/ShopLegacy',
+    collection: 'domains',
+    data: {
+      id: 'ShopLegacy',
+      name: 'ShopLegacy',
+      version: '1.0.0',
+      entities: [
+        { id: 'ShopOrder', version: '1.0.0' },
+        { id: 'ShopCustomer', version: '1.0.0' },
+      ],
+    },
+  },
 ];
 
 const mockServices = [
@@ -420,6 +509,8 @@ describe('Domain Entity Map NodeGraph', () => {
           domainId: 'Orders',
         },
       });
+      // OrderItem is referenced by Order and owned by the domain, so it is not external
+      expect(orderItemNode.data.externalToDomain).toBeUndefined();
 
       // Check external Customer node
       const customerNode = nodes.find((n: any) => n.data.entity.data.id === 'Customer');
@@ -727,6 +818,53 @@ describe('Domain Entity Map NodeGraph', () => {
       // External entities should be marked correctly
       expect(customerNodes[0].data.externalToDomain).toBe(true);
       expect(paymentNodes[0].data.externalToDomain).toBe(true);
+    });
+
+    it('does not mark or warn about a referenced entity that the domain owns', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const { nodes, edges } = await getNodesAndEdges({ id: 'Shop', version: '1.0.0' });
+
+      const shopCustomerNodes = nodes.filter((n: any) => n.data.entity.data.id === 'ShopCustomer');
+      expect(shopCustomerNodes).toHaveLength(1);
+      expect(shopCustomerNodes[0]).toMatchObject({
+        id: 'ShopCustomer-2.0.0',
+        data: {
+          domainName: 'Shop',
+          domainId: 'Shop',
+        },
+      });
+      expect(shopCustomerNodes[0].data.externalToDomain).toBeUndefined();
+
+      expect(edges).toHaveLength(1);
+      expect(edges[0]).toMatchObject({
+        source: 'ShopOrder-1.0.0',
+        sourceHandle: 'customer_id-source',
+        target: 'ShopCustomer-2.0.0',
+        targetHandle: 'customerId-target',
+        label: 'hasOne',
+      });
+
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('does not add an external node when the domain pins an older version of a referenced entity it owns', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const { nodes, edges } = await getNodesAndEdges({ id: 'ShopLegacy', version: '1.0.0' });
+
+      const shopCustomerNodes = nodes.filter((n: any) => n.data.entity.data.id === 'ShopCustomer');
+      expect(shopCustomerNodes).toHaveLength(1);
+      expect(shopCustomerNodes[0].id).toBe('ShopCustomer-1.0.0');
+      expect(shopCustomerNodes[0].data.externalToDomain).toBeUndefined();
+
+      expect(edges).toHaveLength(1);
+      expect(edges[0]).toMatchObject({
+        source: 'ShopOrder-1.0.0',
+        target: 'ShopCustomer-1.0.0',
+      });
+
+      expect(warn).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/core/eventcatalog/src/utils/node-graphs/domain-entity-map.ts
+++ b/packages/core/eventcatalog/src/utils/node-graphs/domain-entity-map.ts
@@ -23,6 +23,10 @@ const getReferencePropertyNames = (entity: Entity, entityMap: Map<string, Entity
     ?.filter((property: any) => getReferencedEntityId(property, entityMap))
     .map((property: any) => property.name) ?? [];
 
+// Entities on a resource are usually hydrated collection entries, whose top-level `id` is the
+// Astro id (`Customer-1.0.0`) rather than the catalog id used by `property.references`.
+const getCatalogId = (entity: any) => entity?.data?.id ?? entity?.id;
+
 const getRelationType = (property: any) => {
   if (property.relationType) return property.relationType;
   if (property.type === 'array' && property.items?.type) return 'hasMany';
@@ -89,7 +93,7 @@ export const getNodesAndEdges = async ({ id, version, entities, type = 'domains'
     .filter((ref: any) => ref !== undefined);
 
   const externalToDomain = Array.from(new Set<string>(listOfReferencedEntities as string[])) // Remove duplicates
-    .filter((entityId: any) => !resourceEntities.some((domainEntity: any) => domainEntity.id === entityId));
+    .filter((entityId: any) => !resourceEntities.some((domainEntity: any) => getCatalogId(domainEntity) === entityId));
 
   // 2. Build optimized maps
   // Only build domain map if we have domains to search


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Motivation

Reported on Discord: a domain that owns both sides of an entity reference still logs `Entity "Customer" not found in catalog`, and in some catalogs renders a ghost copy of the referenced entity badged as external.

In `packages/core/eventcatalog/src/utils/node-graphs/domain-entity-map.ts`, the `externalToDomain` filter compared the reference target against the wrong field:

```ts
.filter((entityId) => !resourceEntities.some((domainEntity) => domainEntity.id === entityId))
```

`resourceEntities` come from `getDomains()` / `getServices()`, which hydrate the resource's `entities` into Astro collection entries. A collection entry's top-level `id` is the Astro id (`Customer-1.0.0` in production, a file path in the test fixtures), whereas `property.references` holds the catalog id (`Customer`). Those never match, so every in-domain reference was classified as external and pushed through the external-entity lookup. The rest of the file already compares `domainEntity.data.id` (in `findEntityDomain`) and `targetEntity.data.id` (when creating edges), so the filter was the odd one out.

Two user-visible symptoms follow from that, both reproduced before the fix:

1. **False warning.** When the referenced entity is absent from `getEntities()` (it filters `hidden: true`, unlike the raw collection that `getDomains()` hydrates from), `findInMap` misses and the code warns `Entity "Customer" not found in catalog` — even though the node and its edge render correctly.
2. **Duplicate external node.** When the domain pins an older version than the catalog's latest, the external lookup resolves `latest` and adds a second node for the same entity, badged `externalToDomain` and attributed to the "owning" domain. A `Shop` domain pinning `Customer@1.0.0` alongside a `Customer@2.0.0` in the catalog rendered `Customer-1.0.0` **and** `Customer-2.0.0`.

## Change

Compare against the entity's catalog id, falling back to the top-level `id` so an unhydrated pointer (`{ id, version }`) still matches:

```ts
const getCatalogId = (entity: any) => entity?.data?.id ?? entity?.id;
```

Entities the resource owns are now skipped by the external lookup entirely, so neither symptom can occur. Genuinely external references are unaffected, as is the `entities` prop filter (entities excluded by that filter are correctly still treated as external).

## Tests

`domain-entity-map.spec.ts` gains a `Shop` domain that owns both `ShopOrder` and `ShopCustomer`, using the production Astro id format (`${id}-${version}`) that the previous fixtures did not exercise:

- `does not mark or warn about a referenced entity that the domain owns` — one `ShopCustomer` node, not `externalToDomain`, edge created, `console.warn` never called.
- `does not add an external node when the domain pins an older version of a referenced entity it owns` — the `ShopLegacy` domain pins `ShopCustomer@1.0.0` while `2.0.0` exists. This test fails on `main` (`expected [ …(2) ] to have a length of 1 but got 2`) and passes with the fix.

Also filled the gap noted in the existing Orders test: it now asserts that `OrderItem`, referenced by `Order` and owned by the same domain, is not marked `externalToDomain`.

All 18 tests in the file pass. The 5 failures elsewhere in `packages/core/eventcatalog/src/utils/__tests__` are pre-existing environment issues (unbuilt `@eventcatalog/sdk` dist and a missing generated `eventcatalog.config.js`), unrelated to this change.

## Editor repository

No corresponding change is needed in `eventcatalog/eventcatalog-editor` — this is core node-graph logic with no editor counterpart.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-78247701-d405-4623-b8f5-7550f95636b3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78247701-d405-4623-b8f5-7550f95636b3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

