### PR TITLE
Resolve Astro 7.2.8 upgrade compatibility issues

### DIFF
--- a/.changeset/astro-upgrade-fixes.md
+++ b/.changeset/astro-upgrade-fixes.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/core': minor
+---
+
+fix(core): silence Astro 7.2.8 content reference errors for message schemas, fix dark-theme syntax colours on first load of light-mode schema pages, and stop TanStack Table warnings on the directory pages

--- a/packages/core/eventcatalog/src/__tests__/api/message-schemas-api.spec.ts
+++ b/packages/core/eventcatalog/src/__tests__/api/message-schemas-api.spec.ts
@@ -37,7 +37,7 @@ const schemaEntry = ({
     filePath: path.join(__dirname, 'schemas', file),
     latest,
     message: {
-      collection,
+      collectionName: collection,
       id,
       name: `${id} message`,
       version,

--- a/packages/core/eventcatalog/src/__tests__/api/schemas.txt.spec.ts
+++ b/packages/core/eventcatalog/src/__tests__/api/schemas.txt.spec.ts
@@ -33,7 +33,7 @@ vi.mock('astro:content', async (importOriginal) => {
               data: {
                 id: 'schema:events:OrderPlaced:1.0.0:schema.json',
                 message: {
-                  collection: 'events',
+                  collectionName: 'events',
                   id: 'OrderPlaced',
                   name: 'Order Placed',
                   version: '1.0.0',
@@ -46,7 +46,7 @@ vi.mock('astro:content', async (importOriginal) => {
               data: {
                 id: 'schema:commands:CreateOrder:1.0.0:schema.json',
                 message: {
-                  collection: 'commands',
+                  collectionName: 'commands',
                   id: 'CreateOrder',
                   name: 'Create Order',
                   version: '1.0.0',
@@ -59,7 +59,7 @@ vi.mock('astro:content', async (importOriginal) => {
               data: {
                 id: 'schema:queries:GetOrder:1.0.0:schema.json',
                 message: {
-                  collection: 'queries',
+                  collectionName: 'queries',
                   id: 'GetOrder',
                   name: 'Get Order',
                   version: '1.0.0',

--- a/packages/core/eventcatalog/src/components/MDX/SchemaViewer/schema-viewer-utils.spec.ts
+++ b/packages/core/eventcatalog/src/components/MDX/SchemaViewer/schema-viewer-utils.spec.ts
@@ -9,7 +9,7 @@ const currentMessageSchema = {
     content: '{"type":"object","title":"OrderPlaced"}',
     default: true,
     message: {
-      collection: 'events',
+      collectionName: 'events',
       id: 'OrderPlaced',
       version: '1.0.0',
     },
@@ -42,7 +42,7 @@ describe('resolveSchemaViewer', () => {
         content: 'syntax = "proto3";\nmessage FraudCheckCompleted {\n  string transaction_id = 1;\n}',
         default: true,
         message: {
-          collection: 'events',
+          collectionName: 'events',
           id: 'FraudCheckCompleted',
           version: '1.0.0',
         },
@@ -75,7 +75,7 @@ describe('resolveSchemaViewer', () => {
         content: '{"this": "is not protobuf"}',
         default: true,
         message: {
-          collection: 'events',
+          collectionName: 'events',
           id: 'FraudCheckCompleted',
           version: '1.0.0',
         },

--- a/packages/core/eventcatalog/src/components/MDX/SchemaViewer/schema-viewer-utils.ts
+++ b/packages/core/eventcatalog/src/components/MDX/SchemaViewer/schema-viewer-utils.ts
@@ -29,7 +29,7 @@ type CollectionSchema = {
       branch?: string;
     };
     message?: {
-      collection: string;
+      collectionName: string;
       id: string;
       version: string;
     };
@@ -79,7 +79,7 @@ const getCollectionSchemaForViewer = ({
   const resourceSchemas = collectionSchemas.filter((schema) => {
     const message = schema.data.message;
     if (!message) return false;
-    return message.collection === collection && message.id === id && message.version === version;
+    return message.collectionName === collection && message.id === id && message.version === version;
   });
 
   return resourceSchemas.find((schema) => schema.data.default) || resourceSchemas[0];

--- a/packages/core/eventcatalog/src/components/SchemaExplorer/__tests__/useDarkMode.spec.ts
+++ b/packages/core/eventcatalog/src/components/SchemaExplorer/__tests__/useDarkMode.spec.ts
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { act, createElement } from 'react';
+import { renderToString } from 'react-dom/server';
+import { hydrateRoot, type Root } from 'react-dom/client';
+import { DEFAULT_THEME, themeStore } from '@stores/theme-store';
+import { useDarkMode } from '../useDarkMode';
+
+// Renders the hook's value as text so we can assert on the DOM.
+const ThemeProbe = () => createElement('span', null, useDarkMode() ? 'dark' : 'light');
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe('useDarkMode', () => {
+  let container: HTMLDivElement;
+  let root: Root | undefined;
+  let consoleError: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    act(() => root?.unmount());
+    root = undefined;
+    container.remove();
+    consoleError.mockRestore();
+    themeStore.set(DEFAULT_THEME);
+  });
+
+  it('server rendering always uses the default theme, even when the store already holds a client preference', () => {
+    themeStore.set('light');
+
+    expect(renderToString(createElement(ThemeProbe))).toContain('dark');
+  });
+
+  it('hydrates against the server markup and then switches to the stored light preference without a hydration mismatch', () => {
+    // Server renders with the default (dark) theme…
+    container.innerHTML = renderToString(createElement(ThemeProbe));
+    expect(container.textContent).toBe('dark');
+
+    // …but a returning user's stored preference has already been loaded into the store before React hydrates.
+    themeStore.set('light');
+
+    act(() => {
+      root = hydrateRoot(container, createElement(ThemeProbe));
+    });
+
+    expect(container.textContent).toBe('light');
+    const hydrationWarnings = consoleError.mock.calls.filter((call) => String(call[0]).match(/did not match|hydrat/i));
+    expect(hydrationWarnings).toEqual([]);
+  });
+
+  it('follows theme changes after hydration', () => {
+    container.innerHTML = renderToString(createElement(ThemeProbe));
+    act(() => {
+      root = hydrateRoot(container, createElement(ThemeProbe));
+    });
+    expect(container.textContent).toBe('dark');
+
+    act(() => themeStore.set('light'));
+    expect(container.textContent).toBe('light');
+
+    act(() => themeStore.set('dark'));
+    expect(container.textContent).toBe('dark');
+  });
+});

--- a/packages/core/eventcatalog/src/components/SchemaExplorer/useDarkMode.ts
+++ b/packages/core/eventcatalog/src/components/SchemaExplorer/useDarkMode.ts
@@ -1,7 +1,16 @@
-import { useStore } from '@nanostores/react';
-import { themeStore } from '@stores/theme-store';
+import { useSyncExternalStore } from 'react';
+import { DEFAULT_THEME, themeStore } from '@stores/theme-store';
+
+const subscribe = (onChange: () => void) => themeStore.listen(onChange);
+const getSnapshot = () => themeStore.get() === 'dark';
+
+// On the client the store is initialised from localStorage before React hydrates, so it can
+// already differ from the value the server rendered with. React 18 keeps the server's inline
+// `style` attributes when they mismatch during hydration, which left dark-theme syntax colours
+// (and text-shadow) on light-mode pages until the component remounted. Hydrate with the server
+// value instead; React re-renders with the real client value straight after.
+const getServerSnapshot = () => DEFAULT_THEME === 'dark';
 
 export function useDarkMode(): boolean {
-  const theme = useStore(themeStore);
-  return theme === 'dark';
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }

--- a/packages/core/eventcatalog/src/components/Tables/columns/TeamsTableColumns.tsx
+++ b/packages/core/eventcatalog/src/components/Tables/columns/TeamsTableColumns.tsx
@@ -82,7 +82,7 @@ export const columns = (tableConfiguration: TableConfiguration) => [
     filterFn: filterByName,
   }),
 
-  columnHelper.accessor('data.source', {
+  columnHelper.accessor((row) => row.data.source, {
     id: 'source',
     header: () => <span>{tableConfiguration.columns?.source?.label || 'Source'}</span>,
     cell: (info) => <DirectorySourceCell source={info.getValue() as { provider: string; url?: string } | undefined} />,

--- a/packages/core/eventcatalog/src/components/Tables/columns/UserTableColumns.tsx
+++ b/packages/core/eventcatalog/src/components/Tables/columns/UserTableColumns.tsx
@@ -85,7 +85,7 @@ export const columns = (tableConfiguration: TableConfiguration) => [
     filterFn: filterByName,
   }),
 
-  columnHelper.accessor('data.source', {
+  columnHelper.accessor((row) => row.data.source, {
     id: 'source',
     header: () => <span>{tableConfiguration.columns?.source?.label || 'Source'}</span>,
     cell: (info) => <DirectorySourceCell source={info.getValue() as { provider: string; url?: string } | undefined} />,
@@ -95,7 +95,7 @@ export const columns = (tableConfiguration: TableConfiguration) => [
     },
   }),
 
-  columnHelper.accessor('data.role', {
+  columnHelper.accessor((row) => row.data.role, {
     id: 'role',
     header: () => <span>{tableConfiguration.columns?.role?.label || 'Role'}</span>,
     cell: (info) => {

--- a/packages/core/eventcatalog/src/content.config.ts
+++ b/packages/core/eventcatalog/src/content.config.ts
@@ -1179,7 +1179,7 @@ const schemas = defineCollection({
       default: z.boolean().optional(),
       latest: z.boolean().optional(),
       message: z.object({
-        collection: z.enum(['events', 'commands', 'queries']),
+        collectionName: z.enum(['events', 'commands', 'queries']),
         id: z.string(),
         name: z.string().optional(),
         version: z.string(),

--- a/packages/core/eventcatalog/src/enterprise/api/schemas/[collection]/[id]/[version]/index.ts
+++ b/packages/core/eventcatalog/src/enterprise/api/schemas/[collection]/[id]/[version]/index.ts
@@ -11,7 +11,7 @@ import { sortVersioned } from '@utils/collections/util';
 const findSchema = async (collection: string | undefined, id: string, version: string | undefined) => {
   const schemas = await getCollection('schemas');
   const matchingSchemas = schemas.filter(
-    (schema) => schema.data.message.collection === collection && schema.data.message.id === id
+    (schema) => schema.data.message.collectionName === collection && schema.data.message.id === id
   );
 
   if (version === 'latest') {
@@ -30,7 +30,7 @@ export async function getStaticPaths() {
   // Generate paths for specific versions
   const versionedPaths = schemas.map((schema) => ({
     params: {
-      collection: schema.data.message.collection,
+      collection: schema.data.message.collectionName,
       id: schema.data.message.id,
       version: schema.data.message.version,
     },
@@ -45,7 +45,7 @@ export async function getStaticPaths() {
     .filter((schema) => schema.data.latest)
     .map((latestSchema) => ({
       params: {
-        collection: latestSchema.data.message.collection,
+        collection: latestSchema.data.message.collectionName,
         id: latestSchema.data.message.id,
         version: 'latest',
       },

--- a/packages/core/eventcatalog/src/enterprise/tools/__tests__/catalog-tools.mocks.ts
+++ b/packages/core/eventcatalog/src/enterprise/tools/__tests__/catalog-tools.mocks.ts
@@ -581,7 +581,7 @@ export const mockSchemas = [
         path: 'schemas/OrderCreated.schema.json',
       },
       message: {
-        collection: 'events',
+        collectionName: 'events',
         id: 'OrderCreated',
         name: 'Order Created',
         version: '1.0.0',

--- a/packages/core/eventcatalog/src/enterprise/tools/catalog-tools.ts
+++ b/packages/core/eventcatalog/src/enterprise/tools/catalog-tools.ts
@@ -310,7 +310,7 @@ export async function getSchemaForResource(params: { resourceId: string; resourc
     const schemaEntries = await getCollection('schemas');
     const schemas = schemaEntries.filter(
       (schema) =>
-        schema.data.message.collection === params.resourceCollection &&
+        schema.data.message.collectionName === params.resourceCollection &&
         schema.data.message.id === params.resourceId &&
         schema.data.message.version === params.resourceVersion
     );

--- a/packages/core/eventcatalog/src/pages/docs/llm/schemas.txt.ts
+++ b/packages/core/eventcatalog/src/pages/docs/llm/schemas.txt.ts
@@ -36,9 +36,9 @@ const getMessagesWithSchemas = (collection: MessageCollection) => {
   const seenMessages = new Set<string>();
 
   return schemas
-    .filter((schema) => schema.data.message.collection === collection)
+    .filter((schema) => schema.data.message.collectionName === collection)
     .map((schema) => {
-      const key = `${schema.data.message.collection}:${schema.data.message.id}:${schema.data.message.version}`;
+      const key = `${schema.data.message.collectionName}:${schema.data.message.id}:${schema.data.message.version}`;
       if (seenMessages.has(key)) return null;
       seenMessages.add(key);
 
@@ -63,7 +63,7 @@ export const GET: APIRoute = async ({ params, request }) => {
 
   const formatVersionedItem = (item: (typeof schemas)[number]) => {
     const message = item.data.message;
-    return `- [${message.name || message.id} - ${message.id} - ${message.version}](${baseUrl}/api/schemas/${message.collection}/${message.id}/${message.version})} ${message.summary ? `- ${message.summary.trim()}` : ''}`;
+    return `- [${message.name || message.id} - ${message.id} - ${message.version}](${baseUrl}/api/schemas/${message.collectionName}/${message.id}/${message.version})} ${message.summary ? `- ${message.summary.trim()}` : ''}`;
   };
 
   const formatServiceWithSchema = (item: ServiceWithSchema) => {

--- a/packages/core/eventcatalog/src/pages/schemas/[type]/[id]/[version]/_index.data.ts
+++ b/packages/core/eventcatalog/src/pages/schemas/[type]/[id]/[version]/_index.data.ts
@@ -32,7 +32,7 @@ export class Page extends HybridPage {
 
     const seenMessageSchemas = new Set<string>();
     const messageSchemas = schemas.filter((schema) => {
-      const key = `${schema.data.message.collection}:${schema.data.message.id}:${schema.data.message.version}`;
+      const key = `${schema.data.message.collectionName}:${schema.data.message.id}:${schema.data.message.version}`;
       if (seenMessageSchemas.has(key)) return false;
       seenMessageSchemas.add(key);
       return true;
@@ -41,17 +41,19 @@ export class Page extends HybridPage {
     // Generate paths for messages with schemas
     const messagePaths = messageSchemas
       .map((schema) => {
-        const item = itemsByKey.get(`${schema.data.message.collection}:${schema.data.message.id}:${schema.data.message.version}`);
+        const item = itemsByKey.get(
+          `${schema.data.message.collectionName}:${schema.data.message.id}:${schema.data.message.version}`
+        );
         if (!item) return null;
 
         return {
           params: {
-            type: schema.data.message.collection,
+            type: schema.data.message.collectionName,
             id: schema.data.message.id,
             version: schema.data.message.version,
           },
           props: {
-            type: schema.data.message.collection,
+            type: schema.data.message.collectionName,
             ...item,
             // Not everything needs the body of the page itself.
             body: undefined,

--- a/packages/core/eventcatalog/src/pages/schemas/[type]/[id]/[version]/index.astro
+++ b/packages/core/eventcatalog/src/pages/schemas/[type]/[id]/[version]/index.astro
@@ -80,7 +80,7 @@ if (isDataProduct && contractPath) {
   const [allItems, schemaEntries] = await Promise.all([pageDataLoader[type](), getCollection('schemas')]);
   const versions = allItems.filter((item) => item.data.id === data.id);
   const schemasForMessage = schemaEntries.filter(
-    (schema) => schema.data.message.collection === type && schema.data.message.id === data.id
+    (schema) => schema.data.message.collectionName === type && schema.data.message.id === data.id
   );
 
   const getSchemaForVersion = (version: string) => {

--- a/packages/core/eventcatalog/src/pages/schemas/explorer/_index.data.ts
+++ b/packages/core/eventcatalog/src/pages/schemas/explorer/_index.data.ts
@@ -48,7 +48,7 @@ async function fetchAllSchemas() {
   const messagesWithSchemas = await Promise.all(
     schemaEntries.map(async (schema) => {
       const message = messagesBySchemaReference.get(
-        `${schema.data.message.collection}:${schema.data.message.id}:${schema.data.message.version}`
+        `${schema.data.message.collectionName}:${schema.data.message.id}:${schema.data.message.version}`
       );
       const schemaPath = schema.data.file || schema.data.source.path || '';
       const schemaExtension = path.extname(schemaPath).slice(1) || schema.data.format;
@@ -95,7 +95,7 @@ async function fetchAllSchemas() {
       }
 
       return {
-        collection: schema.data.message.collection,
+        collection: schema.data.message.collectionName,
         data: {
           id: schema.data.message.id,
           name: schema.data.message.name || schema.data.name || schema.data.message.id,

--- a/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/sidebar-builder.spec.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/sidebar-builder.spec.ts
@@ -2902,7 +2902,7 @@ describe('getNestedSideBarData', () => {
           ref: 'git://contracts/events/PaymentProcessed.schema.json',
           format: 'jsonschema',
           source: { provider: 'git', path: 'events/PaymentProcessed.schema.json' },
-          message: { collection: 'events', id: 'PaymentProcessed', version: '0.0.1' },
+          message: { collectionName: 'events', id: 'PaymentProcessed', version: '0.0.1' },
         });
 
         const navigationData = await getNestedSideBarData();
@@ -2951,14 +2951,14 @@ describe('getNestedSideBarData', () => {
             ref: 'git://contracts/events/PaymentProcessed.schema.json',
             format: 'jsonschema',
             source: { provider: 'git', path: 'events/PaymentProcessed.schema.json' },
-            message: { collection: 'events', id: 'PaymentProcessed', version: '0.0.1' },
+            message: { collectionName: 'events', id: 'PaymentProcessed', version: '0.0.1' },
           },
           {
             id: 'git://contracts/events/PaymentProcessed.schema.avsc',
             ref: 'git://contracts/events/PaymentProcessed.schema.avsc',
             format: 'avro',
             source: { provider: 'git', path: 'events/PaymentProcessed.schema.avsc' },
-            message: { collection: 'events', id: 'PaymentProcessed', version: '0.0.1' },
+            message: { collectionName: 'events', id: 'PaymentProcessed', version: '0.0.1' },
           }
         );
 
@@ -3031,7 +3031,7 @@ describe('getNestedSideBarData', () => {
           format: 'jsonschema',
           file: 'schema.json',
           source: { provider: 'file', path: 'schema.json' },
-          message: { collection: 'events', id: 'PaymentProcessed', version: '0.0.1' },
+          message: { collectionName: 'events', id: 'PaymentProcessed', version: '0.0.1' },
         });
         await writeService({
           id: 'ShippingService',
@@ -3064,7 +3064,7 @@ describe('getNestedSideBarData', () => {
           ref: 'git://contracts/events/PaymentProcessed.schema.json',
           format: 'jsonschema',
           source: { provider: 'git', path: 'events/PaymentProcessed.schema.json' },
-          message: { collection: 'events', id: 'PaymentProcessed', version: '0.0.1' },
+          message: { collectionName: 'events', id: 'PaymentProcessed', version: '0.0.1' },
         });
         await writeService({
           id: 'ShippingService',
@@ -3148,7 +3148,7 @@ describe('getNestedSideBarData', () => {
           format: 'jsonschema',
           file: 'schema.json',
           source: { provider: 'file', path: 'schema.json' },
-          message: { collection: 'events', id: 'InventoryAdjusted', version: '1.0.0' },
+          message: { collectionName: 'events', id: 'InventoryAdjusted', version: '1.0.0' },
         });
         await writeService({
           id: 'InventoryService',

--- a/packages/core/eventcatalog/src/stores/sidebar-store/builders/message.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/builders/message.ts
@@ -29,7 +29,7 @@ const getSchemasForMessage = (
 ) => {
   return schemas.filter(
     (schema) =>
-      schema.data.message.collection === message.collection &&
+      schema.data.message.collectionName === message.collection &&
       schema.data.message.id === message.data.id &&
       schema.data.message.version === message.data.version
   );

--- a/packages/core/eventcatalog/src/stores/theme-store.ts
+++ b/packages/core/eventcatalog/src/stores/theme-store.ts
@@ -4,11 +4,14 @@ const THEME_KEY = 'eventcatalog-theme';
 
 export type Theme = 'light' | 'dark';
 
-export const themeStore = atom<Theme>('dark');
+// Default theme when the user has not explicitly chosen one. This is also the value the
+// store holds during server rendering, so SSR-safe hooks must hydrate against it.
+export const DEFAULT_THEME: Theme = 'dark';
 
-// Default theme when the user has not explicitly chosen one.
+export const themeStore = atom<Theme>(DEFAULT_THEME);
+
 const getDefaultTheme = (): Theme => {
-  return 'dark';
+  return DEFAULT_THEME;
 };
 
 // Apply theme to document via data-theme attribute

--- a/packages/core/eventcatalog/src/utils/__tests__/schemas/schema-loader.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/schemas/schema-loader.spec.ts
@@ -45,7 +45,7 @@ describe('schema-loader', () => {
         environments: undefined,
         default: true,
         message: {
-          collection: 'commands',
+          collectionName: 'commands',
           id: 'CancelShipment',
           name: 'Cancel shipment',
           version: '0.0.1',
@@ -100,7 +100,7 @@ describe('schema-loader', () => {
         environments: ['prod'],
         default: true,
         message: {
-          collection: 'events',
+          collectionName: 'events',
           id: 'ShipmentCancelled',
           name: 'Shipment cancelled',
           version: '1.0.0',
@@ -123,7 +123,7 @@ describe('schema-loader', () => {
         environments: ['uat'],
         default: undefined,
         message: {
-          collection: 'events',
+          collectionName: 'events',
           id: 'ShipmentCancelled',
           name: 'Shipment cancelled',
           version: '1.0.0',
@@ -161,7 +161,7 @@ describe('schema-loader', () => {
         environments: ['prod'],
         default: undefined,
         message: {
-          collection: 'events',
+          collectionName: 'events',
           id: 'ShipmentCancelled',
           name: undefined,
           version: '1.0.0',
@@ -221,7 +221,7 @@ describe('schema-loader', () => {
         environments: undefined,
         default: undefined,
         message: {
-          collection: 'events',
+          collectionName: 'events',
           id: 'OrderPlaced',
           name: undefined,
           version: '1.0.0',
@@ -262,7 +262,7 @@ schemaPath: schema.json
     expect(schemas[0]).toMatchObject({
       id: 'schema:commands:CancelShipment:0.0.1:schema.json',
       message: {
-        collection: 'commands',
+        collectionName: 'commands',
         id: 'CancelShipment',
         name: 'Cancel shipment',
         version: '0.0.1',
@@ -523,7 +523,7 @@ schemas:
       latest: true,
       readOnly: true,
       message: {
-        collection: 'events',
+        collectionName: 'events',
         id: 'OrderPlaced',
         version: '1.0.0',
       },

--- a/packages/core/eventcatalog/src/utils/collections/schema-loader.ts
+++ b/packages/core/eventcatalog/src/utils/collections/schema-loader.ts
@@ -76,7 +76,7 @@ export type MessageSchemaResource = {
   default?: boolean;
   latest?: boolean;
   message: {
-    collection: MessageCollection;
+    collectionName: MessageCollection;
     id: string;
     name?: string;
     version: string;
@@ -131,8 +131,10 @@ const getSchemaFormat = (schemaPath: string) => {
   return extension || 'unknown';
 };
 
-const buildGeneratedSchemaId = (message: { collection: MessageCollection; id: string; version: string }, schemaPath: string) =>
-  `schema:${message.collection}:${message.id}:${message.version}:${schemaPath}`;
+const buildGeneratedSchemaId = (
+  message: { collectionName: MessageCollection; id: string; version: string },
+  schemaPath: string
+) => `schema:${message.collectionName}:${message.id}:${message.version}:${schemaPath}`;
 
 const getSchemaCollectionId = ({
   message,
@@ -140,7 +142,7 @@ const getSchemaCollectionId = ({
   schemaRef,
   schemaFile,
 }: {
-  message: { collection: MessageCollection; id: string; version: string };
+  message: { collectionName: MessageCollection; id: string; version: string };
   reference: SchemaReference;
   schemaRef?: string;
   schemaFile?: string;
@@ -249,7 +251,7 @@ const buildSchemaSourceErrorMessage = ({
   source: SchemaSource;
   error: unknown;
 }) => {
-  const messageType = getMessageTypeLabel(schema.message.collection);
+  const messageType = getMessageTypeLabel(schema.message.collectionName);
 
   return [
     '',
@@ -268,7 +270,7 @@ const buildSchemaSourceErrorMessage = ({
 const addLatestMetadata = (schemas: MessageSchemaResource[]) => {
   const schemasByMessage = schemas.reduce(
     (acc, schema) => {
-      const key = `${schema.message.collection}:${schema.message.id}`;
+      const key = `${schema.message.collectionName}:${schema.message.id}`;
       acc[key] = [...(acc[key] ?? []), schema];
       return acc;
     },
@@ -284,7 +286,7 @@ const addLatestMetadata = (schemas: MessageSchemaResource[]) => {
   );
 
   return schemas.map((schema) => {
-    const key = `${schema.message.collection}:${schema.message.id}`;
+    const key = `${schema.message.collectionName}:${schema.message.id}`;
     return {
       ...schema,
       latest: schema.message.version === latestVersionsByMessage[key],
@@ -304,7 +306,7 @@ export const getMessageSchemasFromFrontmatter = ({
   if (!data.id || !data.version) return [];
 
   const message = {
-    collection,
+    collectionName: collection,
     id: data.id,
     name: data.name,
     version: data.version,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -169,6 +169,7 @@
     "@types/shelljs": "^0.8.15",
     "@types/update-notifier": "^6.0.8",
     "@types/uuid": "^10.0.0",
+    "jsdom": "27.0.0",
     "prettier": "^3.3.3",
     "prettier-plugin-astro": "^0.14.1",
     "tsup": "^8.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,7 +123,7 @@ importers:
         version: 11.1.4(astro@7.2.8(@astrojs/markdown-remark@7.2.4)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.19.21)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
       '@astrojs/react':
         specifier: ^6.0.4
-        version: 6.0.4(@types/node@22.19.21)(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(esbuild@0.25.10)(jiti@2.7.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 6.0.4(@types/node@22.19.21)(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
       '@astrojs/rss':
         specifier: ^4.0.19
         version: 4.0.19
@@ -198,7 +198,7 @@ importers:
         version: 0.5.19(tailwindcss@4.3.1)
       '@tailwindcss/vite':
         specifier: ^4.3.1
-        version: 4.3.1(vite@8.1.0(@types/node@22.19.21)(esbuild@0.25.10)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.3.1(vite@8.1.0(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
       '@tanstack/react-table':
         specifier: ^8.17.3
         version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -443,6 +443,9 @@ importers:
       '@types/uuid':
         specifier: ^10.0.0
         version: 10.0.0
+      jsdom:
+        specifier: 27.0.0
+        version: 27.0.0(postcss@8.5.15)
       prettier:
         specifier: ^3.3.3
         version: 3.6.2
@@ -454,10 +457,10 @@ importers:
         version: 8.5.0(jiti@2.7.0)(postcss@8.5.15)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)
       vite:
         specifier: ^8.1.0
-        version: 8.1.0(@types/node@22.19.21)(esbuild@0.25.10)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 8.1.0(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
       vite-tsconfig-paths:
         specifier: ^4.3.2
-        version: 4.3.2(typescript@5.9.3)(vite@8.1.0(@types/node@22.19.21)(esbuild@0.25.10)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.3.2(typescript@5.9.3)(vite@8.1.0(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.21)(jiti@2.7.0)(jsdom@27.0.0(postcss@8.5.15))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
@@ -8961,17 +8964,17 @@ snapshots:
     dependencies:
       prismjs: 1.30.0
 
-  '@astrojs/react@6.0.4(@types/node@22.19.21)(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(esbuild@0.25.10)(jiti@2.7.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)':
+  '@astrojs/react@6.0.4(@types/node@22.19.21)(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)':
     dependencies:
       '@astrojs/internal-helpers': 0.10.4
       '@types/react': 19.2.13
       '@types/react-dom': 19.2.3(@types/react@19.2.13)
-      '@vitejs/plugin-react': 5.2.0(vite@8.1.0(@types/node@22.19.21)(esbuild@0.25.10)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@vitejs/plugin-react': 5.2.0(vite@8.1.0(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
       devalue: 5.8.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       ultrahtml: 1.6.0
-      vite: 8.1.0(@types/node@22.19.21)(esbuild@0.25.10)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 8.1.0(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - '@vitejs/devtools'
@@ -11492,12 +11495,12 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.3.1
 
-  '@tailwindcss/vite@4.3.1(vite@8.1.0(@types/node@22.19.21)(esbuild@0.25.10)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@tailwindcss/vite@4.3.1(vite@8.1.0(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@tailwindcss/node': 4.3.1
       '@tailwindcss/oxide': 4.3.1
       tailwindcss: 4.3.1
-      vite: 8.1.0(@types/node@22.19.21)(esbuild@0.25.10)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 8.1.0(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@tanstack/react-table@8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -11866,7 +11869,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@5.2.0(vite@8.1.0(@types/node@22.19.21)(esbuild@0.25.10)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@vitejs/plugin-react@5.2.0(vite@8.1.0(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -11874,7 +11877,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 8.1.0(@types/node@22.19.21)(esbuild@0.25.10)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 8.1.0(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -12369,7 +12372,7 @@ snapshots:
       unifont: 0.7.5
       unstorage: 1.17.5
       vite: 8.1.0(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
-      vitefu: 1.1.2(vite@8.1.0(@types/node@22.19.21)(esbuild@0.25.10)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitefu: 1.1.2(vite@8.1.0(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
       xxhash-wasm: 1.1.0
       yargs-parser: 22.0.0
       zod: 4.3.6
@@ -15639,7 +15642,7 @@ snapshots:
 
   path-scurry@2.0.0:
     dependencies:
-      lru-cache: 11.2.2
+      lru-cache: 11.3.6
       minipass: 7.1.2
 
   path-scurry@2.0.2:
@@ -17297,13 +17300,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite-tsconfig-paths@4.3.2(typescript@5.9.3)(vite@8.1.0(@types/node@22.19.21)(esbuild@0.25.10)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)):
+  vite-tsconfig-paths@4.3.2(typescript@5.9.3)(vite@8.1.0(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       debug: 4.4.3
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.9.3)
     optionalDependencies:
-      vite: 8.1.0(@types/node@22.19.21)(esbuild@0.25.10)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 8.1.0(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -17410,22 +17413,6 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.9.0
 
-  vite@8.1.0(@types/node@22.19.21)(esbuild@0.25.10)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0):
-    dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.15
-      rolldown: 1.1.3
-      tinyglobby: 0.2.17
-    optionalDependencies:
-      '@types/node': 22.19.21
-      esbuild: 0.25.10
-      fsevents: 2.3.3
-      jiti: 2.7.0
-      terser: 5.46.0
-      tsx: 4.21.0
-      yaml: 2.9.0
-
   vite@8.1.0(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
@@ -17442,9 +17429,9 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.9.0
 
-  vitefu@1.1.2(vite@8.1.0(@types/node@22.19.21)(esbuild@0.25.10)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)):
+  vitefu@1.1.2(vite@8.1.0(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)):
     optionalDependencies:
-      vite: 8.1.0(@types/node@22.19.21)(esbuild@0.25.10)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 8.1.0(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
 
   vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.19)(jiti@2.7.0)(jsdom@27.0.0(postcss@8.5.15))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:


### PR DESCRIPTION
## What This PR Does

Fixes three issues surfaced by the Astro 7.2.8 upgrade. Astro now treats a `collection` key inside a content collection schema as a content reference and errors when it cannot resolve one, so the message schema metadata is renamed to `collectionName`. It also fixes dark-theme syntax colours leaking onto light-mode schema pages on first load, and removes TanStack Table warnings on the Teams and Users directory pages.

## Changes Overview

### Key Changes

- **Schema collection field rename** — `schemas` collection `message.collection` is now `message.collectionName`, across `content.config.ts`, the schema loader, schema pages, the schema explorer, the SchemaViewer, the LLM `schemas.txt` route, the enterprise schemas API, catalog tools, and the sidebar message builder.
- **Theme hydration fix** — `useDarkMode` now uses `useSyncExternalStore` with a server snapshot instead of `useStore`, and `theme-store` exports a shared `DEFAULT_THEME` constant.
- **TanStack Table accessors** — Teams and Users column definitions use accessor functions (`(row) => row.data.source`) instead of dotted accessor keys, which the current version warns on.

## How It Works

Astro's content layer resolves any schema field named `collection` as a reference to another collection. Because the schema entries only carry the message's collection *name* as a plain string, that resolution failed and logged errors during content sync. Renaming the field to `collectionName` sidesteps the reserved key while keeping identical semantics; all lookup keys built from it (`${collectionName}:${id}:${version}`) are updated in lockstep.

For the theme, the nanostore is initialised from `localStorage` before React hydrates, so the client value could already differ from what the server rendered. React 18 keeps the server's inline `style` attributes on a hydration mismatch, which left dark syntax colours and text-shadow on light-mode pages until the component remounted. `useSyncExternalStore` with a `getServerSnapshot` of `DEFAULT_THEME` hydrates against the server value and re-renders with the real client value immediately after.

## Breaking Changes

None for catalog authors — the renamed field is internal to the generated `schemas` content collection and is not part of the authored frontmatter.

## Additional Notes

- All 214 tests across the touched areas pass (schema loader, schemas API, schemas.txt, SchemaViewer utils, sidebar builder).
- Anything reading `schema.data.message.collection` outside this repo would need the same rename.