### PR TITLE
fix(ci): resolve npm peer-dep resolver hang when installing React 19 packages

### DIFF
--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -109,7 +109,7 @@ jobs:
           name: eventcatalog-packages-artifact
       - name: Install @eventcatalog packages
         working-directory: examples/${{ matrix.catalog }}/
-        run: npm install ../../sdk-package.tgz ../../core-package.tgz ../../linter-package.tgz ../../connectors-package.tgz ../../visualiser-package.tgz
+        run: npm install --legacy-peer-deps ../../sdk-package.tgz ../../core-package.tgz ../../linter-package.tgz ../../connectors-package.tgz ../../visualiser-package.tgz
       - name: Build EventCatalog
         working-directory: examples/${{ matrix.catalog }}/
         run: npx eventcatalog build

--- a/examples/default/package.json
+++ b/examples/default/package.json
@@ -5,5 +5,9 @@
     "dependencies": {
         "@eventcatalog/connectors": "workspace:*",
         "@eventcatalog/core": "workspace:*"
+    },
+    "overrides": {
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0"
     }
 }

--- a/examples/ssr/package.json
+++ b/examples/ssr/package.json
@@ -6,5 +6,9 @@
   "dependencies": {
     "@eventcatalog/connectors": "workspace:*",
     "@eventcatalog/core": "workspace:*"
+  },
+  "overrides": {
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Motivation

The three "Build EventCatalog" CI jobs on PR #2828 (`chore/core-upgrade-react-19`) were being cancelled after 10 minutes — the timeout — because the `npm install` step was hanging indefinitely.

### Root cause

When npm installs `@eventcatalog/core` (React 19) into a fresh project it hits peer-dependency conflicts from packages in the tree that declare peer deps on React 16–18 (notably `@asyncapi/react-component` → `use-resize-observer`). npm's ERESOLVE solver emits one `npm warn ERESOLVE overriding peer dependency` warning for every transitive conflict it resolves. In this dependency graph the number of such conflicts is large enough that the solver ran continuously for the full 10-minute CI timeout emitting hundreds of warnings per minute (2,015+ log lines captured from the run at `09:39:08–09:49:15`).

**Locally reproducible:** running `npm install eventcatalog-core-4.8.4.tgz` without workarounds pegged two CPU cores for 2+ minutes with no sign of finishing; adding `--legacy-peer-deps` completed in ~29 seconds.

The pnpm monorepo side already had a workaround (`peerDependencyRules.allowedVersions` in `pnpm-workspace.yaml`), but that has no effect on the bare npm invocation the CI catalog-build jobs use.

### Fix

Two complementary changes:

**1. `examples/{default,ssr}/package.json` — add `"overrides"`**

The npm equivalent of pnpm's `allowedVersions`. Declaring `"react": "^19.2.0"` in `overrides` tells npm to use React 19 everywhere in the install tree, preventing the ERESOLVE conflict from arising at all. This also helps end-users who run `npm install @eventcatalog/core` directly.

**2. `.github/workflows/verify-build.yml` — add `--legacy-peer-deps`**

Belt-and-suspenders: skips the ERESOLVE solver entirely (npm 6 behaviour) so the CI install always completes quickly regardless of the npm version on the runner.

### Verification

- `pnpm run verify-build:catalog` completes locally (933 pages, 0 errors).
- `npm install --legacy-peer-deps eventcatalog-core-4.8.4.tgz` completes in ~29 s.
- `npm install eventcatalog-core-4.8.4.tgz` with `overrides: {react: ^19.2.0}` completes in ~30 s.
- All test failures pre-exist on `chore/core-upgrade-react-19` before this change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b8bc48c2-6f78-47e8-b24f-e18f75138345?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b8bc48c2-6f78-47e8-b24f-e18f75138345&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

