### PR TITLE
Customize resource sidebars with sidebar.json

### DIFF
--- a/.changeset/proud-sidebars-arrange.md
+++ b/.changeset/proud-sidebars-arrange.md
@@ -1,0 +1,9 @@
+---
+"@eventcatalog/core": minor
+---
+
+feat(core): customize any resource's sidebar with a `sidebar.json` file
+
+Drop a `sidebar.json` next to any resource's `index.mdx` (domains, systems, services, agents, messages, flows, containers, entities, data products and ADRs) to fully define that resource's sidebar. Compose predefined `$sections` (kept live as your catalog changes) with your own groups of resource references (`[[service|order-service]]`), documentation (`[[doc|guides/onboarding]]`), specifications (`[[spec|openapi.yml]]`), schemas (`[[schema|order-placed]]`) and links (with `{id}`/`{version}`/`{collection}` placeholders). Groups nest, accept an explicit `collapsed` initial state, and versioned resources inherit the resource folder's sidebar. Unresolvable tokens and doc/spec/schema references fail the build with an error naming the file and the valid options.
+
+The sidebar also renders as a consistent docs-style tree: every group is collapsible with carets on the right, nested groups indent under a guide line, item counts are removed, the selected item stays in view after navigation, and scroll position is remembered.

--- a/examples/default/domains/Catalog/docs/guides/01-integrating-with-the-catalog.mdx
+++ b/examples/default/domains/Catalog/docs/guides/01-integrating-with-the-catalog.mdx
@@ -1,0 +1,33 @@
+---
+title: Integrating with the Catalog
+summary: How other teams read product data and react to product changes without coupling to the catalog database.
+---
+
+The Catalog domain is the source of truth for product data at Acme. Everything else — checkout, search, promotions, fulfilment — reads from it or reacts to it. This guide covers the two supported ways to integrate.
+
+## Read product data on demand
+
+Use [[query|get-product]] on [[service|product-api]] when you need the current state of a product at request time (a checkout page, an admin screen).
+
+- Responses are cached for 60 seconds at the edge; if you need strong consistency, pass `Cache-Control: no-cache`.
+- Never query [[container|product-database]] directly. Its schema is private to [[system|product-catalog-system]] and changes without notice.
+
+## React to product changes
+
+Subscribe to the domain events published by [[service|product-api]] when you need to keep a local read model in sync or trigger downstream work:
+
+| Event | When it fires |
+| --- | --- |
+| [[event\|product-created]] | A product is first published |
+| [[event\|product-updated]] | Any product attribute, price or variant changes |
+| [[event\|product-deleted]] | A product is withdrawn from sale |
+
+Events are published through a transactional outbox (see ADR-001), so you will never see an event for a change that was rolled back — but you **may** see the same event more than once. Consumers must be idempotent; use the `productId` + `version` pair on each event as the idempotency key.
+
+## Search
+
+If what you need is "find products matching…", don't build it yourself — call [[query|search-products]] on [[service|search-api]]. It is backed by [[container|search-index]], which [[flow|product-search-indexing]] keeps in sync with product events. Expect up to a few seconds of lag between a product change and it appearing in search results.
+
+## Commands are internal
+
+[[command|create-product]], [[command|update-product]] and [[command|delete-product]] are only accepted from the merchandising tools owned by [[team|product-platform]]. If your team needs to change product data, talk to us in `#catalog-support` rather than calling these directly.

--- a/examples/default/domains/Catalog/docs/guides/02-product-data-model.mdx
+++ b/examples/default/domains/Catalog/docs/guides/02-product-data-model.mdx
@@ -1,0 +1,26 @@
+---
+title: Product data model
+summary: The entities behind a product, how they relate, and which one you should key on.
+---
+
+Four entities make up the Catalog domain's model. Most integrations only ever need the first one.
+
+## Product
+
+[[entity|product]] is the unit merchandising manages and customers browse. It carries the identity (`productId`), the name and description, the category assignment and the default price. **Key on `productId`** — it is stable for the life of the product and is the identifier used on every event.
+
+## Product variant
+
+[[entity|product-variant]] is a sellable configuration of a product — a size, a colour, a bundle. A product has one or more variants; stock and SKU live on the variant, not the product. If you are integrating with fulfilment or inventory you will be dealing with variants.
+
+## Category
+
+[[entity|category]] is a tree used for navigation and merchandising rules. A product belongs to exactly one category. Category ids are stable, but the tree shape is not — do not hard-code paths like `Clothing > Shoes`.
+
+## Search document
+
+[[entity|search-document]] is the denormalised shape that [[service|search-indexer]] writes into [[container|search-index]]. It is derived from the three entities above and is **not** something to integrate with directly — treat it as an implementation detail of [[system|search-system]].
+
+## Seeing it visually
+
+The entity diagram on this domain shows the relationships and cardinalities between these four entities, with the fields each one owns.

--- a/examples/default/domains/Catalog/docs/guides/03-event-versioning.mdx
+++ b/examples/default/domains/Catalog/docs/guides/03-event-versioning.mdx
@@ -1,0 +1,32 @@
+---
+title: Event versioning
+summary: How product events evolve, what counts as a breaking change, and how long old versions are supported.
+---
+
+Product events are a public contract. Every consumer of [[event|product-created]], [[event|product-updated]] and [[event|product-deleted]] depends on their shape, so changes follow a fixed set of rules.
+
+## What is a breaking change
+
+| Change | Breaking? |
+| --- | --- |
+| Adding an optional field | No |
+| Adding a value to an enum | No — consumers must ignore unknown values |
+| Removing or renaming a field | **Yes** |
+| Changing a field's type | **Yes** |
+| Making an optional field required | **Yes** |
+
+Non-breaking changes ship on the current version. Breaking changes ship as a new major version of the event, published **alongside** the old one.
+
+## Support window
+
+When a new major version is published, the previous version keeps being emitted for **90 days**. The catalog changelog for each event records the cut-off date. Consumers are expected to migrate inside that window; after it, the old version stops without further notice.
+
+## Finding out what changed
+
+- Each event page in this catalog has a **Changelog** tab listing every version and the diff between them.
+- Schema files are attached to each event page and are the source of truth — the examples in the docs are illustrative.
+- Breaking changes are announced in `#catalog-announcements` at least two weeks before the new version starts flowing.
+
+## Testing against a new version
+
+Point your consumer at the `catalog-events-preview` topic in the staging environment. It carries the next major version for two weeks before production, so you can validate deserialisation and idempotency handling without risk.

--- a/examples/default/domains/Catalog/docs/guides/_category_.json
+++ b/examples/default/domains/Catalog/docs/guides/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Guides",
+  "position": 1
+}

--- a/examples/default/domains/Catalog/docs/runbooks/00-on-call.mdx
+++ b/examples/default/domains/Catalog/docs/runbooks/00-on-call.mdx
@@ -1,0 +1,34 @@
+---
+title: On-call checklist
+summary: What the Catalog on-call engineer checks at handover and how to triage a page.
+badges:
+  - content: Start here
+    backgroundColor: green
+    textColor: green
+    icon: RocketLaunchIcon
+---
+
+## At handover
+
+1. Open the catalog health dashboard and confirm all four panels are green: API error rate, outbox backlog, indexer lag, search cluster health.
+2. Check `#catalog-support` for anything unresolved from the previous shift.
+3. Confirm `catalog reindex status` reports `idle` — a reindex left running across a handover is the most common surprise.
+
+## Triage
+
+| Page | Start with |
+| --- | --- |
+| `ProductAPI 5xx rate` | [[service\|product-api]] logs; usually a bad deploy — roll back first, investigate second |
+| `Outbox backlog growing` | [[doc\|runbooks/search-index-lag]] |
+| `Search index lag` | [[doc\|runbooks/search-index-lag]] |
+| `Search cluster red` | Page search platform on-call; do not touch indices |
+
+## Escalation
+
+- Anything affecting checkout (customers can't see prices or products) is a **Sev 1** — page the incident commander immediately.
+- Search-only degradation is **Sev 2** — fix within the hour, no incident channel needed unless it persists.
+- [[team|product-platform]] is the owning team; the team lead is the escalation point out of hours.
+
+## Before you sign off
+
+Leave a one-line summary in `#catalog-support` even if nothing happened. The next person will thank you.

--- a/examples/default/domains/Catalog/docs/runbooks/01-search-index-lag.mdx
+++ b/examples/default/domains/Catalog/docs/runbooks/01-search-index-lag.mdx
@@ -1,0 +1,33 @@
+---
+title: Search index lag
+summary: What to do when product changes stop showing up in search results.
+badges:
+  - content: Sev 2
+    backgroundColor: orange
+    textColor: orange
+    icon: ExclamationTriangleIcon
+---
+
+## Symptoms
+
+- Merchandising reports a product they updated minutes ago still shows the old price or name in search.
+- The `search_index_lag_seconds` gauge on the catalog health dashboard is above **120s**.
+- [[event|product-updated]] is being published (visible in the product-api consumer lag panel) but [[container|search-index]] documents are stale.
+
+## Likely causes
+
+1. [[service|search-indexer]] is failing to process events and is retrying. Check its error rate first.
+2. [[service|product-search-publisher]] has fallen behind draining the outbox in [[container|product-database]]. Check the `outbox_backlog` gauge.
+3. The search cluster is rejecting writes (disk pressure or a red index).
+
+## Steps
+
+1. **Confirm which stage is lagging.** Compare `outbox_backlog` (publisher side) with `indexer_consumer_lag` (indexer side). Only one of them is usually the problem.
+2. **If the indexer is failing:** look at its logs for the poison message. Move it to the dead-letter topic with the `catalog-dlq` tool and let the consumer continue. Raise a ticket to fix the underlying mapping bug.
+3. **If the publisher is behind:** it is almost always a database connection limit. Scale [[service|product-search-publisher]] to 2 replicas; it is safe to run in parallel because the outbox rows are claimed with `SELECT … FOR UPDATE SKIP LOCKED`.
+4. **If the cluster is rejecting writes:** page the search platform on-call. Do not delete indices.
+5. Watch `search_index_lag_seconds` recover. If it does not fall below 30s within 10 minutes, escalate.
+
+## If all else fails
+
+Run the [[doc|runbooks/reindexing-products]] runbook. A full reindex is safe but takes ~40 minutes for the current catalog size.

--- a/examples/default/domains/Catalog/docs/runbooks/02-reindexing-products.mdx
+++ b/examples/default/domains/Catalog/docs/runbooks/02-reindexing-products.mdx
@@ -1,0 +1,35 @@
+---
+title: Reindexing products
+summary: Rebuild the search index from the product system of record.
+---
+
+A full reindex replays every product from [[container|product-database]] through [[flow|product-search-indexing]] into a fresh index, then swaps the alias. It is safe to run during business hours: reads continue against the old index until the swap.
+
+## Before you start
+
+- Confirm nobody else is mid-reindex: `catalog reindex status` must report `idle`.
+- Check the search cluster has at least **2×** the current index size free. A reindex builds a second copy before swapping.
+- Post in `#catalog-support` so merchandising know that changes made during the run will be picked up by the swap, not immediately.
+
+## Run it
+
+```bash
+catalog reindex start --source product-database --target search-index
+catalog reindex status --watch
+```
+
+The command streams every product as a [[event|product-updated]]-shaped message onto the indexing topic. [[service|search-indexer]] writes them into `products-<timestamp>`. Progress is reported per 10k products; expect ~40 minutes.
+
+## Swap and verify
+
+When status reports `built`, swap the alias:
+
+```bash
+catalog reindex swap
+```
+
+Then verify with a few known queries through [[query|search-products]]. Spot-check a recently changed product to confirm the new index has it.
+
+## Rollback
+
+The previous index is kept for 24 hours. `catalog reindex rollback` re-points the alias at it. After 24 hours it is deleted automatically.

--- a/examples/default/domains/Catalog/docs/runbooks/_category_.json
+++ b/examples/default/domains/Catalog/docs/runbooks/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Runbooks",
+  "position": 2
+}

--- a/examples/default/domains/Catalog/sidebar.json
+++ b/examples/default/domains/Catalog/sidebar.json
@@ -1,0 +1,53 @@
+{
+  "sections": [
+    {
+      "section": "$quick-reference",
+      "title": "Overview"
+    },
+    {
+      "title": "Guides",
+      "icon": "BookOpen",
+      "pages": [
+        "[[doc|guides/integrating-with-the-catalog]]",
+        "[[doc|guides/product-data-model]]",
+        "[[doc|guides/event-versioning]]"
+      ]
+    },
+    {
+      "title": "Integration Events",
+      "icon": "Radio",
+      "pages": [
+        "[[event|product-created]]",
+        "[[event|product-updated]]",
+        "[[event|product-deleted]]"
+      ]
+    },
+    "$architecture",
+    "$systems",
+    "$entities",
+    {
+      "title": "Runbooks",
+      "icon": "Siren",
+      "pages": [
+        "[[doc|runbooks/on-call]]",
+        "[[doc|runbooks/search-index-lag]]",
+        "[[doc|runbooks/reindexing-products]]",
+        {
+          "title": "Health dashboard",
+          "href": "https://grafana.acme.dev/d/catalog-overview"
+        }
+      ]
+    },
+    {
+      "title": "Decisions",
+      "icon": "ClipboardList",
+      "collapsed": true,
+      "pages": [
+        "[[adr|adr-001-use-transactional-outbox]]",
+        "[[adr|adr-002-postgres-as-system-of-record]]",
+        "[[adr|adr-003-offload-async-work-to-worker]]"
+      ]
+    },
+    "$owners"
+  ]
+}

--- a/examples/default/domains/Catalog/systems/product-catalog-system/services/ProductAPI/events/ProductCreated/sidebar.json
+++ b/examples/default/domains/Catalog/systems/product-catalog-system/services/ProductAPI/events/ProductCreated/sidebar.json
@@ -1,0 +1,14 @@
+{
+  "sections": [
+    { "section": "$quick-reference", "title": "Overview" },
+    "$api-and-contracts",
+    "$producers",
+    "$consumers",
+    {
+      "title": "Related events",
+      "icon": "Radio",
+      "pages": ["[[event|product-updated]]", "[[event|product-deleted]]"]
+    },
+    "$owners"
+  ]
+}

--- a/examples/default/domains/Catalog/systems/product-catalog-system/services/ProductAPI/sidebar.json
+++ b/examples/default/domains/Catalog/systems/product-catalog-system/services/ProductAPI/sidebar.json
@@ -1,0 +1,15 @@
+{
+  "sections": [
+    { "section": "$quick-reference", "title": "Overview" },
+    {
+      "title": "Integrate with this service",
+      "icon": "Plug",
+      "pages": ["[[spec|openapi.yml]]", "[[schema|get-product]]", "[[schema|product-created]]", "[[schema|product-updated]]"]
+    },
+    "$outbound-messages",
+    "$inbound-messages",
+    "$architecture",
+    "$state-and-persistence",
+    "$owners"
+  ]
+}

--- a/examples/default/domains/Customer/docs/guides/01-integrating-with-customers.mdx
+++ b/examples/default/domains/Customer/docs/guides/01-integrating-with-customers.mdx
@@ -1,0 +1,42 @@
+---
+title: Integrating with Customers
+summary: How other teams read customer data and react to customer changes without coupling to the customer database.
+---
+
+The Customer domain is the source of truth for who our customers are. Ordering, payments, reviews and support all need customer data at some point — this guide covers the supported ways to get it.
+
+## Read customer data on demand
+
+Use [[query|get-customer]] on [[service|customer-api]] when you need the current state of a customer at request time (a checkout page, a support screen).
+
+- The response is the customer's **profile** — id, email, name and account status. It never includes credentials.
+- Never query [[container|customer-database]] directly. Its schema is private to [[system|customer-management-system]] and changes without notice.
+- A `404` means the customer does not exist. A `SUSPENDED` or `CLOSED` status is returned as a normal `200` — it is your job to decide what that means for your feature.
+
+## React to customer changes
+
+Subscribe to the domain events published by [[service|customer-api]] when you need to keep a local copy of customer data in sync or trigger downstream work:
+
+| Event | When it fires | What it carries |
+| --- | --- | --- |
+| [[event\|customer-registered]] | A new customer completes registration | The full customer profile |
+| [[event\|customer-updated]] | Any profile attribute changes | `customerId` plus a `changes` object containing only the fields that changed |
+
+Two things to get right when consuming these:
+
+1. **Consumers must be idempotent.** You may see the same event more than once. Use `eventId` as the idempotency key.
+2. **`customer-updated` is a partial.** The `changes` object only contains what changed. Merge it into your copy — do not treat missing fields as cleared.
+
+The `status` value on both events is one of `ACTIVE`, `SUSPENDED` or `CLOSED`. Treat unknown values as "do nothing" so we can add states later without breaking you.
+
+## React to sign-ins
+
+[[event|customer-authenticated]] is published by [[service|oauth-api]] in the [[system|identity-provider]] every time a customer signs in successfully. It carries the `customerId`, the authentication `method` (`PASSWORD`, `SSO` or `MFA`) and the source IP. It is intended for auditing, session tracking and fraud signals — **not** for authorising requests. Verify the access token instead.
+
+## Commands are internal
+
+[[command|register-customer]] and [[command|update-customer]] are only accepted from the storefront and the support tooling owned by [[team|customer-platform]]. [[command|authenticate-customer]] is only called by first-party login flows. If your team needs to change customer data, talk to us in `#customer-support` rather than calling these directly.
+
+## Personal data
+
+Everything in this domain is PII. Keep only the fields you need, respect the retention rules in [[doc|guides/customer-data-model]], and never log an email address or IP address in plain text.

--- a/examples/default/domains/Customer/docs/guides/02-customer-data-model.mdx
+++ b/examples/default/domains/Customer/docs/guides/02-customer-data-model.mdx
@@ -1,0 +1,32 @@
+---
+title: Customer data model
+summary: The entities behind a customer, how profile and identity are kept apart, and which id you should key on.
+---
+
+Four entities make up the Customer domain's model. They split cleanly across the two systems — profile data in the [[system|customer-management-system]], identity data in the [[system|identity-provider]] — and that split is deliberate.
+
+## Customer profile
+
+[[entity|customer-profile]] is the customer as the business sees them: `customerId`, `email`, `displayName` and `status`. It is an aggregate root, stored in [[container|customer-database]] and owned by [[service|customer-api]]. **Key on `customerId`** — it is stable for the life of the customer and is the identifier used on every event and query in this domain. Email is unique but it can change; never use it as a foreign key.
+
+The profile carries personal data and is tagged with a data steward. `email` and `displayName` are the fields returned for subject access requests.
+
+## Customer address
+
+[[entity|customer-address]] is a saved address attached to a profile. A customer has zero or more addresses; each carries an `addressId`, the owning `customerId`, an ISO `countryCode` and a `postalCode`. Addresses exist to support checkout and fulfilment, but they stay owned by this domain — copy the `addressId` onto your order rather than the address itself.
+
+## Customer account
+
+[[entity|customer-account]] is the identity used to authenticate a customer. It lives on the Identity Provider side of the boundary in [[container|user-directory]], links back to a profile through `customerId`, and records the `provider` and account lifecycle `status`. It is an aggregate root for the identity side, and it is **not** something order, payment or review services should ever query. If you think you need it, you almost certainly need the profile instead.
+
+## Authentication session
+
+[[entity|authentication-session]] is a successful sign-in: a `sessionId`, the `accountId` it belongs to, and `authenticatedAt` / `expiresAt` timestamps. It is what a [[event|customer-authenticated]] event describes. Sessions are short-lived and are not a durable record of the customer.
+
+## Why profile and identity are separate
+
+Credentials are the most sensitive thing we hold. Keeping them in a dedicated, regulated-classification store means the Customer Management System never sees a password hash, and a bug in a profile screen cannot leak one. The two systems only meet through `customerId`. The [[system|customer-management-system]] delegates authentication to the [[system|identity-provider]] and never reads the user directory.
+
+## Seeing it visually
+
+The entity diagram on this domain shows the relationships and cardinalities between these four entities, with the fields each one owns. The ubiquitous language page defines the domain terms — customer, identity, credential, account status — used throughout.

--- a/examples/default/domains/Customer/docs/guides/03-account-status-lifecycle.mdx
+++ b/examples/default/domains/Customer/docs/guides/03-account-status-lifecycle.mdx
@@ -1,0 +1,33 @@
+---
+title: Account status lifecycle
+summary: What ACTIVE, SUSPENDED and CLOSED mean, who can move a customer between them, and how each state should be treated downstream.
+---
+
+Every customer profile carries a `status`. It is a small enum, but almost every downstream feature has to make a decision based on it, so the rules are written down here.
+
+## The states
+
+| Status | Meaning | Can sign in? | Can place orders? |
+| --- | --- | --- | --- |
+| `ACTIVE` | The account is in good standing | Yes | Yes |
+| `SUSPENDED` | Temporarily blocked — usually fraud review or a payment dispute | No | No |
+| `CLOSED` | The customer has left or the account was terminated | No | No |
+
+## Transitions
+
+- A customer is always created as `ACTIVE` by [[command|register-customer]].
+- Only [[command|update-customer]] changes the status, and only the support tooling owned by [[team|customer-platform]] is allowed to send it with a `status` field. Storefront profile edits cannot change status.
+- `ACTIVE` ↔ `SUSPENDED` is reversible. `CLOSED` is terminal; a customer who returns registers again and gets a new `customerId`.
+- Every transition publishes [[event|customer-updated]] with `status` inside the `changes` object. That event is the only signal you should rely on — do not poll [[query|get-customer]] looking for changes.
+
+## What downstream teams should do
+
+**On `SUSPENDED`:** stop new activity but keep existing state. Do not cancel in-flight orders or delete saved data; the account may be reinstated within hours.
+
+**On `CLOSED`:** treat it as the start of a data-removal window. Anything you copied from a [[event|customer-registered]] or [[event|customer-updated]] event should be deleted or anonymised inside 30 days, unless you have a legal reason to keep it. The customer's [[entity|customer-address]] records are removed by this domain automatically.
+
+**On an unknown value:** do nothing. We reserve the right to add states, and consumers that fail closed on an unrecognised status have caused incidents before.
+
+## Status and authentication
+
+The [[system|identity-provider]] checks the account status before issuing a token, so a `SUSPENDED` or `CLOSED` customer will fail [[command|authenticate-customer]] with a `401` and no [[event|customer-authenticated]] will be published. There is a short propagation delay between the status change in [[container|customer-database]] and the identity side seeing it — see [[doc|runbooks/customer-events-lag]] if that delay grows.

--- a/examples/default/domains/Customer/docs/guides/_category_.json
+++ b/examples/default/domains/Customer/docs/guides/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Guides",
+  "position": 1
+}

--- a/examples/default/domains/Customer/docs/runbooks/00-on-call.mdx
+++ b/examples/default/domains/Customer/docs/runbooks/00-on-call.mdx
@@ -1,0 +1,36 @@
+---
+title: On-call checklist
+summary: What the Customer on-call engineer checks at handover and how to triage a page.
+badges:
+  - content: Start here
+    backgroundColor: green
+    textColor: green
+    icon: RocketLaunchIcon
+---
+
+## At handover
+
+1. Open the customer health dashboard and confirm all four panels are green: Customer API error rate, OAuth API login success rate, customer event publish lag, database connection pool.
+2. Check `#customer-support` for anything unresolved from the previous shift — in particular any open subject access or account closure requests, which have a legal clock on them.
+3. Confirm no bulk status change is in progress. A support script suspending accounts mid-handover is the most common surprise.
+
+## Triage
+
+| Page | Start with |
+| --- | --- |
+| `CustomerAPI 5xx rate` | [[service\|customer-api]] logs; usually a bad deploy — roll back first, investigate second |
+| `Login success rate < 95%` | [[doc\|runbooks/login-failures]] |
+| `Customer event lag` | [[doc\|runbooks/customer-events-lag]] |
+| `Customer DB pool exhausted` | [[container\|customer-database]] connection panel; scale [[service\|customer-api]] down, not up, until the pool recovers |
+| `User directory unreachable` | Page the identity platform on-call; do not restart [[container\|user-directory]] yourself |
+
+## Escalation
+
+- Customers unable to sign in or register is a **Sev 1** — page the incident commander immediately. Everything downstream of [[system|identity-provider]] stops working with it.
+- Stale profile data downstream (event lag) is **Sev 2** — fix within the hour, no incident channel needed unless it persists.
+- Any suspected exposure of credentials or PII from [[container|user-directory]] or [[container|customer-database]] is a **security incident** regardless of scale. Page security on-call and stop — do not investigate the data yourself.
+- [[team|customer-platform]] is the owning team; the team lead is the escalation point out of hours.
+
+## Before you sign off
+
+Leave a one-line summary in `#customer-support` even if nothing happened. The next person will thank you.

--- a/examples/default/domains/Customer/docs/runbooks/01-login-failures.mdx
+++ b/examples/default/domains/Customer/docs/runbooks/01-login-failures.mdx
@@ -1,0 +1,37 @@
+---
+title: Login failures
+summary: What to do when customers cannot sign in or the login success rate drops.
+badges:
+  - content: Sev 1
+    backgroundColor: red
+    textColor: red
+    icon: ExclamationTriangleIcon
+---
+
+## Symptoms
+
+- The `login_success_rate` panel on the customer health dashboard is below **95%**, or support reports customers stuck on the sign-in page.
+- [[command|authenticate-customer]] is returning `401` for customers who insist their password is correct, or `5xx` for everyone.
+- [[event|customer-authenticated]] volume has dropped sharply while sign-in attempts have not.
+
+## Likely causes
+
+1. [[service|oauth-api]] cannot reach [[container|user-directory]] — a connection limit, a failed migration, or a network policy change.
+2. A bad deploy of [[service|oauth-api]] broke credential verification or token issuing.
+3. A bulk status change has suspended more customers than intended, so the identity check is correctly rejecting them.
+4. Rate limiting is tripping on a legitimate traffic spike (marketing email, sale launch).
+
+## Steps
+
+1. **Separate `401` from `5xx`.** `5xx` means the service or its store is broken — go to step 2. A spike in `401` means the service is working and rejecting on purpose — go to step 4.
+2. **Check user directory connectivity.** Look at the OAuth API connection error rate. If it is elevated, check the [[container|user-directory]] connection panel and recent migrations. Do not restart the directory; page the identity platform on-call if it is unhealthy.
+3. **Check for a recent deploy.** If [[service|oauth-api]] deployed in the last hour, roll back first and investigate second. Verify with a synthetic login against a test account.
+4. **Check for a status change.** Query the customer-updated topic for a burst of `status: SUSPENDED` changes. If a support script has run away, stop it and reinstate accounts with [[command|update-customer]] — every reinstatement publishes a [[event|customer-updated]] event, so downstream systems will catch up on their own.
+5. **Check rate limits.** If sign-in attempts are far above baseline and the rejection reason is `rate_limited`, raise the per-IP limit temporarily and confirm the traffic is not credential stuffing before you do.
+6. Watch `login_success_rate` recover. If it is not back above 95% within 15 minutes, escalate to the incident commander.
+
+## What not to do
+
+- Never bypass credential verification, even temporarily, to "let customers in".
+- Never read credential rows from [[container|user-directory]] while debugging. If you need to prove a credential is wrong, use a test account.
+- Do not change [[service|customer-api]] — profile reads and writes are unaffected by an authentication outage and touching them widens the blast radius.

--- a/examples/default/domains/Customer/docs/runbooks/02-customer-events-lag.mdx
+++ b/examples/default/domains/Customer/docs/runbooks/02-customer-events-lag.mdx
@@ -1,0 +1,34 @@
+---
+title: Customer events lag
+summary: What to do when customer registrations and profile changes stop showing up downstream.
+badges:
+  - content: Sev 2
+    backgroundColor: orange
+    textColor: orange
+    icon: ExclamationTriangleIcon
+---
+
+## Symptoms
+
+- Support reports a customer who updated their email minutes ago still gets order confirmations at the old address.
+- The `customer_event_publish_lag_seconds` gauge on the customer health dashboard is above **60s**.
+- [[query|get-customer]] returns the new profile but consumers of [[event|customer-updated]] have not seen a change.
+- Newly registered customers can sign in but downstream systems have no record of them — [[event|customer-registered]] is not arriving.
+
+## Likely causes
+
+1. [[service|customer-api]] is writing to [[container|customer-database]] but its event publisher is failing or retrying. Check the publish error rate first.
+2. The broker is rejecting writes or a partition is under-replicated. Check broker health before touching the service.
+3. A consumer has fallen behind and is reporting lag that is actually theirs, not ours.
+
+## Steps
+
+1. **Confirm the lag is on our side.** Compare `customer_event_publish_lag_seconds` (publisher) with the consumer group lag of the team reporting the problem. If the publish lag is flat and theirs is growing, the fix is on their side — point them at [[doc|guides/integrating-with-customers]].
+2. **If the publisher is failing:** look at [[service|customer-api]] logs for the failing message. A poison message is usually a profile with a value the schema does not allow. Move it to the dead-letter topic with the `customer-dlq` tool and let the publisher continue. Raise a ticket to fix the validation gap in [[command|update-customer]].
+3. **If the broker is unhealthy:** page the messaging platform on-call. Do not delete or recreate topics; both customer events are replayed from the database and a lost topic means a full republish.
+4. **If it is a database issue:** publish lag often shows up alongside connection pool exhaustion. Scale [[service|customer-api]] down to relieve the pool rather than up.
+5. Watch `customer_event_publish_lag_seconds` recover. If it does not fall below 10s within 10 minutes, escalate.
+
+## Replaying events
+
+If events were lost rather than delayed, [[service|customer-api]] can republish [[event|customer-registered]] and [[event|customer-updated]] for a time window from the database. Republished events keep their original `eventId`, so idempotent consumers are unaffected. Announce the replay in `#customer-support` first — consumers who are not idempotent will see duplicates.

--- a/examples/default/domains/Customer/docs/runbooks/_category_.json
+++ b/examples/default/domains/Customer/docs/runbooks/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Runbooks",
+  "position": 2
+}

--- a/examples/default/domains/Customer/index.mdx
+++ b/examples/default/domains/Customer/index.mdx
@@ -60,8 +60,3 @@ The systems in this domain, how they relate, and the people who interact with th
 
 <ContextDiagram />
 
-## Resource Diagram
-
-The components that make up this domain.
-
-<NodeGraph />

--- a/examples/default/domains/Customer/sidebar.json
+++ b/examples/default/domains/Customer/sidebar.json
@@ -1,0 +1,38 @@
+{
+  "sections": [
+    {
+      "section": "$quick-reference",
+      "title": "Overview"
+    },
+    {
+      "title": "Guides",
+      "icon": "BookOpen",
+      "pages": [
+        "[[doc|guides/integrating-with-customers]]",
+        "[[doc|guides/customer-data-model]]",
+        "[[doc|guides/account-status-lifecycle]]"
+      ]
+    },
+    "$architecture",
+    "$systems",
+    "$entities",
+    {
+      "title": "Runbooks",
+      "icon": "Siren",
+      "pages": [
+        "[[doc|runbooks/on-call]]",
+        "[[doc|runbooks/login-failures]]",
+        "[[doc|runbooks/customer-events-lag]]",
+        {
+          "title": "Health dashboard",
+          "href": "https://grafana.acme.dev/d/customer-overview"
+        },
+        {
+          "title": "Login success rate",
+          "href": "https://grafana.acme.dev/d/customer-logins"
+        }
+      ]
+    },
+    "$owners"
+  ]
+}

--- a/examples/default/domains/Fulfilment/docs/guides/01-integrating-with-fulfilment.mdx
+++ b/examples/default/domains/Fulfilment/docs/guides/01-integrating-with-fulfilment.mdx
@@ -1,0 +1,42 @@
+---
+title: Integrating with Fulfilment
+summary: How to reserve stock, check availability and follow an order from the warehouse to the customer's door.
+---
+
+Fulfilment is where an order stops being data and becomes a parcel. Most teams only ever touch it at two points: reserving stock during checkout, and reacting to shipping progress afterwards. This guide covers both, plus what you should **not** call directly.
+
+## Reserve stock during checkout
+
+Send [[command|reserve-inventory]] to [[service|inventory-service]] before you take payment. The service answers asynchronously with exactly one of:
+
+| Event | Meaning |
+| --- | --- |
+| [[event\|inventory-reserved]] | Stock is held. Carry `reservationId` through the rest of your saga |
+| [[event\|inventory-unavailable]] | Not enough stock. Tell the customer and stop |
+
+A reservation is a temporary hold, not a sale. If your saga fails after the hold — payment declined, customer abandons — send [[command|release-inventory]] with the `reservationId` so the stock goes back on sale. Reservations also expire on their own (see `expiresAt` on [[entity|inventory-reservation]]), but do not rely on that: expiry is a safety net for crashed callers, not a cleanup strategy.
+
+## Check availability on demand
+
+Use [[query|get-stock-level]] when you need a point-in-time number — a product page, an admin screen, a "only 3 left" badge. It returns `available` and `reserved` counts read straight from [[container|inventory-database]].
+
+- The response is a snapshot. Stock can be reserved by someone else between the read and your reservation, so always follow it with a real [[command|reserve-inventory]].
+- Do not query [[container|inventory-database]] or [[container|warehouse-database]] directly. Their schemas belong to [[system|inventory-system]] and [[system|warehouse-system]] and change without notice.
+
+## Follow the order after checkout
+
+Once the Ordering domain publishes [[event|order-completed]], Fulfilment takes over and emits progress events you can subscribe to:
+
+| Event | Published by | Use it to |
+| --- | --- | --- |
+| [[event\|order-packed]] | [[service\|picking-worker]] | Show "being packed" in the customer's order history |
+| [[event\|order-ready-for-shipping]] | [[service\|warehouse-service]] | Internal handoff to [[system\|shipping-system]]; rarely useful outside Fulfilment |
+| [[event\|shipment-created]] | [[service\|carrier-tracking-api]] | Send the tracking number to the customer |
+| [[event\|shipment-delivered]] | [[service\|carrier-tracking-api]] | Close the order, start the returns window |
+| [[event\|shipment-failed]] | [[service\|carrier-tracking-api]] | Trigger redelivery, refund or a support ticket. Check `reason` |
+
+All events are keyed on `orderId`. The carrier events also carry `shipmentId`; an order can have more than one shipment when it is split across parcels, so key your read models on the pair, not `orderId` alone. Carrier events come from an external system and can arrive out of order or twice — consumers must be idempotent.
+
+## Commands that are internal
+
+[[command|create-shipment]] is sent by [[service|carrier-adapter]] to the external [[system|carrier]] and nothing else should call it. If you think you need to create a shipment yourself, you almost certainly want to publish something the [[service|shipping-api]] can react to instead — talk to [[team|fulfilment-platform]] in `#fulfilment-support` first.

--- a/examples/default/domains/Fulfilment/docs/guides/02-fulfilment-data-model.mdx
+++ b/examples/default/domains/Fulfilment/docs/guides/02-fulfilment-data-model.mdx
@@ -1,0 +1,45 @@
+---
+title: Fulfilment data model
+summary: The four entities behind fulfilment, the states they move through, and which identifier to key on.
+---
+
+Fulfilment is modelled as four entities, each owned by one system. They are deliberately small: an order's journey is expressed by moving records between them rather than by one large aggregate.
+
+## Stock item
+
+[[entity|stock-item]] is [[system|inventory-system]]'s record of how many units of a product are physically on hand at a location. It carries `availableQuantity` and, in [[container|inventory-database]], a matching `reserved` count. **Key on `productId` + `locationId`.** Stock is never decremented by a reservation, only by a shipment consuming it — that is what keeps `available + reserved` equal to what is on the shelf.
+
+## Inventory reservation
+
+[[entity|inventory-reservation]] is a temporary hold on one or more stock items for a checkout. It is created by [[command|reserve-inventory]], confirmed by [[event|inventory-reserved]] and keyed on `reservationId`. A reservation moves through three states:
+
+| Status | Meaning |
+| --- | --- |
+| `HELD` | Stock is set aside; the checkout is still in progress |
+| `RELEASED` | [[command\|release-inventory]] was sent, or `expiresAt` passed. Stock is back on sale |
+| `CONSUMED` | The order shipped; the hold became a real decrement |
+
+`orderId` is optional on purpose — a reservation is taken against a `cartId` before the order exists and linked to the order later.
+
+## Warehouse pick
+
+[[entity|warehouse-pick]] is the operational task [[system|warehouse-system]] creates when [[event|order-completed]] arrives. It is keyed on `pickId` and has one line per product. [[service|warehouse-service]] creates it as `CREATED`; [[service|picking-worker]] moves it to `PICKING` as staff work through the lines and to `PACKED` when the last one is boxed, at which point [[event|order-packed]] and then [[event|order-ready-for-shipping]] are published.
+
+`assignedTo` may be a person or an automation lane, so do not assume it is a user id.
+
+## Shipment
+
+[[entity|shipment]] is the [[system|shipping-system]]'s view of a parcel in a carrier's hands. It is keyed on `shipmentId` and created when [[command|create-shipment]] is accepted. From there its `status` is driven entirely by the external [[system|carrier]]: [[event|shipment-created]] adds the `carrierReference` (the tracking number customers see), and [[event|shipment-delivered]] or [[event|shipment-failed]] close it out.
+
+One order can produce several shipments if it is split into parcels, which is why the carrier events carry both `shipmentId` and `orderId`.
+
+## Which id do I use?
+
+| If you are... | Key on |
+| --- | --- |
+| Reserving or releasing stock | `reservationId` |
+| Showing availability | `productId` |
+| Tracking an order's progress | `orderId` (plus `shipmentId` for carrier events) |
+| Talking to a carrier | `carrierReference` |
+
+The entity diagram on this domain shows the relationships between these four entities and the `order` and `product` entities they reference from other domains.

--- a/examples/default/domains/Fulfilment/docs/guides/03-order-lifecycle.mdx
+++ b/examples/default/domains/Fulfilment/docs/guides/03-order-lifecycle.mdx
@@ -1,0 +1,34 @@
+---
+title: From order to doorstep
+summary: How the four fulfilment systems hand an order between them, and where each handoff can go wrong.
+---
+
+Fulfilment is a relay between four systems. Three are internal and owned by [[team|fulfilment-platform]]; the fourth is an external carrier. Each system reacts to a message from the one before it and publishes a message for the one after.
+
+## 1. Inventory holds the stock
+
+This step happens during checkout, before the order exists. The Ordering domain sends [[command|reserve-inventory]] to [[service|inventory-service]], which checks [[container|inventory-database]] and replies with [[event|inventory-reserved]] or [[event|inventory-unavailable]]. Nothing physical moves yet, but from this point the stock cannot be sold to anyone else.
+
+## 2. Warehouse picks and packs
+
+When Ordering publishes [[event|order-completed]], [[service|warehouse-service]] creates a [[entity|warehouse-pick]] in [[container|warehouse-database]]. [[service|picking-worker]] works the pick on the warehouse floor, updating each line as it is picked. When the last item is boxed it publishes [[event|order-packed]], and the warehouse service follows with [[event|order-ready-for-shipping]], which carries the shipping address and parcel count the next system needs.
+
+## 3. Shipping picks a carrier
+
+[[service|shipping-api]] consumes [[event|order-ready-for-shipping]], chooses a carrier and service level (`STANDARD`, `EXPRESS` or `NEXT_DAY`) based on the destination and the customer's delivery option, and hands off to [[service|carrier-adapter]]. The adapter is an anti-corruption layer: it translates our shipment request into the carrier's format and sends [[command|create-shipment]] to the external [[service|carrier-shipping-api]]. Keeping the translation in one service means a change of carrier never leaks into the rest of the domain.
+
+## 4. The carrier delivers and reports back
+
+From here the [[system|carrier]] is in control. Its [[service|carrier-tracking-api]] publishes [[event|shipment-created]] once the parcel is dispatched, then either [[event|shipment-delivered]] or [[event|shipment-failed]]. The [[entity|shipment]] record in the shipping system is updated from these events; it is our copy of the carrier's truth, not the other way round.
+
+## Where it goes wrong
+
+| Handoff | Typical failure | Where to look |
+| --- | --- | --- |
+| Checkout → Inventory | Reservations never released, stock looks sold out | [[service\|inventory-service]] `reservations` table, `HELD` rows older than `expiresAt` |
+| Ordering → Warehouse | Order completed but no pick created | [[service\|warehouse-service]] consumer lag on `order-completed` |
+| Warehouse → Shipping | Order packed but never shipped | [[doc\|runbooks/shipments-not-dispatching]] |
+| Shipping → Carrier | `create-shipment` rejected with 400 or 422 | [[service\|carrier-adapter]] logs; usually an address the carrier will not accept |
+| Carrier → us | Tracking events stop arriving | Carrier status page, then [[service\|carrier-tracking-api]] webhook delivery logs |
+
+The [[doc|runbooks/on-call]] checklist lists the dashboards that watch each handoff.

--- a/examples/default/domains/Fulfilment/docs/guides/_category_.json
+++ b/examples/default/domains/Fulfilment/docs/guides/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Guides",
+  "position": 1
+}

--- a/examples/default/domains/Fulfilment/docs/runbooks/00-on-call.mdx
+++ b/examples/default/domains/Fulfilment/docs/runbooks/00-on-call.mdx
@@ -1,0 +1,36 @@
+---
+title: On-call checklist
+summary: What the Fulfilment on-call engineer checks at handover and how to triage a page.
+badges:
+  - content: Start here
+    backgroundColor: green
+    textColor: green
+    icon: RocketLaunchIcon
+---
+
+## At handover
+
+1. Open the fulfilment health dashboard and confirm all five panels are green: reservation error rate, `HELD` reservations past expiry, picking backlog, shipments awaiting dispatch, carrier webhook lag.
+2. Check `#fulfilment-support` for anything unresolved from the previous shift, and `#warehouse-ops` for anything the floor team has flagged.
+3. Confirm the carrier status page is clear. A carrier outage is the most common cause of a quiet-looking dashboard that is actually broken — nothing fails, events just stop.
+
+## Triage
+
+| Page | Start with |
+| --- | --- |
+| `InventoryService reserve 5xx` | [[service\|inventory-service]] logs and [[container\|inventory-database]] connection count; usually a bad deploy — roll back first |
+| `Expired HELD reservations > 500` | The expiry sweeper has stalled. Restart it, then confirm `RELEASED` rows are being written |
+| `Picking backlog > 200 jobs` | Ask `#warehouse-ops` before touching anything — it is usually a physical problem, not a software one |
+| `Shipments awaiting dispatch > 50` | [[doc\|runbooks/shipments-not-dispatching]] |
+| `Carrier webhook lag > 30m` | Carrier status page, then [[service\|carrier-tracking-api]] webhook delivery logs |
+
+## Escalation
+
+- Anything that stops checkout reserving stock is a **Sev 1** — customers cannot buy. Page the incident commander immediately.
+- Orders packed but not shipping is a **Sev 2** if it has been under two hours; it becomes a **Sev 1** if any `NEXT_DAY` shipment will miss its carrier cut-off.
+- Missing carrier tracking events are a **Sev 3** unless [[event|shipment-failed]] is also missing, in which case refunds and redeliveries are silently not happening — treat as **Sev 2**.
+- [[team|fulfilment-platform]] is the owning team; the team lead is the escalation point out of hours. For warehouse floor issues escalate to the warehouse shift manager, not engineering.
+
+## Before you sign off
+
+Leave a one-line summary in `#fulfilment-support` even if nothing happened, and note any shipments you manually re-dispatched so the next person does not re-dispatch them again.

--- a/examples/default/domains/Fulfilment/docs/runbooks/01-shipments-not-dispatching.mdx
+++ b/examples/default/domains/Fulfilment/docs/runbooks/01-shipments-not-dispatching.mdx
@@ -1,0 +1,36 @@
+---
+title: Shipments not dispatching
+summary: What to do when orders are packed but no shipment is being created with the carrier.
+badges:
+  - content: Sev 2
+    backgroundColor: orange
+    textColor: orange
+    icon: ExclamationTriangleIcon
+---
+
+## Symptoms
+
+- The `shipments_awaiting_dispatch` gauge on the fulfilment health dashboard is above **50**, or climbing steadily.
+- [[event|order-ready-for-shipping]] is being published (visible on the [[service|warehouse-service]] producer panel) but no matching [[event|shipment-created]] arrives from [[service|carrier-tracking-api]].
+- Warehouse staff report parcels piling up at the dispatch bay with no labels.
+
+## Likely causes
+
+1. [[service|shipping-api]] has stopped consuming. Check its consumer lag on the `order-ready-for-shipping` topic first.
+2. [[service|carrier-adapter]] is receiving 4xx responses from [[service|carrier-shipping-api]] and retrying. A `422` means the carrier rejected the address or service level; a `400` almost always means a mapping bug after a carrier API change.
+3. The carrier itself is down or rate-limiting us. Check their status page before assuming it is our fault.
+4. A single poison message — most often an address with a non-ISO `country` code — is blocking the partition.
+
+## Steps
+
+1. **Find the stage that is stuck.** Compare [[service|shipping-api]] consumer lag with the [[service|carrier-adapter]] outbound error rate. Only one of them is usually the problem.
+2. **If the shipping API is lagging:** restart it. It is stateless and safe to run with 2 replicas; each [[entity|shipment]] is keyed on `orderId` so a replayed event is a no-op.
+3. **If the adapter is seeing 422s:** pull the rejected [[command|create-shipment]] payloads from its logs. Fix bad addresses in the order admin tool and re-emit; do not edit the carrier request by hand.
+4. **If the adapter is seeing 400s:** the carrier changed their contract. Roll the adapter back to the previous release and raise a ticket — this is not fixable on call.
+5. **If there is a poison message:** move it to the dead-letter topic with the `fulfilment-dlq` tool so the partition drains, then deal with that one order manually.
+6. **If the carrier is down:** nothing to fix on our side. Post an update in `#warehouse-ops` with the expected recovery time so the floor team can plan, and watch the backlog drain when the carrier recovers — the adapter retries with backoff and will catch up on its own.
+7. Watch `shipments_awaiting_dispatch` recover. If it is not falling within 15 minutes of your fix, escalate.
+
+## Afterwards
+
+Check whether any `NEXT_DAY` shipments missed the carrier cut-off during the outage. Customer support will need the list of affected `orderId`s to proactively contact those customers.

--- a/examples/default/domains/Fulfilment/docs/runbooks/_category_.json
+++ b/examples/default/domains/Fulfilment/docs/runbooks/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Runbooks",
+  "position": 2
+}

--- a/examples/default/domains/Fulfilment/sidebar.json
+++ b/examples/default/domains/Fulfilment/sidebar.json
@@ -1,0 +1,46 @@
+{
+  "sections": [
+    {
+      "section": "$quick-reference",
+      "title": "Overview"
+    },
+    {
+      "title": "Guides",
+      "icon": "BookOpen",
+      "pages": [
+        "[[doc|guides/integrating-with-fulfilment]]",
+        "[[doc|guides/fulfilment-data-model]]",
+        "[[doc|guides/order-lifecycle]]"
+      ]
+    },
+    {
+      "title": "Integration Events",
+      "icon": "Radio",
+      "pages": [
+        "[[event|shipment-created]]",
+        "[[event|shipment-delivered]]",
+        "[[event|shipment-failed]]"
+      ]
+    },
+    "$architecture",
+    "$systems",
+    "$entities",
+    {
+      "title": "Runbooks",
+      "icon": "Siren",
+      "pages": [
+        "[[doc|runbooks/on-call]]",
+        "[[doc|runbooks/shipments-not-dispatching]]",
+        {
+          "title": "Health dashboard",
+          "href": "https://grafana.acme.dev/d/fulfilment-overview"
+        },
+        {
+          "title": "Carrier status page",
+          "href": "https://status.carrier.example.com"
+        }
+      ]
+    },
+    "$owners"
+  ]
+}

--- a/examples/default/domains/Ordering/docs/guides/01-integrating-with-ordering.mdx
+++ b/examples/default/domains/Ordering/docs/guides/01-integrating-with-ordering.mdx
@@ -1,0 +1,42 @@
+---
+title: Integrating with Ordering
+summary: How other teams look up orders and react to the order lifecycle without coupling to the order database or the checkout saga.
+---
+
+The Ordering domain owns every order at Acme from the moment a cart is checked out until the order is archived. Fulfilment, payments, customer communications and reporting all integrate with it. This guide covers the supported ways in — and the ones that are off limits.
+
+## Read an order on demand
+
+Call [[query|get-order]] on [[service|order-service]] when you need the current state of a single order at request time (an order-status page, a support tool, a returns flow).
+
+- The response is the live state of the [[entity|order]] aggregate, read straight from [[container|order-database]]. There is no edge cache.
+- Never connect to [[container|order-database]] directly. Its schema is private to [[system|order-management-system]], it is classified confidential, and it changes without notice.
+- There is no "list orders" query today. If you need a bulk view, build a projection from the events below rather than polling `GetOrder`.
+
+## React to the order lifecycle
+
+Subscribe to the events published by [[service|order-service]] on the `ordering.orders` Kafka topic. Pick the most specific event that answers your question:
+
+| I want to know when… | Subscribe to |
+| --- | --- |
+| an order exists and I can start work | [[event\|order-created]] |
+| payment and inventory are secured and it is safe to fulfil | [[event\|order-confirmed]] |
+| the warehouse has started picking | [[event\|order-fulfilment-started]] |
+| the order is done, or gone | [[event\|order-completed]], [[event\|order-cancelled]] |
+| the delivery address changed before dispatch | [[event\|order-delivery-address-changed]] |
+| an order was paused or resumed for review | [[event\|order-placed-on-hold]], [[event\|order-hold-released]] |
+| *any* state transition happened | [[event\|order-status-changed]] |
+
+Prefer the business events over [[event|order-status-changed]] — it exists for generic timelines, search and analytics, not as a substitute for the specific events. See [[doc|guides/order-lifecycle]] for the full state machine.
+
+Events are delivered at-least-once. Consumers **must be idempotent**: key on `orderId` plus the event's `sequence` (on `OrderStatusChanged`) or its timestamp, and treat a replay as a no-op. Do not assume ordering across partitions — an [[event|order-cancelled]] can occasionally arrive before the [[event|order-created]] it relates to during a rebalance.
+
+## Schemas and contracts
+
+Every event has a JSON Schema published alongside it, and the whole event interface is described in the Order Service AsyncAPI document linked from the sidebar. [[event|order-created]] is on version `1.0.0`; older versions (`0.3.0`, `0.6.0`) are still documented so you can see what changed, but new consumers should not target them.
+
+## Commands are internal
+
+[[command|create-order]] is only ever sent by [[service|checkout-orchestrator]] as the final step of the [[flow|checkout-saga]]. [[command|reserve-inventory]] and [[command|authorize-payment]] are likewise orchestrator-only. If your team needs to create orders through a new channel, talk to [[team|ordering-platform]] in `#ordering-support` — we will extend the saga rather than let a second writer bypass it.
+
+[[command|cancel-order]] is the one command other teams may call, and only for orders that have not completed. Cancellation is documented end to end in [[flow|order-cancellation]].

--- a/examples/default/domains/Ordering/docs/guides/02-order-lifecycle.mdx
+++ b/examples/default/domains/Ordering/docs/guides/02-order-lifecycle.mdx
@@ -1,0 +1,52 @@
+---
+title: Order lifecycle
+summary: The order state machine — every status, which event announces each transition, and what consumers should do at each step.
+---
+
+An [[entity|order]] moves through a fixed set of statuses. Each accepted transition is persisted by [[service|order-service]] in [[container|order-database]], recorded as an [[entity|order-status-history]] row, and announced with a business event plus a generic [[event|order-status-changed]].
+
+## Statuses
+
+| Status | Meaning |
+| --- | --- |
+| `CREATED` | The [[flow\|checkout-saga]] finished and [[command\|create-order]] was accepted. Announced by [[event\|order-created]]. |
+| `CONFIRMED` | Validation passed and the payment authorization and stock reservation are secured. Announced by [[event\|order-confirmed]]. |
+| `ON_HOLD` | Progress is paused for a payment, fraud, address or inventory review. Announced by [[event\|order-placed-on-hold]]; leaving it is announced by [[event\|order-hold-released]]. |
+| `AWAITING_FULFILMENT` | Ready for the warehouse but not yet released. Only [[event\|order-status-changed]] is published for this step. |
+| `FULFILLING` | Released to a fulfilment location for picking and packing. Announced by [[event\|order-fulfilment-started]]. |
+| `COMPLETED` | Fully fulfilled. Terminal. Announced by [[event\|order-completed]]. |
+| `CANCELLED` | Cancelled by the customer or by a failed downstream step. Terminal. Announced by [[event\|order-cancelled]]. |
+| `ARCHIVED` | A terminal order moved out of operational storage. Announced by [[event\|order-archived]]. |
+
+## Allowed transitions
+
+```
+CREATED ──► CONFIRMED ──► AWAITING_FULFILMENT ──► FULFILLING ──► COMPLETED ──► ARCHIVED
+   │            │                  │                                              ▲
+   │            └──► ON_HOLD ◄─────┘   (hold released → back to previous status)  │
+   │                                                                              │
+   └──────────────────────► CANCELLED ────────────────────────────────────────────┘
+```
+
+- Cancellation is only accepted while the order is `CREATED`. Anything later must go through returns. The full decision path is in [[flow|order-cancellation]].
+- A hold always returns the order to the status it left. `ON_HOLD` is never terminal; every [[event|order-placed-on-hold]] carries a `reviewBy` deadline and an `ownerTeam` so operational tooling can escalate it.
+- `COMPLETED` and `CANCELLED` are terminal. The only transition out of either is to `ARCHIVED`, which happens on a retention schedule, not on demand.
+
+## Amendments
+
+Two events change an order *without* changing its status:
+
+- [[event|order-amended]] — a quantity adjustment, delivery method change or promotional correction, accepted only before fulfilment begins.
+- [[event|order-delivery-address-changed]] — a new validated delivery destination, accepted only before dispatch.
+
+Both carry a `revision` so a consumer can drop an update that is older than the one it has already applied. Consumers that hold their own copy of the order (fulfilment, customer communications) must handle these; consumers that only care about the outcome can ignore them.
+
+## Keying and ordering guarantees
+
+- `orderId` is the identifier on every event and is stable for the life of the order.
+- `sequence` on [[event|order-status-changed]] is monotonic per order. If you need to rebuild a timeline, sort by it rather than by `changedAt`.
+- Events for a single order are produced in order, but partitioning is by `orderId`, so there is no ordering guarantee *across* orders.
+
+## Seeing it in practice
+
+The [[flow|place-an-order]] flow walks the happy path from checkout to `CREATED`, including the compensation branch when a checkout step fails. The order's status history is available via [[query|get-order]].

--- a/examples/default/domains/Ordering/docs/guides/03-checkout-saga-and-compensation.mdx
+++ b/examples/default/domains/Ordering/docs/guides/03-checkout-saga-and-compensation.mdx
@@ -1,0 +1,37 @@
+---
+title: Checkout saga and compensation
+summary: How checkout is coordinated across inventory, payments and order management, and what it means for the teams on the other end of each step.
+---
+
+Checkout at Acme is not a single transaction. It spans stock, money and the order record, each owned by a different team. The [[service|checkout-orchestrator]] coordinates them as a **saga**: an ordered list of steps where every step has a compensating action that undoes it if a later step fails. This guide explains the contract each step's owner is signing up to.
+
+## The steps
+
+When the [[domain|shopping]] domain checks out a cart, [[service|checkout-api]] validates the request and opens a [[entity|checkout-session]]. The orchestrator then runs the [[flow|checkout-saga]]:
+
+| Step | Command | Compensating action |
+| --- | --- | --- |
+| 1. Reserve inventory | [[command\|reserve-inventory]] | Release the reservation |
+| 2. Authorize payment | [[command\|authorize-payment]] | Void the authorization |
+| 3. Create the order | [[command\|create-order]] | None — this is the pivot; once it succeeds the saga cannot be undone, only cancelled |
+
+Step 3 hands the `paymentAuthorizationId` to [[service|order-service]], which persists the [[entity|order]] and publishes [[event|order-created]]. Funds are captured later, once the order moves to `CONFIRMED`.
+
+## What a failure looks like
+
+If step 1 fails (out of stock) the saga aborts immediately — nothing to compensate. If step 2 fails (declined) the orchestrator releases the reservation and aborts. In both cases **no order is created** and no order event is published. The customer sees a checkout error in the Shopping domain, not a cancelled order.
+
+The one exception is a failure *after* the pivot: if `CreateOrder` succeeds but a downstream check rejects the order, the orchestrator issues [[command|cancel-order]] and the order goes through [[flow|order-cancellation]] with reason `PAYMENT_FAILED` or `OUT_OF_STOCK`. Consumers of [[event|order-cancelled]] should treat these reasons as "unwind whatever you did for `order-created`".
+
+## Contract for step owners
+
+If your service handles one of the saga commands, the orchestrator relies on the following:
+
+1. **Idempotency.** Commands are retried on timeout. `ReserveInventory` and `AuthorizePayment` both carry the `checkoutSessionId`; a repeat call for the same session must return the original result, not create a second reservation or hold.
+2. **A definitive answer.** Return the documented status codes — `409` for a conflict, `402` for a declined payment — rather than a generic `500`. The orchestrator only compensates on a definitive failure; a `500` is retried, which is why a slow payment provider shows up as a stuck session rather than a failed checkout.
+3. **Compensation is always safe to call.** Releasing a reservation that already expired, or voiding an authorization that was never captured, must succeed. The orchestrator will call compensations more than once during recovery.
+4. **Timeouts are yours to enforce.** Reservations and authorizations must expire on their own. The orchestrator will try to release them, but a crash between steps means you cannot rely on it.
+
+## Timing
+
+A healthy saga completes in under two seconds. The `checkout_saga_duration_seconds` histogram on the Ordering health dashboard tracks it; anything over 30 seconds is a session that is probably stuck, and [[doc|runbooks/stuck-checkout-sessions]] covers what to do about it.

--- a/examples/default/domains/Ordering/docs/guides/_category_.json
+++ b/examples/default/domains/Ordering/docs/guides/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Guides",
+  "position": 1
+}

--- a/examples/default/domains/Ordering/docs/runbooks/00-on-call.mdx
+++ b/examples/default/domains/Ordering/docs/runbooks/00-on-call.mdx
@@ -1,0 +1,43 @@
+---
+title: On-call checklist
+summary: What the Ordering on-call engineer checks at handover, how to triage a page, and when to escalate.
+badges:
+  - content: Start here
+    backgroundColor: green
+    textColor: green
+    icon: RocketLaunchIcon
+---
+
+## At handover
+
+1. Open the Ordering health dashboard and confirm the five panels are green: Checkout API error rate, saga success rate, saga p99 duration, Order Service consumer lag, orders on hold past `reviewBy`.
+2. Check `#ordering-support` for anything unresolved from the previous shift.
+3. Confirm `ordering saga list --stuck` returns nothing. A session left half-compensated across a handover is the most common surprise.
+4. Glance at the orders-on-hold panel. Anything past its `reviewBy` deadline is someone else's queue, but you own chasing it.
+
+## Triage
+
+| Page | Start with |
+| --- | --- |
+| `CheckoutAPI 5xx rate` | [[service\|checkout-api]] logs; usually a bad deploy — roll back first, investigate second |
+| `Saga success rate < 99%` | Split by failing step on the dashboard. Step 1 is inventory, step 2 is payments — page that team. Step 3 is us: check [[service\|order-service]] |
+| `Saga p99 duration > 30s` | [[doc\|runbooks/stuck-checkout-sessions]] |
+| `OrderService consumer lag` | [[service\|order-service]] is behind on `ordering.commands`. Check [[container\|order-database]] connection pool saturation before scaling |
+| `Orders on hold past reviewBy` | Not an incident. Post the `holdId`s and `ownerTeam` from [[event\|order-placed-on-hold]] in `#ordering-support` and ping the owning team |
+| `OrderDatabase disk > 85%` | Confirm the archival job that publishes [[event\|order-archived]] has run this week; if it has, page the database platform on-call |
+
+## Escalation
+
+- Customers unable to check out, or orders created without a payment authorization, is a **Sev 1** — page the incident commander immediately and stop any deploy in progress.
+- Sagas failing at a single downstream step (inventory or payments) is a **Sev 2** owned by that team; we stay on the bridge because customers see it as a checkout failure.
+- Delayed lifecycle events (fulfilment starting late, confirmations arriving late) are **Sev 3** unless the lag exceeds 15 minutes.
+- [[team|ordering-platform]] is the owning team; the team lead is the escalation point out of hours.
+
+## Things not to do
+
+- Do not replay `ordering.commands` from an offset. [[command|create-order]] is not idempotent on `cartId` today; a replay creates duplicate orders.
+- Do not edit rows in [[container|order-database]] to "fix" a status. Statuses only change through [[service|order-service]] so that [[event|order-status-changed]] and the [[entity|order-status-history]] audit trail stay consistent.
+
+## Before you sign off
+
+Leave a one-line summary in `#ordering-support` even if nothing happened, and note any sessions you compensated by hand.

--- a/examples/default/domains/Ordering/docs/runbooks/01-stuck-checkout-sessions.mdx
+++ b/examples/default/domains/Ordering/docs/runbooks/01-stuck-checkout-sessions.mdx
@@ -1,0 +1,38 @@
+---
+title: Stuck checkout sessions
+summary: What to do when checkout sagas stop completing — customers see a spinner, and no order is created.
+badges:
+  - content: Sev 2
+    backgroundColor: orange
+    textColor: orange
+    icon: ExclamationTriangleIcon
+---
+
+## Symptoms
+
+- The `checkout_saga_duration_seconds` p99 on the Ordering health dashboard is above **30s**.
+- `ordering saga list --stuck` returns sessions whose [[entity|checkout-session]] status has been `RESERVING` or `AUTHORIZING` for more than a minute.
+- Shopping report customers pressing "Place order" and seeing a spinner or a timeout, with no confirmation email.
+- [[event|order-created]] volume drops on the dashboard while [[service|checkout-api]] request volume does not.
+
+## Likely causes
+
+1. A downstream step is timing out rather than failing. [[command|authorize-payment]] returning `500` (or nothing) is retried indefinitely; a declined `402` would have failed fast. The payment provider is the usual culprit.
+2. [[command|reserve-inventory]] is slow because the inventory service is under load — typically during a promotion.
+3. [[service|checkout-orchestrator]] itself has crashed mid-saga and the recovery loop is not picking sessions back up. Check its restart count.
+4. [[service|order-service]] is rejecting [[command|create-order]] with `409` for a `cartId` it has already seen, so the saga loops on the pivot step.
+
+## Steps
+
+1. **Find the stuck step.** Run `ordering saga list --stuck` and group by `currentStep`. It is almost always one step, and that tells you whose problem it is.
+2. **If stuck on `AUTHORIZING`:** check the payment provider status page and page the payments on-call. Do not void authorizations by hand yet — the orchestrator will compensate once the step returns a definitive answer.
+3. **If stuck on `RESERVING`:** page the inventory on-call. Reservations expire on their own, so a stuck session here is recoverable without manual cleanup.
+4. **If the orchestrator has restarted:** run `ordering saga resume --all`. Recovery replays compensations, which are safe to repeat (see [[doc|guides/checkout-saga-and-compensation]]).
+5. **If stuck on `CREATING_ORDER` with `409`s:** look up the order by `cartId` in [[service|order-service]] logs. If an order already exists, mark the session complete with `ordering saga complete <sessionId> --order <orderId>`. If not, the conflict is on `paymentAuthorizationId` and the session must be aborted: `ordering saga abort <sessionId>`, which releases the reservation and voids the authorization.
+6. Watch the p99 recover. If it is not below 5s within 10 minutes of the downstream fix, escalate to Sev 1 — customers cannot check out.
+
+## After the incident
+
+- Sessions aborted in step 5 produced no [[event|order-created]], so there is nothing to unwind downstream. Confirm that with a count of `checkout_session_aborted` against the dashboard.
+- Any session that was manually completed will have published [[event|order-created]] later than the order's `createdAt`. Warn the fulfilment team in `#ordering-support` so they are not surprised by an out-of-order [[event|order-confirmed]].
+- Open a ticket for the failing step's owner. A `500` that should have been a `402` or `409` is a bug in their contract, not ours.

--- a/examples/default/domains/Ordering/docs/runbooks/_category_.json
+++ b/examples/default/domains/Ordering/docs/runbooks/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Runbooks",
+  "position": 2
+}

--- a/examples/default/domains/Ordering/sidebar.json
+++ b/examples/default/domains/Ordering/sidebar.json
@@ -1,0 +1,48 @@
+{
+  "sections": [
+    {
+      "section": "$quick-reference",
+      "title": "Overview"
+    },
+    {
+      "title": "Guides",
+      "icon": "BookOpen",
+      "pages": [
+        "[[doc|guides/integrating-with-ordering]]",
+        "[[doc|guides/order-lifecycle]]",
+        "[[doc|guides/checkout-saga-and-compensation]]"
+      ]
+    },
+    {
+      "title": "Integration Events",
+      "icon": "Radio",
+      "pages": [
+        "[[event|order-created]]",
+        "[[event|order-confirmed]]",
+        "[[event|order-completed]]",
+        "[[event|order-cancelled]]"
+      ]
+    },
+    "$architecture",
+    "$systems",
+    "$flows",
+    "$entities",
+    {
+      "title": "Runbooks",
+      "icon": "Siren",
+      "pages": [
+        "[[doc|runbooks/on-call]]",
+        "[[doc|runbooks/stuck-checkout-sessions]]",
+        {
+          "title": "Health dashboard",
+          "href": "https://grafana.acme.dev/d/ordering-overview"
+        },
+        {
+          "title": "Saga dashboard",
+          "href": "https://grafana.acme.dev/d/ordering-checkout-saga"
+        }
+      ]
+    },
+    "$owners"
+  ]
+}

--- a/examples/default/domains/Payments/docs/guides/01-reacting-to-payment-events.mdx
+++ b/examples/default/domains/Payments/docs/guides/01-reacting-to-payment-events.mdx
@@ -1,0 +1,37 @@
+---
+title: Reacting to payment events
+summary: How other teams find out whether an order was paid, refunded or blocked, without calling Stripe or touching the payment database.
+---
+
+The Payments domain is event-only. There is no query API for "has this order been paid?" — the answer arrives on Kafka, and every team that cares (ordering, fulfilment, notifications, finance) subscribes to the same events. This guide covers which events to subscribe to and the rules for consuming them.
+
+## The lifecycle in three stages
+
+Everything starts when the Ordering domain sends [[command|authorize-payment]] to [[service|payment-api]]. From there the [[service|payment-worker]] publishes a request, the external providers respond, and the worker records the result in [[container|payment-database]].
+
+| Stage | Event | Published by |
+| --- | --- | --- |
+| Request | [[event\|payment-requested]] | [[service\|payment-worker]] |
+| Fraud verdict | [[event\|fraud-check-passed]] / [[event\|fraud-check-failed]] | [[service\|fraud-api]] |
+| Outcome | [[event\|payment-succeeded]] / [[event\|payment-failed]] | [[service\|stripe-webhook-endpoint]] |
+| Refund | [[event\|refund-requested]] then [[event\|refund-processed]] | [[service\|payment-worker]], then Stripe |
+
+## Which event should you subscribe to?
+
+- **"Ship the order"** — [[event|payment-succeeded]]. Money has moved; this is the only event that means it.
+- **"Tell the customer it didn't work"** — [[event|payment-failed]]. The `reason` enum (`CARD_DECLINED`, `INSUFFICIENT_FUNDS`, `EXPIRED_CARD`, `PROCESSING_ERROR`) is safe to surface to customers; do not invent friendlier text per code.
+- **"The money went back"** — [[event|refund-processed]]. Finance keys ledger entries on `refundId`, not `paymentId`, because one payment can have several partial refunds.
+- **"Was it fraud?"** — [[event|fraud-check-failed]]. Only the Payments and Ordering domains should act on this; see [[doc|guides/payment-and-fraud-model]] before you build on it.
+
+[[event|payment-requested]] is an internal handshake between [[system|payment-processing-system]], [[system|stripe]] and [[system|fraud-detection]]. Do not treat it as "payment in progress" for customer-facing state — it can be followed by a failure seconds later.
+
+## Consumer rules
+
+1. **Be idempotent.** Stripe retries webhooks, and the outcomes topic ([[channel|payments.outcomes]]) is at-least-once. Use `paymentId` (or `refundId`) plus the event name as your idempotency key.
+2. **Do not assume ordering across topics.** A [[event|fraud-check-failed]] can arrive after a [[event|payment-succeeded]] for the same payment. The [[entity|payment]] aggregate in the payment database is the tie-breaker; if you need a consistent view, build a small read model rather than reasoning from a single event.
+3. **Amounts are integers in minor units.** `amount: 1999` with `currency: GBP` is £19.99. Never convert to floats.
+4. **Never read [[container|payment-database]] directly.** It is classified confidential and its schema is private to [[system|payment-processing-system]].
+
+## Getting access
+
+Topic ACLs are granted per consumer group. Ask in `#payments-support` with your group name and which of the events above you need; [[team|payments-platform]] approves within a working day.

--- a/examples/default/domains/Payments/docs/guides/02-payment-and-fraud-model.mdx
+++ b/examples/default/domains/Payments/docs/guides/02-payment-and-fraud-model.mdx
@@ -1,0 +1,41 @@
+---
+title: Payment and fraud model
+summary: The four entities behind a payment, how they relate, and how a fraud verdict changes what a payment is allowed to do.
+---
+
+Four entities make up the Payments model. [[entity|payment]] is the aggregate root and the only one most teams need to think about; the others exist so every decision about money is auditable.
+
+## Payment
+
+[[entity|payment]] is Acme's record of intent and outcome for one order. It carries `paymentId`, the `orderId` it pays for, the `amount` and a `status` that moves through `REQUESTED` → `SUCCEEDED` or `FAILED`. **Key on `paymentId`** — it is stable regardless of how many times Stripe retries a webhook or in which order events arrive. Exactly one payment exists per order; a retried card attempt is the same payment moving from `FAILED` back to `REQUESTED`, not a new one.
+
+## Payment authorization
+
+[[entity|payment-authorization]] links Acme's payment to the provider's view of it. It records the `providerReference` Stripe issued and when the hold was granted. It is written when [[command|authorize-payment]] is handled by [[service|payment-api]] and is what the [[service|payment-worker]] uses to correlate a [[event|payment-succeeded]] or [[event|payment-failed]] back to the right payment. If you are reconciling against Stripe reports, this is the join key.
+
+## Refund
+
+[[entity|refund]] is a second aggregate root, owned by Payments but keyed on its own `refundId`. A payment can have many refunds (partial refunds are common), each with its own `status` of `REQUESTED`, `PROCESSED` or `FAILED`. A refund starts with [[event|refund-requested]] and completes with [[event|refund-processed]]. The sum of processed refunds can never exceed the payment amount — the worker rejects the request before it reaches Stripe.
+
+## Fraud check
+
+[[entity|fraud-check]] records the verdict from [[system|fraud-detection]]. The `result` is `passed`, `failed` or `review`, with a `score` between 0 and 1 attached to the event.
+
+| Result | Event | What Payments does |
+| --- | --- | --- |
+| `passed` | [[event\|fraud-check-passed]] | Nothing — the charge continues |
+| `failed` | [[event\|fraud-check-failed]] | Blocks the charge and the order is cancelled |
+| `review` | _(no event)_ | Holds the payment for a human decision |
+
+`review` verdicts are the ones to know about. They never produce an event; the payment sits in `REQUESTED` until an analyst resolves it, which is why [[doc|runbooks/fraud-review-backlog]] exists. A payment in review can still receive a [[event|payment-succeeded]] from Stripe — the charge and the screen run in parallel — and if the review later fails, the worker issues a refund automatically.
+
+## How they hang together
+
+```
+Order ──paysFor── Payment ──belongsTo── PaymentAuthorization
+                    │
+                    ├──refunds──── Refund (0..n)
+                    └──screens──── FraudCheck (1)
+```
+
+The entity diagram on this domain page shows the same relationships with the fields each entity owns. Everything here is persisted in [[container|payment-database]] and retained for seven years.

--- a/examples/default/domains/Payments/docs/guides/03-pci-what-you-must-never-log.mdx
+++ b/examples/default/domains/Payments/docs/guides/03-pci-what-you-must-never-log.mdx
@@ -1,0 +1,41 @@
+---
+title: "PCI: what you must never log"
+summary: The data-handling rules every consumer of payment events must follow to keep Acme's PCI-DSS scope where it is.
+badges:
+  - content: Compliance
+    backgroundColor: red
+    textColor: red
+    icon: ShieldCheckIcon
+---
+
+Acme is PCI-DSS assessed with a deliberately small scope: card data is only ever handled by [[system|stripe]]. Nothing in [[system|payment-processing-system]] stores, transmits or logs a card number, and the events in this domain are designed so consumers cannot accidentally widen that scope. This guide is the short version of the rules; the assessor's evidence pack lives with [[team|payments-platform]].
+
+## What is on the events
+
+Every event in this domain carries only opaque identifiers and amounts. Take [[event|payment-succeeded]]: `paymentId`, `orderId`, an integer `amount` and `currency`, Stripe's `processorReference` and a timestamp. No PAN, no expiry, no CVV, no cardholder name. If you ever see a field that looks like card data on a payment event, that is an incident — page Payments immediately and do not forward the message.
+
+## Never log
+
+| Data | Where it could leak from | Rule |
+| --- | --- | --- |
+| Card numbers, expiry, CVV | Stripe SDK responses, browser payloads | Never present in our systems; if you find one, it is a Sev 1 |
+| `processorReference` | [[event\|payment-succeeded]] | Allowed in structured logs, **never** in customer-facing text or URLs |
+| `customerId` + `amount` together | [[event\|payment-requested]] | Fine in traces; do not export to analytics tools outside the EU |
+| Fraud `score` and `reason` | [[event\|fraud-check-failed]] | Internal only — never show a customer why they were declined for fraud |
+| Raw webhook bodies | [[service\|stripe-webhook-endpoint]] | Only the Payments ingress may persist them; 30-day retention |
+
+Note the difference between a **decline** ([[event|payment-failed]] with `CARD_DECLINED`) and a **fraud block** ([[event|fraud-check-failed]]). The first is safe to explain to the customer. The second is not: telling someone their payment was blocked for `VELOCITY` teaches fraudsters how the screen works.
+
+## Where data may live
+
+- [[container|payment-database]] is classified **confidential**, resident in `eu-west-1`, retained for seven years. It is the only approved store for payment and refund records.
+- Consumers may keep a local read model of payment *status* keyed by `paymentId` or `orderId`. Do not copy amounts into systems that are not in scope for SOC2.
+- Do not put `paymentId` in URLs that end up in browser history or referrer headers. Use `orderId` for customer-facing links.
+
+## Access to Stripe
+
+Nobody outside Payments has Stripe dashboard access, and that is intentional. If you need to look up a charge, ask in `#payments-support` with the `paymentId`; the on-call will look it up via [[service|stripe-payments-api]] and paste back the status, not the raw record.
+
+## If you are unsure
+
+Ask before you log. A question in `#payments-support` costs a minute; a PCI scope change costs the company a re-assessment.

--- a/examples/default/domains/Payments/docs/guides/_category_.json
+++ b/examples/default/domains/Payments/docs/guides/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Guides",
+  "position": 1
+}

--- a/examples/default/domains/Payments/docs/runbooks/01-payments-stuck-in-requested.mdx
+++ b/examples/default/domains/Payments/docs/runbooks/01-payments-stuck-in-requested.mdx
@@ -1,0 +1,37 @@
+---
+title: Payments stuck in REQUESTED
+summary: What to do when charges are being requested but Stripe outcomes stop arriving and orders pile up unpaid.
+badges:
+  - content: Sev 1
+    backgroundColor: red
+    textColor: red
+    icon: ExclamationTriangleIcon
+---
+
+## Symptoms
+
+- The `payments_requested_age_p95_seconds` gauge on the payments health dashboard is above **300s**.
+- Ordering reports orders sitting in "awaiting payment" for more than five minutes.
+- [[event|payment-requested]] is being published at the normal rate, but [[event|payment-succeeded]] and [[event|payment-failed]] have dropped to near zero on [[channel|payments.outcomes]].
+
+This is a **Sev 1**: customers are being charged (or will be) without Acme recording it. Open an incident channel before you start.
+
+## Likely causes
+
+1. Stripe's [[service|stripe-webhook-endpoint]] is delivering but our ingress is rejecting the calls — almost always a rotated webhook signing secret after a deploy.
+2. Stripe is degraded. Check the Stripe status page before touching anything.
+3. [[service|payment-worker]] is consuming outcomes but failing to write them, so the payment stays `REQUESTED` in [[container|payment-database]].
+4. Charges are never reaching Stripe: [[service|stripe-payments-api]] is returning 4xx to the worker.
+
+## Steps
+
+1. **Find where the outcomes stop.** Compare the Stripe dashboard's "webhook delivery failures" with the `webhook_ingress_4xx` panel. If Stripe shows failed deliveries, it is cause 1.
+2. **If the signing secret is wrong:** roll back the last [[service|payment-worker]] deploy. The secret is injected at deploy time; rolling back restores the previous one. Then ask Stripe to replay failed webhooks from the dashboard — they are idempotent on our side.
+3. **If Stripe is degraded:** do nothing to the pipeline. Post the Stripe incident link in the channel and let requests queue. The worker will pick outcomes up when delivery resumes.
+4. **If the worker is failing writes:** check its logs for `payment-database` connection errors. Scale the worker down to one replica; if the database is at its connection limit, it is usually [[service|payment-api]] holding idle connections — restart it.
+5. **If charges never reach Stripe:** look at the worker's `stripe_request_errors` by status. A 401 is an expired API key (rotate it from the Payments vault); a 429 means we are being rate limited — reduce worker concurrency to 4.
+6. Watch `payments_requested_age_p95_seconds` fall. Payments that were charged while we were blind will resolve as their replayed webhooks arrive.
+
+## After recovery
+
+Run the reconciliation job (`payments reconcile --since <incident start>`). It lists every [[entity|payment]] that is still `REQUESTED` but has a matching charge in Stripe, and moves it to `SUCCEEDED` so the order can proceed. Review the list before confirming — do not bulk-approve. Never mark a payment `SUCCEEDED` by hand in the database.

--- a/examples/default/domains/Payments/docs/runbooks/02-fraud-review-backlog.mdx
+++ b/examples/default/domains/Payments/docs/runbooks/02-fraud-review-backlog.mdx
@@ -1,0 +1,35 @@
+---
+title: Fraud review backlog
+summary: Clearing a growing queue of payments held in manual fraud review, and what to do if the fraud provider stops responding.
+badges:
+  - content: Sev 2
+    backgroundColor: orange
+    textColor: orange
+    icon: ExclamationTriangleIcon
+---
+
+## Symptoms
+
+- The `fraud_review_queue_size` gauge on the payments health dashboard is above **200**, or the oldest item is older than **4 hours**.
+- Customer support reports orders "stuck processing" with no decline email sent.
+- [[event|fraud-check-passed]] and [[event|fraud-check-failed]] volumes have dropped while [[event|payment-requested]] volume is normal.
+
+A payment in review is held in `REQUESTED` and never produces an event (see [[doc|guides/payment-and-fraud-model]]), so nothing downstream can tell the difference between "in review" and "lost". That is why this queue needs watching.
+
+## Likely causes
+
+1. A rule change at [[system|fraud-detection]] pushed a much larger share of payments into `review`. Check the `fraud_verdict_ratio` panel — a step change in the `review` line is the giveaway.
+2. The [[service|fraud-api]] is timing out, and the worker's fallback for a missing verdict is `review`. Check its latency panel.
+3. The analyst tooling that resolves reviews is down or nobody is on shift (weekends, bank holidays).
+
+## Steps
+
+1. **Confirm whether verdicts are arriving at all.** If the fraud-api p99 is above 5s or its error rate is above 2%, treat it as cause 2 and page the fraud provider through their support portal. Do not change our timeout to compensate.
+2. **If a rule change is the cause:** ask the provider to roll it back. In the meantime the on-call may lower the review threshold to `0.85` in the worker config — this is approved only for payments under £250 and must be reverted within 24 hours.
+3. **If the queue is simply unstaffed:** post in `#fraud-ops` and pull in a second analyst. The queue is ordered oldest first; ask them to work from the top.
+4. **Do not auto-approve.** Nobody, including [[team|payments-platform]], has approval to bulk-pass reviews. A held payment that has already received [[event|payment-succeeded]] will be refunded automatically if the review later fails, so holding is always safe; passing is not.
+5. Watch `fraud_review_queue_size` fall. Escalate if the oldest item is older than 8 hours — at that point the Ordering domain starts cancelling orders and customers get a decline with no explanation.
+
+## If the provider is completely down
+
+Keep charging. The screen and the charge run in parallel by design; a missing verdict holds the payment but does not stop the charge. Every payment in the backlog will be resolved when verdicts resume. Note the outage window in the incident channel so the [[entity|fraud-check]] records can be backfilled afterwards.

--- a/examples/default/domains/Payments/docs/runbooks/_category_.json
+++ b/examples/default/domains/Payments/docs/runbooks/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Runbooks",
+  "position": 2
+}

--- a/examples/default/domains/Payments/sidebar.json
+++ b/examples/default/domains/Payments/sidebar.json
@@ -1,0 +1,46 @@
+{
+  "sections": [
+    {
+      "section": "$quick-reference",
+      "title": "Overview"
+    },
+    {
+      "title": "Guides",
+      "icon": "BookOpen",
+      "pages": [
+        "[[doc|guides/reacting-to-payment-events]]",
+        "[[doc|guides/payment-and-fraud-model]]",
+        "[[doc|guides/pci-what-you-must-never-log]]"
+      ]
+    },
+    {
+      "title": "Integration Events",
+      "icon": "Radio",
+      "pages": [
+        "[[event|payment-succeeded]]",
+        "[[event|payment-failed]]",
+        "[[event|refund-processed]]"
+      ]
+    },
+    "$architecture",
+    "$systems",
+    "$entities",
+    {
+      "title": "Runbooks",
+      "icon": "Siren",
+      "pages": [
+        "[[doc|runbooks/payments-stuck-in-requested]]",
+        "[[doc|runbooks/fraud-review-backlog]]",
+        {
+          "title": "Health dashboard",
+          "href": "https://grafana.acme.dev/d/payments-overview"
+        },
+        {
+          "title": "Stripe status",
+          "href": "https://status.stripe.com"
+        }
+      ]
+    },
+    "$owners"
+  ]
+}

--- a/examples/default/domains/Reviews/docs/guides/01-integrating-with-reviews.mdx
+++ b/examples/default/domains/Reviews/docs/guides/01-integrating-with-reviews.mdx
@@ -1,0 +1,39 @@
+---
+title: Integrating with Reviews
+summary: How other teams show ratings and reviews on their surfaces, and react to review activity without coupling to our data stores.
+---
+
+The Reviews & Ratings domain owns everything a customer says about a product after they have bought it. Storefront, search, merchandising and the mobile apps all consume it. This guide covers the three supported ways to integrate; anything else is a conversation in `#reviews-support` first.
+
+## Read reviews and ratings on demand
+
+Call [[query|get-product-reviews]] on [[service|review-api]] when you need reviews for a product detail page or a comparison screen. The response carries the **published** reviews for the product plus its current aggregate rating (average score and count).
+
+- Only reviews in the `published` state are returned. Submitted and rejected reviews are never exposed, so you don't need to filter by status yourself.
+- The aggregate rating comes from [[container|rating-cache]] and is eventually consistent — see [[doc|guides/rating-aggregation]] for what "eventually" means in practice.
+- Never read [[container|review-database]] directly. Its schema is private to [[team|reviews-platform]] and the moderation columns in particular change without notice.
+
+## React to review activity
+
+Subscribe to the domain events when you need to keep a local read model in sync or trigger downstream work. The contracts are described in the AsyncAPI document on this domain page and each event has a JSON schema attached.
+
+| Event | When it fires | Typical consumer |
+| --- | --- | --- |
+| [[event\|rating-updated]] | A product's aggregate rating changed | Search ranking, product listing cards |
+| [[event\|review-published]] | A review passed moderation and is now visible | Notifications ("your review is live"), analytics |
+| [[event\|review-rejected]] | A review failed moderation | Customer comms, fraud tooling |
+| [[event\|review-helpful-voted]] | A customer marked a review as helpful | Personalisation |
+
+[[event|review-submitted]] and [[event|review-flagged]] are **internal** to the domain. They carry unmoderated content and exist only to drive [[service|review-moderation-worker]]; do not subscribe to them from outside [[team|reviews-platform]].
+
+All events are published to Kafka and may be delivered more than once. Use the `reviewId` on review events, and the `productId` + `updatedAt` pair on [[event|rating-updated]], as your idempotency key.
+
+## Submit, vote and flag
+
+Customer-facing surfaces send three commands to [[service|review-api]]:
+
+- [[command|submit-review]] — creates a review in the `submitted` state. It will not be visible until moderation completes; tell the customer that.
+- [[command|vote-review-helpful]] — records one helpful vote per customer per review. Repeat votes are idempotent, not additive.
+- [[command|flag-review]] — reports a published review for re-moderation. This is a customer action, not a moderation tool; it queues the review for another screen rather than hiding it immediately.
+
+The request shapes are in the OpenAPI document attached to this domain. Commands must be sent with the customer's session token — we reject anonymous submissions at the edge.

--- a/examples/default/domains/Reviews/docs/guides/02-moderation-lifecycle.mdx
+++ b/examples/default/domains/Reviews/docs/guides/02-moderation-lifecycle.mdx
@@ -1,0 +1,46 @@
+---
+title: Moderation lifecycle
+summary: How a review moves from submitted to published or rejected, what the automated screen checks, and when a human gets involved.
+badges:
+  - content: Core concept
+    backgroundColor: purple
+    textColor: purple
+    icon: ShieldCheckIcon
+---
+
+Every review passes through moderation before a customer can see it. This guide explains the lifecycle so that teams building on top of reviews know what state a review can be in, and why.
+
+## States
+
+A [[entity|review]] has exactly three lifecycle states, and they only move forward:
+
+| State | Set by | Visible on storefront |
+| --- | --- | --- |
+| `submitted` | [[service\|review-api]] on [[command\|submit-review]] | No |
+| `published` | [[service\|review-moderation-worker]] on approval | Yes |
+| `rejected` | [[service\|review-moderation-worker]] on rejection | No — kept for audit only |
+
+A rejected review is never deleted and never resurrected. If a customer wants to try again they submit a new review, which starts the lifecycle from scratch.
+
+## The screen
+
+[[service|review-moderation-worker]] consumes [[event|review-submitted]] and runs the review through an automated screen. The end-to-end journey is drawn out in [[flow|review-submission]]. In order, the checks are:
+
+1. **Spam classification** — templated text, links, repeated submissions from one account.
+2. **Language policy** — prohibited or abusive language scored against a threshold.
+3. **Duplicate detection** — the same customer reviewing the same product twice.
+4. **Authenticity** — reviewer-risk signals such as account age and purchase history.
+
+Each check produces a confidence score. A review that clears every check with high confidence is published automatically; verified-purchase reviews and reviewers on the trusted fast-track policy clear faster. A review that clearly fails any check is rejected automatically.
+
+## The human queue
+
+Anything in between — a borderline score, or a check that could not run — lands in the manual moderation queue. A moderator approves or rejects it from the moderation console, and the worker publishes the outcome exactly as it would for an automated decision. Our target is a decision within **5 minutes** of submission for the automated path and **24 hours** for the manual queue. If the queue is growing rather than draining, follow [[doc|runbooks/moderation-queue-stuck]].
+
+## Recording the outcome
+
+Whatever the path, the worker writes a [[entity|moderation-decision]] to [[container|review-database]] alongside the review, then publishes [[event|review-published]] or [[event|review-rejected]]. The decision records the outcome and the reason it was reached, so we can answer "why was my review rejected?" and audit the classifier over time.
+
+## Re-moderation
+
+Publication is not the end. When a customer sends [[command|flag-review]], [[service|review-api]] records a [[entity|review-flag]] and publishes [[event|review-flagged]]. The worker picks the review up again and re-runs the screen with the flag reason as an extra signal. A review that fails on re-screen moves to `rejected` and a [[event|review-rejected]] is published — downstream consumers must handle a rejection for a review they have previously seen published. Its contribution to the product rating is removed on the next aggregation.

--- a/examples/default/domains/Reviews/docs/guides/03-rating-aggregation.mdx
+++ b/examples/default/domains/Reviews/docs/guides/03-rating-aggregation.mdx
@@ -1,0 +1,35 @@
+---
+title: Rating aggregation
+summary: How a product's star rating is calculated, where it is served from, and what to expect when it is out of date.
+---
+
+The star rating shown on a product card is a derived value. It is not stored on the review, and it is not the responsibility of whoever renders it. This guide explains how it is produced so consumers can reason about its freshness.
+
+## What is aggregated
+
+For each product, [[service|rating-aggregator]] maintains a [[entity|rating-summary]]: the average rating, the number of reviews behind it, and the time it was last recalculated. Only reviews in the `published` state count. A review that is later rejected on re-moderation is removed from the average the next time the product is recalculated.
+
+Helpful votes recorded by [[command|vote-review-helpful]] do **not** affect the rating. They order reviews within a product; they never weight the score.
+
+## How it is kept up to date
+
+1. [[service|review-moderation-worker]] publishes [[event|review-published]].
+2. [[service|rating-aggregator]] consumes it, reads every published review for that product from [[container|review-database]], and recomputes the summary from scratch. We recompute rather than increment so a replayed event can never double-count.
+3. The summary is written to [[container|rating-cache]] and [[event|rating-updated]] is published with the new value.
+
+Because the aggregator recomputes from the database on every event, it is safe to replay [[event|review-published]] from any offset. That is also how we rebuild the cache — see the "Rebuilding the rating cache" section of [[doc|runbooks/on-call]].
+
+## Where it is served from
+
+[[service|review-api]] reads the summary from [[container|rating-cache]] when serving [[query|get-product-reviews]]. The cache is Redis, transient, and explicitly not authoritative:
+
+- If a product has no entry in the cache, the API returns a rating of `null` with a count of `0`. Render "No reviews yet"; do not treat it as zero stars.
+- Entries are never expired by TTL. They are only overwritten by the aggregator or dropped during a rebuild.
+
+## Consistency expectations
+
+The path from a review being published to the new rating being served is asynchronous. Under normal load it completes in well under a second; during a moderation backlog or a cache rebuild it can lag by minutes. Consumers should:
+
+- Treat [[event|rating-updated]] as the signal that a rating changed, and re-read via [[query|get-product-reviews]] rather than trusting a locally cached value indefinitely.
+- Avoid deriving their own average from the review list. The list is paginated and moderation state can change between pages; the summary is the only figure that is guaranteed to be internally consistent.
+- Expect the count in [[event|rating-updated]] to occasionally go **down** — that is a review being withdrawn after a flag, not a bug.

--- a/examples/default/domains/Reviews/docs/guides/_category_.json
+++ b/examples/default/domains/Reviews/docs/guides/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Guides",
+  "position": 1
+}

--- a/examples/default/domains/Reviews/docs/runbooks/00-on-call.mdx
+++ b/examples/default/domains/Reviews/docs/runbooks/00-on-call.mdx
@@ -1,0 +1,46 @@
+---
+title: On-call checklist
+summary: What the Reviews on-call engineer checks at handover, how to triage a page, and how to rebuild the rating cache safely.
+badges:
+  - content: Start here
+    backgroundColor: green
+    textColor: green
+    icon: RocketLaunchIcon
+---
+
+## At handover
+
+1. Open the reviews health dashboard and confirm the four headline panels are green: API error rate, moderation queue depth, moderation consumer lag, aggregator consumer lag.
+2. Check `#reviews-support` for anything unresolved from the previous shift — moderation questions from Trust & Safety usually land there first.
+3. Confirm no rating cache rebuild is in progress (`reviews ratings rebuild status` should report `idle`).
+
+## Triage
+
+| Page | Start with |
+| --- | --- |
+| `ReviewAPI 5xx rate` | [[service\|review-api]] logs; almost always a bad deploy — roll back first, investigate second |
+| `Moderation queue depth` | [[doc\|runbooks/moderation-queue-stuck]] |
+| `Moderation consumer lag` | [[doc\|runbooks/moderation-queue-stuck]] |
+| `Aggregator consumer lag` | [[service\|rating-aggregator]] logs; check [[container\|review-database]] connection count before scaling |
+| `Rating cache unavailable` | Redis on-call owns the cluster; the API degrades to `null` ratings, so this is Sev 3 unless it persists |
+
+## Rebuilding the rating cache
+
+[[container|rating-cache]] is a derived read model and can be thrown away. If ratings are wrong for many products (not just stale for a few), rebuild it:
+
+1. Announce in `#reviews-support`. Product cards will show "No reviews yet" for the affected products while the rebuild runs.
+2. Run `reviews ratings rebuild --all`. This flushes the cache and replays [[event|review-published]] from the earliest retained offset through [[service|rating-aggregator]].
+3. Watch `rating_cache_fill_ratio` climb back to 100%. For the current review volume this takes about 15 minutes.
+4. Spot-check a handful of high-traffic products via [[query|get-product-reviews]] and confirm [[event|rating-updated]] is flowing again.
+
+Do not rebuild while a moderation backlog is draining — the aggregator will be competing with itself and both will be slow.
+
+## Escalation
+
+- Reviews are never on the checkout path, so the highest severity we own alone is **Sev 2**: reviews or ratings missing from the storefront for more than 30 minutes.
+- Abusive content visible on the storefront is a **Sev 2** regardless of volume. Reject it through the moderation console immediately, then investigate why the screen let it through.
+- [[team|reviews-platform]] is the owning team; the team lead is the escalation point out of hours. Trust & Safety are paged separately for policy questions, not for engineering incidents.
+
+## Before you sign off
+
+Leave a one-line summary in `#reviews-support` even if nothing happened, including the current moderation queue depth.

--- a/examples/default/domains/Reviews/docs/runbooks/01-moderation-queue-stuck.mdx
+++ b/examples/default/domains/Reviews/docs/runbooks/01-moderation-queue-stuck.mdx
@@ -1,0 +1,40 @@
+---
+title: Moderation queue stuck
+summary: What to do when submitted reviews stop being published or rejected and the moderation backlog grows.
+badges:
+  - content: Sev 2
+    backgroundColor: orange
+    textColor: orange
+    icon: ExclamationTriangleIcon
+---
+
+## Symptoms
+
+- Customers report a review they submitted hours ago still says "awaiting moderation".
+- The `moderation_queue_depth` gauge on the reviews health dashboard is climbing rather than oscillating.
+- [[event|review-submitted]] is being published at the normal rate, but [[event|review-published]] and [[event|review-rejected]] have dropped to near zero.
+- The count of [[entity|review]] rows in the `submitted` state in [[container|review-database]] keeps growing.
+
+## Likely causes
+
+1. [[service|review-moderation-worker]] is crash-looping on a poison message. Look for the same `reviewId` at the top of the logs on every restart.
+2. The classifier the worker calls for the spam and language checks is timing out. The worker retries with backoff, so throughput collapses long before the error rate looks alarming.
+3. The manual queue is full but nobody is working it — the automated screen is fine, and the backlog is entirely reviews waiting for a human.
+4. The worker has lost its database connection pool and is failing to write the [[entity|moderation-decision]] row, so it cannot acknowledge anything.
+
+## Steps
+
+1. **Work out which stage is stuck.** Compare `moderation_consumer_lag` (the worker is not keeping up with Kafka) with `moderation_manual_queue_depth` (the worker is fine, humans are the bottleneck). They point at different fixes.
+2. **If the manual queue is the problem:** this is not an engineering incident. Post the queue depth in `#reviews-support` and page the Trust & Safety duty moderator. Do not bulk-approve to clear it.
+3. **If the worker is crash-looping:** find the poison `reviewId` in the logs, move that message to the dead-letter topic with `reviews-dlq park <reviewId>`, and let the consumer continue. Raise a ticket to fix the underlying bug — it is usually an unexpected character set in the review body.
+4. **If the classifier is timing out:** the worker's circuit breaker should have opened; check that it has. If it has, reviews are being routed to the manual queue as designed and will drain once the classifier recovers. If it has not, restart the worker to reset the breaker state.
+5. **If the database pool is exhausted:** check the connection count on [[container|review-database]]. [[service|review-api]] and [[service|rating-aggregator]] share the instance; the aggregator is the usual culprit after a cache rebuild. Scale [[service|review-moderation-worker]] down to 1 replica until the count recovers, then back up.
+6. Watch `moderation_queue_depth` fall. Automated decisions should resume within a couple of minutes of the fix; if the queue is not visibly draining after 10 minutes, escalate to the team lead.
+
+## Flagged reviews
+
+[[event|review-flagged]] shares the same consumer, so a stuck worker also stops re-moderation. Once the backlog is cleared, check the `review_flag` table for flags older than the outage window and confirm each has a corresponding [[entity|moderation-decision]]. Any that do not can be re-queued with `reviews-dlq replay --flags-since <timestamp>`.
+
+## Afterwards
+
+Once published events resume, [[service|rating-aggregator]] will catch up on its own — expect a burst of [[event|rating-updated]] and a short spike in `aggregator_consumer_lag`. That is normal and does not need a cache rebuild.

--- a/examples/default/domains/Reviews/docs/runbooks/_category_.json
+++ b/examples/default/domains/Reviews/docs/runbooks/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Runbooks",
+  "position": 2
+}

--- a/examples/default/domains/Reviews/sidebar.json
+++ b/examples/default/domains/Reviews/sidebar.json
@@ -1,0 +1,38 @@
+{
+  "sections": [
+    {
+      "section": "$quick-reference",
+      "title": "Overview"
+    },
+    {
+      "title": "Guides",
+      "icon": "BookOpen",
+      "pages": [
+        "[[doc|guides/integrating-with-reviews]]",
+        "[[doc|guides/moderation-lifecycle]]",
+        "[[doc|guides/rating-aggregation]]"
+      ]
+    },
+    "$architecture",
+    "$services",
+    "$flows",
+    "$entities",
+    {
+      "title": "Runbooks",
+      "icon": "Siren",
+      "pages": [
+        "[[doc|runbooks/on-call]]",
+        "[[doc|runbooks/moderation-queue-stuck]]",
+        {
+          "title": "Health dashboard",
+          "href": "https://grafana.acme.dev/d/reviews-overview"
+        },
+        {
+          "title": "Moderation queue dashboard",
+          "href": "https://grafana.acme.dev/d/reviews-moderation"
+        }
+      ]
+    },
+    "$owners"
+  ]
+}

--- a/examples/default/domains/Shopping/docs/guides/01-integrating-with-shopping.mdx
+++ b/examples/default/domains/Shopping/docs/guides/01-integrating-with-shopping.mdx
@@ -1,0 +1,35 @@
+---
+title: Integrating with Shopping
+summary: Which cart commands other teams may call, which ones are internal, and how to react to a checkout.
+---
+
+The Shopping domain owns the customer's path to purchase — the cart and the discounts applied to it. Storefronts, mobile apps and checkout-adjacent teams all integrate with it in one of two ways: by sending commands to [[service|cart-api]], or by subscribing to the events it publishes. This guide covers both, and is explicit about what you should **not** call.
+
+## Commands you can call
+
+[[service|cart-api]] is the front door to [[system|cart-system]]. It accepts three commands from any authenticated client. All three are synchronous HTTP calls and are safe to retry.
+
+| Command | What it does | Retry behaviour |
+| --- | --- | --- |
+| [[command\|add-item-to-cart]] | Adds a product to the cart, or increases its quantity if it is already there | Idempotent per `cartId` + `productId` + `quantity` |
+| [[command\|remove-item-from-cart]] | Removes a product line from the cart | Idempotent; removing a missing line returns `404`, not an error you need to handle |
+| [[command\|checkout-cart]] | Prices the cart, applies discounts and commits the purchase | **Idempotent per `cartId`** — a second checkout returns `409` and does not publish a second event |
+
+Always pass the customer's `promotionCode` on [[command|checkout-cart]] rather than trying to price the cart yourself. Pricing is done once, at checkout, by the Cart API.
+
+## Commands that are internal
+
+[[command|calculate-discount]] is sent by [[service|cart-api]] to [[service|promotion-service]] over the [[channel|shopping.discount-commands]] channel. It is **not** a public API. If you call it directly you will get a discount figure that has not been reconciled against the cart, and it will not be reflected in the final `total` at checkout.
+
+If you need to show an *estimated* discount before checkout (a "you could save £5" banner), talk to [[team|shopping-platform]] in `#shopping-support` — we would rather expose a supported preview endpoint than have teams depend on an internal command.
+
+## Events you can subscribe to
+
+| Event | When it fires | Typical consumer |
+| --- | --- | --- |
+| [[event\|cart-checked-out]] | A customer has committed to buy; the cart is priced and final | Orders, payments, fulfilment, analytics |
+| [[event\|discount-calculated]] | A discount has been evaluated for a cart | Promotion analytics, fraud, finance reconciliation |
+
+[[event|cart-checked-out]] is the event most teams care about. It carries the full line items, `subtotal`, `discount` and `total` (all in minor units) so you never need to re-query the cart. Treat `cartId` as the idempotency key: the Cart API guarantees at-least-once delivery, so you may see the same checkout twice.
+
+Do not read from [[container|cart-database]] or [[container|promotion-database]] directly. Their schemas are private to the owning systems and change without notice.

--- a/examples/default/domains/Shopping/docs/guides/02-cart-and-promotion-model.mdx
+++ b/examples/default/domains/Shopping/docs/guides/02-cart-and-promotion-model.mdx
@@ -1,0 +1,45 @@
+---
+title: Cart and promotion model
+summary: The four entities behind a purchase, how they relate, and which identifiers to key on.
+---
+
+Four entities make up the Shopping domain. Two belong to [[system|cart-system]] and two to [[system|promotion-system]]. They are deliberately kept apart so promotion logic can change without touching cart persistence.
+
+## Cart
+
+[[entity|cart]] is the aggregate root of the Cart System. It carries the `cartId`, an optional `customerId` (guest carts have none until login), a `currency` and a `status`. **Key on `cartId`** — it is the identifier on every command and on [[event|cart-checked-out]].
+
+A cart moves through three states:
+
+| Status | Meaning |
+| --- | --- |
+| `OPEN` | The customer is still adding and removing items |
+| `CHECKED_OUT` | [[command\|checkout-cart]] succeeded; the cart is immutable from here on |
+| `ABANDONED` | No activity for the retention window; the cart is pruned and cannot be revived |
+
+Carts are transient. Once checked out, the order — not the cart — is the long-lived record. Do not build reporting on cart rows.
+
+## Cart item
+
+[[entity|cart-item]] is a single product line inside a cart: a `productId`, a `quantity` and the `unitPrice` captured when the item was added. The Cart System does **not** re-price items on every read; the unit price is snapshotted at add time and re-validated only at checkout. This is why an item added yesterday may show a different price at checkout.
+
+There is one cart item per `productId` per cart. Adding the same product twice increases `quantity` rather than creating a second line.
+
+## Promotion
+
+[[entity|promotion]] is the aggregate root of the Promotion System and lives in [[container|promotion-database]]. A promotion has a unique `code`, a `type` (`PERCENTAGE` or `FIXED_AMOUNT`), a `value`, a validity window (`startsAt` / `endsAt`) and a set of eligibility rules — currently a minimum spend and an optional customer segment.
+
+Promotions are managed by the merchandising tools owned by [[team|shopping-platform]]. Nothing in the domain's public API creates or edits them.
+
+## Discount
+
+[[entity|discount]] is the *result* of evaluating promotions against a specific cart. It is produced by [[command|calculate-discount]], carried on [[event|discount-calculated]], and folded into the `discount` and `total` fields of [[event|cart-checked-out]].
+
+A discount is never stored against the cart. It is recalculated every time the cart is priced, which means:
+
+- A promotion that expires between "add to cart" and "checkout" will simply not apply.
+- The `appliedPromotions` list on [[event|discount-calculated]] is the only record of *which* promotion produced a discount — persist it if you need it for reconciliation.
+
+## Money
+
+Every monetary field in this domain — `unitPrice`, `subtotal`, `discount`, `total`, promotion `value` — is an **integer in minor units** (pence, cents). Never send or expect decimals.

--- a/examples/default/domains/Shopping/docs/guides/03-how-discounts-are-calculated.mdx
+++ b/examples/default/domains/Shopping/docs/guides/03-how-discounts-are-calculated.mdx
@@ -1,0 +1,35 @@
+---
+title: How discounts are calculated
+summary: What happens between a customer entering a promotion code and the discount appearing on their total.
+---
+
+Discounts are calculated exactly once per pricing pass, inside [[service|promotion-service]]. This guide walks through that pass so you can reason about why a cart got the discount it did — or didn't.
+
+## The request
+
+When [[service|cart-api]] handles [[command|checkout-cart]], it sends a [[command|calculate-discount]] request over [[channel|shopping.discount-commands]]. The request carries only what the Promotion Service needs to evaluate rules:
+
+- `cartId` and, if known, `customerId`
+- `subtotal` in minor units
+- `currency`
+- the optional `promotionCode` the customer entered
+
+The Promotion Service never sees the line items. Item-level promotions ("20% off shoes") are on the roadmap but are not supported today; if you need them, talk to [[team|shopping-platform]] first.
+
+## Evaluation order
+
+1. **Look up the code.** If a `promotionCode` was supplied, [[service|promotion-service]] loads the matching [[entity|promotion]] from [[container|promotion-database]]. An unknown code is not an error — it is treated as "no code" and the response carries `discount: 0`. Storefronts should show their own "code not recognised" message based on the empty `appliedPromotions` list.
+2. **Check the window.** The promotion must be `active` and the current time must fall between `startsAt` and `endsAt`.
+3. **Check eligibility.** `min_spend_cents` is compared against the `subtotal`, and `customer_segment`, when set, must match the segment attached to the `customerId`. Guest carts never match a segment-scoped promotion.
+4. **Apply the type.** `PERCENTAGE` promotions take `value`% of the subtotal, rounded **down** to the nearest minor unit. `FIXED_AMOUNT` promotions take `value` minor units, capped at the subtotal so the discount can never exceed what is being bought.
+5. **Publish.** The result is returned to the Cart API and published as [[event|discount-calculated]] with the `appliedPromotions` that contributed.
+
+Only one promotion applies per cart today. Stacking is disabled at the service level, not just in the merchandising tools, so two valid codes will never combine.
+
+## What the Cart API does with it
+
+[[service|cart-api]] subtracts `discount` from `subtotal` to produce `total`, persists nothing about the discount to [[container|cart-database]], and publishes [[event|cart-checked-out]] with all three figures. Downstream systems should trust the `total` on that event rather than recomputing it.
+
+## Failure modes
+
+If [[service|promotion-service]] is unavailable, the Cart API **fails the checkout** with a `409` rather than checking out without a discount. We chose this deliberately — a customer who entered a valid code and was charged full price is a worse outcome than a retry. See [[doc|runbooks/discounts-not-applying]] for what to do when this is happening at scale.

--- a/examples/default/domains/Shopping/docs/guides/_category_.json
+++ b/examples/default/domains/Shopping/docs/guides/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Guides",
+  "position": 1
+}

--- a/examples/default/domains/Shopping/docs/runbooks/01-discounts-not-applying.mdx
+++ b/examples/default/domains/Shopping/docs/runbooks/01-discounts-not-applying.mdx
@@ -1,0 +1,37 @@
+---
+title: Discounts not applying
+summary: What to do when customers report a valid promotion code is being ignored, or checkouts are failing with 409.
+badges:
+  - content: Sev 2
+    backgroundColor: orange
+    textColor: orange
+    icon: ExclamationTriangleIcon
+---
+
+## Symptoms
+
+- Customer support reports "my code doesn't work" for a promotion that merchandising says is live.
+- The `checkout_409_rate` panel on the Shopping health dashboard is climbing. [[service|cart-api]] returns `409` when it cannot get a discount, so a spike here usually means [[service|promotion-service]] is unhealthy, not that customers are double-submitting.
+- [[event|discount-calculated]] volume has dropped while [[command|checkout-cart]] volume has not.
+
+## Likely causes
+
+1. **The promotion is misconfigured.** Wrong `starts_at`, `ends_at` in the past, `active = false`, or a `min_spend_cents` higher than merchandising intended. This is by far the most common cause and is not an incident.
+2. **The discount channel is backed up.** [[service|cart-api]] sends [[command|calculate-discount]] over [[channel|shopping.discount-commands]]; if the consumer lag on that channel is growing, checkouts time out waiting for a response.
+3. **[[service|promotion-service]] is failing.** A bad deploy, or [[container|promotion-database]] connection exhaustion.
+
+## Steps
+
+1. **Rule out configuration first.** Look the code up in [[container|promotion-database]] (read replica only) and check `active`, the validity window and `eligibility_rules`. If it is wrong, hand it to merchandising in `#shopping-support` — do not edit rows by hand. Remember that segment-scoped promotions never apply to guest carts; a "broken" code is often just a customer who is not logged in.
+2. **Check the channel.** Open the `discount_commands_consumer_lag` gauge. If it is above **5s**, the Promotion Service is not keeping up. Go to step 3.
+3. **Check the Promotion Service.** Look at its error rate and recent deploys. If a deploy landed in the last hour, roll back first and investigate second. If the errors are `too many connections`, restart the pods — the connection pool leaks on a known Go driver bug that is being tracked.
+4. **Confirm recovery.** `checkout_409_rate` should fall back under 0.5% within five minutes and [[event|discount-calculated]] volume should recover to match checkouts.
+
+## Do not
+
+- Do not "fix" the problem by letting checkouts proceed without a discount. The Cart API fails closed on purpose (see [[doc|guides/how-discounts-are-calculated]]); overriding that means charging customers full price for a code they entered correctly.
+- Do not replay [[command|calculate-discount]] messages from the channel. The Cart API has already returned a `409` to the customer; a late response has nowhere to go.
+
+## Escalation
+
+Anything that stops customers checking out for more than 10 minutes is a **Sev 1**. Page [[team|shopping-platform]]'s on-call lead and open an incident channel.

--- a/examples/default/domains/Shopping/docs/runbooks/02-abandoned-cart-backlog.mdx
+++ b/examples/default/domains/Shopping/docs/runbooks/02-abandoned-cart-backlog.mdx
@@ -1,0 +1,36 @@
+---
+title: Abandoned cart backlog
+summary: What to do when abandoned carts stop being pruned and the cart database starts to grow.
+badges:
+  - content: Sev 3
+    backgroundColor: yellow
+    textColor: yellow
+    icon: ArchiveBoxIcon
+---
+
+## Background
+
+Carts are transient. Any [[entity|cart]] in `OPEN` status with no activity for the retention window (currently **30 days**) is moved to `ABANDONED` and its rows are deleted from [[container|cart-database]] by a nightly pruning job inside [[system|cart-system]]. When that job stops running, nothing breaks immediately — but the `carts` and `cart_items` tables grow, [[service|cart-api]] latency creeps up as the `idx_carts_customer` index bloats, and eventually the database runs out of disk.
+
+## Symptoms
+
+- The `open_carts_older_than_30d` gauge on the Shopping health dashboard is above **zero** for more than 24 hours.
+- [[service|cart-api]] p95 latency on [[command|add-item-to-cart]] is rising with no matching rise in traffic.
+- The cart database disk usage alert has fired.
+
+## Steps
+
+1. **Check the prune job ran.** `cart prune status` reports the last run time and how many carts it moved to `ABANDONED`. If the last run was more than 25 hours ago, the job is stuck or was not scheduled.
+2. **Look at why it stopped.** The two usual reasons are a lock timeout — the job runs `DELETE … WHERE status = 'ABANDONED'` in batches of 5,000 and will back off if it cannot get a lock — or a failed deploy that removed the cron entry.
+3. **Run it by hand.** `cart prune run --batch-size 5000` is safe to run during business hours. It only touches carts that are already past the retention window and never touches `CHECKED_OUT` carts, which are deleted separately after the order is confirmed.
+4. **If the backlog is very large** (more than 500k carts), run with `--batch-size 1000` and `--sleep 500ms` between batches so [[command|checkout-cart]] traffic is not starved of connections.
+5. **Confirm recovery.** `open_carts_older_than_30d` should drop to zero and stay there after the next nightly run.
+
+## Do not
+
+- Do not `TRUNCATE` or bulk-delete from `carts` directly. Customers with an `OPEN` cart inside the retention window expect it to still be there when they come back.
+- Do not shorten the retention window as a shortcut. It is a product decision owned by [[team|shopping-platform]] and the storefront team, not an operational knob.
+
+## Escalation
+
+This is a **Sev 3** unless the disk alert has fired, in which case treat it as **Sev 2** and involve the database on-call before running any large prune.

--- a/examples/default/domains/Shopping/docs/runbooks/_category_.json
+++ b/examples/default/domains/Shopping/docs/runbooks/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Runbooks",
+  "position": 2
+}

--- a/examples/default/domains/Shopping/sidebar.json
+++ b/examples/default/domains/Shopping/sidebar.json
@@ -1,0 +1,37 @@
+{
+  "sections": [
+    {
+      "section": "$quick-reference",
+      "title": "Overview"
+    },
+    {
+      "title": "Guides",
+      "icon": "BookOpen",
+      "pages": [
+        "[[doc|guides/integrating-with-shopping]]",
+        "[[doc|guides/cart-and-promotion-model]]",
+        "[[doc|guides/how-discounts-are-calculated]]"
+      ]
+    },
+    "$architecture",
+    "$systems",
+    "$entities",
+    {
+      "title": "Runbooks",
+      "icon": "Siren",
+      "pages": [
+        "[[doc|runbooks/discounts-not-applying]]",
+        "[[doc|runbooks/abandoned-cart-backlog]]",
+        {
+          "title": "Health dashboard",
+          "href": "https://grafana.acme.dev/d/shopping-overview"
+        },
+        {
+          "title": "Checkout funnel",
+          "href": "https://grafana.acme.dev/d/shopping-checkout"
+        }
+      ]
+    },
+    "$owners"
+  ]
+}

--- a/packages/core/eventcatalog/src/components/Badge.astro
+++ b/packages/core/eventcatalog/src/components/Badge.astro
@@ -23,6 +23,8 @@ type Props = {
 
 const { badge, className = '' } = Astro.props;
 const href = getBadgeHref(badge);
+// Only links that leave the catalog get the external-link arrow.
+const isExternalHref = !!href && (/^[a-z][a-z0-9+.-]*:/i.test(href) || href.startsWith('//'));
 const Icon = badge.icon || badge.iconComponent;
 const hasThemedIcon = badge.iconURLLight && badge.iconURLDark;
 const classes = `
@@ -59,7 +61,7 @@ const classes = `
         <img src={badge.iconURL} class="w-3 h-3 flex-shrink-0 opacity-80" alt="" onerror="this.style.display='none'" />
       )}
       <span>{badge.content}</span>
-      <ArrowTopRightOnSquareIcon className="w-2.5 h-2.5 flex-shrink-0 opacity-70" aria-hidden="true" />
+      {isExternalHref && <ArrowTopRightOnSquareIcon className="w-2.5 h-2.5 flex-shrink-0 opacity-70" aria-hidden="true" />}
     </a>
   ) : (
     <span id={badge.id || undefined} class={classes} style={getBadgeStyle(badge)} title={badge.content}>

--- a/packages/core/eventcatalog/src/components/FieldsExplorer/FieldNodeGraph.tsx
+++ b/packages/core/eventcatalog/src/components/FieldsExplorer/FieldNodeGraph.tsx
@@ -224,11 +224,6 @@ function FieldNodeGraphInner({
   const { fitView } = useReactFlow();
   const wrapperRef = useRef<HTMLDivElement>(null);
 
-  // Load visualiser styles (animations, hover effects, theme variables)
-  useEffect(() => {
-    import('@eventcatalog/visualiser/styles-core.css');
-  }, []);
-
   useEffect(() => {
     const timer = setTimeout(() => fitView({ padding: 0.2 }), 50);
     return () => clearTimeout(timer);

--- a/packages/core/eventcatalog/src/components/MDX/Design/Design.astro
+++ b/packages/core/eventcatalog/src/components/MDX/Design/Design.astro
@@ -4,6 +4,8 @@ import fs from 'fs';
 import { getAbsoluteFilePathForAstroFile } from '@utils/files';
 import Admonition from '@components/MDX/Admonition';
 import AstroNodeGraph from '../NodeGraph/AstroNodeGraph';
+// Visualiser styles ship in the page head so ClientRouter navigations keep them (see NodeGraph.astro).
+import '@eventcatalog/visualiser/styles-core.css';
 
 import { isVisualiserEnabled, isEventCatalogChatEnabled, isDevMode } from '@utils/feature';
 import { loadSavedLayout, applyLayoutToNodes, buildResourceKey } from '@utils/node-graphs/layout-persistence';

--- a/packages/core/eventcatalog/src/components/MDX/EntityMap/EntityMap.astro
+++ b/packages/core/eventcatalog/src/components/MDX/EntityMap/EntityMap.astro
@@ -3,6 +3,8 @@ import { getDomains } from '@utils/collections/domains';
 import { getNodesAndEdges } from '@utils/node-graphs/domain-entity-map.ts';
 import Admonition from '@components/MDX/Admonition';
 import AstroNodeGraph from '../NodeGraph/AstroNodeGraph';
+// Visualiser styles ship in the page head so ClientRouter navigations keep them (see NodeGraph.astro).
+import '@eventcatalog/visualiser/styles-core.css';
 import { getVersionFromCollection } from '@utils/collections/versions';
 import { getServices } from '@utils/collections/services';
 import { isEventCatalogChatEnabled, isDevMode } from '@utils/feature';

--- a/packages/core/eventcatalog/src/components/MDX/Flow/Flow.astro
+++ b/packages/core/eventcatalog/src/components/MDX/Flow/Flow.astro
@@ -3,6 +3,8 @@ import { getFlows } from '@utils/collections/flows';
 import { getNodesAndEdges } from '@utils/node-graphs/flows-node-graph';
 import Admonition from '@components/MDX/Admonition';
 import AstroNodeGraph from '../NodeGraph/AstroNodeGraph';
+// Visualiser styles ship in the page head so ClientRouter navigations keep them (see NodeGraph.astro).
+import '@eventcatalog/visualiser/styles-core.css';
 import { getVersionFromCollection } from '@utils/collections/versions';
 import { isVisualiserEnabled, isEventCatalogChatEnabled, isDevMode } from '@utils/feature';
 import { loadSavedLayout, applyLayoutToNodes, buildResourceKey } from '@utils/node-graphs/layout-persistence';

--- a/packages/core/eventcatalog/src/components/MDX/NodeGraph/AstroNodeGraph.tsx
+++ b/packages/core/eventcatalog/src/components/MDX/NodeGraph/AstroNodeGraph.tsx
@@ -6,9 +6,13 @@
  * - Navigation using Astro's navigate function
  * - Layout persistence via Astro API routes
  * - URL building with Astro's URL utilities
+ *
+ * Note: the visualiser stylesheet is deliberately NOT imported here. Every Astro file that
+ * renders this component imports `@eventcatalog/visualiser/styles-core.css` itself so the
+ * CSS ships in the page head and survives ClientRouter navigations (see NodeGraph.astro).
  */
 
-import { useCallback, lazy, Suspense, useEffect } from 'react';
+import { useCallback, lazy, Suspense } from 'react';
 import type { Node, Edge } from '@xyflow/react';
 import { buildUrl } from '@utils/url-builder';
 
@@ -42,12 +46,6 @@ interface AstroNodeGraphProps {
 }
 
 const AstroNodeGraph = ({ isDevMode = false, resourceKey, ...otherProps }: AstroNodeGraphProps) => {
-  useEffect(() => {
-    // Load visualizer styles only when this component is mounted.
-    // Use the core-scoped stylesheet so visualizer styles don't override EventCatalog utility classes globally.
-    import('@eventcatalog/visualiser/styles-core.css');
-  }, []);
-
   // Astro-specific navigation handler
   const handleNavigate = useCallback((url: string) => {
     // Use window.location for navigation since we can't import astro:transitions/client in a React component

--- a/packages/core/eventcatalog/src/components/MDX/NodeGraph/NodeGraph.astro
+++ b/packages/core/eventcatalog/src/components/MDX/NodeGraph/NodeGraph.astro
@@ -1,5 +1,10 @@
 ---
 import AstroNodeGraph from './AstroNodeGraph';
+// Imported here (server side) rather than from the React island: Astro then emits it as a
+// <link> in the page head, which survives ClientRouter navigations. A dynamic import from the
+// island injects a <style> that the view-transition head swap removes — and the cached module
+// never re-injects it, leaving the graph unstyled until a full reload.
+import '@eventcatalog/visualiser/styles-core.css';
 import { getNodesAndEdges as getNodesAndEdgesForAgent } from '@utils/node-graphs/agents-node-graph';
 import { getNodesAndEdges as getNodesAndEdgesForService } from '@utils/node-graphs/services-node-graph';
 import {

--- a/packages/core/eventcatalog/src/components/SideNav/NestedSideBar/index.tsx
+++ b/packages/core/eventcatalog/src/components/SideNav/NestedSideBar/index.tsx
@@ -1,10 +1,17 @@
 'use client';
 
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import * as LucideIcons from 'lucide-react';
 import { ChevronRight, ChevronLeft, ChevronDown, Home, Star } from 'lucide-react';
 import type { NavNode, ChildRef } from '@stores/sidebar-store/state';
-import { saveState, loadState, saveCollapsedSections, loadCollapsedSections } from './storage';
+import {
+  saveState,
+  loadState,
+  saveCollapsedSections,
+  loadCollapsedSections,
+  saveScrollPosition,
+  loadScrollPosition,
+} from './storage';
 import { useStore } from '@nanostores/react';
 import { sidebarStore } from '@stores/sidebar-store';
 import {
@@ -13,7 +20,14 @@ import {
   removeFavorite as removeFavoriteAction,
   type FavoriteItem,
 } from '@stores/favorites-store';
-import { canCollapseGroup, findNodeKeyByUrl, getBadgeClasses, getGroupLabel, isGroupCollapsed } from './utils';
+import {
+  canCollapseGroup,
+  findNodeKeyByUrl,
+  getBadgeClasses,
+  getDefaultCollapsedState,
+  isGroupCollapsed,
+  toggleGroupCollapsed,
+} from './utils';
 import { resolveIconUrl } from '@utils/icon';
 
 const cn = (...classes: (string | false | undefined)[]) => classes.filter(Boolean).join(' ');
@@ -60,6 +74,7 @@ export default function NestedSideBar() {
   const [sectionCollapsePreferences, setSectionCollapsePreferences] = useState(loadCollapsedSections);
   const [showPathPreview, setShowPathPreview] = useState(false);
   const [showFullPath, setShowFullPath] = useState(false);
+  const navRef = useRef<HTMLElement | null>(null);
 
   // Build a lookup map for faster URL navigation
   // Map format: "type:id" -> "nodeKey"
@@ -94,19 +109,9 @@ export default function NestedSideBar() {
   /**
    * Toggle section collapse state
    */
-  const toggleSectionCollapse = (sectionId: string) => {
+  const toggleSectionCollapse = (sectionId: string, defaultCollapsed = true) => {
     setSectionCollapsePreferences((previousPreferences) => {
-      const nextPreferences = {
-        expanded: new Set(previousPreferences.expanded),
-      };
-      const isCurrentlyCollapsed = isGroupCollapsed(true, sectionId, previousPreferences);
-
-      if (isCurrentlyCollapsed) {
-        nextPreferences.expanded.add(sectionId);
-      } else {
-        nextPreferences.expanded.delete(sectionId);
-      }
-
+      const nextPreferences = toggleGroupCollapsed(sectionId, previousPreferences, defaultCollapsed);
       saveCollapsedSections(nextPreferences);
       return nextPreferences;
     });
@@ -417,6 +422,50 @@ export default function NestedSideBar() {
   }, [isInitialized, findAndNavigateToUrl, currentPath]);
 
   /**
+   * Keep the selected item visible. On a full page load the nav remounts scrolled to the
+   * top, so first restore the offset saved for this drill-down path, then nudge the
+   * active item into view if it still isn't. `block: 'nearest'` never scrolls when the
+   * item is already visible, so clicking around near the top doesn't jump.
+   */
+  useEffect(() => {
+    if (!isInitialized) return;
+    const nav = navRef.current;
+    if (!nav) return;
+
+    const pathKey = getCurrentPath().join('/') || 'root';
+    const savedScrollTop = loadScrollPosition(pathKey);
+    if (savedScrollTop !== null) nav.scrollTop = savedScrollTop;
+
+    const active = nav.querySelector<HTMLElement>('[data-active="true"]');
+    if (!active) return;
+
+    const navRect = nav.getBoundingClientRect();
+    const activeRect = active.getBoundingClientRect();
+    const isVisible = activeRect.top >= navRect.top && activeRect.bottom <= navRect.bottom;
+    if (!isVisible) active.scrollIntoView({ block: 'nearest' });
+  }, [isInitialized, currentPath, navigationStack, getCurrentPath]);
+
+  /**
+   * Persist the nav scroll offset as it changes.
+   */
+  useEffect(() => {
+    if (!isInitialized) return;
+    const nav = navRef.current;
+    if (!nav) return;
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const onScroll = () => {
+      clearTimeout(timer);
+      timer = setTimeout(() => saveScrollPosition(getCurrentPath().join('/') || 'root', nav.scrollTop), 150);
+    };
+    nav.addEventListener('scroll', onScroll, { passive: true });
+    return () => {
+      clearTimeout(timer);
+      nav.removeEventListener('scroll', onScroll);
+    };
+  }, [isInitialized, navigationStack, getCurrentPath]);
+
+  /**
    * Check if a node is favorited
    * Note: This hook must be defined before any early returns to comply with Rules of Hooks
    */
@@ -658,14 +707,15 @@ export default function NestedSideBar() {
   };
 
   /**
-   * Render a group with its children
+   * Render a group with its children.
+   *
+   * Groups render as a docs-style tree: every group has its caret on the right; top-level
+   * sections also carry an icon tile. Each level's children hang off a vertical guide.
    */
-  const renderGroup = (group: NavNode, groupKey: string | null, index: number) => {
-    // Get optional icon for group
+  const renderGroup = (group: NavNode, groupKey: string | null, index: number, depth = 0) => {
     const GroupIcon = group.icon ? (LucideIcons as unknown as Record<string, LucideIcons.LucideIcon>)[group.icon] : null;
-    const isSubtleGroup = group.subtle === true;
+    const isNested = depth > 0;
 
-    // Get visible children
     const visibleChildren =
       group.pages?.filter((childRef) => {
         const child = resolveRef(childRef);
@@ -673,46 +723,36 @@ export default function NestedSideBar() {
       }) ?? [];
 
     const groupId = groupKey || group.collapseKey || `${currentLevel.key ?? 'root'}:group:${group.title}`;
-    const canCollapse = canCollapseGroup(visibleChildren.length, isTopLevel, group.collapsible);
-    const isCollapsed = isGroupCollapsed(canCollapse, groupId, sectionCollapsePreferences);
-
-    // When a group's children are subtle subgroups (e.g. Resources > Services/Flows/Data Stores),
-    // they render flush under the parent icon instead of inside the indented border guide.
-    const hasSubtleChildren = visibleChildren.some((childRef) => {
-      const child = resolveRef(childRef);
-      return child && isGroup(child) && child.subtle === true;
-    });
-
-    const headerContent = (
+    const canCollapse = canCollapseGroup(isTopLevel, group.collapsible, group.collapsed);
+    const defaultCollapsed = getDefaultCollapsedState(visibleChildren.length, group.collapsed);
+    const isCollapsed = isGroupCollapsed(canCollapse, groupId, sectionCollapsePreferences, defaultCollapsed);
+    const header = isNested ? (
       <>
-        <div className="flex items-center gap-2">
-          {GroupIcon && (
-            <span
-              className={cn(
-                'flex items-center justify-center w-5 h-5 rounded',
-                isSubtleGroup
-                  ? 'bg-[rgb(var(--ec-content-hover))] text-[rgb(var(--ec-content-text-muted))]'
-                  : 'bg-[rgb(var(--ec-group-icon-bg))] text-[rgb(var(--ec-group-icon-text))]'
-              )}
-            >
-              <GroupIcon className="w-3 h-3" />
-            </span>
-          )}
-          <span
-            className={cn(
-              isSubtleGroup
-                ? 'text-[9px] font-semibold uppercase tracking-[0.1em] text-[rgb(var(--ec-content-text-muted))]'
-                : 'text-[12px] font-semibold tracking-tight text-[rgb(var(--ec-content-text))]'
-            )}
-          >
-            {getGroupLabel(group.title, visibleChildren.length)}
-          </span>
-        </div>
+        {GroupIcon && <GroupIcon className="w-3.5 h-3.5 flex-shrink-0 text-[rgb(var(--ec-content-text-muted))]" />}
+        <span className="text-[12px] font-medium text-[rgb(var(--ec-content-text))] truncate">{group.title}</span>
         {canCollapse && (
           <ChevronDown
             className={cn(
-              isSubtleGroup ? 'w-3.5 h-3.5' : 'w-4 h-4',
-              'text-[rgb(var(--ec-icon-color))] transition-transform',
+              'ml-auto w-3.5 h-3.5 flex-shrink-0 text-[rgb(var(--ec-icon-color))] transition-transform',
+              isCollapsed && '-rotate-90'
+            )}
+          />
+        )}
+      </>
+    ) : (
+      <>
+        {GroupIcon && (
+          <span className="flex items-center justify-center w-5 h-5 flex-shrink-0 rounded bg-[rgb(var(--ec-group-icon-bg))] text-[rgb(var(--ec-group-icon-text))]">
+            <GroupIcon className="w-3 h-3" />
+          </span>
+        )}
+        <span className="text-[12px] font-semibold tracking-tight text-[rgb(var(--ec-content-text))] truncate">
+          {group.title}
+        </span>
+        {canCollapse && (
+          <ChevronDown
+            className={cn(
+              'ml-auto w-4 h-4 flex-shrink-0 text-[rgb(var(--ec-icon-color))] transition-transform',
               isCollapsed && '-rotate-90'
             )}
           />
@@ -720,32 +760,30 @@ export default function NestedSideBar() {
       </>
     );
 
+    const headerClasses = cn(
+      'group flex items-center w-full rounded-md text-left transition-colors',
+      isNested ? 'gap-1.5 px-2 py-1.5' : 'gap-2 px-2 py-1.5',
+      canCollapse && 'cursor-pointer hover:bg-[rgb(var(--ec-content-hover))]'
+    );
+
+    // Top level: the guide line sits under the centre of the icon tile (8px padding + half of
+    // 20px). Nested: carets sit on the right, so the guide is simply inset from the label.
+    const childrenClasses = cn(
+      'flex flex-col gap-px mt-0.5 border-l border-[rgb(var(--ec-content-border))]',
+      isNested ? 'ml-3 pl-1.5' : 'ml-[18px] pl-2'
+    );
+
     return (
-      <div key={`group-${groupKey || index}`} className={cn(isSubtleGroup ? 'mb-2 last:mb-1' : 'mb-5 last:mb-2')}>
+      <div key={`group-${groupKey || index}`} className={cn(isNested ? 'mt-0.5' : 'mb-4 last:mb-1')}>
         {canCollapse ? (
-          <button
-            onClick={() => toggleSectionCollapse(groupId)}
-            className={cn(
-              'flex items-center justify-between w-full rounded-md transition-colors cursor-pointer',
-              isSubtleGroup
-                ? 'px-2 py-1 hover:bg-[rgb(var(--ec-content-hover))]/60'
-                : 'px-2 py-1.5 hover:bg-[rgb(var(--ec-content-hover))]'
-            )}
-          >
-            {headerContent}
+          <button type="button" onClick={() => toggleSectionCollapse(groupId, defaultCollapsed)} className={headerClasses}>
+            {header}
           </button>
         ) : (
-          <div className={cn('flex items-center justify-between', isSubtleGroup ? 'px-2 py-1' : 'px-2 py-1.5')}>
-            {headerContent}
-          </div>
+          <div className={headerClasses}>{header}</div>
         )}
         {!isCollapsed && (
-          <div
-            className={cn(
-              'flex flex-col gap-0.5 border-[rgb(var(--ec-content-border))]',
-              isSubtleGroup ? 'border-l ml-4 mt-1' : hasSubtleChildren ? 'mt-1' : 'border-l ml-4 mt-1'
-            )}
-          >
+          <div className={childrenClasses}>
             {visibleChildren.map((childRef, childIndex) => {
               const child = resolveRef(childRef);
               if (!child) return null;
@@ -753,22 +791,13 @@ export default function NestedSideBar() {
               const childKey = typeof childRef === 'string' ? childRef : null;
 
               if (isGroup(child)) {
-                // Skip nested groups with no visible children
                 if (!hasVisibleChildren(child)) return null;
-
-                return (
-                  <div
-                    key={`nested-group-${childKey || childIndex}`}
-                    className={cn(child.subtle ? 'mt-1' : 'ml-3 mt-1.5 pl-3 border-l border-[rgb(var(--ec-content-border))]')}
-                  >
-                    {renderGroup(child, childKey, childIndex)}
-                  </div>
-                );
+                return renderGroup(child, childKey, childIndex, depth + 1);
               }
-              // Inside a subtle subgroup (e.g. a domain's Resources > Services list) the
-              // section header already conveys the resource type, so suppress the default
-              // per-item icon and only keep a custom icon if one is defined.
-              return renderItem(child, childKey, childIndex, isSubtleGroup);
+
+              // Under a nested group the header already conveys the resource type, so the
+              // default per-collection glyph is dropped; custom icons still show.
+              return renderItem(child, childKey, childIndex, isNested);
             })}
           </div>
         )}
@@ -845,7 +874,7 @@ export default function NestedSideBar() {
     );
 
     const baseClasses =
-      'group flex items-center justify-between w-full px-3 py-1.5 border border-transparent cursor-pointer text-left transition-colors hover:bg-[rgb(var(--ec-content-hover))] active:bg-[rgb(var(--ec-content-hover))]';
+      'group flex items-center justify-between w-full px-2 py-1.5 rounded-md cursor-pointer text-left transition-colors hover:bg-[rgb(var(--ec-content-hover))] active:bg-[rgb(var(--ec-content-hover))]';
     const parentClasses = itemHasChildren ? 'font-medium' : '';
     const activeClasses = isActive ? 'bg-[rgb(var(--ec-rail-active-bg))] hover:bg-[rgb(var(--ec-rail-active-bg))]' : '';
 
@@ -857,6 +886,8 @@ export default function NestedSideBar() {
           href={item.href}
           title={item.title}
           target={item.external ? '_blank' : undefined}
+          aria-current={isActive ? 'page' : undefined}
+          data-active={isActive ? 'true' : undefined}
           className={cn(baseClasses, parentClasses, activeClasses)}
         >
           {content}
@@ -870,6 +901,7 @@ export default function NestedSideBar() {
         key={`item-${itemKey || index}`}
         title={item.title}
         onClick={() => handleDrillDown(item, itemKey)}
+        data-active={isActive ? 'true' : undefined}
         className={cn(baseClasses, parentClasses, activeClasses)}
       >
         {content}
@@ -1040,6 +1072,7 @@ export default function NestedSideBar() {
       {/* Navigation Content */}
       <nav
         key={animationKey}
+        ref={navRef}
         className={cn('min-h-0 flex-1 overflow-y-auto overflow-x-hidden p-4 px-2', getAnimationClass())}
         style={{
           scrollbarWidth: 'thin',

--- a/packages/core/eventcatalog/src/components/SideNav/NestedSideBar/storage.ts
+++ b/packages/core/eventcatalog/src/components/SideNav/NestedSideBar/storage.ts
@@ -1,4 +1,4 @@
-import type { SectionCollapsePreferences } from './utils';
+import { createSectionCollapsePreferences, type SectionCollapsePreferences } from './utils';
 
 // ============================================
 // Local Storage Persistence
@@ -7,6 +7,7 @@ import type { SectionCollapsePreferences } from './utils';
 const STORAGE_KEY = 'eventcatalog-sidebar-nav';
 const SECTION_PREFERENCES_KEY = 'eventcatalog-sidebar-sections:v2';
 const FAVORITES_KEY = 'eventcatalog-sidebar-favorites';
+const SCROLL_KEY = 'eventcatalog-sidebar-scroll';
 
 // ============================================
 // Types
@@ -48,12 +49,44 @@ export const loadState = (): PersistedState | null => {
 };
 
 // ============================================
+// Scroll position
+// ============================================
+
+/**
+ * The sidebar remounts on every full page load, which resets its scroll offset to the
+ * top. Persist it (per tab) so the list looks stationary when you follow a link near
+ * the bottom. Keyed by the drilled-down path so a different level starts fresh.
+ */
+export const saveScrollPosition = (pathKey: string, scrollTop: number): void => {
+  try {
+    sessionStorage.setItem(SCROLL_KEY, JSON.stringify({ pathKey, scrollTop }));
+  } catch (e) {
+    console.warn('Failed to save sidebar scroll position:', e);
+  }
+};
+
+export const loadScrollPosition = (pathKey: string): number | null => {
+  try {
+    const stored = sessionStorage.getItem(SCROLL_KEY);
+    if (!stored) return null;
+    const parsed = JSON.parse(stored);
+    return parsed?.pathKey === pathKey && typeof parsed.scrollTop === 'number' ? parsed.scrollTop : null;
+  } catch (e) {
+    console.warn('Failed to load sidebar scroll position:', e);
+    return null;
+  }
+};
+
+// ============================================
 // Collapsed Sections
 // ============================================
 
 export const saveCollapsedSections = (preferences: SectionCollapsePreferences): void => {
   try {
-    localStorage.setItem(SECTION_PREFERENCES_KEY, JSON.stringify({ expanded: [...preferences.expanded] }));
+    localStorage.setItem(
+      SECTION_PREFERENCES_KEY,
+      JSON.stringify({ expanded: [...preferences.expanded], collapsed: [...preferences.collapsed] })
+    );
   } catch (e) {
     console.warn('Failed to save collapsed sections:', e);
   }
@@ -64,15 +97,16 @@ export const loadCollapsedSections = (): SectionCollapsePreferences => {
     const stored = localStorage.getItem(SECTION_PREFERENCES_KEY);
     if (stored) {
       const preferences = JSON.parse(stored);
-      return {
-        expanded: new Set(Array.isArray(preferences.expanded) ? preferences.expanded : []),
-      };
+      return createSectionCollapsePreferences(
+        Array.isArray(preferences.expanded) ? preferences.expanded : [],
+        Array.isArray(preferences.collapsed) ? preferences.collapsed : []
+      );
     }
 
-    return { expanded: new Set() };
+    return createSectionCollapsePreferences();
   } catch (e) {
     console.warn('Failed to load collapsed sections:', e);
-    return { expanded: new Set() };
+    return createSectionCollapsePreferences();
   }
 };
 

--- a/packages/core/eventcatalog/src/components/SideNav/NestedSideBar/storage.ts
+++ b/packages/core/eventcatalog/src/components/SideNav/NestedSideBar/storage.ts
@@ -54,12 +54,25 @@ export const loadState = (): PersistedState | null => {
 
 /**
  * The sidebar remounts on every full page load, which resets its scroll offset to the
- * top. Persist it (per tab) so the list looks stationary when you follow a link near
- * the bottom. Keyed by the drilled-down path so a different level starts fresh.
+ * top. Persist offsets (per tab) so the list looks stationary when you follow a link near
+ * the bottom. A capped map keyed by drill-down path, so scrolling one level doesn't lose
+ * another level's offset (root -> drill in -> scroll -> back keeps the root position).
  */
+const MAX_SCROLL_ENTRIES = 30;
+
 export const saveScrollPosition = (pathKey: string, scrollTop: number): void => {
   try {
-    sessionStorage.setItem(SCROLL_KEY, JSON.stringify({ pathKey, scrollTop }));
+    const stored = sessionStorage.getItem(SCROLL_KEY);
+    const parsed = stored ? JSON.parse(stored) : {};
+    const offsets: Record<string, number> = parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+    // Re-insert so the map stays ordered by recency, then drop the oldest beyond the cap.
+    delete offsets[pathKey];
+    offsets[pathKey] = scrollTop;
+    const keys = Object.keys(offsets);
+    for (const stale of keys.slice(0, Math.max(0, keys.length - MAX_SCROLL_ENTRIES))) {
+      delete offsets[stale];
+    }
+    sessionStorage.setItem(SCROLL_KEY, JSON.stringify(offsets));
   } catch (e) {
     console.warn('Failed to save sidebar scroll position:', e);
   }
@@ -69,8 +82,9 @@ export const loadScrollPosition = (pathKey: string): number | null => {
   try {
     const stored = sessionStorage.getItem(SCROLL_KEY);
     if (!stored) return null;
-    const parsed = JSON.parse(stored);
-    return parsed?.pathKey === pathKey && typeof parsed.scrollTop === 'number' ? parsed.scrollTop : null;
+    const offsets = JSON.parse(stored);
+    const scrollTop = offsets && typeof offsets === 'object' ? offsets[pathKey] : undefined;
+    return typeof scrollTop === 'number' ? scrollTop : null;
   } catch (e) {
     console.warn('Failed to load sidebar scroll position:', e);
     return null;

--- a/packages/core/eventcatalog/src/components/SideNav/NestedSideBar/utils.spec.ts
+++ b/packages/core/eventcatalog/src/components/SideNav/NestedSideBar/utils.spec.ts
@@ -1,30 +1,40 @@
 import { describe, expect, it } from 'vitest';
-import { canCollapseGroup, findNodeKeyByUrl, getGroupLabel, isGroupCollapsed } from './utils';
+import {
+  canCollapseGroup,
+  createSectionCollapsePreferences,
+  findNodeKeyByUrl,
+  getDefaultCollapsedState,
+  isGroupCollapsed,
+  toggleGroupCollapsed,
+} from './utils';
 
-const preferences = (expanded: string[] = []) => ({
-  expanded: new Set(expanded),
-});
+const preferences = (expanded: string[] = [], collapsed: string[] = []) => createSectionCollapsePreferences(expanded, collapsed);
 
 describe('sidebar group presentation', () => {
-  it('includes the visible child count in the group label', () => {
-    expect(getGroupLabel('Outbound Messages', 10)).toBe('Outbound Messages (10)');
+  it('keeps root-level groups expanded', () => {
+    expect(canCollapseGroup(true)).toBe(false);
   });
 
-  it.each(['Quick Reference', 'Architecture', 'Resources'])('does not include the child count for %s', (title) => {
-    expect(getGroupLabel(title, 10)).toBe(title);
-  });
-
-  it('keeps top-level groups expanded', () => {
-    expect(canCollapseGroup(6, true)).toBe(false);
-  });
-
-  it('only allows nested groups with more than five children to collapse', () => {
-    expect(canCollapseGroup(5, false)).toBe(false);
-    expect(canCollapseGroup(6, false)).toBe(true);
+  it('lets every group inside a resource sidebar collapse, whatever its size', () => {
+    expect(canCollapseGroup(false)).toBe(true);
+    expect(canCollapseGroup(false)).toBe(true);
   });
 
   it('keeps groups marked as non-collapsible expanded regardless of their size', () => {
-    expect(canCollapseGroup(100, false, false)).toBe(false);
+    expect(canCollapseGroup(false, false)).toBe(false);
+  });
+
+  it('starts long lists collapsed and short ones open unless told otherwise', () => {
+    expect(getDefaultCollapsedState(5)).toBe(false);
+    expect(getDefaultCollapsedState(6)).toBe(true);
+    expect(getDefaultCollapsedState(6, false)).toBe(false);
+    expect(getDefaultCollapsedState(2, true)).toBe(true);
+  });
+
+  it('always allows collapsing when an explicit collapsed state is set, overriding every other rule', () => {
+    expect(canCollapseGroup(false, true, true)).toBe(true);
+    expect(canCollapseGroup(false, true, false)).toBe(true);
+    expect(canCollapseGroup(true, false, true)).toBe(true);
   });
 });
 
@@ -39,6 +49,40 @@ describe('isGroupCollapsed', () => {
 
   it('uses an explicit expanded preference', () => {
     expect(isGroupCollapsed(true, 'outbound-messages', preferences(['outbound-messages']))).toBe(false);
+  });
+
+  it('starts expanded when the group defaults to expanded, until the user collapses it', () => {
+    expect(isGroupCollapsed(true, 'owners', preferences(), false)).toBe(false);
+    expect(isGroupCollapsed(true, 'owners', preferences([], ['owners']), false)).toBe(true);
+  });
+});
+
+describe('toggleGroupCollapsed', () => {
+  it('records the user overriding a collapsed-by-default group, then clears it on the way back', () => {
+    const opened = toggleGroupCollapsed('g', preferences());
+    expect([...opened.expanded]).toEqual(['g']);
+    expect(opened.collapsed.size).toBe(0);
+
+    const closedAgain = toggleGroupCollapsed('g', opened);
+    expect(closedAgain.expanded.size).toBe(0);
+    expect([...closedAgain.collapsed]).toEqual(['g']);
+  });
+
+  it('records the user overriding an expanded-by-default group', () => {
+    const closed = toggleGroupCollapsed('g', preferences(), false);
+    expect([...closed.collapsed]).toEqual(['g']);
+    expect(isGroupCollapsed(true, 'g', closed, false)).toBe(true);
+
+    const reopened = toggleGroupCollapsed('g', closed, false);
+    expect(reopened.collapsed.size).toBe(0);
+    expect([...reopened.expanded]).toEqual(['g']);
+  });
+
+  it('does not mutate the previous preferences', () => {
+    const before = preferences();
+    toggleGroupCollapsed('g', before);
+    expect(before.expanded.size).toBe(0);
+    expect(before.collapsed.size).toBe(0);
   });
 });
 

--- a/packages/core/eventcatalog/src/components/SideNav/NestedSideBar/utils.ts
+++ b/packages/core/eventcatalog/src/components/SideNav/NestedSideBar/utils.ts
@@ -1,20 +1,66 @@
 // Shared utilities for NestedSideBar components
 
 export const SIDEBAR_GROUP_COLLAPSE_THRESHOLD = 5;
-const GROUP_TITLES_WITHOUT_COUNT = new Set(['Quick Reference', 'Architecture', 'Resources']);
 
+/**
+ * The user's overrides of each group's default collapse state, keyed by group id.
+ * A group is in at most one set; absence means "use the group's default".
+ */
 export type SectionCollapsePreferences = {
   expanded: Set<string>;
+  collapsed: Set<string>;
 };
 
-export const canCollapseGroup = (childCount: number, isTopLevel: boolean, collapsible = true): boolean =>
-  collapsible && !isTopLevel && childCount > SIDEBAR_GROUP_COLLAPSE_THRESHOLD;
+export const createSectionCollapsePreferences = (
+  expanded: Iterable<string> = [],
+  collapsed: Iterable<string> = []
+): SectionCollapsePreferences => ({
+  expanded: new Set(expanded),
+  collapsed: new Set(collapsed),
+});
 
-export const getGroupLabel = (title: string, childCount: number): string =>
-  GROUP_TITLES_WITHOUT_COUNT.has(title) ? title : `${title} (${childCount})`;
+/**
+ * Whether a group shows a caret and can be toggled. Every group inside a resource's sidebar
+ * can collapse (docs-sidebar behaviour); the root catalog level stays open. An explicit
+ * `collapsed` (set via sidebar.json) overrides every other rule, including `collapsible: false`.
+ */
+export const canCollapseGroup = (isTopLevel: boolean, collapsible = true, collapsed?: boolean): boolean => {
+  if (collapsed !== undefined) return true;
+  return collapsible && !isTopLevel;
+};
 
-export const isGroupCollapsed = (canCollapse: boolean, groupId: string, preferences: SectionCollapsePreferences): boolean => {
-  return canCollapse && !preferences.expanded.has(groupId);
+/**
+ * The state a group starts in before the user touches it: an explicit `collapsed` wins,
+ * otherwise long lists start collapsed and short ones start open.
+ */
+export const getDefaultCollapsedState = (childCount: number, collapsed?: boolean): boolean =>
+  collapsed ?? childCount > SIDEBAR_GROUP_COLLAPSE_THRESHOLD;
+
+export const isGroupCollapsed = (
+  canCollapse: boolean,
+  groupId: string,
+  preferences: SectionCollapsePreferences,
+  defaultCollapsed = true
+): boolean => {
+  if (!canCollapse) return false;
+  if (preferences.expanded.has(groupId)) return false;
+  if (preferences.collapsed.has(groupId)) return true;
+  return defaultCollapsed;
+};
+
+/** Flip a group's state, recording it as an override of its default. */
+export const toggleGroupCollapsed = (
+  groupId: string,
+  preferences: SectionCollapsePreferences,
+  defaultCollapsed = true
+): SectionCollapsePreferences => {
+  const next = createSectionCollapsePreferences(preferences.expanded, preferences.collapsed);
+  const isCurrentlyCollapsed = isGroupCollapsed(true, groupId, preferences, defaultCollapsed);
+  next.expanded.delete(groupId);
+  next.collapsed.delete(groupId);
+  if (isCurrentlyCollapsed) next.expanded.add(groupId);
+  else next.collapsed.add(groupId);
+  return next;
 };
 
 /**

--- a/packages/core/eventcatalog/src/content.config.ts
+++ b/packages/core/eventcatalog/src/content.config.ts
@@ -1199,6 +1199,66 @@ const schemas = defineCollection({
     .extend(baseSchema.shape),
 });
 
+// Optional `sidebar.json` next to a resource's index.mdx. When present it fully
+// replaces the generated sidebar for that resource (see stores/sidebar-store/custom-sidebar.ts).
+const sidebarLinkSchema = z
+  .object({
+    title: z.string(),
+    href: z.string(),
+    icon: z.string().optional(),
+  })
+  .strict();
+
+// { "title": "Runbooks", "icon": "Siren", "collapsed": true, "pages": [...] } (custom group).
+// Groups nest: a page can itself be a group, rendered as a subsection.
+type SidebarGroupInput = {
+  title: string;
+  icon?: string;
+  collapsed?: boolean;
+  pages: Array<string | z.input<typeof sidebarLinkSchema> | SidebarGroupInput>;
+};
+const sidebarGroupSchema: z.ZodType<SidebarGroupInput> = z.lazy(() =>
+  z
+    .object({
+      title: z.string(),
+      icon: z.string().optional(),
+      collapsed: z.boolean().optional(),
+      // "$quick-reference", "[[service|OrderService@1.0.0]]", "[[doc|guides/sla]]", { title, href } or a nested group
+      pages: z.array(z.union([z.string(), sidebarLinkSchema, sidebarGroupSchema])),
+    })
+    .strict()
+);
+
+const sidebarSchema = z
+  .object({
+    $schema: z.string().optional(),
+    sections: z.array(
+      z.union([
+        // "$quick-reference" (predefined section)
+        z.string(),
+        // { "section": "$owners", "title": "Team", "collapsed": false } (predefined section, adjusted)
+        z
+          .object({
+            section: z.string(),
+            title: z.string().optional(),
+            icon: z.string().optional(),
+            collapsed: z.boolean().optional(),
+          })
+          .strict(),
+        sidebarGroupSchema,
+      ])
+    ),
+  })
+  .strict();
+
+const sidebars = defineCollection({
+  loader: globWithSafeWatcher({
+    pattern: withIgnoredBuildArtifacts(withFederatedContent(['**/sidebar.json', '!**/node_modules/**'])),
+    base: projectDirBase,
+  }),
+  schema: sidebarSchema,
+});
+
 export const collections = {
   events,
   commands,
@@ -1236,4 +1296,7 @@ export const collections = {
 
   // Generated from message schema references
   schemas,
+
+  // Optional per-resource sidebar overrides (sidebar.json)
+  sidebars,
 };

--- a/packages/core/eventcatalog/src/content.config.ts
+++ b/packages/core/eventcatalog/src/content.config.ts
@@ -1253,7 +1253,14 @@ const sidebarSchema = z
 
 const sidebars = defineCollection({
   loader: globWithSafeWatcher({
-    pattern: withIgnoredBuildArtifacts(withFederatedContent(['**/sidebar.json', '!**/node_modules/**'])),
+    // Anchored to the resource roots (like resourceDocCategories) so an unrelated
+    // sidebar.json elsewhere in the project — or the public/generated mirror — is ignored.
+    pattern: withIgnoredBuildArtifacts(
+      withFederatedContent([
+        '{services,events,commands,queries,flows,containers,channels,entities,data-products,systems,agents,adrs}/**/sidebar.json',
+        'domains/**/sidebar.json',
+      ])
+    ),
     base: projectDirBase,
   }),
   schema: sidebarSchema,

--- a/packages/core/eventcatalog/src/enterprise/collections/resource-docs-utils.ts
+++ b/packages/core/eventcatalog/src/enterprise/collections/resource-docs-utils.ts
@@ -71,6 +71,25 @@ type InferredResource = {
   resourceVersion: string;
 };
 
+const DOC_TYPE_LABELS: Record<string, string> = {
+  adrs: 'ADR',
+  runbooks: 'Runbook',
+  contracts: 'Contract',
+  troubleshooting: 'Troubleshooting',
+  guides: 'Guide',
+};
+
+/** Human label for a doc type folder, e.g. `guides` → "Guide", `release-notes` → "Release Notes". */
+export const getResourceDocTypeLabel = (type: string): string => {
+  if (DOC_TYPE_LABELS[type]) return DOC_TYPE_LABELS[type];
+  const normalized = type
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+  return normalized || 'Doc';
+};
+
 let memoryCache: ResourceDocEntry[] | null = null;
 let memoryCategoryCache: ResourceDocCategoryEntry[] | null = null;
 let memoryResourceLookupCache: Record<ResourceCollection, ResourceLookup> | null = null;

--- a/packages/core/eventcatalog/src/enterprise/fields/pages/fields.astro
+++ b/packages/core/eventcatalog/src/enterprise/fields/pages/fields.astro
@@ -1,4 +1,6 @@
 ---
+// Visualiser styles ship in the page head so ClientRouter navigations keep them (see NodeGraph.astro).
+import '@eventcatalog/visualiser/styles-core.css';
 import VerticalSideBarLayout from '@layouts/VerticalSideBarLayout.astro';
 import FieldsExplorer from '@components/FieldsExplorer/FieldsExplorer';
 import { isEventCatalogScaleEnabled } from '@utils/feature';

--- a/packages/core/eventcatalog/src/pages/architecture/[type]/[id]/[version]/index.astro
+++ b/packages/core/eventcatalog/src/pages/architecture/[type]/[id]/[version]/index.astro
@@ -24,7 +24,7 @@ const specifications = type === 'services' ? getSpecificationsForService(props) 
 <VerticalSideBarLayout title={pageTitle}>
   <main class="flex docs-layout min-h-full bg-[rgb(var(--ec-page-bg))]">
     <div class="flex docs-layout w-full">
-      <div class="w-full lg:mr-2 pr-24 py-8 bg-[rgb(var(--ec-page-bg))]">
+      <div class="w-full min-w-0 lg:mr-2 pr-24 py-8 bg-[rgb(var(--ec-page-bg))]">
         {type === 'domains' && <DomainGrid domain={domain} client:load />}
         {type === 'systems' && <SystemGrid system={props} client:load />}
         {

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/[docType]/[docId]/[docVersion]/index.astro
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/[docType]/[docId]/[docVersion]/index.astro
@@ -8,7 +8,8 @@ import CopyAsMarkdown from '@components/CopyAsMarkdown';
 import Badge from '@components/Badge.astro';
 import { buildUrl } from '@utils/url-builder';
 import { AlignLeftIcon, HistoryIcon } from 'lucide-react';
-import { isEventCatalogChatEnabled, isResourceDocsEnabled } from '@utils/feature';
+import { isEventCatalogChatEnabled, isMarkdownDownloadEnabled, isResourceDocsEnabled } from '@utils/feature';
+import { getResourceDocTypeLabel } from '@utils/collections/resource-docs';
 import { getIcon } from '@utils/badges';
 import { collectionToResourceMap } from '@utils/collections/util';
 
@@ -51,28 +52,28 @@ const pagefindAttributes =
 <VerticalSideBarLayout title={pageTitle} description={props.data.summary}>
   <main class="flex docs-layout min-h-full bg-[rgb(var(--ec-page-bg))]" {...pagefindAttributes}>
     <div class="flex docs-layout w-full">
-      <div class="w-full lg:mr-2 pr-24 py-8 bg-[rgb(var(--ec-page-bg))]">
-        <div class="border-b border-[rgb(var(--ec-page-border))] md:pb-2">
-          <div>
-            <div class="flex items-center">
-              <div class="flex items-center gap-2">
-                <h2 id="doc-page-header" class="text-2xl md:text-4xl font-bold text-[rgb(var(--ec-page-text))]">{title}</h2>
-              </div>
-            </div>
+      <div class="w-full min-w-0 lg:mr-2 pr-24 py-8 bg-[rgb(var(--ec-page-bg))]">
+        {/* Header mirrors the latest-doc page ([docId]/index.astro) and the resource page. */}
+        <div class="border-b border-[rgb(var(--ec-page-border))] md:pb-3 pt-4">
+          <div class="flex flex-col gap-4">
+            <span class="text-xs md:text-sm font-semibold text-[rgb(var(--ec-accent))] capitalize">
+              {getResourceDocTypeLabel(props.data.type)}
+            </span>
+            <h2 id="doc-page-header" class="text-2xl md:text-4xl font-bold text-[rgb(var(--ec-page-text))]">{title}</h2>
           </div>
           {
             props.data.summary && (
-              <p class="text-base pt-2 text-[rgb(var(--ec-page-text-muted))] font-light">{props.data.summary}</p>
+              <p class="text-base pt-4 text-[rgb(var(--ec-page-text-muted))] font-light">{props.data.summary}</p>
             )
           }
           {
             badges.length > 0 && (
-              <div class="flex flex-wrap gap-1.5 py-3">
+              <div class="flex flex-wrap gap-1.5 pt-4">
                 {badges.map((badge: any) => <Badge badge={badge} />)}
               </div>
             )
           }
-          <div class="pt-4">
+          <div class="pt-5">
             <CopyAsMarkdown
               client:only="react"
               variant="toolbar"
@@ -80,9 +81,9 @@ const pagefindAttributes =
               chatQuery={chatQuery}
               chatEnabled={chatEnabled}
               editUrl=""
-              markdownDownloadEnabled={true}
+              markdownDownloadEnabled={isMarkdownDownloadEnabled()}
               rssFeedEnabled={false}
-              preferChatAsDefault={false}
+              preferChatAsDefault={chatEnabled}
             />
           </div>
         </div>
@@ -100,7 +101,7 @@ const pagefindAttributes =
             )
           }
         </div>
-        <div class="prose py-4 max-w-none">
+        <div class="prose prose-md pt-8 pb-4 w-full text-[15px]">
           <Content components={components(props)} />
         </div>
       </div>

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/[docType]/[docId]/index.astro
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/[docType]/[docId]/index.astro
@@ -8,9 +8,10 @@ import CopyAsMarkdown from '@components/CopyAsMarkdown';
 import Badge from '@components/Badge.astro';
 import { buildUrl } from '@utils/url-builder';
 import { AlignLeftIcon, HistoryIcon } from 'lucide-react';
-import { isEventCatalogChatEnabled, isResourceDocsEnabled } from '@utils/feature';
+import { isEventCatalogChatEnabled, isMarkdownDownloadEnabled, isResourceDocsEnabled } from '@utils/feature';
 import { getIcon } from '@utils/badges';
 import { collectionToResourceMap } from '@utils/collections/util';
+import { getResourceDocTypeLabel } from '@utils/collections/resource-docs';
 
 import { Page } from './_index.data';
 
@@ -36,6 +37,7 @@ const docsBasePath = `/docs/${props.data.resourceCollection}/${props.data.resour
 const singularResourceName =
   collectionToResourceMap[props.data.resourceCollection as keyof typeof collectionToResourceMap] ??
   props.data.resourceCollection.slice(0, props.data.resourceCollection.length - 1);
+const typeLabel = getResourceDocTypeLabel(props.data.type);
 const chatEnabled = isEventCatalogChatEnabled();
 const chatQuery = `Tell me about the ${props.data.type} doc "${title}" for ${props.data.resourceId} (version ${props.data.version})`;
 
@@ -51,20 +53,22 @@ const pagefindAttributes =
 <VerticalSideBarLayout title={pageTitle} description={props.data.summary}>
   <main class="flex docs-layout min-h-full bg-[rgb(var(--ec-page-bg))]" {...pagefindAttributes}>
     <div class="flex docs-layout w-full">
-      <div class="w-full lg:mr-2 pr-24 py-8 bg-[rgb(var(--ec-page-bg))]">
-        <div class="border-b border-[rgb(var(--ec-page-border))] md:pb-2">
+      <div class="w-full min-w-0 lg:mr-2 pr-24 py-8 bg-[rgb(var(--ec-page-bg))]">
+        {/* Header mirrors the resource page (docs/[type]/[id]/[version]/index.astro) so docs feel like part of the resource. */}
+        <div class="border-b border-[rgb(var(--ec-page-border))] md:pb-3 pt-4">
           <div class="flex flex-col gap-4">
-            <div class="flex items-center gap-4">
-              <h2 id="doc-page-header" class="text-2xl md:text-4xl font-bold text-[rgb(var(--ec-page-text))]">{title}</h2>
-            </div>
-            {props.data.summary && <p class="text-base text-[rgb(var(--ec-page-text-muted))] font-light">{props.data.summary}</p>}
-            {
-              badges.length > 0 && (
-                <div class="flex flex-wrap gap-1.5 py-1">
-                  {badges.map((badge: any) => <Badge badge={badge} />)}
-                </div>
-              )
-            }
+            <span class="text-xs md:text-sm font-semibold text-[rgb(var(--ec-accent))] capitalize">{typeLabel}</span>
+            <h2 id="doc-page-header" class="text-2xl md:text-4xl font-bold text-[rgb(var(--ec-page-text))]">{title}</h2>
+          </div>
+          {props.data.summary && <p class="text-base pt-4 text-[rgb(var(--ec-page-text-muted))] font-light">{props.data.summary}</p>}
+          {
+            badges.length > 0 && (
+              <div class="flex flex-wrap gap-1.5 pt-4">
+                {badges.map((badge: any) => <Badge badge={badge} />)}
+              </div>
+            )
+          }
+          <div class="pt-5">
             <CopyAsMarkdown
               client:only="react"
               variant="toolbar"
@@ -72,9 +76,9 @@ const pagefindAttributes =
               chatQuery={chatQuery}
               chatEnabled={chatEnabled}
               editUrl=""
-              markdownDownloadEnabled={true}
+              markdownDownloadEnabled={isMarkdownDownloadEnabled()}
               rssFeedEnabled={false}
-              preferChatAsDefault={false}
+              preferChatAsDefault={chatEnabled}
             />
           </div>
         </div>
@@ -92,7 +96,7 @@ const pagefindAttributes =
             )
           }
         </div>
-        <div class="prose py-4 max-w-none">
+        <div class="prose prose-md pt-8 pb-4 w-full text-[15px]">
           <Content components={components(props)} />
         </div>
       </div>

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/graphql/[filename].astro
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/graphql/[filename].astro
@@ -66,7 +66,7 @@ const pagefindAttributes =
 <VerticalSideBarLayout title={pageTitle} description={`GraphQL schema for ${data.name}`}>
   <main class="flex docs-layout min-h-full bg-[rgb(var(--ec-page-bg))]" {...pagefindAttributes}>
     <div class="flex docs-layout w-full">
-      <div class="w-full lg:mr-2 pr-24 py-8 bg-[rgb(var(--ec-page-bg))]">
+      <div class="w-full min-w-0 lg:mr-2 pr-24 py-8 bg-[rgb(var(--ec-page-bg))]">
         <div class="border-b border-[rgb(var(--ec-page-border))] md:pb-2">
           <div>
             <div class="flex justify-between items-start">

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/index.astro
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/index.astro
@@ -408,8 +408,8 @@ if (!isAdrPage && !hasCurrentFlowEmbed && !hasCurrentPageNodeGraph) {
 <VerticalSideBarLayout title={pageTitle} description={props.data.summary}>
   <main class="flex docs-layout min-h-full bg-[rgb(var(--ec-page-bg))]" {...pagefindAttributes}>
     <div class="flex docs-layout w-full">
-      <div class="w-full lg:mr-2 pr-24 py-8 bg-[rgb(var(--ec-page-bg))]">
-        <div class="border-b border-[rgb(var(--ec-page-border))] md:pb-6 pt-4">
+      <div class="w-full min-w-0 lg:mr-2 pr-24 py-8 bg-[rgb(var(--ec-page-bg))]">
+        <div class="border-b border-[rgb(var(--ec-page-border))] md:pb-3 pt-4">
           <div>
             <div>
               <div class="flex flex-col gap-4">
@@ -447,7 +447,7 @@ if (!isAdrPage && !hasCurrentFlowEmbed && !hasCurrentPageNodeGraph) {
               </div>
             </div>
 
-            <h2 class="text-base pt-4 text-[rgb(var(--ec-page-text-muted))] font-light">{props.data.summary}</h2>
+            <p class="text-base pt-4 text-[rgb(var(--ec-page-text-muted))] font-light">{props.data.summary}</p>
             {
               badges && (
                 <div class="flex flex-wrap gap-1.5 pt-4">
@@ -596,7 +596,7 @@ if (!isAdrPage && !hasCurrentFlowEmbed && !hasCurrentPageNodeGraph) {
           }
         </div>
 
-        <div class="prose prose-md py-4 w-full text-[15px]">
+        <div class="prose prose-md pt-8 pb-4 w-full text-[15px]">
           <Content components={components(props)} />
         </div>
         <div data-pagefind-ignore>

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/resources/index.astro
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/resources/index.astro
@@ -29,6 +29,8 @@ const hrefForResource = (collection: SystemResourceCollection, id: string, versi
   return buildUrl(`/docs/${collection}/${id}/${version}`);
 };
 
+const ownerTypeLabel = ownerCollection === 'domains' ? 'Domain' : 'System';
+
 const resources: SystemResourceItem[] = resourceGroups.flatMap(({ collection, items }) =>
   items.map((item: any) => ({
     collection,
@@ -45,16 +47,22 @@ const resources: SystemResourceItem[] = resourceGroups.flatMap(({ collection, it
 <VerticalSideBarLayout title={`${data.name} | Resources`}>
   <main class="flex docs-layout min-h-full bg-[rgb(var(--ec-page-bg))]">
     <div class="flex docs-layout w-full">
-      <div class="w-full lg:mr-2 pr-24 py-8 bg-[rgb(var(--ec-page-bg))]">
-        <div class="border-b border-[rgb(var(--ec-page-border))] pb-4">
-          <h2 class="text-2xl md:text-4xl font-bold text-[rgb(var(--ec-page-text))]">{data.name} Resources</h2>
-          <h2 class="text-lg pt-2 text-[rgb(var(--ec-page-text-muted))] font-light">
-            A group of resources that are mapped to the {data.name}{' '}
-            {ownerCollection === 'domains' ? 'domain' : 'system'}.
-          </h2>
+      <div class="w-full min-w-0 lg:mr-2 pr-24 py-8 bg-[rgb(var(--ec-page-bg))]">
+        {/* Header mirrors the resource page (docs/[type]/[id]/[version]/index.astro). */}
+        <div class="border-b border-[rgb(var(--ec-page-border))] md:pb-3 pt-4">
+          <div class="flex flex-col gap-4">
+            <span class="text-xs md:text-sm font-semibold text-[rgb(var(--ec-accent))] capitalize">{ownerTypeLabel}</span>
+            <h2 id="doc-page-header" class="text-2xl md:text-4xl font-bold text-[rgb(var(--ec-page-text))]">
+              {data.name} Resources
+            </h2>
+          </div>
+          <p class="text-base pt-4 pb-1 text-[rgb(var(--ec-page-text-muted))] font-light">
+            {resources.length} {resources.length === 1 ? 'resource' : 'resources'} mapped to the {data.name}{' '}
+            {ownerTypeLabel.toLowerCase()}.
+          </p>
         </div>
 
-        <div class="py-8 w-full">
+        <div class="pt-8 pb-4 w-full">
           <SystemResourcesTable resources={resources} client:only="react" />
         </div>
       </div>

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/language/[dictionaryId]/index.astro
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/language/[dictionaryId]/index.astro
@@ -25,90 +25,73 @@ const editUrl = resolveUbiquitousLanguageTermEditUrl({
   configEditUrl: config.editUrl,
 });
 
-marked.setOptions({
-  breaks: true,
-  gfm: true,
-});
+// Pass options per call rather than via `marked.setOptions`, which mutates module-global
+// state and leaks between pages (and between HMR reloads) in the same process.
+const renderMarkdown = (markdown: string) => marked.parse(markdown, { gfm: true, breaks: false }) as string;
 
+const TermIcon = ubiquitousLanguage.icon
+  ? ((LucideIcons as unknown as Record<string, LucideIcons.LucideIcon>)[ubiquitousLanguage.icon] ?? null)
+  : null;
+
+// Badges double as navigation back up the hierarchy: the owning domain and its glossary.
 const badges = [
   {
     content: props.domain.name,
     icon: RectangleGroupIcon,
+    url: buildUrl(`/docs/${props.type}/${props.domainId}/${props.domain.latestVersion}`),
+  },
+  {
+    content: 'Ubiquitous Language',
+    icon: LucideIcons.BookOpen,
+    url: buildUrl(`/docs/${props.type}/${props.domainId}/language`),
   },
 ];
 ---
 
 <VerticalSideBarLayout title={pageTitle} description={ubiquitousLanguage.summary}>
   <main
-    class="flex sm:px-8 docs-layout min-h-full max-w-7xl bg-[rgb(var(--ec-page-bg))]"
+    class="flex docs-layout min-h-full bg-[rgb(var(--ec-page-bg))]"
     data-pagefind-body
     data-pagefind-meta={`title:${pageTitle}`}
   >
     <div class="flex docs-layout w-full">
-      <div class="w-full lg:mr-2 pr-8 py-8 min-h-[50em]">
-        {/* Breadcrumb */}
-        <nav class="mb-4 flex items-center space-x-2 text-sm text-[rgb(var(--ec-page-text-muted))]" aria-label="Breadcrumb">
-          <a
-            href={buildUrl(`/docs/${props.type}/${props.domainId}/${props.domain.latestVersion}`)}
-            class="hover:text-[rgb(var(--ec-page-text))] hover:underline flex items-center gap-2"
-          >
-            <RectangleGroupIcon className="h-4 w-4" />
-            {props.domain.name}
-          </a>
-          <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"></path>
-          </svg>
-          <a
-            href={buildUrl(`/docs/${props.type}/${props.domainId}/language`)}
-            class="hover:text-[rgb(var(--ec-page-text))] hover:underline flex items-center gap-2"
-          >
-            {
-              (() => {
-                const BookOpen = LucideIcons.BookOpen;
-                //@ts-ignore
-                return <BookOpen className="h-4 w-4" />;
-              })()
-            }
-            Ubiquitous Language Explorer
-          </a>
-          <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"></path>
-          </svg>
-          <span class="text-[rgb(var(--ec-page-text))]">{ubiquitousLanguage.name}</span>
-        </nav>
-
-        <div class="border-b border-[rgb(var(--ec-page-border))] flex justify-between items-start md:pb-2">
-          <div>
-            <h2 id="doc-page-header" class="text-2xl md:text-4xl font-bold text-[rgb(var(--ec-page-text))]">
-              {ubiquitousLanguage.name}
-            </h2>
-            <p class="text-lg pt-2 text-[rgb(var(--ec-page-text-muted))] font-light">{ubiquitousLanguage.summary}</p>
-            <!-- Add badge -->
-            {
-              badges && badges.length > 0 && (
-                <div class="flex flex-wrap gap-3 py-4">
-                  {badges.map((badge: any) => {
-                    return <Badge badge={badge} />;
-                  })}
-                </div>
-              )
-            }
+      <div class="w-full min-w-0 lg:mr-2 pr-24 py-8 min-h-[50em]">
+        {/* Header mirrors the resource page (docs/[type]/[id]/[version]/index.astro). */}
+        <div class="border-b border-[rgb(var(--ec-page-border))] md:pb-3 pt-4">
+          <div class="flex flex-col gap-4">
+            <span class="text-xs md:text-sm font-semibold text-[rgb(var(--ec-accent))] capitalize">Term</span>
+            <div class="flex items-center gap-3">
+              {
+                TermIcon && (
+                  <div class="flex items-center justify-center w-8 h-8 md:w-10 md:h-10 rounded-md bg-[rgb(var(--ec-accent-subtle))] shrink-0">
+                    <TermIcon className="w-5 h-5 md:w-6 md:h-6 text-[rgb(var(--ec-accent))]" />
+                  </div>
+                )
+              }
+              <h2 id="doc-page-header" class="text-2xl md:text-4xl font-bold text-[rgb(var(--ec-page-text))]">
+                {ubiquitousLanguage.name}
+              </h2>
+            </div>
+          </div>
+          {
+            ubiquitousLanguage.summary && (
+              <p class="text-base pt-4 text-[rgb(var(--ec-page-text-muted))] font-light">{ubiquitousLanguage.summary}</p>
+            )
+          }
+          <div class="flex flex-wrap gap-1.5 pt-4 pb-1">
+            {badges.map((badge: any) => <Badge badge={badge} />)}
           </div>
         </div>
 
-        {
-          ubiquitousLanguage.description && (
-            <div class="prose prose-md py-4 max-w-none" set:html={marked.parse(ubiquitousLanguage.description)} />
-          )
-        }
-
-        {
-          !ubiquitousLanguage.description && (
-            <div class="prose prose-md py-4 max-w-none">
+        <div class="prose prose-md pt-8 pb-4 w-full text-[15px]">
+          {
+            ubiquitousLanguage.description ? (
+              <Fragment set:html={renderMarkdown(ubiquitousLanguage.description)} />
+            ) : (
               <p>No description for {ubiquitousLanguage.name} available.</p>
-            </div>
-          )
-        }
+            )
+          }
+        </div>
 
         <Footer />
         <div class="flex justify-end">

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/language/index.astro
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/language/index.astro
@@ -19,6 +19,11 @@ const pageTitle = `${props.collection} | ${props.data.name}`.replace(/^\w/, (c) 
 const ubiquitousLanguageData = await getUbiquitousLanguageWithSubdomains(props);
 const ubiquitousLanguage = ubiquitousLanguageData.domain;
 const { subdomains, duplicateTerms } = ubiquitousLanguageData;
+
+const termCount =
+  (ubiquitousLanguage?.data.dictionary?.length ?? 0) +
+  subdomains.reduce((total, subdomain: any) => total + (subdomain.ubiquitousLanguage?.data.dictionary?.length ?? 0), 0);
+const ownerTypeLabel = props.collection === 'domains' ? 'Domain' : 'System';
 ---
 
 <VerticalSideBarLayout title={pageTitle} description={props.data.summary}>
@@ -28,26 +33,31 @@ const { subdomains, duplicateTerms } = ubiquitousLanguageData;
     data-pagefind-meta={`title:${pageTitle}`}
   >
     <div class="flex docs-layout w-full">
-      <div class="w-full lg:mr-2 pr-24 py-8 min-h-[50em]">
-        {/* Title Section */}
-        <div class="relative border-b border-[rgb(var(--ec-page-border))] mb-6 pb-6">
-          <div class="xl:flex xl:items-start xl:justify-between">
-            <div class="min-w-0 flex-1">
-              <h1 class="text-2xl md:text-4xl font-bold text-[rgb(var(--ec-page-text))]">Ubiquitous Language</h1>
-              <p class="pt-2 text-base text-[rgb(var(--ec-page-text-muted))] font-light">
-                Browse and discover ubiquitous language terms in the {props.data.name} domain{
-                  subdomains.length > 0 ? ' and its subdomains' : ''
-                }
-              </p>
-            </div>
+      <div class="w-full min-w-0 lg:mr-2 pr-24 py-8 min-h-[50em]">
+        {/* Header mirrors the resource page (docs/[type]/[id]/[version]/index.astro). */}
+        <div class="border-b border-[rgb(var(--ec-page-border))] md:pb-3 pt-4">
+          <div class="flex flex-col gap-4">
+            <span class="text-xs md:text-sm font-semibold text-[rgb(var(--ec-accent))] capitalize">{ownerTypeLabel}</span>
+            <h1 id="doc-page-header" class="text-2xl md:text-4xl font-bold text-[rgb(var(--ec-page-text))]">
+              Ubiquitous Language
+            </h1>
+          </div>
+          <p class="text-base pt-4 pb-1 text-[rgb(var(--ec-page-text-muted))] font-light">
+            {termCount} {termCount === 1 ? 'term' : 'terms'} used in the {props.data.name} {ownerTypeLabel.toLowerCase()}{
+              subdomains.length > 0 ? ' and its subdomains' : ''
+            }.
+          </p>
+        </div>
 
-            <div class="mt-4 xl:mt-0 xl:ml-4 xl:flex-shrink-0">
-              <div class="relative w-full xl:w-80">
+        {
+          !ubiquitousLanguage && termCount > 0 && (
+            <div class="pt-8">
+              <div class="relative w-full max-w-md">
                 <input
                   type="text"
                   id="searchInput"
                   placeholder="Search terms..."
-                  class="block w-full rounded-md border-0 py-1.5 pr-4 pl-10 text-sm font-light text-[rgb(var(--ec-header-text))] bg-[rgb(var(--ec-header-bg))] shadow-xs ring-1 ring-inset ring-[rgb(var(--ec-dropdown-border))] placeholder:text-[rgb(var(--ec-icon-color))] focus:ring-2 focus:ring-[rgb(var(--ec-accent))] focus:outline-none"
+                  class="block w-full rounded-md border-0 py-2 pr-4 pl-10 text-sm font-light text-[rgb(var(--ec-header-text))] bg-[rgb(var(--ec-header-bg))] shadow-xs ring-1 ring-inset ring-[rgb(var(--ec-dropdown-border))] placeholder:text-[rgb(var(--ec-icon-color))] focus:ring-2 focus:ring-[rgb(var(--ec-accent))] focus:outline-none"
                 />
                 <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
                   <svg class="h-4 w-4 text-[rgb(var(--ec-icon-color))]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -60,8 +70,8 @@ const { subdomains, duplicateTerms } = ubiquitousLanguageData;
                 </div>
               </div>
             </div>
-          </div>
-        </div>
+          )
+        }
 
         {
           !ubiquitousLanguage && subdomains.length === 0 && (
@@ -82,7 +92,7 @@ const { subdomains, duplicateTerms } = ubiquitousLanguageData;
           )
         }
 
-        <div class="py-4 w-full min-h-[calc(100vh-10em)]">
+        <div class="pt-8 pb-4 w-full min-h-[calc(100vh-10em)]">
           {
             (ubiquitousLanguage || subdomains.some((s) => s.ubiquitousLanguage)) && (
               <div>
@@ -100,6 +110,23 @@ const { subdomains, duplicateTerms } = ubiquitousLanguageData;
                             ({ubiquitousLanguage?.data?.dictionary?.length || 0} terms)
                           </span>
                         </h3>
+                      </div>
+                      <div class="relative w-64 flex-shrink-0">
+                        <input
+                          type="text"
+                          id="searchInput"
+                          placeholder="Search terms..."
+                          class="block w-full rounded-md border-0 py-1.5 pr-4 pl-9 text-sm font-light text-[rgb(var(--ec-header-text))] bg-[rgb(var(--ec-header-bg))] shadow-xs ring-1 ring-inset ring-[rgb(var(--ec-dropdown-border))] placeholder:text-[rgb(var(--ec-icon-color))] focus:ring-2 focus:ring-[rgb(var(--ec-accent))] focus:outline-none"
+                        />
+                        <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                          <svg class="h-4 w-4 text-[rgb(var(--ec-icon-color))]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
+                          </svg>
+                        </div>
                       </div>
                     </div>
                     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4" data-terms-grid="main">

--- a/packages/core/eventcatalog/src/pages/docs/teams/[id]/index.astro
+++ b/packages/core/eventcatalog/src/pages/docs/teams/[id]/index.astro
@@ -103,7 +103,7 @@ const sourceTitle = sourceLabel ? `Synced from ${sourceLabel}` : undefined;
     data-pagefind-meta={`title:${pageTitle}`}
   >
     <div class="flex docs-layout w-full">
-      <div class="w-full lg:mr-2 pr-24 py-8 bg-[rgb(var(--ec-page-bg))]">
+      <div class="w-full min-w-0 lg:mr-2 pr-24 py-8 bg-[rgb(var(--ec-page-bg))]">
         <div class="border-b border-[rgb(var(--ec-page-border))] pb-6">
           <div class="flex justify-start">
             <div class="flex flex-col justify-between space-y-3">

--- a/packages/core/eventcatalog/src/pages/docs/users/[id]/index.astro
+++ b/packages/core/eventcatalog/src/pages/docs/users/[id]/index.astro
@@ -100,7 +100,7 @@ const sourceTitle = sourceLabel ? `Synced from ${sourceLabel}` : undefined;
     data-pagefind-meta={`title:${pageTitle}`}
   >
     <div class="flex docs-layout w-full">
-      <div class="w-full lg:mr-2 pr-24 py-8 bg-[rgb(var(--ec-page-bg))]">
+      <div class="w-full min-w-0 lg:mr-2 pr-24 py-8 bg-[rgb(var(--ec-page-bg))]">
         <div class="border-b border-[rgb(var(--ec-page-border))] pb-6">
           <div class="flex justify-start gap-6">
             {

--- a/packages/core/eventcatalog/src/pages/schemas/[type]/[id]/[version]/index.astro
+++ b/packages/core/eventcatalog/src/pages/schemas/[type]/[id]/[version]/index.astro
@@ -130,7 +130,11 @@ const apiAccessEnabled = isEventCatalogScaleEnabled();
 ---
 
 <VerticalSideBarLayout title={pageTitle}>
-  <div class="h-[calc(100vh-4rem)] w-full overflow-hidden flex flex-col">
+  {/* The schema viewer is an app-style surface: pull it out of the content gutter so it sits flush against the sidebar. */}
+  <div
+    class="h-[calc(100vh-4rem)] overflow-hidden flex flex-col"
+    style="margin-left: calc(var(--ec-app-content-padding-left, 5rem) * -1); margin-right: calc(var(--ec-app-content-padding-right, 5rem) * -1);"
+  >
     {
       currentMessage ? (
         <SchemaPageViewer

--- a/packages/core/eventcatalog/src/pages/triggers/[type]/[id]/[version]/index.astro
+++ b/packages/core/eventcatalog/src/pages/triggers/[type]/[id]/[version]/index.astro
@@ -3,6 +3,8 @@ import { getCollection, type CollectionEntry } from 'astro:content';
 
 import LineageScenarioSwitcher from '@components/Lineage/LineageScenarioSwitcher';
 import AstroNodeGraph from '@components/MDX/NodeGraph/AstroNodeGraph';
+// Visualiser styles ship in the page head so ClientRouter navigations keep them (see NodeGraph.astro).
+import '@eventcatalog/visualiser/styles-core.css';
 import ResourceRef from '@components/MDX/ResourceRef/ResourceRef.astro';
 import Footer from '@layouts/Footer.astro';
 import VerticalSideBarLayout from '@layouts/VerticalSideBarLayout.astro';

--- a/packages/core/eventcatalog/src/pages/visualiser/designs/[id]/index.astro
+++ b/packages/core/eventcatalog/src/pages/visualiser/designs/[id]/index.astro
@@ -1,5 +1,7 @@
 ---
 import AstroNodeGraph from '@components/MDX/NodeGraph/AstroNodeGraph';
+// Visualiser styles ship in the page head so ClientRouter navigations keep them (see NodeGraph.astro).
+import '@eventcatalog/visualiser/styles-core.css';
 import { ClientRouter } from 'astro:transitions';
 import VerticalSideBarLayout from '@layouts/VerticalSideBarLayout.astro';
 import { isEventCatalogChatEnabled } from '@utils/feature';

--- a/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/custom-sidebar.spec.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/custom-sidebar.spec.ts
@@ -328,6 +328,25 @@ describe('applyCustomSidebar', () => {
     });
   });
 
+  it('gives sibling groups with duplicate or empty slugs distinct collapse keys', () => {
+    const groups = applyCustomSidebar(
+      spec([
+        { title: 'Links', pages: [] },
+        { title: 'Links', pages: [] },
+        { title: 'リンク', pages: [] },
+        { title: 'ドキュメント', pages: [] },
+      ]),
+      sections,
+      resource
+    ) as NavNode[];
+    const keys = groups.map((group) => group.collapseKey);
+    expect(new Set(keys).size).toBe(4);
+    expect(keys[0]).toBe('custom:domains:Catalog:1.0.0:links');
+    expect(keys[1]).toBe('custom:domains:Catalog:1.0.0:links-2');
+    expect(keys[2]).toBe('custom:domains:Catalog:1.0.0:group');
+    expect(keys[3]).toBe('custom:domains:Catalog:1.0.0:group-2');
+  });
+
   it('fails the build with a helpful message for unknown or unprefixed sections', () => {
     expect(() => applyCustomSidebar(spec(['$nope']), sections, resource)).toThrow(
       /Unknown section "\$nope" in sidebar \(domains\/Catalog\/sidebar\.json\)\. Available sections for this resource: \$quick-reference, \$owners/

--- a/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/custom-sidebar.spec.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/custom-sidebar.spec.ts
@@ -85,7 +85,6 @@ describe('applyCustomSidebar', () => {
             '[[event|OrderPlaced]]',
             '[[adr|adr-001-outbox]]',
             '[[doc|guides/sla]]',
-            '[[doc|guides/missing]]',
             { title: 'On-call', href: 'https://runbooks.acme.dev/orders' },
             { title: 'Internal', href: '/docs/domains/Catalog/1.0.0/resources' },
           ],
@@ -108,7 +107,6 @@ describe('applyCustomSidebar', () => {
       'event:OrderPlaced',
       'adr:adr-001-outbox',
       { type: 'item', title: 'SLA & error budgets', href: '/base/docs/domains/Catalog/1.0.0/guides/sla' },
-      { type: 'item', title: 'missing', href: '/base/docs/domains/Catalog/1.0.0/guides/missing' },
       { type: 'item', title: 'On-call', href: 'https://runbooks.acme.dev/orders', external: true },
       { type: 'item', title: 'Internal', href: '/base/docs/domains/Catalog/1.0.0/resources' },
     ]);
@@ -333,6 +331,44 @@ describe('applyCustomSidebar', () => {
       /Unknown section "\$nope" in sidebar \(domains\/Catalog\/sidebar\.json\)\. Available sections for this resource: \$quick-reference, \$owners/
     );
     expect(() => applyCustomSidebar(spec(['owners']), sections, resource)).toThrow(/did you mean "\$owners"/);
+  });
+
+  it('fails the build when a doc ref does not resolve, listing the available docs', () => {
+    const resourceDocs = [
+      {
+        data: {
+          resourceCollection: 'domains',
+          resourceId: 'Catalog',
+          resourceVersion: '1.0.0',
+          type: 'guides',
+          id: 'sla',
+          title: 'SLA',
+        },
+      },
+    ] as any;
+    expect(() =>
+      applyCustomSidebar(spec([{ title: 'X', pages: ['[[doc|guides/missing]]'] }]), sections, resource, { resourceDocs })
+    ).toThrow(/has no documentation page "guides\/missing"\. Available: guides\/sla\./);
+    expect(() => applyCustomSidebar(spec([{ title: 'X', pages: ['[[doc|guides/anything]]'] }]), sections, resource)).toThrow(
+      /has no documentation pages/
+    );
+  });
+
+  it('fails the build when pinning a historical version of a latest-only collection', () => {
+    const context = {
+      services: [{ collection: 'services', data: { id: 'orders', name: 'Orders', version: '2.0.0' } }],
+    } as any;
+    expect(() =>
+      applyCustomSidebar(spec([{ title: 'X', pages: ['[[service|orders@1.0.0]]'] }]), sections, resource, context)
+    ).toThrow(/only the latest version \(2\.0\.0\) of a service can be referenced/);
+    // Pinning the latest version is fine, and unknown ids keep the silent resource-ref contract.
+    const [group] = applyCustomSidebar(
+      spec([{ title: 'X', pages: ['[[service|orders@2.0.0]]', '[[service|ghost@1.0.0]]'] }]),
+      sections,
+      resource,
+      context
+    ) as NavNode[];
+    expect(group.pages).toEqual(['service:orders:2.0.0', 'service:ghost:1.0.0']);
   });
 
   it('fails the build for pages it cannot resolve', () => {

--- a/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/custom-sidebar.spec.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/custom-sidebar.spec.ts
@@ -333,6 +333,13 @@ describe('applyCustomSidebar', () => {
     expect(() => applyCustomSidebar(spec(['owners']), sections, resource)).toThrow(/did you mean "\$owners"/);
   });
 
+  it('renders nothing for doc refs when the resource-docs feature is disabled (community mode)', () => {
+    const [group] = applyCustomSidebar(spec([{ title: 'X', pages: ['[[doc|guides/anything]]'] }]), sections, resource, {
+      resourceDocsEnabled: false,
+    }) as NavNode[];
+    expect(group.pages).toEqual([]);
+  });
+
   it('fails the build when a doc ref does not resolve, listing the available docs', () => {
     const resourceDocs = [
       {

--- a/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/custom-sidebar.spec.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/custom-sidebar.spec.ts
@@ -299,6 +299,36 @@ describe('applyCustomSidebar', () => {
       ]);
     });
 
+    it('resolves specifications owned by messages', () => {
+      const messageContext = {
+        ...context,
+        events: [
+          {
+            collection: 'events',
+            data: {
+              id: 'order-created',
+              version: '1.0.0',
+              specifications: [{ type: 'asyncapi', path: 'asyncapi.yml', name: 'Order events' }],
+            },
+          },
+        ],
+      } as any;
+      const [group] = applyCustomSidebar(
+        spec([{ title: 'X', pages: ['[[spec|event/order-created/asyncapi.yml]]'] }]),
+        sections,
+        ownResource,
+        messageContext
+      ) as NavNode[];
+      expect(group.pages).toEqual([
+        {
+          type: 'item',
+          title: 'Order events',
+          leftIcon: '/icons/asyncapi-black.svg',
+          href: '/base/docs/events/order-created/1.0.0/asyncapi/asyncapi',
+        },
+      ]);
+    });
+
     it('fails clearly when a spec cannot be found', () => {
       expect(() => pagesOf(['[[spec|nope.yml]]'])).toThrow(/"Catalog" has no specification file "nope.yml"/);
       expect(() => pagesOf(['[[spec|missing-service/openapi.yml]]'])).toThrow(/resource "missing-service" not found/);

--- a/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/custom-sidebar.spec.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/custom-sidebar.spec.ts
@@ -176,6 +176,13 @@ describe('applyCustomSidebar', () => {
       resource
     ) as NavNode[];
     expect(group.pages).toEqual([{ type: 'item', title: 'Mail', href: 'mailto:team@acme.dev', external: true }]);
+
+    const [prGroup] = applyCustomSidebar(
+      spec([{ title: 'X', pages: [{ title: 'Runbook', href: '//runbooks.acme.dev/orders' }] }]),
+      sections,
+      resource
+    ) as NavNode[];
+    expect(prGroup.pages).toEqual([{ type: 'item', title: 'Runbook', href: '//runbooks.acme.dev/orders', external: true }]);
   });
 
   it('renders nested groups as subtle subsections with path-based collapse keys', () => {

--- a/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/custom-sidebar.spec.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/custom-sidebar.spec.ts
@@ -1,0 +1,386 @@
+import { describe, expect, it, vi } from 'vitest';
+import { applyCustomSidebar, indexSidebarsByFolder, getSidebarForResource, parseResourceRef } from '../custom-sidebar';
+import type { SidebarSections, SidebarSpec } from '../custom-sidebar';
+import type { NavNode } from '../builders/shared';
+
+vi.mock('@utils/url-builder', () => ({
+  buildUrl: (path: string) => `/base${path}`,
+}));
+
+const group = (title: string, pages: string[] = []): NavNode => ({ type: 'group', title, icon: 'Box', pages });
+
+const sections: SidebarSections = {
+  'quick-reference': group('Quick Reference'),
+  owners: group('Owners', ['team:product-platform']),
+  services: group('Services', ['service:Orders:1.0.0']),
+  entities: null,
+  'resource-groups': [group('Group A'), group('Group B')],
+};
+
+const resource = { collection: 'domains' as const, id: 'Catalog', version: '1.0.0' };
+
+const spec = (entries: SidebarSpec['sections']): SidebarSpec => ({
+  sections: entries,
+  sourcePath: 'domains/Catalog/sidebar.json',
+});
+
+describe('parseResourceRef', () => {
+  it('parses type, id and optional version', () => {
+    expect(parseResourceRef('[[service|OrderService]]')).toEqual({ type: 'service', id: 'OrderService', version: undefined });
+    expect(parseResourceRef('[[service|OrderService@1.2.3]]')).toEqual({ type: 'service', id: 'OrderService', version: '1.2.3' });
+  });
+
+  it('keeps doc targets as paths and never extracts a version from them', () => {
+    expect(parseResourceRef('[[doc|guides/sla@v2]]')).toEqual({ type: 'doc', id: 'guides/sla@v2', version: undefined });
+  });
+
+  it('returns null for anything that is not a [[type|target]] ref', () => {
+    expect(parseResourceRef('services')).toBeNull();
+    expect(parseResourceRef('[[Order]]')).toBeNull();
+  });
+});
+
+describe('applyCustomSidebar', () => {
+  it('renders predefined sections in the order they are listed and nothing else', () => {
+    const pages = applyCustomSidebar(spec(['$owners', '$quick-reference']), sections, resource);
+    expect(pages.map((page) => (typeof page === 'string' ? page : page.title))).toEqual(['Owners', 'Quick Reference']);
+  });
+
+  it('omits predefined sections that have nothing to render', () => {
+    expect(applyCustomSidebar(spec(['$entities']), sections, resource)).toEqual([]);
+  });
+
+  it('expands tokens that map to several groups', () => {
+    const pages = applyCustomSidebar(spec(['$resource-groups']), sections, resource);
+    expect(pages.map((page) => (page as NavNode).title)).toEqual(['Group A', 'Group B']);
+  });
+
+  it('relabels a predefined section without touching its contents', () => {
+    const [owners] = applyCustomSidebar(spec([{ section: '$owners', title: 'Team', icon: 'Users' }]), sections, resource);
+    expect(owners).toEqual({ type: 'group', title: 'Team', icon: 'Users', pages: ['team:product-platform'] });
+  });
+
+  it('builds custom groups from resource refs, doc refs and links', () => {
+    const resourceDocs = [
+      {
+        data: {
+          resourceCollection: 'domains',
+          resourceId: 'Catalog',
+          resourceVersion: '1.0.0',
+          type: 'guides',
+          id: 'sla',
+          title: 'SLA & error budgets',
+        },
+      },
+    ] as any;
+
+    const [runbooks] = applyCustomSidebar(
+      spec([
+        {
+          title: 'Runbooks',
+          icon: 'Siren',
+          pages: [
+            '[[service|Orders]]',
+            '[[service|Payments@2.0.0]]',
+            '[[event|OrderPlaced]]',
+            '[[adr|adr-001-outbox]]',
+            '[[doc|guides/sla]]',
+            '[[doc|guides/missing]]',
+            { title: 'On-call', href: 'https://runbooks.acme.dev/orders' },
+            { title: 'Internal', href: '/docs/domains/Catalog/1.0.0/resources' },
+          ],
+        },
+      ]),
+      sections,
+      resource,
+      { resourceDocs }
+    ) as NavNode[];
+
+    expect(runbooks).toMatchObject({
+      type: 'group',
+      title: 'Runbooks',
+      icon: 'Siren',
+      collapseKey: 'custom:domains:Catalog:1.0.0:runbooks',
+    });
+    expect(runbooks.pages).toEqual([
+      'service:Orders',
+      'service:Payments:2.0.0',
+      'event:OrderPlaced',
+      'adr:adr-001-outbox',
+      { type: 'item', title: 'SLA & error budgets', href: '/base/docs/domains/Catalog/1.0.0/guides/sla' },
+      { type: 'item', title: 'missing', href: '/base/docs/domains/Catalog/1.0.0/guides/missing' },
+      { type: 'item', title: 'On-call', href: 'https://runbooks.acme.dev/orders', external: true },
+      { type: 'item', title: 'Internal', href: '/base/docs/domains/Catalog/1.0.0/resources' },
+    ]);
+  });
+
+  it("splices a predefined section's items into a custom group, wherever the token sits", () => {
+    const [extended] = applyCustomSidebar(
+      spec([
+        {
+          title: 'Quick Reference',
+          icon: 'BookOpen',
+          pages: [{ title: 'Before', href: '/before' }, '$services', { title: 'After', href: '/after' }],
+        },
+      ]),
+      sections,
+      resource
+    ) as NavNode[];
+
+    expect(extended.pages).toEqual([
+      { type: 'item', title: 'Before', href: '/base/before' },
+      'service:Orders:1.0.0',
+      { type: 'item', title: 'After', href: '/base/after' },
+    ]);
+  });
+
+  it('splices nothing when the predefined section has nothing to render', () => {
+    const [group] = applyCustomSidebar(spec([{ title: 'X', pages: ['$entities'] }]), sections, resource) as NavNode[];
+    expect(group.pages).toEqual([]);
+  });
+
+  it('refuses to splice a token that expands to several groups', () => {
+    expect(() => applyCustomSidebar(spec([{ title: 'X', pages: ['$resource-groups'] }]), sections, resource)).toThrow(
+      /Cannot splice "\$resource-groups" into a group/
+    );
+    expect(() => applyCustomSidebar(spec([{ title: 'X', pages: ['$nope'] }]), sections, resource)).toThrow(
+      /Unknown section "\$nope"/
+    );
+  });
+
+  it('interpolates {id}, {version} and {collection} into link titles and hrefs', () => {
+    const [group] = applyCustomSidebar(
+      spec([
+        {
+          title: 'Links',
+          pages: [
+            { title: 'Visualiser ({version})', href: '/visualiser/{collection}/{id}/{version}' },
+            { title: 'Dashboard', href: 'https://grafana.acme.dev/d/{id}?v={version}' },
+            { title: 'Unknown placeholder untouched', href: '/x/{nope}' },
+          ],
+        },
+      ]),
+      sections,
+      resource
+    ) as NavNode[];
+
+    expect(group.pages).toEqual([
+      { type: 'item', title: 'Visualiser (1.0.0)', href: '/base/visualiser/domains/Catalog/1.0.0' },
+      { type: 'item', title: 'Dashboard', href: 'https://grafana.acme.dev/d/Catalog?v=1.0.0', external: true },
+      { type: 'item', title: 'Unknown placeholder untouched', href: '/base/x/{nope}' },
+    ]);
+  });
+
+  it('treats any protocol as external and leaves it untouched by buildUrl', () => {
+    const [group] = applyCustomSidebar(
+      spec([{ title: 'X', pages: [{ title: 'Mail', href: 'mailto:team@acme.dev' }] }]),
+      sections,
+      resource
+    ) as NavNode[];
+    expect(group.pages).toEqual([{ type: 'item', title: 'Mail', href: 'mailto:team@acme.dev', external: true }]);
+  });
+
+  it('renders nested groups as subtle subsections with path-based collapse keys', () => {
+    const [parent] = applyCustomSidebar(
+      spec([
+        {
+          title: 'Product data',
+          icon: 'Package',
+          pages: [
+            '[[system|product-catalog-system]]',
+            {
+              title: 'Entities',
+              collapsed: true,
+              pages: ['[[entity|product]]', { title: 'Deeper', pages: ['[[entity|category]]'] }],
+            },
+          ],
+        },
+      ]),
+      sections,
+      resource
+    ) as NavNode[];
+
+    expect(parent.collapseKey).toBe('custom:domains:Catalog:1.0.0:product-data');
+    expect(parent.subtle).toBeUndefined();
+    expect(parent.pages?.[0]).toBe('system:product-catalog-system');
+
+    const entities = parent.pages?.[1] as NavNode;
+    expect(entities).toMatchObject({
+      type: 'group',
+      title: 'Entities',
+      subtle: true,
+      collapsed: true,
+      collapseKey: 'custom:domains:Catalog:1.0.0:product-data:entities',
+    });
+    expect(entities.icon).toBeUndefined();
+
+    const deeper = entities.pages?.[1] as NavNode;
+    expect(deeper).toMatchObject({
+      title: 'Deeper',
+      subtle: true,
+      collapseKey: 'custom:domains:Catalog:1.0.0:product-data:entities:deeper',
+      pages: ['entity:category'],
+    });
+    expect(deeper.collapsed).toBeUndefined();
+  });
+
+  it('passes an explicit collapsed state through on custom groups and predefined sections', () => {
+    const [custom, owners, untouched] = applyCustomSidebar(
+      spec([{ title: 'Links', collapsed: false, pages: [] }, { section: '$owners', collapsed: true }, '$services']),
+      sections,
+      resource
+    ) as NavNode[];
+
+    expect(custom.collapsed).toBe(false);
+    expect(owners).toEqual({ type: 'group', title: 'Owners', icon: 'Box', collapsed: true, pages: ['team:product-platform'] });
+    expect(untouched.collapsed).toBeUndefined();
+  });
+
+  describe('spec and schema refs', () => {
+    const ownResource = {
+      ...resource,
+      entry: { data: { specifications: [{ type: 'openapi', path: 'openapi.yml', name: 'Catalog API' }] } },
+    };
+    const context = {
+      services: [
+        {
+          collection: 'services',
+          data: {
+            id: 'product-api',
+            name: 'Product API',
+            version: '1.0.0',
+            specifications: [
+              { type: 'asyncapi', path: 'specs/events.yaml', name: 'Product events' },
+              { type: 'graphql', path: 'schema.graphql', name: 'Product GraphQL' },
+            ],
+          },
+        },
+      ],
+      domains: [],
+      events: [{ collection: 'events', data: { id: 'product-created', name: 'Product Created', version: '2.0.0' } }],
+      commands: [{ collection: 'commands', data: { id: 'create-product', name: 'Create Product', version: '1.0.0' } }],
+      queries: [],
+      schemas: [
+        { data: { message: { collectionName: 'events', id: 'product-created', version: '2.0.0' } } },
+        { data: { message: { collectionName: 'events', id: 'product-created', version: '1.0.0' } } },
+        { data: { message: { collectionName: 'commands', id: 'create-product', version: '1.0.0' } } },
+      ],
+    } as any;
+
+    const pagesOf = (entries: string[], res = ownResource) =>
+      (applyCustomSidebar(spec([{ title: 'X', pages: entries }]), sections, res, context)[0] as NavNode).pages;
+
+    it("resolves this resource's own specification by filename", () => {
+      expect(pagesOf(['[[spec|openapi.yml]]'])).toEqual([
+        {
+          type: 'item',
+          title: 'Catalog API',
+          leftIcon: '/icons/openapi-black.svg',
+          href: '/base/docs/domains/Catalog/1.0.0/spec/openapi',
+        },
+      ]);
+    });
+
+    it("resolves another resource's specification by id, type-qualified id, and pinned version", () => {
+      const expected = {
+        type: 'item',
+        title: 'Product events',
+        leftIcon: '/icons/asyncapi-black.svg',
+        href: '/base/docs/services/product-api/1.0.0/asyncapi/events',
+      };
+      expect(pagesOf(['[[spec|product-api/events.yaml]]'])).toEqual([expected]);
+      expect(pagesOf(['[[spec|service/product-api/events.yaml]]'])).toEqual([expected]);
+      expect(pagesOf(['[[spec|service/product-api@1.0.0/events.yaml]]'])).toEqual([expected]);
+      expect(pagesOf(['[[spec|product-api/schema]]'])).toEqual([
+        {
+          type: 'item',
+          title: 'Product GraphQL',
+          leftIcon: '/icons/graphql-black.svg',
+          href: '/base/docs/services/product-api/1.0.0/graphql/schema',
+        },
+      ]);
+    });
+
+    it('fails clearly when a spec cannot be found', () => {
+      expect(() => pagesOf(['[[spec|nope.yml]]'])).toThrow(/"Catalog" has no specification file "nope.yml"/);
+      expect(() => pagesOf(['[[spec|missing-service/openapi.yml]]'])).toThrow(/resource "missing-service" not found/);
+      expect(() => pagesOf(['[[spec|service/product-api@9.9.9/events.yaml]]'])).toThrow(/resource "product-api" not found/);
+      expect(() => pagesOf(['[[spec|widget/thing/openapi.yml]]'])).toThrow(/Unknown resource type "widget"/);
+      expect(() => pagesOf(['[[spec|openapi.yml]]'], resource)).toThrow(/resource not found/);
+    });
+
+    it("resolves a message's schema page by id, type-qualified id, and pinned version", () => {
+      expect(pagesOf(['[[schema|product-created]]'])).toEqual([
+        { type: 'item', title: 'Product Created schema', href: '/base/schemas/events/product-created/2.0.0' },
+      ]);
+      expect(pagesOf(['[[schema|event/product-created@1.0.0]]'])).toEqual([
+        { type: 'item', title: 'Product Created schema', href: '/base/schemas/events/product-created/1.0.0' },
+      ]);
+      expect(pagesOf(['[[schema|command/create-product]]'])).toEqual([
+        { type: 'item', title: 'Create Product schema', href: '/base/schemas/commands/create-product/1.0.0' },
+      ]);
+    });
+
+    it('fails clearly when a schema cannot be found', () => {
+      expect(() => pagesOf(['[[schema|nope]]'])).toThrow(/message "nope" not found/);
+      expect(() => pagesOf(['[[schema|product-created@3.0.0]]'])).toThrow(/"product-created" v3.0.0 has no schema/);
+      expect(() => pagesOf(['[[schema|widget/thing]]'])).toThrow(/Unknown message type "widget"/);
+    });
+  });
+
+  it('fails the build with a helpful message for unknown or unprefixed sections', () => {
+    expect(() => applyCustomSidebar(spec(['$nope']), sections, resource)).toThrow(
+      /Unknown section "\$nope" in sidebar \(domains\/Catalog\/sidebar\.json\)\. Available sections for this resource: \$quick-reference, \$owners/
+    );
+    expect(() => applyCustomSidebar(spec(['owners']), sections, resource)).toThrow(/did you mean "\$owners"/);
+  });
+
+  it('fails the build for pages it cannot resolve', () => {
+    expect(() => applyCustomSidebar(spec([{ title: 'X', pages: ['owners'] }]), sections, resource)).toThrow(
+      /Invalid page "owners"/
+    );
+    expect(() => applyCustomSidebar(spec([{ title: 'X', pages: ['[[widget|Thing]]'] }]), sections, resource)).toThrow(
+      /Unknown resource type "widget"/
+    );
+    expect(() => applyCustomSidebar(spec([{ title: 'X', pages: ['[[doc|sla]]'] }]), sections, resource)).toThrow(
+      /Expected "\[\[doc\|<type>\/<id>\]\]"/
+    );
+  });
+});
+
+describe('indexSidebarsByFolder / getSidebarForResource', () => {
+  it('matches a resource to the sidebar.json in its own folder', () => {
+    const byFolder = indexSidebarsByFolder([
+      { filePath: 'domains/Catalog/sidebar.json', data: { sections: ['$owners'] } },
+      { filePath: 'domains/Catalog/versioned/0.0.1/sidebar.json', data: { sections: [] } },
+    ] as any);
+
+    expect(getSidebarForResource(byFolder, { filePath: 'domains/Catalog/index.mdx' })).toMatchObject({
+      sections: ['$owners'],
+      sourcePath: 'domains/Catalog/sidebar.json',
+    });
+    expect(getSidebarForResource(byFolder, { filePath: 'domains/Catalog/versioned/0.0.1/index.mdx' })).toMatchObject({
+      sections: [],
+    });
+    expect(getSidebarForResource(byFolder, { filePath: 'domains/Orders/index.mdx' })).toBeUndefined();
+    expect(getSidebarForResource(byFolder, {})).toBeUndefined();
+  });
+
+  it("versioned copies inherit the resource folder's sidebar unless their folder has its own", () => {
+    const byFolder = indexSidebarsByFolder([
+      { filePath: 'events/OrderCreated/sidebar.json', data: { sections: ['$producers'] } },
+      { filePath: 'events/OrderCreated/versioned/0.0.1/sidebar.json', data: { sections: ['$owners'] } },
+    ] as any);
+
+    // No sidebar of its own → inherits the resource folder's.
+    expect(getSidebarForResource(byFolder, { filePath: 'events/OrderCreated/versioned/1.0.0/index.mdx' })).toMatchObject({
+      sections: ['$producers'],
+    });
+    // Its own file wins over inheritance.
+    expect(getSidebarForResource(byFolder, { filePath: 'events/OrderCreated/versioned/0.0.1/index.mdx' })).toMatchObject({
+      sections: ['$owners'],
+    });
+    // Unrelated versioned resources inherit nothing.
+    expect(getSidebarForResource(byFolder, { filePath: 'events/OrderPlaced/versioned/1.0.0/index.mdx' })).toBeUndefined();
+  });
+});

--- a/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/custom-sidebar.spec.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/custom-sidebar.spec.ts
@@ -302,7 +302,9 @@ describe('applyCustomSidebar', () => {
     it('fails clearly when a spec cannot be found', () => {
       expect(() => pagesOf(['[[spec|nope.yml]]'])).toThrow(/"Catalog" has no specification file "nope.yml"/);
       expect(() => pagesOf(['[[spec|missing-service/openapi.yml]]'])).toThrow(/resource "missing-service" not found/);
-      expect(() => pagesOf(['[[spec|service/product-api@9.9.9/events.yaml]]'])).toThrow(/resource "product-api" not found/);
+      expect(() => pagesOf(['[[spec|service/product-api@9.9.9/events.yaml]]'])).toThrow(
+        /only the latest version \(1\.0\.0\) of "product-api" can be referenced/
+      );
       expect(() => pagesOf(['[[spec|widget/thing/openapi.yml]]'])).toThrow(/Unknown resource type "widget"/);
       expect(() => pagesOf(['[[spec|openapi.yml]]'], resource)).toThrow(/resource not found/);
     });
@@ -359,6 +361,38 @@ describe('applyCustomSidebar', () => {
     expect(() => applyCustomSidebar(spec([{ title: 'X', pages: ['[[doc|guides/anything]]'] }]), sections, resource)).toThrow(
       /has no documentation pages/
     );
+  });
+
+  it('covers adrs, channels and diagrams in the latest-only pin guard', () => {
+    const context = {
+      adrs: [{ collection: 'adrs', data: { id: 'adr-1', version: '2.0.0' } }],
+      channels: [{ collection: 'channels', data: { id: 'orders-topic', version: '1.1.0' } }],
+    } as any;
+    expect(() => applyCustomSidebar(spec([{ title: 'X', pages: ['[[adr|adr-1@1.0.0]]'] }]), sections, resource, context)).toThrow(
+      /only the latest version \(2\.0\.0\) of a adr/
+    );
+    expect(() =>
+      applyCustomSidebar(spec([{ title: 'X', pages: ['[[channel|orders-topic@1.0.0]]'] }]), sections, resource, context)
+    ).toThrow(/only the latest version \(1\.1\.0\) of a channel/);
+  });
+
+  it('explains latest-only when a spec ref pins a historical owner version', () => {
+    const context = {
+      services: [
+        {
+          collection: 'services',
+          data: { id: 'orders', version: '2.0.0', specifications: [{ type: 'openapi', path: 'openapi.yml' }] },
+        },
+      ],
+    } as any;
+    expect(() =>
+      applyCustomSidebar(
+        spec([{ title: 'X', pages: ['[[spec|service/orders@1.0.0/openapi.yml]]'] }]),
+        sections,
+        resource,
+        context
+      )
+    ).toThrow(/only the latest version \(2\.0\.0\) of "orders" can be referenced/);
   });
 
   it('fails the build when pinning a historical version of a latest-only collection', () => {

--- a/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/data-product-builder.spec.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/data-product-builder.spec.ts
@@ -526,4 +526,18 @@ describe('buildDataProductNode', () => {
       expect(ownersSection).toBeUndefined();
     });
   });
+
+  describe('custom sidebar', () => {
+    it('renders only the referenced sections, in the order listed in sidebar.json', () => {
+      const dataProduct = createMockDataProduct({ owners: [{ id: 'user1' }] });
+      const owners = [{ id: 'user1', data: { id: 'user1', name: 'User One' }, collection: 'users' }];
+
+      const result = buildDataProductNode(dataProduct, owners as any, emptyContext, [], {
+        sidebar: { sections: ['$owners', '$quick-reference'] },
+      });
+
+      const titles = (result.pages as any[]).map((p: any) => p.title);
+      expect(titles).toEqual(['Owners', 'Quick Reference']);
+    });
+  });
 });

--- a/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/entity-builder.spec.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/entity-builder.spec.ts
@@ -72,4 +72,16 @@ describe('buildEntityNode', () => {
       ],
     });
   });
+
+  it('renders exactly the listed custom sidebar sections, in order', () => {
+    const entity = createEntity({ domains: [createDomain('Orders', '0.0.1')] as any });
+    const owners = [{ collection: 'teams', data: { id: 'ordering', name: 'Ordering Team' } }];
+
+    const result = buildEntityNode(entity, owners, emptyContext, {
+      sidebar: { sections: ['$owners', '$quick-reference'] },
+    });
+
+    const titles = (result.pages || []).map((page) => (typeof page === 'string' ? page : page.title));
+    expect(titles).toEqual(['Owners', 'Quick Reference']);
+  });
 });

--- a/packages/core/eventcatalog/src/stores/sidebar-store/builders/__tests__/adr-builder.spec.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/builders/__tests__/adr-builder.spec.ts
@@ -88,4 +88,24 @@ describe('buildAdrNode', () => {
       expect(appliesToSection).toBeUndefined();
     });
   });
+
+  describe('custom sidebar', () => {
+    it('renders only the referenced sections, in the order listed in sidebar.json', () => {
+      const adr = createMockAdr();
+      const owners = [{ id: 'user1', data: { id: 'user1', name: 'User One' }, collection: 'users' }];
+
+      const result = buildAdrNode(
+        adr,
+        owners,
+        [],
+        { ...emptyContext, adrs: [adr] },
+        {
+          sidebar: { sections: ['$owners', '$quick-reference'] },
+        }
+      );
+
+      const titles = (result.pages as any[]).map((p: any) => p.title);
+      expect(titles).toEqual(['Owners', 'Quick Reference']);
+    });
+  });
 });

--- a/packages/core/eventcatalog/src/stores/sidebar-store/builders/__tests__/agent-builder.spec.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/builders/__tests__/agent-builder.spec.ts
@@ -1,0 +1,62 @@
+import type { CollectionEntry } from 'astro:content';
+import { describe, expect, it, vi } from 'vitest';
+import { buildAgentNode } from '../agent';
+
+vi.mock('@utils/feature', () => ({
+  isVisualiserEnabled: () => true,
+  isChangelogEnabled: () => false,
+}));
+
+vi.mock('@utils/url-builder', () => ({
+  buildUrl: (path: string) => path,
+}));
+
+const agent = {
+  id: 'agents/SupportAgent/index.mdx',
+  slug: 'agents/SupportAgent',
+  collection: 'agents',
+  data: {
+    id: 'SupportAgent',
+    name: 'Support Agent',
+    version: '1.0.0',
+    latestVersion: '1.0.0',
+    owners: [],
+  },
+} as unknown as CollectionEntry<'agents'>;
+
+const emptyContext = {
+  services: [],
+  domains: [],
+  events: [],
+  commands: [],
+  queries: [],
+  flows: [],
+  containers: [],
+  dataProducts: [],
+  diagrams: [],
+  adrs: [],
+  resourceDocs: [],
+  resourceDocCategories: [],
+} as any;
+
+const titles = (node: ReturnType<typeof buildAgentNode>) =>
+  (node.pages || []).map((page) => (typeof page === 'string' ? page : page.title));
+
+describe('buildAgentNode', () => {
+  it('keeps the generated sidebar when no custom sidebar is given', () => {
+    const owners = [{ collection: 'teams', data: { id: 'support', name: 'Support Team' } }];
+    expect(titles(buildAgentNode(agent, owners, emptyContext))).toEqual(['Quick Reference', 'Architecture', 'Owners']);
+  });
+});
+
+describe('buildAgentNode with a custom sidebar', () => {
+  const owners = [{ collection: 'teams', data: { id: 'support', name: 'Support Team' } }];
+
+  it('renders exactly the listed sections, in order', () => {
+    const node = buildAgentNode(agent, owners, emptyContext, [], [], {
+      sidebar: { sections: ['$owners', '$quick-reference'] },
+    });
+
+    expect(titles(node)).toEqual(['Owners', 'Quick Reference']);
+  });
+});

--- a/packages/core/eventcatalog/src/stores/sidebar-store/builders/__tests__/container-builder.spec.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/builders/__tests__/container-builder.spec.ts
@@ -1,0 +1,66 @@
+import type { CollectionEntry } from 'astro:content';
+import { describe, expect, it, vi } from 'vitest';
+import { buildContainerNode } from '../container';
+
+vi.mock('@utils/feature', () => ({
+  isVisualiserEnabled: () => true,
+  isChangelogEnabled: () => false,
+}));
+
+vi.mock('@utils/url-builder', () => ({
+  buildUrl: (path: string) => path,
+}));
+
+const container = {
+  id: 'containers/OrdersDb/index.mdx',
+  slug: 'containers/OrdersDb',
+  collection: 'containers',
+  data: {
+    id: 'OrdersDb',
+    name: 'Orders Database',
+    version: '1.0.0',
+    owners: [],
+    servicesThatWriteToContainer: [{ data: { id: 'OrderService', version: '1.0.0' } }],
+  },
+} as unknown as CollectionEntry<'containers'>;
+
+const owners = [{ collection: 'teams', data: { id: 'ordering', name: 'Ordering Team' } }];
+
+const emptyContext = {
+  services: [],
+  domains: [],
+  events: [],
+  commands: [],
+  queries: [],
+  flows: [],
+  containers: [],
+  dataProducts: [],
+  diagrams: [],
+  adrs: [],
+  resourceDocs: [],
+  resourceDocCategories: [],
+} as any;
+
+const titles = (node: ReturnType<typeof buildContainerNode>) =>
+  (node.pages || []).map((page) => (typeof page === 'string' ? page : page.title));
+
+describe('buildContainerNode', () => {
+  it('keeps the generated sidebar when no custom sidebar is given', () => {
+    expect(titles(buildContainerNode(container, owners, emptyContext))).toEqual([
+      'Quick Reference',
+      'Architecture',
+      'Writes',
+      'Owners',
+    ]);
+  });
+});
+
+describe('buildContainerNode with a custom sidebar', () => {
+  it('renders exactly the listed sections, in order', () => {
+    const node = buildContainerNode(container, owners, emptyContext, [], {
+      sidebar: { sections: ['$owners', '$quick-reference'] },
+    });
+
+    expect(titles(node)).toEqual(['Owners', 'Quick Reference']);
+  });
+});

--- a/packages/core/eventcatalog/src/stores/sidebar-store/builders/__tests__/domain-builder.spec.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/builders/__tests__/domain-builder.spec.ts
@@ -71,3 +71,61 @@ describe('buildDomainNode', () => {
     expect(getQuickReferenceLinks(createDomain())).not.toContainEqual(expect.objectContaining({ title: 'Domain Resources' }));
   });
 });
+
+describe('buildDomainNode with a custom sidebar', () => {
+  it('respects detailsPanel.architectureDecisions for $decision-records', () => {
+    const domain = createDomain({ detailsPanel: { architectureDecisions: { visible: false } } });
+    const context = {
+      ...emptyContext,
+      adrs: [
+        {
+          collection: 'adrs',
+          data: { id: 'adr-1', name: 'ADR 1', version: '1.0.0', appliesTo: [{ type: 'domain', id: 'Ordering' }] },
+        },
+      ],
+    };
+    const node = buildDomainNode(domain, [], context, { sidebar: { sections: ['$decision-records'] } });
+    expect(node.pages).toEqual([]);
+  });
+
+  const domain = createDomain({
+    systems: [resource('OrderingSystem')],
+    entities: [resource('Order')],
+    services: [resource('OrderService')],
+  });
+  const owners = [{ collection: 'teams', data: { id: 'ordering', name: 'Ordering Team' } }];
+
+  const titles = (node: ReturnType<typeof buildDomainNode>) =>
+    (node.pages || []).map((page) => (typeof page === 'string' ? page : page.title));
+
+  it('renders exactly the listed sections, in order', () => {
+    const node = buildDomainNode(domain, owners, emptyContext, {
+      sidebar: {
+        sections: [
+          '$quick-reference',
+          { title: 'Start here', icon: 'Star', pages: ['[[service|OrderService]]'] },
+          '$entities',
+          '$systems',
+          { section: '$owners', title: 'Team' },
+        ],
+      },
+    });
+
+    expect(titles(node)).toEqual(['Quick Reference', 'Start here', 'Entities', 'Systems', 'Team']);
+  });
+
+  it('renders resource subsections as top-level groups (not subtle) when used directly', () => {
+    const node = buildDomainNode(domain, owners, emptyContext, { sidebar: { sections: ['$services'] } });
+    expect(node.pages).toEqual([{ type: 'group', title: 'Services', icon: 'Server', pages: ['service:OrderService:1.0.0'] }]);
+  });
+
+  it('keeps the generated sidebar when no custom sidebar is given', () => {
+    expect(titles(buildDomainNode(domain, owners, emptyContext))).toEqual([
+      'Quick Reference',
+      'Architecture',
+      'Systems',
+      'Resources',
+      'Owners',
+    ]);
+  });
+});

--- a/packages/core/eventcatalog/src/stores/sidebar-store/builders/__tests__/flow-builder.spec.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/builders/__tests__/flow-builder.spec.ts
@@ -1,0 +1,63 @@
+import type { CollectionEntry } from 'astro:content';
+import { describe, expect, it, vi } from 'vitest';
+import { buildFlowNode } from '../flow';
+
+vi.mock('@utils/feature', () => ({
+  isVisualiserEnabled: () => true,
+  isChangelogEnabled: () => false,
+}));
+
+vi.mock('@utils/url-builder', () => ({
+  buildUrl: (path: string) => path,
+}));
+
+const service = {
+  id: 'services/OrderService/index.mdx',
+  collection: 'services',
+  data: { id: 'OrderService', name: 'Order Service', version: '1.0.0' },
+};
+
+const flow = {
+  id: 'flows/Checkout/index.mdx',
+  slug: 'flows/Checkout',
+  collection: 'flows',
+  data: {
+    id: 'Checkout',
+    name: 'Checkout',
+    version: '1.0.0',
+    steps: [{ id: 'place-order', title: 'Place order', service: { id: 'OrderService', version: '1.0.0' } }],
+  },
+} as unknown as CollectionEntry<'flows'>;
+
+const context = {
+  services: [service],
+  domains: [],
+  events: [],
+  commands: [],
+  queries: [],
+  flows: [],
+  containers: [],
+  dataProducts: [],
+  diagrams: [],
+  adrs: [],
+  resourceDocs: [],
+  resourceDocCategories: [],
+} as any;
+
+const titles = (node: ReturnType<typeof buildFlowNode>) =>
+  (node.pages || []).map((page) => (typeof page === 'string' ? page : page.title));
+
+describe('buildFlowNode', () => {
+  it('keeps the generated sidebar when no custom sidebar is given', () => {
+    expect(titles(buildFlowNode(flow, context))).toEqual(['Quick Reference', 'Architecture', 'Services']);
+  });
+});
+
+describe('buildFlowNode with a custom sidebar', () => {
+  it('renders exactly the listed sections, in order', () => {
+    const node = buildFlowNode(flow, context, { sidebar: { sections: ['$services', '$quick-reference'] } });
+
+    expect(titles(node)).toEqual(['Services', 'Quick Reference']);
+    expect(node.pages?.[0]).toEqual({ type: 'group', title: 'Services', icon: 'Server', pages: ['service:OrderService:1.0.0'] });
+  });
+});

--- a/packages/core/eventcatalog/src/stores/sidebar-store/builders/__tests__/message-builder.spec.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/builders/__tests__/message-builder.spec.ts
@@ -1,0 +1,87 @@
+import type { CollectionEntry } from 'astro:content';
+import { describe, expect, it, vi } from 'vitest';
+import { buildMessageNode, buildMessageSections, DEFAULT_MESSAGE_SECTION_ORDER } from '../message';
+
+vi.mock('@utils/feature', () => ({
+  isVisualiserEnabled: () => true,
+  isChangelogEnabled: () => false,
+}));
+
+vi.mock('@utils/url-builder', () => ({
+  buildUrl: (path: string) => path,
+}));
+
+const createEvent = (overrides: Record<string, unknown> = {}): CollectionEntry<'events'> =>
+  ({
+    id: 'events/OrderCreated/index.mdx',
+    slug: 'events/OrderCreated',
+    collection: 'events',
+    data: {
+      id: 'OrderCreated',
+      name: 'Order Created',
+      version: '1.0.0',
+      owners: [],
+      ...overrides,
+    },
+  }) as unknown as CollectionEntry<'events'>;
+
+const emptyContext = {
+  services: [],
+  domains: [],
+  events: [],
+  commands: [],
+  queries: [],
+  flows: [],
+  containers: [],
+  dataProducts: [],
+  diagrams: [],
+  adrs: [],
+  schemas: [],
+  resourceDocs: [],
+  resourceDocCategories: [],
+} as any;
+
+const owners = [{ collection: 'teams', data: { id: 'ordering', name: 'Ordering Team' } }];
+
+const titles = (node: ReturnType<typeof buildMessageNode>) =>
+  (node.pages || []).map((page) => (typeof page === 'string' ? page : page.title));
+
+describe('buildMessageSections', () => {
+  it('exposes every key in the default order (plus decision-records for custom sidebars)', () => {
+    const sections = buildMessageSections(createEvent(), owners, emptyContext);
+    const keys = Object.keys(sections).sort();
+    expect(keys).toEqual([...DEFAULT_MESSAGE_SECTION_ORDER, 'decision-records'].sort());
+  });
+});
+
+describe('buildMessageNode with a custom sidebar', () => {
+  const event = createEvent({
+    producers: [{ collection: 'services', data: { id: 'OrderService', version: '1.0.0' } }],
+  });
+
+  it('renders exactly the listed sections, in order', () => {
+    const node = buildMessageNode(
+      event,
+      owners,
+      emptyContext,
+      false,
+      [],
+      { triggers: [], triggeredBy: [] },
+      {
+        sidebar: { sections: ['$owners', '$quick-reference'] },
+      }
+    );
+
+    expect(titles(node)).toEqual(['Owners', 'Quick Reference']);
+    expect(node.pages).toHaveLength(2);
+  });
+
+  it('keeps the generated sidebar when no custom sidebar is given', () => {
+    expect(titles(buildMessageNode(event, owners, emptyContext))).toEqual([
+      'Quick Reference',
+      'Architecture',
+      'Producers',
+      'Owners',
+    ]);
+  });
+});

--- a/packages/core/eventcatalog/src/stores/sidebar-store/builders/__tests__/service-builder.spec.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/builders/__tests__/service-builder.spec.ts
@@ -55,3 +55,18 @@ describe('buildServiceNode', () => {
     });
   });
 });
+
+describe('buildServiceNode with a custom sidebar', () => {
+  const owners = [{ collection: 'teams', data: { id: 'products', name: 'Products Team' } }];
+
+  it('renders exactly the listed sections, in order', () => {
+    const node = buildServiceNode(service, owners, emptyContext, [], [], {
+      sidebar: { sections: ['$owners', '$quick-reference'] },
+    });
+
+    expect((node.pages || []).map((page) => (typeof page === 'string' ? page : page.title))).toEqual([
+      'Owners',
+      'Quick Reference',
+    ]);
+  });
+});

--- a/packages/core/eventcatalog/src/stores/sidebar-store/builders/__tests__/system-builder.spec.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/builders/__tests__/system-builder.spec.ts
@@ -364,4 +364,26 @@ describe('buildSystemNode', () => {
       expect(attachmentsSection).toBeUndefined();
     });
   });
+
+  describe('with a custom sidebar', () => {
+    const owners = [{ id: 'user1', data: { id: 'user1', name: 'User One' }, collection: 'users' }];
+    const titles = (node: ReturnType<typeof buildSystemNode>) =>
+      (node.pages || []).map((page) => (typeof page === 'string' ? page : page.title));
+
+    it('renders exactly the listed sections, in order', () => {
+      const system = createMockSystem({ services: [createMockService('OrdersService', '1.0.0')] as any });
+      const node = buildSystemNode(system, owners as any, emptyContext, {
+        sidebar: { sections: ['$owners', '$quick-reference'] },
+      });
+
+      expect(titles(node)).toEqual(['Owners', 'Quick Reference']);
+    });
+
+    it('renders resource subsections as top-level groups (not subtle) when used directly', () => {
+      const system = createMockSystem({ services: [createMockService('OrdersService', '1.0.0')] as any });
+      const node = buildSystemNode(system, [], emptyContext, { sidebar: { sections: ['$services'] } });
+
+      expect(node.pages).toEqual([{ type: 'group', title: 'Services', icon: 'Server', pages: ['service:OrdersService:1.0.0'] }]);
+    });
+  });
 });

--- a/packages/core/eventcatalog/src/stores/sidebar-store/builders/adr.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/builders/adr.ts
@@ -8,7 +8,7 @@ import {
   type AdrResource,
 } from '@utils/collections/adrs';
 import { collectionToResourceMap, createVersionedMap, findInMap } from '@utils/collections/util';
-import type { ChildRef, NavNode, ResourceGroupContext } from './shared';
+import type { NavNode, ResourceGroupContext } from './shared';
 import {
   buildAttachmentsSection,
   buildOwnersSection,
@@ -17,6 +17,7 @@ import {
   shouldRenderSideBarSection,
 } from './shared';
 import { isChangelogEnabled } from '@utils/feature';
+import { resolveSidebarPages, toCustomSidebarContext, type SidebarSpec } from '../custom-sidebar';
 
 const firstClassResourceCollections = [
   'agents',
@@ -102,13 +103,105 @@ const buildDecisionMakersSection = (decisionMakers: any[]): NavNode | null => {
   };
 };
 
-export const buildAdrNode = (adr: Adr, owners: any[], decisionMakers: any[], context: ResourceGroupContext): NavNode => {
+/**
+ * Predefined sidebar sections for a decision record, keyed by the token users reference from
+ * `sidebar.json` (e.g. `$quick-reference`). Each token is the kebab-cased title of the
+ * section as it appears in the default sidebar.
+ */
+export type AdrSectionKey =
+  | 'quick-reference'
+  | 'applies-to'
+  | 'supersedes'
+  | 'superseded-by'
+  | 'amends'
+  | 'amended-by'
+  | 'related-decisions'
+  | 'decision-makers'
+  | 'owners'
+  | 'code'
+  | 'attachments';
+
+export type AdrSections = Record<AdrSectionKey, NavNode | NavNode[] | null>;
+
+/** Order of sections in the default (generated) sidebar. */
+export const DEFAULT_ADR_SECTION_ORDER: AdrSectionKey[] = [
+  'quick-reference',
+  'applies-to',
+  'supersedes',
+  'superseded-by',
+  'amends',
+  'amended-by',
+  'related-decisions',
+  'decision-makers',
+  'owners',
+  'code',
+  'attachments',
+];
+
+export const buildAdrSections = (adr: Adr, owners: any[], decisionMakers: any[], context: ResourceGroupContext): AdrSections => {
   const relationships = getAdrRelationships(adr, context.adrs);
   const appliesToRefs = resolveAppliedResourceRefs(adr, context);
   const hasAttachments = adr.data.attachments && adr.data.attachments.length > 0;
   const renderOwners = owners.length > 0 && shouldRenderSideBarSection(adr, 'owners');
   const renderDecisionMakers = decisionMakers.length > 0 && shouldRenderSideBarSection(adr, 'decisionMakers');
   const renderRepository = adr.data.repository && shouldRenderSideBarSection(adr, 'repository');
+  const renderRelationships = shouldRenderSideBarSection(adr, 'relationships');
+
+  return {
+    'quick-reference': buildQuickReferenceSection(
+      [
+        { title: 'Overview', href: buildUrl(`/docs/adrs/${adr.data.id}/${adr.data.version}`) },
+        isChangelogEnabled() &&
+          shouldRenderSideBarSection(adr, 'changelog') && {
+            title: 'Changelog',
+            href: buildUrl(`/docs/adrs/${adr.data.id}/${adr.data.version}/changelog`),
+          },
+      ].filter(Boolean) as { title: string; href: string }[]
+    ),
+    'applies-to':
+      appliesToRefs.length > 0 && shouldRenderSideBarSection(adr, 'appliesTo')
+        ? {
+            type: 'group',
+            title: 'Applies to',
+            icon: 'GitBranch',
+            pages: appliesToRefs,
+          }
+        : null,
+    supersedes: renderRelationships ? buildAdrRelationshipSection('Supersedes', 'History', relationships.supersedes) : null,
+    'superseded-by': renderRelationships
+      ? buildAdrRelationshipSection('Superseded by', 'History', relationships.supersededBy)
+      : null,
+    amends: renderRelationships ? buildAdrRelationshipSection('Amends', 'Pencil', relationships.amends) : null,
+    'amended-by': renderRelationships ? buildAdrRelationshipSection('Amended by', 'Pencil', relationships.amendedBy) : null,
+    'related-decisions': renderRelationships
+      ? buildAdrRelationshipSection('Related decisions', 'Link', resolveAdrPointers(adr.data.related, context.adrs))
+      : null,
+    'decision-makers': renderDecisionMakers ? buildDecisionMakersSection(decisionMakers) : null,
+    owners: renderOwners ? buildOwnersSection(owners) : null,
+    code: renderRepository ? buildRepositorySection(adr.data.repository as { url: string; language: string }) : null,
+    attachments: hasAttachments ? buildAttachmentsSection(adr.data.attachments as any[]) : null,
+  };
+};
+
+export type BuildAdrNodeOptions = {
+  /** A parsed `sidebar.json` for this decision record. When present it replaces the generated sidebar. */
+  sidebar?: SidebarSpec;
+};
+
+export const buildAdrNode = (
+  adr: Adr,
+  owners: any[],
+  decisionMakers: any[],
+  context: ResourceGroupContext,
+  options: BuildAdrNodeOptions = {}
+): NavNode => {
+  const sections = buildAdrSections(adr, owners, decisionMakers, context);
+
+  const pages = resolveSidebarPages(sections, DEFAULT_ADR_SECTION_ORDER, {
+    sidebar: options.sidebar,
+    resource: { collection: 'adrs', id: adr.data.id, version: adr.data.version, entry: adr },
+    context: toCustomSidebarContext(context),
+  });
 
   return {
     type: 'item',
@@ -116,37 +209,6 @@ export const buildAdrNode = (adr: Adr, owners: any[], decisionMakers: any[], con
     badge: 'Decision record',
     summary: adr.data.summary,
     icon: 'ClipboardList',
-    pages: [
-      buildQuickReferenceSection(
-        [
-          { title: 'Overview', href: buildUrl(`/docs/adrs/${adr.data.id}/${adr.data.version}`) },
-          isChangelogEnabled() &&
-            shouldRenderSideBarSection(adr, 'changelog') && {
-              title: 'Changelog',
-              href: buildUrl(`/docs/adrs/${adr.data.id}/${adr.data.version}/changelog`),
-            },
-        ].filter(Boolean) as { title: string; href: string }[]
-      ),
-      appliesToRefs.length > 0 &&
-        shouldRenderSideBarSection(adr, 'appliesTo') && {
-          type: 'group',
-          title: 'Applies to',
-          icon: 'GitBranch',
-          pages: appliesToRefs,
-        },
-      shouldRenderSideBarSection(adr, 'relationships') &&
-        buildAdrRelationshipSection('Supersedes', 'History', relationships.supersedes),
-      shouldRenderSideBarSection(adr, 'relationships') &&
-        buildAdrRelationshipSection('Superseded by', 'History', relationships.supersededBy),
-      shouldRenderSideBarSection(adr, 'relationships') && buildAdrRelationshipSection('Amends', 'Pencil', relationships.amends),
-      shouldRenderSideBarSection(adr, 'relationships') &&
-        buildAdrRelationshipSection('Amended by', 'Pencil', relationships.amendedBy),
-      shouldRenderSideBarSection(adr, 'relationships') &&
-        buildAdrRelationshipSection('Related decisions', 'Link', resolveAdrPointers(adr.data.related, context.adrs)),
-      renderDecisionMakers && buildDecisionMakersSection(decisionMakers),
-      renderOwners && buildOwnersSection(owners),
-      renderRepository && buildRepositorySection(adr.data.repository as { url: string; language: string }),
-      hasAttachments && buildAttachmentsSection(adr.data.attachments as any[]),
-    ].filter(Boolean) as ChildRef[],
+    pages,
   };
 };

--- a/packages/core/eventcatalog/src/stores/sidebar-store/builders/agent.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/builders/agent.ts
@@ -11,21 +11,67 @@ import {
   buildAttachmentsSection,
   buildDiagramNavItems,
   buildResourceDocsSection,
+  buildArchitectureDecisionsSection,
 } from './shared';
 import { isChangelogEnabled } from '@utils/feature';
 import { isVisualiserEnabled } from '@utils/feature';
 import { pluralizeMessageType } from '@utils/collections/messages';
 import { iconFieldsForResource } from '@utils/icon';
+import { resolveSidebarPages, toCustomSidebarContext, type SidebarSpec } from '../custom-sidebar';
 
 const uniqueRefs = (refs: string[]) => [...new Set(refs)];
 
-export const buildAgentNode = (
+/**
+ * Predefined sidebar sections for an agent, keyed by the token users reference from
+ * `sidebar.json` (e.g. `$quick-reference`). Each token is the kebab-cased title of the
+ * section as it appears in the default sidebar.
+ */
+export type AgentSectionKey =
+  | 'quick-reference'
+  | 'documentation'
+  | 'architecture'
+  | 'diagrams'
+  | 'resource-groups'
+  | 'state-and-persistence'
+  | 'outbound-messages'
+  | 'inbound-messages'
+  | 'channels'
+  | 'flows'
+  | 'decision-records'
+  | 'owners'
+  | 'code'
+  | 'attachments';
+
+export type AgentSections = Record<AgentSectionKey, NavNode | NavNode[] | null>;
+
+/**
+ * Order of sections in the default (generated) sidebar. `decision-records` is deliberately
+ * absent — in default mode it is inserted before Owners by `withArchitectureDecisionsSection`
+ * in state.ts, and only becomes a first-class token for custom sidebars.
+ */
+export const DEFAULT_AGENT_SECTION_ORDER: AgentSectionKey[] = [
+  'quick-reference',
+  'documentation',
+  'architecture',
+  'diagrams',
+  'resource-groups',
+  'state-and-persistence',
+  'outbound-messages',
+  'inbound-messages',
+  'channels',
+  'flows',
+  'owners',
+  'code',
+  'attachments',
+];
+
+export const buildAgentSections = (
   agent: CollectionEntry<'agents'>,
   owners: any[],
   context: ResourceGroupContext,
   agentChannels: CollectionEntry<'channels'>[] = [],
   flowRefs: string[] = []
-): NavNode => {
+): AgentSections => {
   const sendsMessages = agent.data.sends || [];
   const receivesMessages = agent.data.receives || [];
 
@@ -61,83 +107,129 @@ export const buildAgentNode = (
   const hasDiagrams = diagramNavItems.length > 0;
 
   return {
+    'quick-reference': buildQuickReferenceSection(
+      [
+        { title: 'Overview', href: buildUrl(`/docs/agents/${agent.data.id}/${agent.data.version}`) },
+        isChangelogEnabled() &&
+          shouldRenderSideBarSection(agent, 'changelog') && {
+            title: 'Changelog',
+            href: buildUrl(`/docs/agents/${agent.data.id}/${agent.data.version}/changelog`),
+          },
+      ].filter(Boolean) as { title: string; href: string }[]
+    ),
+    documentation: docsSection,
+    architecture: renderVisualiser
+      ? {
+          type: 'group',
+          title: 'Architecture',
+          icon: 'Workflow',
+          pages: [
+            {
+              type: 'item',
+              title: 'Map',
+              href: buildUrl(`/visualiser/agents/${agent.data.id}/${agent.data.version}`),
+            },
+          ].filter(Boolean) as ChildRef[],
+        }
+      : null,
+    diagrams: hasDiagrams
+      ? {
+          type: 'group',
+          title: 'Diagrams',
+          icon: 'FileImage',
+          pages: diagramNavItems,
+        }
+      : null,
+    'resource-groups': renderResourceGroups
+      ? (buildResourceGroupSections(resourceGroups, context).filter(Boolean) as NavNode[])
+      : null,
+    'state-and-persistence': hasDataStores
+      ? {
+          type: 'group',
+          title: 'State and Persistence',
+          icon: 'Database',
+          pages: dataStoresInAgent.map(
+            (dataStore) => `container:${(dataStore as any).data.id}:${(dataStore as any).data.version}`
+          ),
+        }
+      : null,
+    'outbound-messages':
+      sendsMessages.length > 0 && renderMessages
+        ? {
+            type: 'group',
+            title: 'Outbound Messages',
+            icon: 'Mail',
+            pages: sendsMessages.map(
+              (message) => `${pluralizeMessageType(message as any)}:${(message as any).data.id}:${(message as any).data.version}`
+            ),
+          }
+        : null,
+    'inbound-messages':
+      receivesMessages.length > 0 && renderMessages
+        ? {
+            type: 'group',
+            title: 'Inbound Messages',
+            icon: 'Mail',
+            pages: receivesMessages.map(
+              (receive) => `${pluralizeMessageType(receive as any)}:${(receive as any).data.id}:${(receive as any).data.version}`
+            ),
+          }
+        : null,
+    channels:
+      agentChannels.length > 0
+        ? {
+            type: 'group',
+            title: 'Channels',
+            icon: 'ArrowRightLeft',
+            pages: agentChannels.map((channel) => `channel:${(channel as any).data.id}:${(channel as any).data.version}`),
+          }
+        : null,
+    flows: hasFlows
+      ? {
+          type: 'group',
+          // If the agent declares its own flows it owns them ("Flows"); otherwise it is
+          // only referenced as a step in someone else's flow ("Appears in flows").
+          title: agentFlows.length > 0 ? 'Flows' : 'Appears in flows',
+          icon: 'Waypoints',
+          pages: agentFlowRefs,
+        }
+      : null,
+    'decision-records': shouldRenderSideBarSection(agent, 'architectureDecisions')
+      ? buildArchitectureDecisionsSection(agent, context.adrs || [])
+      : null,
+    owners: renderOwners ? buildOwnersSection(owners) : null,
+    code: renderRepository ? buildRepositorySection(agent.data.repository as { url: string; language: string }) : null,
+    attachments: hasAttachments ? buildAttachmentsSection(agent.data.attachments as any[]) : null,
+  };
+};
+
+export type BuildAgentNodeOptions = {
+  /** A parsed `sidebar.json` for this agent. When present it replaces the generated sidebar. */
+  sidebar?: SidebarSpec;
+};
+
+export const buildAgentNode = (
+  agent: CollectionEntry<'agents'>,
+  owners: any[],
+  context: ResourceGroupContext,
+  agentChannels: CollectionEntry<'channels'>[] = [],
+  flowRefs: string[] = [],
+  options: BuildAgentNodeOptions = {}
+): NavNode => {
+  const sections = buildAgentSections(agent, owners, context, agentChannels, flowRefs);
+
+  const pages = resolveSidebarPages(sections, DEFAULT_AGENT_SECTION_ORDER, {
+    sidebar: options.sidebar,
+    resource: { collection: 'agents', id: agent.data.id, version: agent.data.version, entry: agent },
+    context: toCustomSidebarContext(context),
+  });
+
+  return {
     type: 'item',
     title: agent.data.name,
     badge: 'Agent',
     summary: agent.data.summary,
     ...iconFieldsForResource(agent.data, 'Bot'),
-    pages: [
-      buildQuickReferenceSection(
-        [
-          { title: 'Overview', href: buildUrl(`/docs/agents/${agent.data.id}/${agent.data.version}`) },
-          isChangelogEnabled() &&
-            shouldRenderSideBarSection(agent, 'changelog') && {
-              title: 'Changelog',
-              href: buildUrl(`/docs/agents/${agent.data.id}/${agent.data.version}/changelog`),
-            },
-        ].filter(Boolean) as { title: string; href: string }[]
-      ),
-      docsSection,
-      renderVisualiser && {
-        type: 'group',
-        title: 'Architecture',
-        icon: 'Workflow',
-        pages: [
-          {
-            type: 'item',
-            title: 'Map',
-            href: buildUrl(`/visualiser/agents/${agent.data.id}/${agent.data.version}`),
-          },
-        ].filter(Boolean) as ChildRef[],
-      },
-      hasDiagrams && {
-        type: 'group',
-        title: 'Diagrams',
-        icon: 'FileImage',
-        pages: diagramNavItems,
-      },
-      renderResourceGroups && buildResourceGroupSections(resourceGroups, context),
-      hasDataStores && {
-        type: 'group',
-        title: 'State and Persistence',
-        icon: 'Database',
-        pages: dataStoresInAgent.map((dataStore) => `container:${(dataStore as any).data.id}:${(dataStore as any).data.version}`),
-      },
-      sendsMessages.length > 0 &&
-        renderMessages && {
-          type: 'group',
-          title: 'Outbound Messages',
-          icon: 'Mail',
-          pages: sendsMessages.map(
-            (message) => `${pluralizeMessageType(message as any)}:${(message as any).data.id}:${(message as any).data.version}`
-          ),
-        },
-      receivesMessages.length > 0 &&
-        renderMessages && {
-          type: 'group',
-          title: 'Inbound Messages',
-          icon: 'Mail',
-          pages: receivesMessages.map(
-            (receive) => `${pluralizeMessageType(receive as any)}:${(receive as any).data.id}:${(receive as any).data.version}`
-          ),
-        },
-      agentChannels.length > 0 && {
-        type: 'group',
-        title: 'Channels',
-        icon: 'ArrowRightLeft',
-        pages: agentChannels.map((channel) => `channel:${(channel as any).data.id}:${(channel as any).data.version}`),
-      },
-      hasFlows && {
-        type: 'group',
-        // If the agent declares its own flows it owns them ("Flows"); otherwise it is
-        // only referenced as a step in someone else's flow ("Appears in flows").
-        title: agentFlows.length > 0 ? 'Flows' : 'Appears in flows',
-        icon: 'Waypoints',
-        pages: agentFlowRefs,
-      },
-      renderOwners && buildOwnersSection(owners),
-      renderRepository && buildRepositorySection(agent.data.repository as { url: string; language: string }),
-      hasAttachments && buildAttachmentsSection(agent.data.attachments as any[]),
-    ].filter(Boolean) as ChildRef[],
+    pages,
   };
 };

--- a/packages/core/eventcatalog/src/stores/sidebar-store/builders/container.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/builders/container.ts
@@ -1,6 +1,6 @@
 import type { CollectionEntry } from 'astro:content';
 import { buildUrl } from '@utils/url-builder';
-import type { NavNode, ChildRef, ResourceGroupContext } from './shared';
+import type { NavNode, ResourceGroupContext } from './shared';
 import {
   buildQuickReferenceSection,
   buildOwnersSection,
@@ -9,16 +9,56 @@ import {
   buildAttachmentsSection,
   buildDiagramNavItems,
   buildResourceDocsSection,
+  buildArchitectureDecisionsSection,
 } from './shared';
 import { isVisualiserEnabled, isChangelogEnabled } from '@utils/feature';
 import { iconFieldsForResource } from '@utils/icon';
+import { resolveSidebarPages, toCustomSidebarContext, type SidebarSpec } from '../custom-sidebar';
 
-export const buildContainerNode = (
+/**
+ * Predefined sidebar sections for a container, keyed by the token users reference from
+ * `sidebar.json` (e.g. `$quick-reference`). Each token is the kebab-cased title of the
+ * section as it appears in the default sidebar.
+ */
+export type ContainerSectionKey =
+  | 'quick-reference'
+  | 'documentation'
+  | 'architecture'
+  | 'diagrams'
+  | 'writes'
+  | 'reads'
+  | 'appears-in-flows'
+  | 'decision-records'
+  | 'owners'
+  | 'code'
+  | 'attachments';
+
+export type ContainerSections = Record<ContainerSectionKey, NavNode | NavNode[] | null>;
+
+/**
+ * Order of sections in the default (generated) sidebar. `decision-records` is deliberately
+ * absent — in default mode it is inserted before Owners by `withArchitectureDecisionsSection`
+ * in state.ts, and only becomes a first-class token for custom sidebars.
+ */
+export const DEFAULT_CONTAINER_SECTION_ORDER: ContainerSectionKey[] = [
+  'quick-reference',
+  'documentation',
+  'architecture',
+  'diagrams',
+  'writes',
+  'reads',
+  'appears-in-flows',
+  'owners',
+  'code',
+  'attachments',
+];
+
+export const buildContainerSections = (
   container: CollectionEntry<'containers'>,
   owners: any[],
   context: ResourceGroupContext,
   flowRefs: string[] = []
-): NavNode => {
+): ContainerSections => {
   const servicesWritingToContainer = container.data.servicesThatWriteToContainer || [];
   const servicesReadingFromContainer = container.data.servicesThatReadFromContainer || [];
   const dataProductsWritingToContainer = (container.data as any).dataProductsThatWriteToContainer || [];
@@ -60,66 +100,102 @@ export const buildContainerNode = (
   const hasDiagrams = diagramNavItems.length > 0;
 
   return {
+    'quick-reference': buildQuickReferenceSection(
+      [
+        {
+          title: 'Overview',
+          href: buildUrl(`/docs/containers/${container.data.id}/${container.data.version}`),
+        },
+        isChangelogEnabled() &&
+          shouldRenderSideBarSection(container, 'changelog') && {
+            title: 'Changelog',
+            href: buildUrl(`/docs/containers/${container.data.id}/${container.data.version}/changelog`),
+          },
+      ].filter(Boolean) as { title: string; href: string }[]
+    ),
+    documentation: docsSection,
+    architecture: renderVisualiser
+      ? {
+          type: 'group',
+          title: 'Architecture',
+          icon: 'Workflow',
+          pages: [
+            {
+              type: 'item',
+              title: 'Map',
+              href: buildUrl(`/visualiser/containers/${container.data.id}/${container.data.version}`),
+            },
+          ],
+        }
+      : null,
+    diagrams: hasDiagrams
+      ? {
+          type: 'group',
+          title: 'Diagrams',
+          icon: 'FileImage',
+          pages: diagramNavItems,
+        }
+      : null,
+    writes: renderWrites
+      ? {
+          type: 'group',
+          title: 'Writes',
+          icon: 'ArrowUpFromLine',
+          pages: allWrites,
+        }
+      : null,
+    reads: renderReads
+      ? {
+          type: 'group',
+          title: 'Reads',
+          icon: 'ArrowDownToLine',
+          pages: allReads,
+        }
+      : null,
+    'appears-in-flows': renderFlows
+      ? {
+          type: 'group',
+          title: 'Appears in flows',
+          icon: 'Waypoints',
+          pages: flowRefs,
+          visible: flowRefs.length > 0,
+        }
+      : null,
+    'decision-records': shouldRenderSideBarSection(container, 'architectureDecisions')
+      ? buildArchitectureDecisionsSection(container, context.adrs || [])
+      : null,
+    owners: renderOwners ? buildOwnersSection(owners) : null,
+    code: renderRepository ? buildRepositorySection(container.data.repository as { url: string; language: string }) : null,
+    attachments: hasAttachments ? buildAttachmentsSection(container.data.attachments as any[]) : null,
+  };
+};
+
+export type BuildContainerNodeOptions = {
+  /** A parsed `sidebar.json` for this container. When present it replaces the generated sidebar. */
+  sidebar?: SidebarSpec;
+};
+
+export const buildContainerNode = (
+  container: CollectionEntry<'containers'>,
+  owners: any[],
+  context: ResourceGroupContext,
+  flowRefs: string[] = [],
+  options: BuildContainerNodeOptions = {}
+): NavNode => {
+  const sections = buildContainerSections(container, owners, context, flowRefs);
+
+  const pages = resolveSidebarPages(sections, DEFAULT_CONTAINER_SECTION_ORDER, {
+    sidebar: options.sidebar,
+    resource: { collection: 'containers', id: container.data.id, version: container.data.version, entry: container },
+    context: toCustomSidebarContext(context),
+  });
+
+  return {
     type: 'item',
     title: container.data.name,
     badge: 'Container',
     summary: container.data.summary,
     ...iconFieldsForResource(container.data, 'Database'),
-    pages: [
-      buildQuickReferenceSection(
-        [
-          {
-            title: 'Overview',
-            href: buildUrl(`/docs/containers/${container.data.id}/${container.data.version}`),
-          },
-          isChangelogEnabled() &&
-            shouldRenderSideBarSection(container, 'changelog') && {
-              title: 'Changelog',
-              href: buildUrl(`/docs/containers/${container.data.id}/${container.data.version}/changelog`),
-            },
-        ].filter(Boolean) as { title: string; href: string }[]
-      ),
-      docsSection,
-      renderVisualiser && {
-        type: 'group',
-        title: 'Architecture',
-        icon: 'Workflow',
-        pages: [
-          {
-            type: 'item',
-            title: 'Map',
-            href: buildUrl(`/visualiser/containers/${container.data.id}/${container.data.version}`),
-          },
-        ],
-      },
-      hasDiagrams && {
-        type: 'group',
-        title: 'Diagrams',
-        icon: 'FileImage',
-        pages: diagramNavItems,
-      },
-      renderWrites && {
-        type: 'group',
-        title: 'Writes',
-        icon: 'ArrowUpFromLine',
-        pages: allWrites,
-      },
-      renderReads && {
-        type: 'group',
-        title: 'Reads',
-        icon: 'ArrowDownToLine',
-        pages: allReads,
-      },
-      renderFlows && {
-        type: 'group',
-        title: 'Appears in flows',
-        icon: 'Waypoints',
-        pages: flowRefs,
-        visible: flowRefs.length > 0,
-      },
-      renderOwners && buildOwnersSection(owners),
-      renderRepository && buildRepositorySection(container.data.repository as { url: string; language: string }),
-      hasAttachments && buildAttachmentsSection(container.data.attachments as any[]),
-    ].filter(Boolean) as ChildRef[],
+    pages,
   };
 };

--- a/packages/core/eventcatalog/src/stores/sidebar-store/builders/data-product.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/builders/data-product.ts
@@ -1,18 +1,26 @@
 import type { CollectionEntry } from 'astro:content';
 import { buildUrl } from '@utils/url-builder';
-import type { NavNode, ChildRef, ResourceGroupContext } from './shared';
-import { buildQuickReferenceSection, buildOwnersSection, shouldRenderSideBarSection, buildResourceDocsSection } from './shared';
+import type { NavNode, ResourceGroupContext } from './shared';
+import {
+  buildQuickReferenceSection,
+  buildOwnersSection,
+  shouldRenderSideBarSection,
+  buildResourceDocsSection,
+  buildArchitectureDecisionsSection,
+} from './shared';
 import { isVisualiserEnabled, isChangelogEnabled } from '@utils/feature';
 import { getItemsFromCollectionByIdAndSemverOrLatest, sortVersioned } from '@utils/collections/util';
 import { getSchemaFormatFromURL } from '@utils/collections/schemas';
 import { iconFieldsForResource } from '@utils/icon';
+import { resolveSidebarPages, toCustomSidebarContext, type SidebarSpec } from '../custom-sidebar';
 
 type DataProductContext = Pick<
   ResourceGroupContext,
   'events' | 'commands' | 'queries' | 'services' | 'containers' | 'resourceDocs' | 'resourceDocCategories'
-> & {
-  channels: CollectionEntry<'channels'>[];
-};
+> &
+  Partial<Pick<ResourceGroupContext, 'adrs'>> & {
+    channels: CollectionEntry<'channels'>[];
+  };
 
 // Get highest version from matched items (semver ranges may return multiple matches)
 const getHighestVersion = <T extends { data: { version: string } }>(items: T[]): T | undefined => {
@@ -57,12 +65,46 @@ const resolvePointerToRef = (pointer: { id: string; version?: string }, context:
   return null;
 };
 
-export const buildDataProductNode = (
+/**
+ * Predefined sidebar sections for a data product, keyed by the token users reference from
+ * `sidebar.json` (e.g. `$quick-reference`). Each token is the kebab-cased title of the
+ * section as it appears in the default sidebar.
+ */
+export type DataProductSectionKey =
+  | 'quick-reference'
+  | 'documentation'
+  | 'architecture'
+  | 'inputs'
+  | 'outputs'
+  | 'data-contracts'
+  | 'appears-in-flows'
+  | 'decision-records'
+  | 'owners';
+
+export type DataProductSections = Record<DataProductSectionKey, NavNode | NavNode[] | null>;
+
+/**
+ * Order of sections in the default (generated) sidebar. `decision-records` is deliberately
+ * absent — in default mode it is inserted before Owners by `withArchitectureDecisionsSection`
+ * in state.ts, and only becomes a first-class token for custom sidebars.
+ */
+export const DEFAULT_DATA_PRODUCT_SECTION_ORDER: DataProductSectionKey[] = [
+  'quick-reference',
+  'documentation',
+  'architecture',
+  'inputs',
+  'outputs',
+  'data-contracts',
+  'appears-in-flows',
+  'owners',
+];
+
+export const buildDataProductSections = (
   dataProduct: CollectionEntry<'data-products'>,
   owners: any[],
   context: DataProductContext,
   flowRefs: string[] = []
-): NavNode => {
+): DataProductSections => {
   const inputs = dataProduct.data.inputs || [];
   const outputs = dataProduct.data.outputs || [];
 
@@ -94,61 +136,105 @@ export const buildDataProductNode = (
     }));
 
   return {
+    'quick-reference': buildQuickReferenceSection(
+      [
+        { title: 'Overview', href: buildUrl(`/docs/data-products/${dataProduct.data.id}/${dataProduct.data.version}`) },
+        isChangelogEnabled() &&
+          shouldRenderSideBarSection(dataProduct, 'changelog') && {
+            title: 'Changelog',
+            href: buildUrl(`/docs/data-products/${dataProduct.data.id}/${dataProduct.data.version}/changelog`),
+          },
+      ].filter(Boolean) as { title: string; href: string }[]
+    ),
+    documentation: docsSection,
+    architecture: renderVisualiser
+      ? {
+          type: 'group',
+          title: 'Architecture',
+          icon: 'Workflow',
+          pages: [
+            {
+              type: 'item',
+              title: 'Map',
+              href: buildUrl(`/visualiser/data-products/${dataProduct.data.id}/${dataProduct.data.version}`),
+            },
+          ],
+        }
+      : null,
+    inputs:
+      resolvedInputs.length > 0
+        ? {
+            type: 'group',
+            title: 'Inputs',
+            icon: 'ArrowDownToLine',
+            pages: resolvedInputs,
+          }
+        : null,
+    outputs:
+      resolvedOutputs.length > 0
+        ? {
+            type: 'group',
+            title: 'Outputs',
+            icon: 'ArrowUpFromLine',
+            pages: resolvedOutputs,
+          }
+        : null,
+    'data-contracts':
+      dataContracts.length > 0
+        ? {
+            type: 'group',
+            title: 'Data Contracts',
+            icon: 'FileCheck',
+            pages: dataContracts,
+          }
+        : null,
+    'appears-in-flows': renderFlows
+      ? {
+          type: 'group',
+          title: 'Appears in flows',
+          icon: 'Waypoints',
+          pages: flowRefs,
+          visible: flowRefs.length > 0,
+        }
+      : null,
+    'decision-records': shouldRenderSideBarSection(dataProduct, 'architectureDecisions')
+      ? buildArchitectureDecisionsSection(dataProduct, context.adrs || [])
+      : null,
+    owners: renderOwners ? buildOwnersSection(owners) : null,
+  };
+};
+
+export type BuildDataProductNodeOptions = {
+  /** A parsed `sidebar.json` for this data product. When present it replaces the generated sidebar. */
+  sidebar?: SidebarSpec;
+};
+
+export const buildDataProductNode = (
+  dataProduct: CollectionEntry<'data-products'>,
+  owners: any[],
+  context: DataProductContext,
+  flowRefs: string[] = [],
+  options: BuildDataProductNodeOptions = {}
+): NavNode => {
+  const sections = buildDataProductSections(dataProduct, owners, context, flowRefs);
+
+  const pages = resolveSidebarPages(sections, DEFAULT_DATA_PRODUCT_SECTION_ORDER, {
+    sidebar: options.sidebar,
+    resource: {
+      collection: 'data-products',
+      id: dataProduct.data.id,
+      version: dataProduct.data.version,
+      entry: dataProduct,
+    },
+    context: toCustomSidebarContext(context),
+  });
+
+  return {
     type: 'item',
     title: dataProduct.data.name,
     badge: 'Data Product',
     summary: dataProduct.data.summary,
     ...iconFieldsForResource(dataProduct.data, 'Package'),
-    pages: [
-      buildQuickReferenceSection(
-        [
-          { title: 'Overview', href: buildUrl(`/docs/data-products/${dataProduct.data.id}/${dataProduct.data.version}`) },
-          isChangelogEnabled() &&
-            shouldRenderSideBarSection(dataProduct, 'changelog') && {
-              title: 'Changelog',
-              href: buildUrl(`/docs/data-products/${dataProduct.data.id}/${dataProduct.data.version}/changelog`),
-            },
-        ].filter(Boolean) as { title: string; href: string }[]
-      ),
-      docsSection,
-      renderVisualiser && {
-        type: 'group',
-        title: 'Architecture',
-        icon: 'Workflow',
-        pages: [
-          {
-            type: 'item',
-            title: 'Map',
-            href: buildUrl(`/visualiser/data-products/${dataProduct.data.id}/${dataProduct.data.version}`),
-          },
-        ],
-      },
-      resolvedInputs.length > 0 && {
-        type: 'group',
-        title: 'Inputs',
-        icon: 'ArrowDownToLine',
-        pages: resolvedInputs,
-      },
-      resolvedOutputs.length > 0 && {
-        type: 'group',
-        title: 'Outputs',
-        icon: 'ArrowUpFromLine',
-        pages: resolvedOutputs,
-      },
-      dataContracts.length > 0 && {
-        type: 'group',
-        title: 'Data Contracts',
-        icon: 'FileCheck',
-        pages: dataContracts,
-      },
-      renderFlows && {
-        type: 'group',
-        title: 'Appears in flows',
-        icon: 'Waypoints',
-        pages: flowRefs,
-        visible: flowRefs.length > 0,
-      },
-      renderOwners && buildOwnersSection(owners),
-    ].filter(Boolean) as ChildRef[],
+    pages,
   };
 };

--- a/packages/core/eventcatalog/src/stores/sidebar-store/builders/domain.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/builders/domain.ts
@@ -10,16 +10,75 @@ import {
   buildAttachmentsSection,
   buildDiagramNavItems,
   buildResourceDocsSection,
+  buildArchitectureDecisionsSection,
 } from './shared';
 import { isVisualiserEnabled, isChangelogEnabled } from '@utils/feature';
 import { pluralizeMessageType } from '@utils/collections/messages';
 import { getSpecificationsForDomain, hasUbiquitousLanguageTermsWithSubdomainsInCollection } from '@utils/collections/domains';
 import { customIconFieldsForResource } from '@utils/icon';
+import { resolveSidebarPages, toCustomSidebarContext, type SidebarSpec } from '../custom-sidebar';
 
 // Sort resolved collection entries A-Z by their display name (falling back to id).
 const byResourceName = (a: any, b: any) => (a.data?.name || a.data?.id || '').localeCompare(b.data?.name || b.data?.id || '');
 
-export const buildDomainNode = (domain: CollectionEntry<'domains'>, owners: any[], context: ResourceGroupContext): NavNode => {
+/**
+ * Predefined sidebar sections for a domain, keyed by the token users reference from
+ * `sidebar.json` (e.g. `$quick-reference`). Each token is the kebab-cased title of the
+ * section as it appears in the default sidebar.
+ */
+export type DomainSectionKey =
+  | 'quick-reference'
+  | 'documentation'
+  | 'architecture'
+  | 'diagrams'
+  | 'api-and-contracts'
+  | 'systems'
+  | 'subdomains'
+  | 'resources'
+  | 'services'
+  | 'flows'
+  | 'entities'
+  | 'domain-events'
+  | 'external-events'
+  | 'resource-groups'
+  | 'agents'
+  | 'external-integrations'
+  | 'data-products'
+  | 'decision-records'
+  | 'owners'
+  | 'code'
+  | 'attachments';
+
+export type DomainSections = Record<DomainSectionKey, NavNode | NavNode[] | null>;
+
+/**
+ * Order of sections in the default (generated) sidebar. `decision-records` is deliberately
+ * absent — in default mode it is inserted before Owners by `withArchitectureDecisionsSection`
+ * in state.ts, and only becomes a first-class token for custom sidebars.
+ */
+export const DEFAULT_DOMAIN_SECTION_ORDER: DomainSectionKey[] = [
+  'quick-reference',
+  'documentation',
+  'architecture',
+  'diagrams',
+  'api-and-contracts',
+  'systems',
+  'subdomains',
+  'resources',
+  'resource-groups',
+  'agents',
+  'external-integrations',
+  'data-products',
+  'owners',
+  'code',
+  'attachments',
+];
+
+export const buildDomainSections = (
+  domain: CollectionEntry<'domains'>,
+  owners: any[],
+  context: ResourceGroupContext
+): DomainSections => {
   const agentsInDomain = domain.data.agents || [];
   const renderAgents = agentsInDomain.length > 0 && shouldRenderSideBarSection(domain, 'agents');
 
@@ -117,6 +176,251 @@ export const buildDomainNode = (domain: CollectionEntry<'domains'>, owners: any[
   const graphQLSpecifications = specifications.filter((specification) => specification.type === 'graphql');
   const renderSpecifications = hasSpecifications && shouldRenderSideBarSection(domain, 'specifications');
 
+  // Resource subsections. These are built once and shared between the "Resources"
+  // umbrella (where they render as subtle subgroups) and their standalone tokens
+  // (`$services`, `$entities`, ...) for custom sidebars.
+  const servicesSection: NavNode | null = renderServices
+    ? {
+        type: 'group',
+        title: 'Services',
+        icon: 'Server',
+        pages: servicesInDomain.map((service) => `service:${(service as any).data.id}:${(service as any).data.version}`),
+      }
+    : null;
+
+  const flowsSection: NavNode | null = hasFlows
+    ? {
+        type: 'group',
+        title: 'Flows',
+        icon: 'Waypoints',
+        pages: domainFlows.map((flow) => `flow:${(flow as any).data.id}:${(flow as any).data.version}`),
+      }
+    : null;
+
+  const entitiesSection: NavNode | null = renderEntities
+    ? {
+        type: 'group',
+        title: 'Entities',
+        icon: 'Box',
+        pages: entitiesInDomain.map((entity) => ({
+          type: 'item',
+          title: (entity as any).data?.name || (entity as any).data.id,
+          href: buildUrl(`/docs/entities/${(entity as any).data.id}/${(entity as any).data.version}`),
+        })),
+      }
+    : null;
+
+  const domainEventsSection: NavNode | null =
+    renderMessages && sendsMessages.length > 0
+      ? {
+          type: 'group',
+          title: 'Domain Events',
+          icon: 'Mail',
+          pages: sortedSendsMessages.map(
+            (message) => `${pluralizeMessageType(message as any)}:${(message as any).data.id}:${(message as any).data.version}`
+          ),
+        }
+      : null;
+
+  const externalEventsSection: NavNode | null =
+    renderMessages && receivesMessages.length > 0
+      ? {
+          type: 'group',
+          title: 'External Events',
+          icon: 'Mail',
+          pages: sortedReceivesMessages.map(
+            (receive) => `${pluralizeMessageType(receive as any)}:${(receive as any).data.id}:${(receive as any).data.version}`
+          ),
+        }
+      : null;
+
+  const resourceSubsections = [servicesSection, flowsSection, entitiesSection, domainEventsSection, externalEventsSection].filter(
+    Boolean
+  ) as NavNode[];
+
+  return {
+    'quick-reference': buildQuickReferenceSection(
+      [
+        { title: 'Overview', href: buildUrl(`/docs/domains/${domain.data.id}/${domain.data.version}`) },
+        hasResources && {
+          title: 'Domain Resources',
+          href: buildUrl(`/docs/domains/${domain.data.id}/${domain.data.version}/resources`),
+        },
+        renderUbiquitousLanguage && {
+          title: 'Ubiquitous Language',
+          href: buildUrl(`/docs/domains/${domain.data.id}/language`),
+        },
+        isChangelogEnabled() &&
+          shouldRenderSideBarSection(domain, 'changelog') && {
+            title: 'Changelog',
+            href: buildUrl(`/docs/domains/${domain.data.id}/${domain.data.version}/changelog`),
+          },
+      ].filter(Boolean) as { title: string; href: string }[]
+    ),
+    documentation: docsSection,
+    architecture: {
+      type: 'group',
+      title: 'Architecture',
+      icon: 'Workflow',
+      pages: [
+        {
+          type: 'item',
+          title: 'Overview',
+          href: buildUrl(`/architecture/domains/${domain.data.id}/${domain.data.version}`),
+        },
+        renderSystems &&
+          renderVisualiser &&
+          hasSystemContext && {
+            type: 'item',
+            title: 'System Diagram',
+            href: buildUrl(`/visualiser/domains/${domain.data.id}/${domain.data.version}/systems-context`),
+          },
+        renderVisualiser &&
+          hasResourceDiagram && {
+            type: 'item',
+            title: 'Resource Diagram',
+            href: buildUrl(`/visualiser/domains/${domain.data.id}/${domain.data.version}`),
+          },
+        renderEntities &&
+          renderVisualiser && {
+            type: 'item',
+            title: 'Entity Diagram',
+            href: buildUrl(`/visualiser/domains/${domain.data.id}/${domain.data.version}/entity-map`),
+          },
+      ].filter(Boolean) as ChildRef[],
+    },
+    diagrams: hasDiagrams
+      ? {
+          type: 'group',
+          title: 'Diagrams',
+          icon: 'FileImage',
+          pages: diagramNavItems,
+        }
+      : null,
+    'api-and-contracts': renderSpecifications
+      ? {
+          type: 'group',
+          title: 'API & Contracts',
+          icon: 'FileCode',
+          pages: [
+            ...openAPISpecifications.map((specification) => ({
+              type: 'item',
+              title: specification.name,
+              leftIcon: '/icons/openapi-black.svg',
+              href: buildUrl(
+                `/docs/domains/${domain.data.id}/${domain.data.version}/spec/${specification.filenameWithoutExtension}`
+              ),
+            })),
+            ...asyncAPISpecifications.map((specification) => ({
+              type: 'item',
+              title: specification.name,
+              leftIcon: '/icons/asyncapi-black.svg',
+              href: buildUrl(
+                `/docs/domains/${domain.data.id}/${domain.data.version}/asyncapi/${specification.filenameWithoutExtension}`
+              ),
+            })),
+            ...graphQLSpecifications.map((specification) => ({
+              type: 'item',
+              title: specification.name,
+              leftIcon: '/icons/graphql-black.svg',
+              href: buildUrl(
+                `/docs/domains/${domain.data.id}/${domain.data.version}/graphql/${specification.filenameWithoutExtension}`
+              ),
+            })),
+          ],
+        }
+      : null,
+    systems: renderSystems
+      ? {
+          type: 'group',
+          title: 'Systems',
+          icon: 'Group',
+          pages: systemsInDomain.map((system) => `system:${(system as any).data.id}:${(system as any).data.version}`),
+        }
+      : null,
+    subdomains: renderSubDomains
+      ? {
+          type: 'group',
+          title: 'Subdomains',
+          icon: 'Boxes',
+          pages: subDomains.map((domain) => `domain:${(domain as any).data.id}:${(domain as any).data.version}`),
+        }
+      : null,
+    resources:
+      resourceSubsections.length > 0
+        ? {
+            type: 'group',
+            title: 'Resources',
+            icon: 'Boxes',
+            // Resource type subsections are ordered A-Z by their title, and the
+            // resources within each subsection are ordered A-Z by name (sorted above).
+            pages: resourceSubsections
+              .map((section) => ({ ...section, subtle: true }))
+              .sort((a, b) => a.title.localeCompare(b.title)) as ChildRef[],
+          }
+        : null,
+    services: servicesSection,
+    flows: flowsSection,
+    entities: entitiesSection,
+    'domain-events': domainEventsSection,
+    'external-events': externalEventsSection,
+    'resource-groups': hasResourceGroups
+      ? (buildResourceGroupSections(resourceGroups, context).filter(Boolean) as NavNode[])
+      : null,
+    agents: renderAgents
+      ? {
+          type: 'group',
+          title: 'Agents In Domain',
+          icon: 'Bot',
+          pages: agentsInDomain.map((agent) => `agent:${(agent as any).data.id}:${(agent as any).data.version}`),
+        }
+      : null,
+    'external-integrations': renderExternalSystems
+      ? {
+          type: 'group',
+          title: 'External Integrations',
+          icon: 'Globe',
+          pages: externalSystemsInDomain.map((service) => `service:${(service as any).data.id}:${(service as any).data.version}`),
+        }
+      : null,
+    'data-products': renderDataProducts
+      ? {
+          type: 'group',
+          title: 'Data Products',
+          icon: 'Package',
+          pages: dataProductsInDomain.map(
+            (dataProduct) => `data-product:${(dataProduct as any).data.id}:${(dataProduct as any).data.version}`
+          ),
+        }
+      : null,
+    'decision-records': shouldRenderSideBarSection(domain, 'architectureDecisions')
+      ? buildArchitectureDecisionsSection(domain, context.adrs || [])
+      : null,
+    owners: renderOwners ? buildOwnersSection(owners) : null,
+    code: renderRepository ? buildRepositorySection(domain.data.repository as { url: string; language: string }) : null,
+    attachments: hasAttachments ? buildAttachmentsSection(domain.data.attachments as any[]) : null,
+  };
+};
+
+export type BuildDomainNodeOptions = {
+  /** A parsed `sidebar.json` for this domain. When present it replaces the generated sidebar. */
+  sidebar?: SidebarSpec;
+};
+
+export const buildDomainNode = (
+  domain: CollectionEntry<'domains'>,
+  owners: any[],
+  context: ResourceGroupContext,
+  options: BuildDomainNodeOptions = {}
+): NavNode => {
+  const sections = buildDomainSections(domain, owners, context);
+
+  const pages = resolveSidebarPages(sections, DEFAULT_DOMAIN_SECTION_ORDER, {
+    sidebar: options.sidebar,
+    resource: { collection: 'domains', id: domain.data.id, version: domain.data.version, entry: domain },
+    context: toCustomSidebarContext(context),
+  });
+
   return {
     type: 'item',
     title: domain.data.name,
@@ -126,192 +430,6 @@ export const buildDomainNode = (domain: CollectionEntry<'domains'>, owners: any[
     // 'Domains' section header (and Domain badge) already convey the type, so the
     // default Boxes glyph on every item is redundant.
     ...customIconFieldsForResource(domain.data),
-    pages: [
-      buildQuickReferenceSection(
-        [
-          { title: 'Overview', href: buildUrl(`/docs/domains/${domain.data.id}/${domain.data.version}`) },
-          hasResources && {
-            title: 'Domain Resources',
-            href: buildUrl(`/docs/domains/${domain.data.id}/${domain.data.version}/resources`),
-          },
-          renderUbiquitousLanguage && {
-            title: 'Ubiquitous Language',
-            href: buildUrl(`/docs/domains/${domain.data.id}/language`),
-          },
-          isChangelogEnabled() &&
-            shouldRenderSideBarSection(domain, 'changelog') && {
-              title: 'Changelog',
-              href: buildUrl(`/docs/domains/${domain.data.id}/${domain.data.version}/changelog`),
-            },
-        ].filter(Boolean) as { title: string; href: string }[]
-      ),
-      docsSection,
-      {
-        type: 'group',
-        title: 'Architecture',
-        icon: 'Workflow',
-        pages: [
-          {
-            type: 'item',
-            title: 'Overview',
-            href: buildUrl(`/architecture/domains/${domain.data.id}/${domain.data.version}`),
-          },
-          renderSystems &&
-            renderVisualiser &&
-            hasSystemContext && {
-              type: 'item',
-              title: 'System Diagram',
-              href: buildUrl(`/visualiser/domains/${domain.data.id}/${domain.data.version}/systems-context`),
-            },
-          renderVisualiser &&
-            hasResourceDiagram && {
-              type: 'item',
-              title: 'Resource Diagram',
-              href: buildUrl(`/visualiser/domains/${domain.data.id}/${domain.data.version}`),
-            },
-          renderEntities &&
-            renderVisualiser && {
-              type: 'item',
-              title: 'Entity Diagram',
-              href: buildUrl(`/visualiser/domains/${domain.data.id}/${domain.data.version}/entity-map`),
-            },
-        ].filter(Boolean) as ChildRef[],
-      },
-      hasDiagrams && {
-        type: 'group',
-        title: 'Diagrams',
-        icon: 'FileImage',
-        pages: diagramNavItems,
-      },
-      renderSpecifications && {
-        type: 'group',
-        title: 'API & Contracts',
-        icon: 'FileCode',
-        pages: [
-          ...openAPISpecifications.map((specification) => ({
-            type: 'item',
-            title: specification.name,
-            leftIcon: '/icons/openapi-black.svg',
-            href: buildUrl(
-              `/docs/domains/${domain.data.id}/${domain.data.version}/spec/${specification.filenameWithoutExtension}`
-            ),
-          })),
-          ...asyncAPISpecifications.map((specification) => ({
-            type: 'item',
-            title: specification.name,
-            leftIcon: '/icons/asyncapi-black.svg',
-            href: buildUrl(
-              `/docs/domains/${domain.data.id}/${domain.data.version}/asyncapi/${specification.filenameWithoutExtension}`
-            ),
-          })),
-          ...graphQLSpecifications.map((specification) => ({
-            type: 'item',
-            title: specification.name,
-            leftIcon: '/icons/graphql-black.svg',
-            href: buildUrl(
-              `/docs/domains/${domain.data.id}/${domain.data.version}/graphql/${specification.filenameWithoutExtension}`
-            ),
-          })),
-        ],
-      },
-      renderSystems && {
-        type: 'group',
-        title: 'Systems',
-        icon: 'Group',
-        pages: systemsInDomain.map((system) => `system:${(system as any).data.id}:${(system as any).data.version}`),
-      },
-      renderSubDomains && {
-        type: 'group',
-        title: 'Subdomains',
-        icon: 'Boxes',
-        pages: subDomains.map((domain) => `domain:${(domain as any).data.id}:${(domain as any).data.version}`),
-      },
-      (renderServices ||
-        hasFlows ||
-        renderEntities ||
-        (renderMessages && (sendsMessages.length > 0 || receivesMessages.length > 0))) && {
-        type: 'group',
-        title: 'Resources',
-        icon: 'Boxes',
-        // Resource type subsections are ordered A-Z by their title, and the
-        // resources within each subsection are ordered A-Z by name (sorted above).
-        pages: (
-          [
-            renderServices && {
-              type: 'group',
-              title: 'Services',
-              subtle: true,
-              icon: 'Server',
-              pages: servicesInDomain.map((service) => `service:${(service as any).data.id}:${(service as any).data.version}`),
-            },
-            hasFlows && {
-              type: 'group',
-              title: 'Flows',
-              subtle: true,
-              icon: 'Waypoints',
-              pages: domainFlows.map((flow) => `flow:${(flow as any).data.id}:${(flow as any).data.version}`),
-            },
-            renderEntities && {
-              type: 'group',
-              title: 'Entities',
-              subtle: true,
-              icon: 'Box',
-              pages: entitiesInDomain.map((entity) => ({
-                type: 'item',
-                title: (entity as any).data?.name || (entity as any).data.id,
-                href: buildUrl(`/docs/entities/${(entity as any).data.id}/${(entity as any).data.version}`),
-              })),
-            },
-            renderMessages &&
-              sendsMessages.length > 0 && {
-                type: 'group',
-                title: 'Domain Events',
-                subtle: true,
-                icon: 'Mail',
-                pages: sortedSendsMessages.map(
-                  (message) =>
-                    `${pluralizeMessageType(message as any)}:${(message as any).data.id}:${(message as any).data.version}`
-                ),
-              },
-            renderMessages &&
-              receivesMessages.length > 0 && {
-                type: 'group',
-                title: 'External Events',
-                subtle: true,
-                icon: 'Mail',
-                pages: sortedReceivesMessages.map(
-                  (receive) =>
-                    `${pluralizeMessageType(receive as any)}:${(receive as any).data.id}:${(receive as any).data.version}`
-                ),
-              },
-          ].filter(Boolean) as NavNode[]
-        ).sort((a, b) => a.title.localeCompare(b.title)) as ChildRef[],
-      },
-
-      ...(hasResourceGroups ? buildResourceGroupSections(resourceGroups, context) : []),
-      renderAgents && {
-        type: 'group',
-        title: 'Agents In Domain',
-        icon: 'Bot',
-        pages: agentsInDomain.map((agent) => `agent:${(agent as any).data.id}:${(agent as any).data.version}`),
-      },
-      renderExternalSystems && {
-        type: 'group',
-        title: 'External Integrations',
-        icon: 'Globe',
-        pages: externalSystemsInDomain.map((service) => `service:${(service as any).data.id}:${(service as any).data.version}`),
-      },
-      renderDataProducts && {
-        type: 'group',
-        title: 'Data Products',
-        icon: 'Package',
-        pages: dataProductsInDomain.map(
-          (dataProduct) => `data-product:${(dataProduct as any).data.id}:${(dataProduct as any).data.version}`
-        ),
-      },
-      renderOwners && buildOwnersSection(owners),
-      renderRepository && buildRepositorySection(domain.data.repository as { url: string; language: string }),
-      hasAttachments && buildAttachmentsSection(domain.data.attachments as any[]),
-    ].filter(Boolean) as ChildRef[],
+    pages,
   };
 };

--- a/packages/core/eventcatalog/src/stores/sidebar-store/builders/entity.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/builders/entity.ts
@@ -1,7 +1,8 @@
 import type { CollectionEntry } from 'astro:content';
 import { buildUrl } from '@utils/url-builder';
-import type { NavNode, ChildRef, ResourceGroupContext } from './shared';
+import type { NavNode, ResourceGroupContext } from './shared';
 import {
+  buildArchitectureDecisionsSection,
   buildAttachmentsSection,
   buildOwnersSection,
   buildQuickReferenceSection,
@@ -10,8 +11,45 @@ import {
 } from './shared';
 import { isChangelogEnabled, isVisualiserEnabled } from '@utils/feature';
 import { iconFieldsForResource } from '@utils/icon';
+import { resolveSidebarPages, toCustomSidebarContext, type SidebarSpec } from '../custom-sidebar';
 
-export const buildEntityNode = (entity: CollectionEntry<'entities'>, owners: any[], context: ResourceGroupContext): NavNode => {
+/**
+ * Predefined sidebar sections for an entity, keyed by the token users reference from
+ * `sidebar.json` (e.g. `$quick-reference`). Each token is the kebab-cased title of the
+ * section as it appears in the default sidebar.
+ */
+export type EntitySectionKey =
+  | 'quick-reference'
+  | 'documentation'
+  | 'architecture'
+  | 'domains'
+  | 'services'
+  | 'decision-records'
+  | 'owners'
+  | 'attachments';
+
+export type EntitySections = Record<EntitySectionKey, NavNode | NavNode[] | null>;
+
+/**
+ * Order of sections in the default (generated) sidebar. `decision-records` is deliberately
+ * absent — in default mode it is inserted before Owners by `withArchitectureDecisionsSection`
+ * in state.ts, and only becomes a first-class token for custom sidebars.
+ */
+export const DEFAULT_ENTITY_SECTION_ORDER: EntitySectionKey[] = [
+  'quick-reference',
+  'documentation',
+  'architecture',
+  'domains',
+  'services',
+  'owners',
+  'attachments',
+];
+
+export const buildEntitySections = (
+  entity: CollectionEntry<'entities'>,
+  owners: any[],
+  context: ResourceGroupContext
+): EntitySections => {
   const domains = entity.data.domains || [];
   const services = entity.data.services || [];
 
@@ -41,47 +79,78 @@ export const buildEntityNode = (entity: CollectionEntry<'entities'>, owners: any
   );
 
   return {
+    'quick-reference': buildQuickReferenceSection(
+      [
+        { title: 'Overview', href: buildUrl(`/docs/entities/${entity.data.id}/${entity.data.version}`) },
+        isChangelogEnabled() &&
+          shouldRenderSideBarSection(entity, 'changelog') && {
+            title: 'Changelog',
+            href: buildUrl(`/docs/entities/${entity.data.id}/${entity.data.version}/changelog`),
+          },
+      ].filter(Boolean) as { title: string; href: string }[]
+    ),
+    documentation: docsSection,
+    architecture: renderArchitecture
+      ? {
+          type: 'group',
+          title: 'Architecture',
+          icon: 'Workflow',
+          pages: entityMapTargets.map((target) => ({
+            type: 'item',
+            title: entityMapTargets.length === 1 ? 'Entity Map' : `${target.label} Entity Map`,
+            href: target.href,
+          })),
+        }
+      : null,
+    domains: renderDomains
+      ? {
+          type: 'group',
+          title: 'Domains',
+          icon: 'Boxes',
+          pages: domains.map((domain: any) => `domain:${domain.data.id}:${domain.data.version}`),
+        }
+      : null,
+    services: renderServices
+      ? {
+          type: 'group',
+          title: 'Services',
+          icon: 'Server',
+          pages: services.map((service: any) => `service:${service.data.id}:${service.data.version}`),
+        }
+      : null,
+    'decision-records': shouldRenderSideBarSection(entity, 'architectureDecisions')
+      ? buildArchitectureDecisionsSection(entity, context.adrs || [])
+      : null,
+    owners: renderOwners ? buildOwnersSection(owners) : null,
+    attachments: hasAttachments ? buildAttachmentsSection(entity.data.attachments as any[]) : null,
+  };
+};
+
+export type BuildEntityNodeOptions = {
+  /** A parsed `sidebar.json` for this entity. When present it replaces the generated sidebar. */
+  sidebar?: SidebarSpec;
+};
+
+export const buildEntityNode = (
+  entity: CollectionEntry<'entities'>,
+  owners: any[],
+  context: ResourceGroupContext,
+  options: BuildEntityNodeOptions = {}
+): NavNode => {
+  const sections = buildEntitySections(entity, owners, context);
+
+  const pages = resolveSidebarPages(sections, DEFAULT_ENTITY_SECTION_ORDER, {
+    sidebar: options.sidebar,
+    resource: { collection: 'entities', id: entity.data.id, version: entity.data.version, entry: entity },
+    context: toCustomSidebarContext(context),
+  });
+
+  return {
     type: 'item',
     title: entity.data.name,
     badge: 'Entity',
     summary: entity.data.summary,
     ...iconFieldsForResource(entity.data, 'Box'),
-    pages: [
-      buildQuickReferenceSection(
-        [
-          { title: 'Overview', href: buildUrl(`/docs/entities/${entity.data.id}/${entity.data.version}`) },
-          isChangelogEnabled() &&
-            shouldRenderSideBarSection(entity, 'changelog') && {
-              title: 'Changelog',
-              href: buildUrl(`/docs/entities/${entity.data.id}/${entity.data.version}/changelog`),
-            },
-        ].filter(Boolean) as { title: string; href: string }[]
-      ),
-      docsSection,
-      renderArchitecture && {
-        type: 'group',
-        title: 'Architecture',
-        icon: 'Workflow',
-        pages: entityMapTargets.map((target) => ({
-          type: 'item',
-          title: entityMapTargets.length === 1 ? 'Entity Map' : `${target.label} Entity Map`,
-          href: target.href,
-        })),
-      },
-      renderDomains && {
-        type: 'group',
-        title: 'Domains',
-        icon: 'Boxes',
-        pages: domains.map((domain: any) => `domain:${domain.data.id}:${domain.data.version}`),
-      },
-      renderServices && {
-        type: 'group',
-        title: 'Services',
-        icon: 'Server',
-        pages: services.map((service: any) => `service:${service.data.id}:${service.data.version}`),
-      },
-      renderOwners && buildOwnersSection(owners),
-      hasAttachments && buildAttachmentsSection(entity.data.attachments as any[]),
-    ].filter(Boolean) as ChildRef[],
+    pages,
   };
 };

--- a/packages/core/eventcatalog/src/stores/sidebar-store/builders/flow.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/builders/flow.ts
@@ -1,10 +1,16 @@
 import type { CollectionEntry } from 'astro:content';
 import { buildUrl } from '@utils/url-builder';
 import type { NavNode, ChildRef, ResourceGroupContext } from './shared';
-import { buildQuickReferenceSection, buildResourceDocsSection, shouldRenderSideBarSection } from './shared';
+import {
+  buildQuickReferenceSection,
+  buildResourceDocsSection,
+  shouldRenderSideBarSection,
+  buildArchitectureDecisionsSection,
+} from './shared';
 import { isChangelogEnabled } from '@utils/feature';
 import { createVersionedMap, findInMap } from '@utils/collections/util';
 import { pluralizeMessageType } from '@utils/collections/messages';
+import { resolveSidebarPages, toCustomSidebarContext, type SidebarSpec } from '../custom-sidebar';
 
 type VersionedEntry = { collection?: string; data: { id: string; version: string } };
 type VersionedEntryMap<T extends VersionedEntry> = Map<string, T[]>;
@@ -42,7 +48,43 @@ const resolveMessageStep = (
   return message ? `${pluralizeMessageType(message as any)}:${message.data.id}:${message.data.version}` : null;
 };
 
-export const buildFlowNode = (flow: CollectionEntry<'flows'>, context: ResourceGroupContext): NavNode => {
+/**
+ * Predefined sidebar sections for a flow, keyed by the token users reference from
+ * `sidebar.json` (e.g. `$quick-reference`). Each token is the kebab-cased title of the
+ * section as it appears in the default sidebar.
+ */
+export type FlowSectionKey =
+  | 'quick-reference'
+  | 'documentation'
+  | 'architecture'
+  | 'messages'
+  | 'services'
+  | 'agents'
+  | 'subflows'
+  | 'data-stores'
+  | 'data-products'
+  | 'decision-records';
+
+export type FlowSections = Record<FlowSectionKey, NavNode | NavNode[] | null>;
+
+/**
+ * Order of sections in the default (generated) sidebar. `decision-records` is deliberately
+ * absent — in default mode it is appended by `withArchitectureDecisionsSection` in state.ts,
+ * and only becomes a first-class token for custom sidebars.
+ */
+export const DEFAULT_FLOW_SECTION_ORDER: FlowSectionKey[] = [
+  'quick-reference',
+  'documentation',
+  'architecture',
+  'messages',
+  'services',
+  'agents',
+  'subflows',
+  'data-stores',
+  'data-products',
+];
+
+export const buildFlowSections = (flow: CollectionEntry<'flows'>, context: ResourceGroupContext): FlowSections => {
   const docsSection = buildResourceDocsSection(
     'flows',
     flow.data.id,
@@ -112,71 +154,113 @@ export const buildFlowNode = (flow: CollectionEntry<'flows'>, context: ResourceG
   );
 
   return {
+    'quick-reference': buildQuickReferenceSection(
+      [
+        { title: 'Overview', href: buildUrl(`/docs/flows/${flow.data.id}/${flow.data.version}`) },
+        isChangelogEnabled() &&
+          shouldRenderSideBarSection(flow, 'changelog') && {
+            title: 'Changelog',
+            href: buildUrl(`/docs/flows/${flow.data.id}/${flow.data.version}/changelog`),
+          },
+      ].filter(Boolean) as { title: string; href: string }[]
+    ),
+    documentation: docsSection,
+    architecture: {
+      type: 'group',
+      title: 'Architecture',
+      icon: 'Workflow',
+      pages: [
+        {
+          type: 'item',
+          title: 'Flow Diagram',
+          href: buildUrl(`/visualiser/flows/${flow.data.id}/${flow.data.version}`),
+        },
+      ].filter(Boolean) as ChildRef[],
+    },
+    messages:
+      messageRefs.length > 0
+        ? {
+            type: 'group',
+            title: 'Messages',
+            icon: 'Mail',
+            pages: messageRefs,
+          }
+        : null,
+    services:
+      serviceRefs.length > 0
+        ? {
+            type: 'group',
+            title: 'Services',
+            icon: 'Server',
+            pages: serviceRefs,
+          }
+        : null,
+    agents:
+      agentRefs.length > 0
+        ? {
+            type: 'group',
+            title: 'Agents',
+            icon: 'Bot',
+            pages: agentRefs,
+          }
+        : null,
+    subflows:
+      flowRefs.length > 0
+        ? {
+            type: 'group',
+            title: 'Subflows',
+            icon: 'Waypoints',
+            pages: flowRefs,
+          }
+        : null,
+    'data-stores':
+      containerRefs.length > 0
+        ? {
+            type: 'group',
+            title: 'Data Stores',
+            icon: 'Database',
+            pages: containerRefs,
+          }
+        : null,
+    'data-products':
+      dataProductRefs.length > 0
+        ? {
+            type: 'group',
+            title: 'Data Products',
+            icon: 'Package',
+            pages: dataProductRefs,
+          }
+        : null,
+    'decision-records': shouldRenderSideBarSection(flow, 'architectureDecisions')
+      ? buildArchitectureDecisionsSection(flow, context.adrs || [])
+      : null,
+  };
+};
+
+export type BuildFlowNodeOptions = {
+  /** A parsed `sidebar.json` for this flow. When present it replaces the generated sidebar. */
+  sidebar?: SidebarSpec;
+};
+
+export const buildFlowNode = (
+  flow: CollectionEntry<'flows'>,
+  context: ResourceGroupContext,
+  options: BuildFlowNodeOptions = {}
+): NavNode => {
+  const sections = buildFlowSections(flow, context);
+
+  const pages = resolveSidebarPages(sections, DEFAULT_FLOW_SECTION_ORDER, {
+    sidebar: options.sidebar,
+    resource: { collection: 'flows', id: flow.data.id, version: flow.data.version, entry: flow },
+    context: toCustomSidebarContext(context),
+  });
+
+  return {
     type: 'item',
     title: flow.data.name,
     icon: 'Waypoint',
     badge: 'Flow',
     summary: flow.data.summary,
-    pages: [
-      buildQuickReferenceSection(
-        [
-          { title: 'Overview', href: buildUrl(`/docs/flows/${flow.data.id}/${flow.data.version}`) },
-          isChangelogEnabled() &&
-            shouldRenderSideBarSection(flow, 'changelog') && {
-              title: 'Changelog',
-              href: buildUrl(`/docs/flows/${flow.data.id}/${flow.data.version}/changelog`),
-            },
-        ].filter(Boolean) as { title: string; href: string }[]
-      ),
-      docsSection,
-      {
-        type: 'group',
-        title: 'Architecture',
-        icon: 'Workflow',
-        pages: [
-          {
-            type: 'item',
-            title: 'Flow Diagram',
-            href: buildUrl(`/visualiser/flows/${flow.data.id}/${flow.data.version}`),
-          },
-        ].filter(Boolean) as ChildRef[],
-      },
-      messageRefs.length > 0 && {
-        type: 'group',
-        title: 'Messages',
-        icon: 'Mail',
-        pages: messageRefs,
-      },
-      serviceRefs.length > 0 && {
-        type: 'group',
-        title: 'Services',
-        icon: 'Server',
-        pages: serviceRefs,
-      },
-      agentRefs.length > 0 && {
-        type: 'group',
-        title: 'Agents',
-        icon: 'Bot',
-        pages: agentRefs,
-      },
-      flowRefs.length > 0 && {
-        type: 'group',
-        title: 'Subflows',
-        icon: 'Waypoints',
-        pages: flowRefs,
-      },
-      containerRefs.length > 0 && {
-        type: 'group',
-        title: 'Data Stores',
-        icon: 'Database',
-        pages: containerRefs,
-      },
-      dataProductRefs.length > 0 && {
-        type: 'group',
-        title: 'Data Products',
-        icon: 'Package',
-        pages: dataProductRefs,
-      },
-    ].filter(Boolean) as ChildRef[],
+    pages,
   };
 };

--- a/packages/core/eventcatalog/src/stores/sidebar-store/builders/message.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/builders/message.ts
@@ -10,23 +10,24 @@ import {
   buildAttachmentsSection,
   buildDiagramNavItems,
   buildResourceDocsSection,
+  buildArchitectureDecisionsSection,
 } from './shared';
 import { isVisualiserEnabled, isChangelogEnabled } from '@utils/feature';
 import { iconFieldsForResource } from '@utils/icon';
 import { collectionToResourceMap } from '@utils/collections/util';
 import type { MessageTrigger } from '@utils/collections/message-triggers';
+import { resolveSidebarPages, toCustomSidebarContext, type SidebarSpec } from '../custom-sidebar';
 
 type MessageSchemaEntry = CollectionEntry<'schemas'>;
+type MessageEntry = CollectionEntry<'events' | 'commands' | 'queries'>;
+type MessageTriggers = { triggers: MessageTrigger[]; triggeredBy: MessageTrigger[] };
 
 const getProducerConsumerPageRef = (resource: any) => {
   const resourceType = collectionToResourceMap[resource.collection as keyof typeof collectionToResourceMap];
   return `${resourceType}:${resource.data.id}:${resource.data.version}`;
 };
 
-const getSchemasForMessage = (
-  message: CollectionEntry<'events' | 'commands' | 'queries'>,
-  schemas: MessageSchemaEntry[] = []
-) => {
+const getSchemasForMessage = (message: MessageEntry, schemas: MessageSchemaEntry[] = []) => {
   return schemas.filter(
     (schema) =>
       schema.data.message.collectionName === message.collection &&
@@ -43,14 +44,58 @@ const getSchemaNavTitle = (schemas: MessageSchemaEntry[]) => {
   return format ? `Schema (${format.toUpperCase()})` : 'Schema';
 };
 
-export const buildMessageNode = (
-  message: CollectionEntry<'events' | 'commands' | 'queries'>,
+/**
+ * Predefined sidebar sections for a message (event, command or query), keyed by the token
+ * users reference from `sidebar.json` (e.g. `$quick-reference`). Each token is the
+ * kebab-cased title of the section as it appears in the default sidebar.
+ */
+export type MessageSectionKey =
+  | 'quick-reference'
+  | 'documentation'
+  | 'architecture'
+  | 'diagrams'
+  | 'api-and-contracts'
+  | 'producers'
+  | 'consumers'
+  | 'triggered-by'
+  | 'triggers'
+  | 'appears-in-flows'
+  | 'decision-records'
+  | 'owners'
+  | 'code'
+  | 'attachments';
+
+export type MessageSections = Record<MessageSectionKey, NavNode | NavNode[] | null>;
+
+/**
+ * Order of sections in the default (generated) sidebar. `decision-records` is deliberately
+ * absent — in default mode it is inserted before Owners by `withArchitectureDecisionsSection`
+ * in state.ts, and only becomes a first-class token for custom sidebars.
+ */
+export const DEFAULT_MESSAGE_SECTION_ORDER: MessageSectionKey[] = [
+  'quick-reference',
+  'documentation',
+  'architecture',
+  'diagrams',
+  'api-and-contracts',
+  'producers',
+  'consumers',
+  'triggered-by',
+  'triggers',
+  'appears-in-flows',
+  'owners',
+  'code',
+  'attachments',
+];
+
+export const buildMessageSections = (
+  message: MessageEntry,
   owners: any[],
   context: ResourceGroupContext,
   hasFieldUsage: boolean = false,
   flowRefs: string[] = [],
-  messageTriggers: { triggers: MessageTrigger[]; triggeredBy: MessageTrigger[] } = { triggers: [], triggeredBy: [] }
-): NavNode => {
+  messageTriggers: MessageTriggers = { triggers: [], triggeredBy: [] }
+): MessageSections => {
   const producers = message.data.producers || [];
   const consumers = message.data.consumers || [];
   const collection = message.collection;
@@ -64,21 +109,6 @@ export const buildMessageNode = (
   const renderFlows = flowRefs.length > 0 && shouldRenderSideBarSection(message, 'flows');
   const renderRepository = message.data.repository && shouldRenderSideBarSection(message, 'repository');
   const hasTriggerPaths = messageTriggers.triggers.length > 0 || messageTriggers.triggeredBy.length > 0;
-
-  // Determine badge based on collection type
-  const badgeMap: Record<string, string> = {
-    events: 'Event',
-    commands: 'Command',
-    queries: 'Query',
-  };
-  const badge = badgeMap[collection] || 'Message';
-
-  const iconMap: Record<string, string> = {
-    events: 'Zap',
-    commands: 'MessageSquare',
-    queries: 'Search',
-  };
-  const defaultIcon = iconMap[collection] || 'Mail';
 
   const resolvedSchemas = getSchemasForMessage(message, context.schemas);
   const hasSchema = resolvedSchemas.length > 0;
@@ -101,108 +131,169 @@ export const buildMessageNode = (
   const hasDiagrams = diagramNavItems.length > 0;
 
   return {
+    'quick-reference': buildQuickReferenceSection(
+      [
+        {
+          title: 'Overview',
+          href: buildUrl(`/docs/${collection}/${message.data.id}/${message.data.version}`),
+        },
+        isChangelogEnabled() &&
+          shouldRenderSideBarSection(message, 'changelog') && {
+            title: 'Changelog',
+            href: buildUrl(`/docs/${collection}/${message.data.id}/${message.data.version}/changelog`),
+          },
+      ].filter(Boolean) as { title: string; href: string }[]
+    ),
+    documentation: docsSection,
+    architecture: renderVisualiser
+      ? {
+          type: 'group',
+          title: 'Architecture',
+          icon: 'Workflow',
+          pages: [
+            {
+              type: 'item',
+              title: 'Map',
+              href: buildUrl(`/visualiser/${collection}/${message.data.id}/${message.data.version}`),
+            },
+            ...(hasTriggerPaths
+              ? [
+                  {
+                    type: 'item' as const,
+                    title: 'Trigger paths',
+                    href: buildUrl(`/triggers/${collection}/${message.data.id}/${message.data.version}`),
+                  },
+                ]
+              : []),
+          ],
+        }
+      : null,
+    diagrams: hasDiagrams
+      ? {
+          type: 'group',
+          title: 'Diagrams',
+          icon: 'FileImage',
+          pages: diagramNavItems,
+        }
+      : null,
+    'api-and-contracts': hasSchema
+      ? {
+          type: 'group',
+          title: 'API & Contracts',
+          icon: 'FileJson',
+          pages: [
+            {
+              type: 'item',
+              title: getSchemaNavTitle(resolvedSchemas),
+              href: buildUrl(`/schemas/${collection}/${message.data.id}/${message.data.version}`),
+            },
+            hasFieldUsage && {
+              type: 'item',
+              title: 'Field Usage',
+              href: buildUrl(`/docs/${collection}/${message.data.id}/${message.data.version}/field-lineage`),
+            },
+          ].filter(Boolean) as ChildRef[],
+        }
+      : null,
+    producers: renderProducers
+      ? {
+          type: 'group',
+          title: 'Producers',
+          icon: 'Server',
+          pages: producers.map(getProducerConsumerPageRef),
+          visible: producers.length > 0,
+        }
+      : null,
+    consumers: renderConsumers
+      ? {
+          type: 'group',
+          title: 'Consumers',
+          icon: 'Server',
+          pages: consumers.map(getProducerConsumerPageRef),
+          visible: consumers.length > 0,
+        }
+      : null,
+    'triggered-by': renderTriggeredBy
+      ? {
+          type: 'group',
+          title: 'Triggered by',
+          icon: 'Mail',
+          pages: triggeredByRefs,
+          visible: triggeredByRefs.length > 0,
+        }
+      : null,
+    triggers: renderTriggers
+      ? {
+          type: 'group',
+          title: 'Triggers',
+          icon: 'Mail',
+          pages: triggerRefs,
+          visible: triggerRefs.length > 0,
+        }
+      : null,
+    'appears-in-flows': renderFlows
+      ? {
+          type: 'group',
+          title: 'Appears in flows',
+          icon: 'Waypoints',
+          pages: flowRefs,
+          visible: flowRefs.length > 0,
+        }
+      : null,
+    'decision-records': shouldRenderSideBarSection(message, 'architectureDecisions')
+      ? buildArchitectureDecisionsSection(message, context.adrs || [])
+      : null,
+    owners: renderOwners ? buildOwnersSection(owners) : null,
+    code: renderRepository ? buildRepositorySection(message.data.repository as { url: string; language: string }) : null,
+    attachments: hasAttachments ? buildAttachmentsSection(message.data.attachments as any[]) : null,
+  };
+};
+
+export type BuildMessageNodeOptions = {
+  /** A parsed `sidebar.json` for this message. When present it replaces the generated sidebar. */
+  sidebar?: SidebarSpec;
+};
+
+export const buildMessageNode = (
+  message: MessageEntry,
+  owners: any[],
+  context: ResourceGroupContext,
+  hasFieldUsage: boolean = false,
+  flowRefs: string[] = [],
+  messageTriggers: MessageTriggers = { triggers: [], triggeredBy: [] },
+  options: BuildMessageNodeOptions = {}
+): NavNode => {
+  const collection = message.collection;
+
+  // Determine badge based on collection type
+  const badgeMap: Record<string, string> = {
+    events: 'Event',
+    commands: 'Command',
+    queries: 'Query',
+  };
+  const badge = badgeMap[collection] || 'Message';
+
+  const iconMap: Record<string, string> = {
+    events: 'Zap',
+    commands: 'MessageSquare',
+    queries: 'Search',
+  };
+  const defaultIcon = iconMap[collection] || 'Mail';
+
+  const sections = buildMessageSections(message, owners, context, hasFieldUsage, flowRefs, messageTriggers);
+
+  const pages = resolveSidebarPages(sections, DEFAULT_MESSAGE_SECTION_ORDER, {
+    sidebar: options.sidebar,
+    resource: { collection, id: message.data.id, version: message.data.version, entry: message },
+    context: toCustomSidebarContext(context),
+  });
+
+  return {
     type: 'item',
     title: message.data.name,
     badge,
     summary: message.data.summary,
     ...iconFieldsForResource(message.data, defaultIcon),
-    pages: [
-      buildQuickReferenceSection(
-        [
-          {
-            title: 'Overview',
-            href: buildUrl(`/docs/${collection}/${message.data.id}/${message.data.version}`),
-          },
-          isChangelogEnabled() &&
-            shouldRenderSideBarSection(message, 'changelog') && {
-              title: 'Changelog',
-              href: buildUrl(`/docs/${collection}/${message.data.id}/${message.data.version}/changelog`),
-            },
-        ].filter(Boolean) as { title: string; href: string }[]
-      ),
-      docsSection,
-      renderVisualiser && {
-        type: 'group',
-        title: 'Architecture',
-        icon: 'Workflow',
-        pages: [
-          {
-            type: 'item',
-            title: 'Map',
-            href: buildUrl(`/visualiser/${collection}/${message.data.id}/${message.data.version}`),
-          },
-          ...(hasTriggerPaths
-            ? [
-                {
-                  type: 'item' as const,
-                  title: 'Trigger paths',
-                  href: buildUrl(`/triggers/${collection}/${message.data.id}/${message.data.version}`),
-                },
-              ]
-            : []),
-        ],
-      },
-      hasDiagrams && {
-        type: 'group',
-        title: 'Diagrams',
-        icon: 'FileImage',
-        pages: diagramNavItems,
-      },
-      hasSchema && {
-        type: 'group',
-        title: 'API & Contracts',
-        icon: 'FileJson',
-        pages: [
-          {
-            type: 'item',
-            title: getSchemaNavTitle(resolvedSchemas),
-            href: buildUrl(`/schemas/${collection}/${message.data.id}/${message.data.version}`),
-          },
-          hasFieldUsage && {
-            type: 'item',
-            title: 'Field Usage',
-            href: buildUrl(`/docs/${collection}/${message.data.id}/${message.data.version}/field-lineage`),
-          },
-        ].filter(Boolean),
-      },
-      renderProducers && {
-        type: 'group',
-        title: 'Producers',
-        icon: 'Server',
-        pages: producers.map(getProducerConsumerPageRef),
-        visible: producers.length > 0,
-      },
-      renderConsumers && {
-        type: 'group',
-        title: 'Consumers',
-        icon: 'Server',
-        pages: consumers.map(getProducerConsumerPageRef),
-        visible: consumers.length > 0,
-      },
-      renderTriggeredBy && {
-        type: 'group',
-        title: 'Triggered by',
-        icon: 'Mail',
-        pages: triggeredByRefs,
-        visible: triggeredByRefs.length > 0,
-      },
-      renderTriggers && {
-        type: 'group',
-        title: 'Triggers',
-        icon: 'Mail',
-        pages: triggerRefs,
-        visible: triggerRefs.length > 0,
-      },
-      renderFlows && {
-        type: 'group',
-        title: 'Appears in flows',
-        icon: 'Waypoints',
-        pages: flowRefs,
-        visible: flowRefs.length > 0,
-      },
-      renderOwners && buildOwnersSection(owners),
-      renderRepository && buildRepositorySection(message.data.repository as { url: string; language: string }),
-      hasAttachments && buildAttachmentsSection(message.data.attachments as any[]),
-    ].filter(Boolean) as ChildRef[],
+    pages,
   };
 };

--- a/packages/core/eventcatalog/src/stores/sidebar-store/builders/service.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/builders/service.ts
@@ -12,20 +12,70 @@ import {
   buildAttachmentsSection,
   buildDiagramNavItems,
   buildResourceDocsSection,
+  buildArchitectureDecisionsSection,
 } from './shared';
 import { isVisualiserEnabled, isChangelogEnabled } from '@utils/feature';
 import { pluralizeMessageType } from '@utils/collections/messages';
 import { iconFieldsForResource } from '@utils/icon';
+import { resolveSidebarPages, toCustomSidebarContext, type SidebarSpec } from '../custom-sidebar';
 
 const uniqueRefs = (refs: string[]) => [...new Set(refs)];
 
-export const buildServiceNode = (
+/**
+ * Predefined sidebar sections for a service, keyed by the token users reference from
+ * `sidebar.json` (e.g. `$quick-reference`). Each token is the kebab-cased title of the
+ * section as it appears in the default sidebar.
+ */
+export type ServiceSectionKey =
+  | 'quick-reference'
+  | 'documentation'
+  | 'architecture'
+  | 'diagrams'
+  | 'api-and-contracts'
+  | 'resource-groups'
+  | 'state-and-persistence'
+  | 'entities'
+  | 'outbound-messages'
+  | 'inbound-messages'
+  | 'channels'
+  | 'flows'
+  | 'decision-records'
+  | 'owners'
+  | 'code'
+  | 'attachments';
+
+export type ServiceSections = Record<ServiceSectionKey, NavNode | NavNode[] | null>;
+
+/**
+ * Order of sections in the default (generated) sidebar. `decision-records` is deliberately
+ * absent — in default mode it is inserted before Owners by `withArchitectureDecisionsSection`
+ * in state.ts, and only becomes a first-class token for custom sidebars.
+ */
+export const DEFAULT_SERVICE_SECTION_ORDER: ServiceSectionKey[] = [
+  'quick-reference',
+  'documentation',
+  'architecture',
+  'diagrams',
+  'api-and-contracts',
+  'resource-groups',
+  'state-and-persistence',
+  'entities',
+  'outbound-messages',
+  'inbound-messages',
+  'channels',
+  'flows',
+  'owners',
+  'code',
+  'attachments',
+];
+
+export const buildServiceSections = (
   service: CollectionEntry<'services'>,
   owners: any[],
   context: ResourceGroupContext,
   serviceChannels: CollectionEntry<'channels'>[] = [],
   flowRefs: string[] = []
-): NavNode => {
+): ServiceSections => {
   const sendsMessages = service.data.sends || [];
   const receivesMessages = service.data.receives || [];
   const serviceEntities = service.data.entities || [];
@@ -72,6 +122,178 @@ export const buildServiceNode = (
   const diagramNavItems = buildDiagramNavItems(serviceDiagrams, context.diagrams);
   const hasDiagrams = diagramNavItems.length > 0;
 
+  return {
+    'quick-reference': buildQuickReferenceSection(
+      [
+        { title: 'Overview', href: buildUrl(docsBasePath) },
+        isChangelogEnabled() &&
+          shouldRenderSideBarSection(service, 'changelog') && {
+            title: 'Changelog',
+            href: buildUrl(`${docsBasePath}/changelog`),
+          },
+      ].filter(Boolean) as { title: string; href: string }[]
+    ),
+    documentation: docsSection,
+    architecture: {
+      type: 'group',
+      title: 'Architecture',
+      icon: 'Workflow',
+      pages: [
+        {
+          type: 'item',
+          title: 'Overview',
+          href: buildUrl(`/architecture/services/${service.data.id}/${service.data.version}`),
+        },
+        renderVisualiser && {
+          type: 'item',
+          title: 'Map',
+          href: buildUrl(`/visualiser/services/${service.data.id}/${service.data.version}`),
+        },
+        renderVisualiser &&
+          renderEntities && {
+            type: 'item',
+            title: 'Entity Map',
+            href: buildUrl(`/visualiser/services/${service.data.id}/${service.data.version}/entity-map`),
+          },
+        renderVisualiser &&
+          hasDataStores && {
+            type: 'item',
+            title: 'Data Dependency Graph',
+            href: buildUrl(`/visualiser/services/${service.data.id}/${service.data.version}/data`),
+          },
+      ].filter(Boolean) as ChildRef[],
+    },
+    diagrams: hasDiagrams
+      ? {
+          type: 'group',
+          title: 'Diagrams',
+          icon: 'FileImage',
+          pages: diagramNavItems,
+        }
+      : null,
+    'api-and-contracts': renderSpecifications
+      ? {
+          type: 'group',
+          title: 'API & Contracts',
+          icon: 'FileCode',
+          pages: [
+            ...openAPISpecifications.map((specification) => ({
+              type: 'item',
+              title: `${specification.name}`,
+              leftIcon: '/icons/openapi-black.svg',
+              href: buildUrl(`${docsBasePath}/spec/${specification.filenameWithoutExtension}`),
+            })),
+            ...asyncAPISpecifications.map((specification) => ({
+              type: 'item',
+              title: `${specification.name}`,
+              leftIcon: '/icons/asyncapi-black.svg',
+              href: buildUrl(`${docsBasePath}/asyncapi/${specification.filenameWithoutExtension}`),
+            })),
+            ...graphQLSpecifications.map((specification) => ({
+              type: 'item',
+              title: `${specification.name}`,
+              leftIcon: '/icons/graphql-black.svg',
+              href: buildUrl(`${docsBasePath}/graphql/${specification.filenameWithoutExtension}`),
+            })),
+          ],
+        }
+      : null,
+    'resource-groups': renderResourceGroups
+      ? (buildResourceGroupSections(resourceGroups, context).filter(Boolean) as NavNode[])
+      : null,
+    'state-and-persistence': hasDataStores
+      ? {
+          type: 'group',
+          title: 'State and Persistence',
+          icon: 'Database',
+          pages: dataStoresInService.map(
+            (dataStore) => `container:${(dataStore as any).data.id}:${(dataStore as any).data.version}`
+          ),
+        }
+      : null,
+    entities: renderEntities
+      ? {
+          type: 'group',
+          title: 'Entities',
+          icon: 'Box',
+          pages: serviceEntities.map((entity) => ({
+            type: 'item',
+            title: (entity as any).data?.name || (entity as any).data.id,
+            href: buildUrl(`/docs/entities/${(entity as any).data.id}/${(entity as any).data.version}`),
+          })),
+        }
+      : null,
+    'outbound-messages':
+      sendsMessages.length > 0 && renderMessages
+        ? {
+            type: 'group',
+            title: 'Outbound Messages',
+            icon: 'Mail',
+            pages: sendsMessages.map(
+              (message) => `${pluralizeMessageType(message as any)}:${(message as any).data.id}:${(message as any).data.version}`
+            ),
+          }
+        : null,
+    'inbound-messages':
+      receivesMessages.length > 0 && renderMessages
+        ? {
+            type: 'group',
+            title: 'Inbound Messages',
+            icon: 'Mail',
+            pages: receivesMessages.map(
+              (receive) => `${pluralizeMessageType(receive as any)}:${(receive as any).data.id}:${(receive as any).data.version}`
+            ),
+          }
+        : null,
+    channels:
+      serviceChannels.length > 0
+        ? {
+            type: 'group',
+            title: 'Channels',
+            icon: 'ArrowRightLeft',
+            pages: serviceChannels.map((channel) => `channel:${(channel as any).data.id}:${(channel as any).data.version}`),
+          }
+        : null,
+    flows: hasFlows
+      ? {
+          type: 'group',
+          // If the service declares its own flows it owns them ("Flows"); otherwise it is
+          // only referenced as a step in someone else's flow ("Appears in flows").
+          title: serviceFlows.length > 0 ? 'Flows' : 'Appears in flows',
+          icon: 'Waypoints',
+          pages: serviceFlowRefs,
+        }
+      : null,
+    'decision-records': shouldRenderSideBarSection(service, 'architectureDecisions')
+      ? buildArchitectureDecisionsSection(service, context.adrs || [])
+      : null,
+    owners: renderOwners ? buildOwnersSection(owners) : null,
+    code: renderRepository ? buildRepositorySection(service.data.repository as { url: string; language: string }) : null,
+    attachments: hasAttachments ? buildAttachmentsSection(service.data.attachments as any[]) : null,
+  };
+};
+
+export type BuildServiceNodeOptions = {
+  /** A parsed `sidebar.json` for this service. When present it replaces the generated sidebar. */
+  sidebar?: SidebarSpec;
+};
+
+export const buildServiceNode = (
+  service: CollectionEntry<'services'>,
+  owners: any[],
+  context: ResourceGroupContext,
+  serviceChannels: CollectionEntry<'channels'>[] = [],
+  flowRefs: string[] = [],
+  options: BuildServiceNodeOptions = {}
+): NavNode => {
+  const sections = buildServiceSections(service, owners, context, serviceChannels, flowRefs);
+
+  const pages = resolveSidebarPages(sections, DEFAULT_SERVICE_SECTION_ORDER, {
+    sidebar: options.sidebar,
+    resource: { collection: 'services', id: service.data.id, version: service.data.version, entry: service },
+    context: toCustomSidebarContext(context),
+  });
+
   const isExternalSystem = !!service.data.externalSystem;
 
   return {
@@ -80,132 +302,6 @@ export const buildServiceNode = (
     badge: isExternalSystem ? 'External System' : 'Service',
     summary: service.data.summary,
     ...iconFieldsForResource(service.data, isExternalSystem ? 'Globe' : 'Server'),
-    pages: [
-      buildQuickReferenceSection(
-        [
-          { title: 'Overview', href: buildUrl(docsBasePath) },
-          isChangelogEnabled() &&
-            shouldRenderSideBarSection(service, 'changelog') && {
-              title: 'Changelog',
-              href: buildUrl(`${docsBasePath}/changelog`),
-            },
-        ].filter(Boolean) as { title: string; href: string }[]
-      ),
-      docsSection,
-      {
-        type: 'group',
-        title: 'Architecture',
-        icon: 'Workflow',
-        pages: [
-          {
-            type: 'item',
-            title: 'Overview',
-            href: buildUrl(`/architecture/services/${service.data.id}/${service.data.version}`),
-          },
-          renderVisualiser && {
-            type: 'item',
-            title: 'Map',
-            href: buildUrl(`/visualiser/services/${service.data.id}/${service.data.version}`),
-          },
-          renderVisualiser &&
-            renderEntities && {
-              type: 'item',
-              title: 'Entity Map',
-              href: buildUrl(`/visualiser/services/${service.data.id}/${service.data.version}/entity-map`),
-            },
-          renderVisualiser &&
-            hasDataStores && {
-              type: 'item',
-              title: 'Data Dependency Graph',
-              href: buildUrl(`/visualiser/services/${service.data.id}/${service.data.version}/data`),
-            },
-        ].filter(Boolean) as ChildRef[],
-      },
-      hasDiagrams && {
-        type: 'group',
-        title: 'Diagrams',
-        icon: 'FileImage',
-        pages: diagramNavItems,
-      },
-      renderSpecifications && {
-        type: 'group',
-        title: 'API & Contracts',
-        icon: 'FileCode',
-        pages: [
-          ...openAPISpecifications.map((specification) => ({
-            type: 'item',
-            title: `${specification.name}`,
-            leftIcon: '/icons/openapi-black.svg',
-            href: buildUrl(`${docsBasePath}/spec/${specification.filenameWithoutExtension}`),
-          })),
-          ...asyncAPISpecifications.map((specification) => ({
-            type: 'item',
-            title: `${specification.name}`,
-            leftIcon: '/icons/asyncapi-black.svg',
-            href: buildUrl(`${docsBasePath}/asyncapi/${specification.filenameWithoutExtension}`),
-          })),
-          ...graphQLSpecifications.map((specification) => ({
-            type: 'item',
-            title: `${specification.name}`,
-            leftIcon: '/icons/graphql-black.svg',
-            href: buildUrl(`${docsBasePath}/graphql/${specification.filenameWithoutExtension}`),
-          })),
-        ],
-      },
-      renderResourceGroups && buildResourceGroupSections(resourceGroups, context),
-      hasDataStores && {
-        type: 'group',
-        title: 'State and Persistence',
-        icon: 'Database',
-        pages: dataStoresInService.map(
-          (dataStore) => `container:${(dataStore as any).data.id}:${(dataStore as any).data.version}`
-        ),
-      },
-      renderEntities && {
-        type: 'group',
-        title: 'Entities',
-        icon: 'Box',
-        pages: serviceEntities.map((entity) => ({
-          type: 'item',
-          title: (entity as any).data?.name || (entity as any).data.id,
-          href: buildUrl(`/docs/entities/${(entity as any).data.id}/${(entity as any).data.version}`),
-        })),
-      },
-      sendsMessages.length > 0 &&
-        renderMessages && {
-          type: 'group',
-          title: 'Outbound Messages',
-          icon: 'Mail',
-          pages: sendsMessages.map(
-            (message) => `${pluralizeMessageType(message as any)}:${(message as any).data.id}:${(message as any).data.version}`
-          ),
-        },
-      receivesMessages.length > 0 &&
-        renderMessages && {
-          type: 'group',
-          title: 'Inbound Messages',
-          icon: 'Mail',
-          pages: receivesMessages.map(
-            (receive) => `${pluralizeMessageType(receive as any)}:${(receive as any).data.id}:${(receive as any).data.version}`
-          ),
-        },
-      serviceChannels.length > 0 && {
-        type: 'group',
-        title: 'Channels',
-        icon: 'ArrowRightLeft',
-        pages: serviceChannels.map((channel) => `channel:${(channel as any).data.id}:${(channel as any).data.version}`),
-      },
-      hasFlows && {
-        type: 'group',
-        // If the service declares its own flows it owns them ("Flows"); otherwise it is
-        // only referenced as a step in someone else's flow ("Appears in flows").
-        title: serviceFlows.length > 0 ? 'Flows' : 'Appears in flows',
-        icon: 'Waypoints',
-        pages: serviceFlowRefs,
-      },
-      renderOwners && buildOwnersSection(owners),
-      renderRepository && buildRepositorySection(service.data.repository as { url: string; language: string }),
-      hasAttachments && buildAttachmentsSection(service.data.attachments as any[]),
-    ].filter(Boolean) as ChildRef[],
+    pages,
   };
 };

--- a/packages/core/eventcatalog/src/stores/sidebar-store/builders/shared.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/builders/shared.ts
@@ -5,6 +5,7 @@ import { getAdrNodeKey, getAdrsForResource, type Adr, type AdrResource } from '@
 import { buildUrl } from '@utils/url-builder';
 import {
   getGroupedResourceDocsByType,
+  getResourceDocTypeLabel,
   type ResourceCollection,
   type ResourceDocEntry,
   type ResourceDocCategoryEntry,
@@ -25,6 +26,7 @@ export type NavNode = {
   title: string;
   collapseKey?: string; // Stable key used to persist collapse state for inline groups
   collapsible?: boolean; // Set to false to keep a group expanded regardless of its size
+  collapsed?: boolean; // Explicit initial collapse state (from sidebar.json). Overrides size/collapsible heuristics.
   icon?: string; // Lucide icon name
   subtle?: boolean; // Render lightweight styling for nested subgroup headers
   leftIcon?: string; // Path to SVG icon shown on the left of the label
@@ -218,35 +220,13 @@ export const buildResourceDocsSection = (
     return null;
   }
 
-  const typeLabelMap: Record<string, string> = {
-    adrs: 'ADR',
-    runbooks: 'Runbook',
-    contracts: 'Contract',
-    troubleshooting: 'Troubleshooting',
-    guides: 'Guide',
-  };
-
-  const toTypeLabel = (value: string) => {
-    if (typeLabelMap[value]) {
-      return typeLabelMap[value];
-    }
-
-    const normalized = value
-      .split(/[-_\s]+/)
-      .filter(Boolean)
-      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-      .join(' ');
-
-    return normalized || 'Doc';
-  };
-
   return {
     type: 'group',
     title: 'Documentation',
     icon: 'BookText',
     pages: groupedDocs.map((group) => ({
       type: 'group',
-      title: group.label || toTypeLabel(group.type),
+      title: group.label || getResourceDocTypeLabel(group.type),
       subtle: true,
       pages: group.docs.map((doc) => ({
         type: 'item',

--- a/packages/core/eventcatalog/src/stores/sidebar-store/builders/system.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/builders/system.ts
@@ -9,14 +9,59 @@ import {
   buildAttachmentsSection,
   buildDiagramNavItems,
   buildResourceDocsSection,
+  buildArchitectureDecisionsSection,
 } from './shared';
 import { isChangelogEnabled, isVisualiserEnabled } from '@utils/feature';
 import { customIconFieldsForResource } from '@utils/icon';
+import { resolveSidebarPages, toCustomSidebarContext, type SidebarSpec } from '../custom-sidebar';
 
 // Sort resolved collection entries A-Z by their display name (falling back to id).
 const byResourceName = (a: any, b: any) => (a.data?.name || a.data?.id || '').localeCompare(b.data?.name || b.data?.id || '');
 
-export const buildSystemNode = (system: CollectionEntry<'systems'>, owners: any[], context: ResourceGroupContext): NavNode => {
+/**
+ * Predefined sidebar sections for a system, keyed by the token users reference from
+ * `sidebar.json` (e.g. `$quick-reference`). Each token is the kebab-cased title of the
+ * section as it appears in the default sidebar.
+ */
+export type SystemSectionKey =
+  | 'quick-reference'
+  | 'documentation'
+  | 'architecture'
+  | 'diagrams'
+  | 'resources'
+  | 'services'
+  | 'flows'
+  | 'data-stores'
+  | 'entities'
+  | 'decision-records'
+  | 'owners'
+  | 'code'
+  | 'attachments';
+
+export type SystemSections = Record<SystemSectionKey, NavNode | NavNode[] | null>;
+
+/**
+ * Order of sections in the default (generated) sidebar. `decision-records` is deliberately
+ * absent — in default mode it is inserted before Owners by `withArchitectureDecisionsSection`
+ * in state.ts, and only becomes a first-class token for custom sidebars.
+ */
+export const DEFAULT_SYSTEM_SECTION_ORDER: SystemSectionKey[] = [
+  'quick-reference',
+  'documentation',
+  'architecture',
+  'diagrams',
+  'resources',
+  'entities',
+  'owners',
+  'code',
+  'attachments',
+];
+
+export const buildSystemSections = (
+  system: CollectionEntry<'systems'>,
+  owners: any[],
+  context: ResourceGroupContext
+): SystemSections => {
   const servicesInSystem = [...(system.data.services || [])].sort(byResourceName);
   const renderServices = servicesInSystem.length > 0 && shouldRenderSideBarSection(system, 'services');
 
@@ -57,6 +102,146 @@ export const buildSystemNode = (system: CollectionEntry<'systems'>, owners: any[
     context.resourceDocCategories
   );
 
+  // Resource subsections. These are built once and shared between the "Resources"
+  // umbrella (where they render as subtle subgroups) and their standalone tokens
+  // (`$services`, `$flows`, `$data-stores`) for custom sidebars.
+  const servicesSection: NavNode | null = renderServices
+    ? {
+        type: 'group',
+        title: 'Services',
+        icon: 'Server',
+        pages: servicesInSystem.map((service) => `service:${(service as any).data.id}:${(service as any).data.version}`),
+      }
+    : null;
+
+  const flowsSection: NavNode | null = renderFlows
+    ? {
+        type: 'group',
+        title: 'Flows',
+        icon: 'Waypoints',
+        pages: flowsInSystem.map((flow) => `flow:${(flow as any).data.id}:${(flow as any).data.version}`),
+      }
+    : null;
+
+  const dataStoresSection: NavNode | null = renderContainers
+    ? {
+        type: 'group',
+        title: 'Data Stores',
+        icon: 'Database',
+        pages: containersInSystem.map(
+          (container) => `container:${(container as any).data.id}:${(container as any).data.version}`
+        ),
+      }
+    : null;
+
+  const resourceSubsections = [servicesSection, flowsSection, dataStoresSection].filter(Boolean) as NavNode[];
+
+  return {
+    'quick-reference': buildQuickReferenceSection(
+      [
+        {
+          title: 'Overview',
+          href: buildUrl(`/docs/systems/${system.data.id}/${system.data.version}`),
+        },
+        hasResources && {
+          title: 'System Resources',
+          href: buildUrl(`/docs/systems/${system.data.id}/${system.data.version}/resources`),
+        },
+        isChangelogEnabled() &&
+          shouldRenderSideBarSection(system, 'changelog') && {
+            title: 'Changelog',
+            href: buildUrl(`/docs/systems/${system.data.id}/${system.data.version}/changelog`),
+          },
+      ].filter(Boolean) as { title: string; href: string }[]
+    ),
+    documentation: docsSection,
+    architecture: {
+      type: 'group',
+      title: 'Architecture',
+      icon: 'Workflow',
+      pages: [
+        {
+          type: 'item',
+          title: 'Overview',
+          href: buildUrl(`/architecture/systems/${system.data.id}/${system.data.version}`),
+        },
+        renderVisualiser &&
+          hasRelationships && {
+            type: 'item',
+            title: 'Context Diagram',
+            href: buildUrl(`/visualiser/systems/${system.data.id}/${system.data.version}/context`),
+          },
+        renderVisualiser && {
+          type: 'item',
+          title: 'Resource Diagram',
+          href: buildUrl(`/visualiser/systems/${system.data.id}/${system.data.version}`),
+        },
+      ].filter(Boolean) as ChildRef[],
+    },
+    diagrams: hasDiagrams
+      ? {
+          type: 'group',
+          title: 'Diagrams',
+          icon: 'FileImage',
+          pages: diagramNavItems,
+        }
+      : null,
+    resources:
+      resourceSubsections.length > 0
+        ? {
+            type: 'group',
+            title: 'Resources',
+            icon: 'Boxes',
+            // Resource type subsections are ordered A-Z by their title, and the
+            // resources within each subsection are ordered A-Z by name (sorted above).
+            pages: resourceSubsections
+              .map((section) => ({ ...section, subtle: true }))
+              .sort((a, b) => a.title.localeCompare(b.title)) as ChildRef[],
+          }
+        : null,
+    services: servicesSection,
+    flows: flowsSection,
+    'data-stores': dataStoresSection,
+    entities: renderEntities
+      ? {
+          type: 'group',
+          title: 'Entities',
+          icon: 'Box',
+          pages: entitiesInSystem.map((entity) => ({
+            type: 'item',
+            title: (entity as any).data?.name || (entity as any).data.id,
+            href: buildUrl(`/docs/entities/${(entity as any).data.id}/${(entity as any).data.version}`),
+          })),
+        }
+      : null,
+    'decision-records': shouldRenderSideBarSection(system, 'architectureDecisions')
+      ? buildArchitectureDecisionsSection(system, context.adrs || [])
+      : null,
+    owners: renderOwners ? buildOwnersSection(owners) : null,
+    code: renderRepository ? buildRepositorySection(system.data.repository as { url: string; language: string }) : null,
+    attachments: hasAttachments ? buildAttachmentsSection(system.data.attachments as any[]) : null,
+  };
+};
+
+export type BuildSystemNodeOptions = {
+  /** A parsed `sidebar.json` for this system. When present it replaces the generated sidebar. */
+  sidebar?: SidebarSpec;
+};
+
+export const buildSystemNode = (
+  system: CollectionEntry<'systems'>,
+  owners: any[],
+  context: ResourceGroupContext,
+  options: BuildSystemNodeOptions = {}
+): NavNode => {
+  const sections = buildSystemSections(system, owners, context);
+
+  const pages = resolveSidebarPages(sections, DEFAULT_SYSTEM_SECTION_ORDER, {
+    sidebar: options.sidebar,
+    resource: { collection: 'systems', id: system.data.id, version: system.data.version, entry: system },
+    context: toCustomSidebarContext(context),
+  });
+
   return {
     type: 'item',
     title: system.data.name,
@@ -66,101 +251,6 @@ export const buildSystemNode = (system: CollectionEntry<'systems'>, owners: any[
     // 'Systems' section header (and System badge) already convey the type, so the
     // default Group glyph on every item is redundant.
     ...customIconFieldsForResource(system.data),
-    pages: [
-      buildQuickReferenceSection(
-        [
-          {
-            title: 'Overview',
-            href: buildUrl(`/docs/systems/${system.data.id}/${system.data.version}`),
-          },
-          hasResources && {
-            title: 'System Resources',
-            href: buildUrl(`/docs/systems/${system.data.id}/${system.data.version}/resources`),
-          },
-          isChangelogEnabled() &&
-            shouldRenderSideBarSection(system, 'changelog') && {
-              title: 'Changelog',
-              href: buildUrl(`/docs/systems/${system.data.id}/${system.data.version}/changelog`),
-            },
-        ].filter(Boolean) as { title: string; href: string }[]
-      ),
-      docsSection,
-      {
-        type: 'group',
-        title: 'Architecture',
-        icon: 'Workflow',
-        pages: [
-          {
-            type: 'item',
-            title: 'Overview',
-            href: buildUrl(`/architecture/systems/${system.data.id}/${system.data.version}`),
-          },
-          renderVisualiser &&
-            hasRelationships && {
-              type: 'item',
-              title: 'Context Diagram',
-              href: buildUrl(`/visualiser/systems/${system.data.id}/${system.data.version}/context`),
-            },
-          renderVisualiser && {
-            type: 'item',
-            title: 'Resource Diagram',
-            href: buildUrl(`/visualiser/systems/${system.data.id}/${system.data.version}`),
-          },
-        ].filter(Boolean) as ChildRef[],
-      },
-      hasDiagrams && {
-        type: 'group',
-        title: 'Diagrams',
-        icon: 'FileImage',
-        pages: diagramNavItems,
-      },
-      (renderServices || renderFlows || renderContainers) && {
-        type: 'group',
-        title: 'Resources',
-        icon: 'Boxes',
-        // Resource type subsections are ordered A-Z by their title, and the
-        // resources within each subsection are ordered A-Z by name (sorted above).
-        pages: (
-          [
-            renderServices && {
-              type: 'group',
-              title: 'Services',
-              subtle: true,
-              icon: 'Server',
-              pages: servicesInSystem.map((service) => `service:${(service as any).data.id}:${(service as any).data.version}`),
-            },
-            renderFlows && {
-              type: 'group',
-              title: 'Flows',
-              subtle: true,
-              icon: 'Waypoints',
-              pages: flowsInSystem.map((flow) => `flow:${(flow as any).data.id}:${(flow as any).data.version}`),
-            },
-            renderContainers && {
-              type: 'group',
-              title: 'Data Stores',
-              subtle: true,
-              icon: 'Database',
-              pages: containersInSystem.map(
-                (container) => `container:${(container as any).data.id}:${(container as any).data.version}`
-              ),
-            },
-          ].filter(Boolean) as NavNode[]
-        ).sort((a, b) => a.title.localeCompare(b.title)) as ChildRef[],
-      },
-      renderEntities && {
-        type: 'group',
-        title: 'Entities',
-        icon: 'Box',
-        pages: entitiesInSystem.map((entity) => ({
-          type: 'item',
-          title: (entity as any).data?.name || (entity as any).data.id,
-          href: buildUrl(`/docs/entities/${(entity as any).data.id}/${(entity as any).data.version}`),
-        })),
-      },
-      renderOwners && buildOwnersSection(owners),
-      renderRepository && buildRepositorySection(system.data.repository as { url: string; language: string }),
-      hasAttachments && buildAttachmentsSection(system.data.attachments as any[]),
-    ].filter(Boolean) as ChildRef[],
+    pages,
   };
 };

--- a/packages/core/eventcatalog/src/stores/sidebar-store/custom-sidebar.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/custom-sidebar.ts
@@ -75,6 +75,12 @@ export type CustomSidebarContext = {
   resourceDocs?: ResourceDocEntry[];
   domains?: EntryLike[];
   services?: EntryLike[];
+  systems?: EntryLike[];
+  agents?: EntryLike[];
+  flows?: EntryLike[];
+  containers?: EntryLike[];
+  entities?: EntryLike[];
+  dataProducts?: EntryLike[];
   events?: EntryLike[];
   commands?: EntryLike[];
   queries?: EntryLike[];
@@ -112,6 +118,23 @@ const MESSAGE_COLLECTIONS: Record<string, keyof CustomSidebarContext> = {
   event: 'events',
   command: 'commands',
   query: 'queries',
+};
+
+/**
+ * Sidebar nodes exist for every version of a message, but only the latest version of the
+ * other collections (state.ts loads them with `getAllVersions: false`). A ref pinned to a
+ * historical version of those would silently render nothing, so fail the build instead.
+ * Maps ref types to the context collection we can validate against.
+ */
+const LATEST_ONLY_COLLECTIONS: Record<string, keyof CustomSidebarContext> = {
+  domain: 'domains',
+  service: 'services',
+  system: 'systems',
+  agent: 'agents',
+  flow: 'flows',
+  container: 'containers',
+  entity: 'entities',
+  'data-product': 'dataProducts',
 };
 
 const RESOURCE_REF_PATTERN = /^\[\[([a-z-]+)\|([^[\]]+?)\]\]$/;
@@ -193,18 +216,24 @@ const resolveDocPage = (
     );
   }
 
-  const doc = (context.resourceDocs || []).find(
+  const docsForResource = (context.resourceDocs || []).filter(
     (entry) =>
       entry.data.resourceCollection === resource.collection &&
       entry.data.resourceId === resource.id &&
-      entry.data.resourceVersion === resource.version &&
-      entry.data.type === docType &&
-      entry.data.id === docId
+      entry.data.resourceVersion === resource.version
   );
+  const doc = docsForResource.find((entry) => entry.data.type === docType && entry.data.id === docId);
+
+  if (!doc) {
+    const available = docsForResource.map((entry) => `${entry.data.type}/${entry.data.id}`).join(', ');
+    throw new Error(
+      `Cannot resolve "[[doc|${ref.id}]]" in sidebar${describeSource(spec)}: ${resource.id} v${resource.version} has no documentation page "${ref.id}".${available ? ` Available: ${available}.` : ' This resource has no documentation pages.'}`
+    );
+  }
 
   return {
     type: 'item',
-    title: doc?.data.title || docId,
+    title: doc.data.title || docId,
     href: buildUrl(
       `/docs/${resource.collection}/${resource.id}/${resource.version}/${encodeURIComponent(docType)}/${encodeURIComponent(docId)}`
     ),
@@ -391,6 +420,18 @@ const resolvePage = (
     );
   }
 
+  // Only messages have sidebar nodes for every version; pinning a historical version of a
+  // latest-only collection would silently render nothing, so fail loudly when we can tell.
+  if (ref.version && LATEST_ONLY_COLLECTIONS[ref.type]) {
+    const pool = context[LATEST_ONLY_COLLECTIONS[ref.type]] as EntryLike[] | undefined;
+    const latest = pool?.find((entry) => entry.data.id === ref.id);
+    if (latest && latest.data.version !== ref.version) {
+      throw new Error(
+        `Cannot resolve "${page}" in sidebar${describeSource(spec)}: only the latest version (${latest.data.version}) of a ${ref.type} can be referenced in a sidebar. Drop the "@${ref.version}" to link the latest version.`
+      );
+    }
+  }
+
   // Unversioned keys are aliases to the latest version in the node map.
   return [ref.version ? `${prefix}:${ref.id}:${ref.version}` : `${prefix}:${ref.id}`];
 };
@@ -519,6 +560,12 @@ export const toCustomSidebarContext = (context: {
   resourceDocs?: ResourceDocEntry[];
   domains?: unknown[];
   services?: unknown[];
+  systems?: unknown[];
+  agents?: unknown[];
+  flows?: unknown[];
+  containers?: unknown[];
+  entities?: unknown[];
+  dataProducts?: unknown[];
   events?: unknown[];
   commands?: unknown[];
   queries?: unknown[];
@@ -527,6 +574,12 @@ export const toCustomSidebarContext = (context: {
   resourceDocs: context.resourceDocs,
   domains: context.domains as EntryLike[] | undefined,
   services: context.services as EntryLike[] | undefined,
+  systems: context.systems as EntryLike[] | undefined,
+  agents: context.agents as EntryLike[] | undefined,
+  flows: context.flows as EntryLike[] | undefined,
+  containers: context.containers as EntryLike[] | undefined,
+  entities: context.entities as EntryLike[] | undefined,
+  dataProducts: context.dataProducts as EntryLike[] | undefined,
   events: context.events as EntryLike[] | undefined,
   commands: context.commands as EntryLike[] | undefined,
   queries: context.queries as EntryLike[] | undefined,

--- a/packages/core/eventcatalog/src/stores/sidebar-store/custom-sidebar.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/custom-sidebar.ts
@@ -186,6 +186,20 @@ const slugify = (value: string) =>
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-|-$/g, '');
 
+/**
+ * Collapse state is persisted per collapseKey, so sibling groups must never share one —
+ * duplicate titles (or titles that slugify to nothing, e.g. non-Latin) get a numeric
+ * suffix. Keys stay stable for the common unique-title case.
+ */
+const uniqueCollapseKey = (candidate: string, usedKeys: Set<string>): string => {
+  let key = candidate;
+  for (let n = 2; usedKeys.has(key); n++) {
+    key = `${candidate}-${n}`;
+  }
+  usedKeys.add(key);
+  return key;
+};
+
 const describeSource = (spec: SidebarSpec) => (spec.sourcePath ? ` (${spec.sourcePath})` : '');
 
 const formatTokenList = (sections: SidebarSections) =>
@@ -397,10 +411,11 @@ const resolvePage = (
   resource: CustomSidebarResource,
   context: CustomSidebarContext,
   spec: SidebarSpec,
+  usedCollapseKeys: Set<string>,
   parentKey: string
 ): ChildRef[] => {
   if (isNestedGroup(page)) {
-    return [resolveCustomGroup(page, sections, resource, context, spec, parentKey)];
+    return [resolveCustomGroup(page, sections, resource, context, spec, usedCollapseKeys, parentKey)];
   }
 
   if (typeof page !== 'string') {
@@ -507,11 +522,14 @@ const resolveCustomGroup = (
   resource: CustomSidebarResource,
   context: CustomSidebarContext,
   spec: SidebarSpec,
+  usedCollapseKeys: Set<string>,
   parentKey = ''
 ): NavNode => {
-  const collapseKey = parentKey
-    ? `${parentKey}:${slugify(group.title)}`
-    : `custom:${resource.collection}:${resource.id}:${resource.version}:${slugify(group.title)}`;
+  const slug = slugify(group.title) || 'group';
+  const collapseKey = uniqueCollapseKey(
+    parentKey ? `${parentKey}:${slug}` : `custom:${resource.collection}:${resource.id}:${resource.version}:${slug}`,
+    usedCollapseKeys
+  );
 
   return {
     type: 'group',
@@ -520,7 +538,7 @@ const resolveCustomGroup = (
     ...(parentKey ? { subtle: true } : {}),
     ...(group.collapsed !== undefined ? { collapsed: group.collapsed } : {}),
     collapseKey,
-    pages: group.pages.flatMap((page) => resolvePage(page, sections, resource, context, spec, collapseKey)),
+    pages: group.pages.flatMap((page) => resolvePage(page, sections, resource, context, spec, usedCollapseKeys, collapseKey)),
   };
 };
 
@@ -534,6 +552,7 @@ export const applyCustomSidebar = (
   resource: CustomSidebarResource,
   context: CustomSidebarContext = {}
 ): ChildRef[] => {
+  const usedCollapseKeys = new Set<string>();
   return spec.sections.flatMap((entry): ChildRef[] => {
     if (typeof entry === 'string') {
       return resolvePredefinedSection(entry, {}, sections, spec);
@@ -546,7 +565,7 @@ export const applyCustomSidebar = (
         spec
       );
     }
-    return [resolveCustomGroup(entry, sections, resource, context, spec)];
+    return [resolveCustomGroup(entry, sections, resource, context, spec, usedCollapseKeys)];
   });
 };
 

--- a/packages/core/eventcatalog/src/stores/sidebar-store/custom-sidebar.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/custom-sidebar.ts
@@ -87,6 +87,9 @@ export type CustomSidebarContext = {
   containers?: EntryLike[];
   entities?: EntryLike[];
   dataProducts?: EntryLike[];
+  adrs?: EntryLike[];
+  channels?: EntryLike[];
+  diagrams?: EntryLike[];
   events?: EntryLike[];
   commands?: EntryLike[];
   queries?: EntryLike[];
@@ -141,6 +144,9 @@ const LATEST_ONLY_COLLECTIONS: Record<string, keyof CustomSidebarContext> = {
   container: 'containers',
   entity: 'entities',
   'data-product': 'dataProducts',
+  adr: 'adrs',
+  channel: 'channels',
+  diagram: 'diagrams',
 };
 
 const RESOURCE_REF_PATTERN = /^\[\[([a-z-]+)\|([^[\]]+?)\]\]$/;
@@ -285,7 +291,18 @@ const resolveSpecPage = (
       ? [context[SPEC_OWNER_COLLECTIONS[locator.type]] as EntryLike[] | undefined]
       : [context.services, context.domains];
     const entry = findEntry(pools, locator.id, locator.version);
-    if (entry) owner = { collection: entry.collection, id: entry.data.id, version: entry.data.version, data: entry.data };
+    if (entry) {
+      owner = { collection: entry.collection, id: entry.data.id, version: entry.data.version, data: entry.data };
+    } else if (locator.version) {
+      // The id may exist at a different version: only the latest version's specifications
+      // can be referenced (state.ts loads these collections latest-only).
+      const latest = findEntry(pools, locator.id);
+      if (latest) {
+        throw new Error(
+          `Cannot resolve "[[spec|${target}]]" in sidebar${describeSource(spec)}: only the latest version (${latest.data.version}) of "${locator.id}" can be referenced. Drop the "@${locator.version}" to link its latest specifications.`
+        );
+      }
+    }
   }
 
   if (!owner) {
@@ -576,6 +593,9 @@ export const toCustomSidebarContext = (context: {
   containers?: unknown[];
   entities?: unknown[];
   dataProducts?: unknown[];
+  adrs?: unknown[];
+  channels?: unknown[];
+  diagrams?: unknown[];
   events?: unknown[];
   commands?: unknown[];
   queries?: unknown[];
@@ -591,6 +611,9 @@ export const toCustomSidebarContext = (context: {
   containers: context.containers as EntryLike[] | undefined,
   entities: context.entities as EntryLike[] | undefined,
   dataProducts: context.dataProducts as EntryLike[] | undefined,
+  adrs: context.adrs as EntryLike[] | undefined,
+  channels: context.channels as EntryLike[] | undefined,
+  diagrams: context.diagrams as EntryLike[] | undefined,
   events: context.events as EntryLike[] | undefined,
   commands: context.commands as EntryLike[] | undefined,
   queries: context.queries as EntryLike[] | undefined,

--- a/packages/core/eventcatalog/src/stores/sidebar-store/custom-sidebar.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/custom-sidebar.ts
@@ -73,6 +73,12 @@ type EntryLike = { collection: string; data: Record<string, any> };
 
 export type CustomSidebarContext = {
   resourceDocs?: ResourceDocEntry[];
+  /**
+   * Whether the resource-docs feature is available on this plan. When explicitly false
+   * (community mode) `[[doc|…]]` refs render nothing — the pages they'd link to don't
+   * exist — instead of failing the build. Missing docs still fail when the feature is on.
+   */
+  resourceDocsEnabled?: boolean;
   domains?: EntryLike[];
   services?: EntryLike[];
   systems?: EntryLike[];
@@ -206,7 +212,9 @@ const resolveDocPage = (
   resource: CustomSidebarResource,
   context: CustomSidebarContext,
   spec: SidebarSpec
-): NavNode => {
+): NavNode | null => {
+  if (context.resourceDocsEnabled === false) return null;
+
   const [docType, ...rest] = ref.id.split('/');
   const docId = rest.join('/');
 
@@ -404,7 +412,8 @@ const resolvePage = (
   }
 
   if (ref.type === 'doc') {
-    return [resolveDocPage(ref, resource, context, spec)];
+    const docPage = resolveDocPage(ref, resource, context, spec);
+    return docPage ? [docPage] : [];
   }
   if (ref.type === 'spec') {
     return [resolveSpecPage(ref.id, resource, context, spec)];
@@ -558,6 +567,7 @@ export const resolveSidebarPages = <K extends string>(
  */
 export const toCustomSidebarContext = (context: {
   resourceDocs?: ResourceDocEntry[];
+  resourceDocsEnabled?: boolean;
   domains?: unknown[];
   services?: unknown[];
   systems?: unknown[];
@@ -572,6 +582,7 @@ export const toCustomSidebarContext = (context: {
   schemas?: unknown[];
 }): CustomSidebarContext => ({
   resourceDocs: context.resourceDocs,
+  resourceDocsEnabled: context.resourceDocsEnabled,
   domains: context.domains as EntryLike[] | undefined,
   services: context.services as EntryLike[] | undefined,
   systems: context.systems as EntryLike[] | undefined,

--- a/packages/core/eventcatalog/src/stores/sidebar-store/custom-sidebar.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/custom-sidebar.ts
@@ -424,7 +424,8 @@ const resolvePage = (
 
   if (typeof page !== 'string') {
     const href = interpolateResourcePlaceholders(page.href, resource);
-    const isExternal = EXTERNAL_HREF_PATTERN.test(href);
+    // Protocol-relative URLs (//host/path) are external too — buildUrl would mangle them.
+    const isExternal = EXTERNAL_HREF_PATTERN.test(href) || href.startsWith('//');
     return [
       {
         type: 'item',

--- a/packages/core/eventcatalog/src/stores/sidebar-store/custom-sidebar.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/custom-sidebar.ts
@@ -115,6 +115,10 @@ const parseResourceLocator = (value: string): { type?: string; id: string; versi
 const SPEC_OWNER_COLLECTIONS: Record<string, keyof CustomSidebarContext> = {
   domain: 'domains',
   service: 'services',
+  // Messages extend the same base schema and get specification pages too.
+  event: 'events',
+  command: 'commands',
+  query: 'queries',
 };
 
 const SPEC_ROUTES: Record<string, { segment: string; icon: string }> = {

--- a/packages/core/eventcatalog/src/stores/sidebar-store/custom-sidebar.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/custom-sidebar.ts
@@ -1,0 +1,567 @@
+import path from 'node:path';
+import type { CollectionEntry } from 'astro:content';
+import { buildUrl } from '@utils/url-builder';
+import { processSpecifications } from '@utils/collections/util';
+import type { ResourceCollection, ResourceDocEntry } from '@utils/collections/resource-docs';
+import type { NavNode, ChildRef } from './builders/shared';
+
+/**
+ * Custom sidebars: an optional `sidebar.json` next to any resource's `index.mdx` — domains,
+ * systems, services, agents, events, commands, queries, flows, containers, entities,
+ * data products and ADRs. Each builder exposes its own predefined `$tokens` (see the
+ * `<Type>SectionKey` union and `DEFAULT_<TYPE>_SECTION_ORDER` in `builders/<type>.ts`).
+ *
+ * When the file exists it *is* the sidebar — nothing is merged in, nothing is hidden,
+ * what's listed is what renders, in that order. The grammar is intentionally tiny:
+ *
+ *   A section is one of
+ *     "$quick-reference"                                   predefined section (kept live)
+ *     { "section": "$owners", "title": "Team" }            predefined section, relabelled
+ *     { "title": "Runbooks", "icon": "Siren", "pages": [] } a custom group
+ *
+ *   A page (inside a custom group) is one of
+ *     "$quick-reference"                                   the *items* of a predefined section, spliced in
+ *     "[[service|OrderService@1.0.0]]"                     a resource (nested sidebar)
+ *     "[[doc|guides/sla]]"                                 one of this resource's docs
+ *     "[[spec|openapi.yml]]"                               one of this resource's specifications
+ *     "[[spec|service/product-api@1.0.0/openapi.yml]]"     another resource's specification
+ *     "[[schema|event/product-created@1.0.0]]"             a message's schema page
+ *     { "title": "Runbook", "href": "https://..." }        a plain link (external inferred)
+ *     { "title": "Runbooks", "pages": [] }                 a nested group (rendered as a subsection)
+ *
+ *   Any object-form section or group accepts `"collapsed": true | false` — an explicit initial
+ *   state that overrides the renderer's size-based heuristic. Users can still toggle it.
+ *
+ * Splicing is how you extend a predefined section: wrap it in your own group and put
+ * your pages before or after the token — placement is just list order.
+ *
+ * Link titles and hrefs may use `{id}`, `{version}` and `{collection}` placeholders for the
+ * resource the sidebar belongs to, e.g. "/visualiser/{collection}/{id}/{version}". Internal
+ * hrefs (no protocol) are passed through `buildUrl` so they respect the configured base path.
+ */
+
+export type SidebarLink = { title: string; href: string; icon?: string };
+export type SidebarCustomGroup = { title: string; icon?: string; collapsed?: boolean; pages: SidebarPageEntry[] };
+export type SidebarPageEntry = string | SidebarLink | SidebarCustomGroup;
+export type SidebarSectionOverride = { section: string; title?: string; icon?: string; collapsed?: boolean };
+export type SidebarSectionEntry = string | SidebarSectionOverride | SidebarCustomGroup;
+
+export type SidebarSpec = {
+  $schema?: string;
+  sections: SidebarSectionEntry[];
+  /** Where the spec came from — used in error messages only. */
+  sourcePath?: string;
+};
+
+/**
+ * The predefined sections a builder exposes for a resource, keyed by token (without the `$`).
+ * Values are what the builder would normally render: null/false/undefined when the section
+ * has nothing to show, or an array for tokens that expand to several groups (e.g. resource groups).
+ */
+export type SidebarSections = Record<string, NavNode | NavNode[] | null | undefined | false>;
+
+export type CustomSidebarResource = {
+  /** The Astro collection name, e.g. `domains`, `services`, `events`, `adrs`. */
+  collection: ResourceCollection | string;
+  id: string;
+  version: string;
+  /** The resource's own collection entry — needed to resolve its own `[[spec|…]]` refs. */
+  entry?: { data: Record<string, any> };
+};
+
+type EntryLike = { collection: string; data: Record<string, any> };
+
+export type CustomSidebarContext = {
+  resourceDocs?: ResourceDocEntry[];
+  domains?: EntryLike[];
+  services?: EntryLike[];
+  events?: EntryLike[];
+  commands?: EntryLike[];
+  queries?: EntryLike[];
+  schemas?: Array<{ data: { message: { collectionName: string; id: string; version: string } } }>;
+};
+
+/** `[type/]id[@version]` — the resource half of a spec or schema ref. */
+const parseResourceLocator = (value: string): { type?: string; id: string; version?: string } => {
+  let rest = value.trim();
+  let type: string | undefined;
+  const slash = rest.indexOf('/');
+  if (slash !== -1) {
+    type = rest.slice(0, slash).toLowerCase();
+    rest = rest.slice(slash + 1);
+  }
+  const at = rest.lastIndexOf('@');
+  if (at > 0 && /^[\d.]+$/.test(rest.slice(at + 1))) {
+    return { type, id: rest.slice(0, at), version: rest.slice(at + 1) };
+  }
+  return { type, id: rest };
+};
+
+const SPEC_OWNER_COLLECTIONS: Record<string, keyof CustomSidebarContext> = {
+  domain: 'domains',
+  service: 'services',
+};
+
+const SPEC_ROUTES: Record<string, { segment: string; icon: string }> = {
+  openapi: { segment: 'spec', icon: '/icons/openapi-black.svg' },
+  asyncapi: { segment: 'asyncapi', icon: '/icons/asyncapi-black.svg' },
+  graphql: { segment: 'graphql', icon: '/icons/graphql-black.svg' },
+};
+
+const MESSAGE_COLLECTIONS: Record<string, keyof CustomSidebarContext> = {
+  event: 'events',
+  command: 'commands',
+  query: 'queries',
+};
+
+const RESOURCE_REF_PATTERN = /^\[\[([a-z-]+)\|([^[\]]+?)\]\]$/;
+const EXTERNAL_HREF_PATTERN = /^[a-z][a-z0-9+.-]*:/i; // any protocol: https:, mailto:, slack:, ...
+const PLACEHOLDER_PATTERN = /\{(id|version|collection)\}/g;
+
+/** Replace `{id}`, `{version}` and `{collection}` with the owning resource's values. */
+export const interpolateResourcePlaceholders = (value: string, resource: CustomSidebarResource): string =>
+  value.replace(PLACEHOLDER_PATTERN, (_match, key: 'id' | 'version' | 'collection') => resource[key]);
+
+/**
+ * Maps `[[type|...]]` ref types to the node-key prefix used in the sidebar node map
+ * (see state.ts). Messages are keyed by their singular type (`event:`, `command:`, `query:`).
+ */
+const REF_TYPE_TO_NODE_PREFIX: Record<string, string> = {
+  domain: 'domain',
+  system: 'system',
+  service: 'service',
+  agent: 'agent',
+  flow: 'flow',
+  container: 'container',
+  entity: 'entity',
+  channel: 'channel',
+  diagram: 'diagram',
+  team: 'team',
+  user: 'user',
+  'data-product': 'data-product',
+  adr: 'adr',
+  event: 'event',
+  command: 'command',
+  query: 'query',
+};
+
+const slugify = (value: string) =>
+  value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+
+const describeSource = (spec: SidebarSpec) => (spec.sourcePath ? ` (${spec.sourcePath})` : '');
+
+const formatTokenList = (sections: SidebarSections) =>
+  Object.keys(sections)
+    .map((key) => `$${key}`)
+    .join(', ');
+
+export const parseResourceRef = (value: string): { type: string; id: string; version?: string } | null => {
+  const match = value.trim().match(RESOURCE_REF_PATTERN);
+  if (!match) return null;
+
+  const type = match[1].trim().toLowerCase();
+  let id = match[2].trim();
+  let version: string | undefined;
+
+  // Docs and specs are addressed by path and carry any version mid-string, not at the end.
+  if (type !== 'doc' && type !== 'spec') {
+    const versionMatch = id.match(/^(.*)@([\d.]+)$/);
+    if (versionMatch) {
+      id = versionMatch[1].trim();
+      version = versionMatch[2];
+    }
+  }
+
+  return { type, id, version };
+};
+
+const resolveDocPage = (
+  ref: { id: string },
+  resource: CustomSidebarResource,
+  context: CustomSidebarContext,
+  spec: SidebarSpec
+): NavNode => {
+  const [docType, ...rest] = ref.id.split('/');
+  const docId = rest.join('/');
+
+  if (!docType || !docId) {
+    throw new Error(
+      `Invalid doc reference "[[doc|${ref.id}]]" in sidebar${describeSource(spec)}. Expected "[[doc|<type>/<id>]]", e.g. "[[doc|guides/onboarding]]".`
+    );
+  }
+
+  const doc = (context.resourceDocs || []).find(
+    (entry) =>
+      entry.data.resourceCollection === resource.collection &&
+      entry.data.resourceId === resource.id &&
+      entry.data.resourceVersion === resource.version &&
+      entry.data.type === docType &&
+      entry.data.id === docId
+  );
+
+  return {
+    type: 'item',
+    title: doc?.data.title || docId,
+    href: buildUrl(
+      `/docs/${resource.collection}/${resource.id}/${resource.version}/${encodeURIComponent(docType)}/${encodeURIComponent(docId)}`
+    ),
+  };
+};
+
+const findEntry = (collections: Array<EntryLike[] | undefined>, id: string, version?: string): EntryLike | undefined => {
+  for (const collection of collections) {
+    const match = (collection || []).find(
+      (entry) => entry.data.id === id && (version === undefined || entry.data.version === version)
+    );
+    if (match) return match;
+  }
+  return undefined;
+};
+
+/**
+ * `[[spec|<filename>]]` (this resource) or `[[spec|[type/]<id>[@version]/<filename>]]` (any resource).
+ */
+const resolveSpecPage = (
+  target: string,
+  resource: CustomSidebarResource,
+  context: CustomSidebarContext,
+  spec: SidebarSpec
+): NavNode => {
+  const lastSlash = target.lastIndexOf('/');
+  const filename = lastSlash === -1 ? target : target.slice(lastSlash + 1);
+  const locator = lastSlash === -1 ? null : parseResourceLocator(target.slice(0, lastSlash));
+
+  let owner: { collection: string; id: string; version: string; data: Record<string, any> } | undefined;
+  if (!locator) {
+    if (resource.entry)
+      owner = { collection: resource.collection, id: resource.id, version: resource.version, data: resource.entry.data };
+  } else {
+    if (locator.type && !SPEC_OWNER_COLLECTIONS[locator.type]) {
+      throw new Error(
+        `Unknown resource type "${locator.type}" in "[[spec|${target}]]" in sidebar${describeSource(spec)}. Specifications belong to: ${Object.keys(SPEC_OWNER_COLLECTIONS).join(', ')}.`
+      );
+    }
+    const pools = locator.type
+      ? [context[SPEC_OWNER_COLLECTIONS[locator.type]] as EntryLike[] | undefined]
+      : [context.services, context.domains];
+    const entry = findEntry(pools, locator.id, locator.version);
+    if (entry) owner = { collection: entry.collection, id: entry.data.id, version: entry.data.version, data: entry.data };
+  }
+
+  if (!owner) {
+    throw new Error(
+      `Cannot resolve "[[spec|${target}]]" in sidebar${describeSource(spec)}: resource${locator ? ` "${locator.id}"` : ''} not found.`
+    );
+  }
+
+  const wanted = filename.replace(/\.[^.]+$/, '');
+  const specification = processSpecifications(owner.data.specifications).find(
+    (candidate) => candidate.filename === filename || candidate.filenameWithoutExtension === wanted
+  );
+  const route = specification && SPEC_ROUTES[specification.type];
+  if (!specification || !route) {
+    throw new Error(
+      `Cannot resolve "[[spec|${target}]]" in sidebar${describeSource(spec)}: "${owner.id}" has no specification file "${filename}".`
+    );
+  }
+
+  return {
+    type: 'item',
+    title: specification.name,
+    leftIcon: route.icon,
+    href: buildUrl(
+      `/docs/${owner.collection}/${owner.id}/${owner.version}/${route.segment}/${specification.filenameWithoutExtension}`
+    ),
+  };
+};
+
+/**
+ * `[[schema|[type/]<message id>[@version]]]` — a message's schema page.
+ */
+const resolveSchemaPage = (target: string, context: CustomSidebarContext, spec: SidebarSpec): NavNode => {
+  const locator = parseResourceLocator(target);
+  if (locator.type && !MESSAGE_COLLECTIONS[locator.type]) {
+    throw new Error(
+      `Unknown message type "${locator.type}" in "[[schema|${target}]]" in sidebar${describeSource(spec)}. Schemas belong to: ${Object.keys(MESSAGE_COLLECTIONS).join(', ')}.`
+    );
+  }
+
+  const pools = locator.type
+    ? [context[MESSAGE_COLLECTIONS[locator.type]] as EntryLike[] | undefined]
+    : [context.events, context.commands, context.queries];
+  const message = findEntry(pools, locator.id);
+  if (!message) {
+    throw new Error(
+      `Cannot resolve "[[schema|${target}]]" in sidebar${describeSource(spec)}: message "${locator.id}" not found.`
+    );
+  }
+
+  const version = locator.version || message.data.version;
+  if (context.schemas) {
+    const hasSchema = context.schemas.some(
+      (schema) =>
+        schema.data.message.collectionName === message.collection &&
+        schema.data.message.id === message.data.id &&
+        schema.data.message.version === version
+    );
+    if (!hasSchema) {
+      throw new Error(
+        `Cannot resolve "[[schema|${target}]]" in sidebar${describeSource(spec)}: "${message.data.id}" v${version} has no schema.`
+      );
+    }
+  }
+
+  return {
+    type: 'item',
+    title: `${message.data.name || message.data.id} schema`,
+    href: buildUrl(`/schemas/${message.collection}/${message.data.id}/${version}`),
+  };
+};
+
+/**
+ * `$token` inside a group's pages splices in the predefined section's items
+ * (not the section itself), so users can extend a section with their own pages.
+ */
+const splicePredefinedSectionPages = (token: string, sections: SidebarSections, spec: SidebarSpec): ChildRef[] => {
+  const nodes = resolvePredefinedSection(token, {}, sections, spec);
+  if (nodes.length > 1) {
+    throw new Error(
+      `Cannot splice "${token}" into a group in sidebar${describeSource(spec)} because it expands to several groups. Use it as a top-level section instead.`
+    );
+  }
+  return nodes.flatMap((node) => node.pages || []);
+};
+
+const isNestedGroup = (page: SidebarPageEntry): page is SidebarCustomGroup => typeof page !== 'string' && 'pages' in page;
+
+const resolvePage = (
+  page: SidebarPageEntry,
+  sections: SidebarSections,
+  resource: CustomSidebarResource,
+  context: CustomSidebarContext,
+  spec: SidebarSpec,
+  parentKey: string
+): ChildRef[] => {
+  if (isNestedGroup(page)) {
+    return [resolveCustomGroup(page, sections, resource, context, spec, parentKey)];
+  }
+
+  if (typeof page !== 'string') {
+    const href = interpolateResourcePlaceholders(page.href, resource);
+    const isExternal = EXTERNAL_HREF_PATTERN.test(href);
+    return [
+      {
+        type: 'item',
+        title: interpolateResourcePlaceholders(page.title, resource),
+        href: isExternal ? href : buildUrl(href),
+        ...(page.icon ? { icon: page.icon } : {}),
+        ...(isExternal ? { external: true } : {}),
+      },
+    ];
+  }
+
+  if (page.startsWith('$')) {
+    return splicePredefinedSectionPages(page, sections, spec);
+  }
+
+  const ref = parseResourceRef(page);
+  if (!ref) {
+    throw new Error(
+      `Invalid page "${page}" in sidebar${describeSource(spec)}. Pages must be a predefined section like "$quick-reference", a resource reference like "[[service|OrderService]]", a doc reference like "[[doc|guides/onboarding]]", or a link { "title", "href" }.`
+    );
+  }
+
+  if (ref.type === 'doc') {
+    return [resolveDocPage(ref, resource, context, spec)];
+  }
+  if (ref.type === 'spec') {
+    return [resolveSpecPage(ref.id, resource, context, spec)];
+  }
+  if (ref.type === 'schema') {
+    return [resolveSchemaPage(ref.version ? `${ref.id}@${ref.version}` : ref.id, context, spec)];
+  }
+
+  const prefix = REF_TYPE_TO_NODE_PREFIX[ref.type];
+  if (!prefix) {
+    throw new Error(
+      `Unknown resource type "${ref.type}" in "${page}" in sidebar${describeSource(spec)}. Supported types: ${Object.keys(REF_TYPE_TO_NODE_PREFIX).join(', ')}, doc, spec, schema.`
+    );
+  }
+
+  // Unversioned keys are aliases to the latest version in the node map.
+  return [ref.version ? `${prefix}:${ref.id}:${ref.version}` : `${prefix}:${ref.id}`];
+};
+
+const resolvePredefinedSection = (
+  token: string,
+  overrides: { title?: string; icon?: string; collapsed?: boolean },
+  sections: SidebarSections,
+  spec: SidebarSpec
+): NavNode[] => {
+  if (!token.startsWith('$')) {
+    throw new Error(
+      `Unknown section "${token}" in sidebar${describeSource(spec)}. Predefined sections start with "$" — did you mean "$${token}"?`
+    );
+  }
+
+  const key = token.slice(1);
+  if (!(key in sections)) {
+    throw new Error(
+      `Unknown section "${token}" in sidebar${describeSource(spec)}. Available sections for this resource: ${formatTokenList(sections)}.`
+    );
+  }
+
+  const value = sections[key];
+  if (!value) return [];
+
+  const nodes = Array.isArray(value) ? value : [value];
+  const hasOverrides = overrides.title !== undefined || overrides.icon !== undefined || overrides.collapsed !== undefined;
+  if (!hasOverrides) return nodes;
+
+  return nodes.map((node) => ({
+    ...node,
+    ...(overrides.title !== undefined ? { title: overrides.title } : {}),
+    ...(overrides.icon !== undefined ? { icon: overrides.icon } : {}),
+    ...(overrides.collapsed !== undefined ? { collapsed: overrides.collapsed } : {}),
+  }));
+};
+
+/**
+ * `parentKey` is the collapseKey of the enclosing group ('' at the top level); nested groups
+ * extend it so collapse state is persisted per path. Nested groups render as subtle
+ * subsections, matching the built-in Resources > Services/Entities look.
+ */
+const resolveCustomGroup = (
+  group: SidebarCustomGroup,
+  sections: SidebarSections,
+  resource: CustomSidebarResource,
+  context: CustomSidebarContext,
+  spec: SidebarSpec,
+  parentKey = ''
+): NavNode => {
+  const collapseKey = parentKey
+    ? `${parentKey}:${slugify(group.title)}`
+    : `custom:${resource.collection}:${resource.id}:${resource.version}:${slugify(group.title)}`;
+
+  return {
+    type: 'group',
+    title: group.title,
+    ...(group.icon ? { icon: group.icon } : {}),
+    ...(parentKey ? { subtle: true } : {}),
+    ...(group.collapsed !== undefined ? { collapsed: group.collapsed } : {}),
+    collapseKey,
+    pages: group.pages.flatMap((page) => resolvePage(page, sections, resource, context, spec, collapseKey)),
+  };
+};
+
+/**
+ * Turn a sidebar spec into the `pages` of a resource node. Throws on anything it can't
+ * resolve so a typo fails the build with a pointer at the offending file.
+ */
+export const applyCustomSidebar = (
+  spec: SidebarSpec,
+  sections: SidebarSections,
+  resource: CustomSidebarResource,
+  context: CustomSidebarContext = {}
+): ChildRef[] => {
+  return spec.sections.flatMap((entry): ChildRef[] => {
+    if (typeof entry === 'string') {
+      return resolvePredefinedSection(entry, {}, sections, spec);
+    }
+    if ('section' in entry) {
+      return resolvePredefinedSection(
+        entry.section,
+        { title: entry.title, icon: entry.icon, collapsed: entry.collapsed },
+        sections,
+        spec
+      );
+    }
+    return [resolveCustomGroup(entry, sections, resource, context, spec)];
+  });
+};
+
+/**
+ * Everything a builder needs to turn its named sections into a node's `pages`.
+ * With a `sidebar` spec the spec decides; without one the builder's default order does.
+ */
+export type ResolveSidebarPagesOptions = {
+  sidebar?: SidebarSpec;
+  resource: CustomSidebarResource;
+  context: CustomSidebarContext;
+};
+
+/**
+ * Builders produce a map of named sections plus a default order. This turns that into the
+ * node's `pages`, either by applying a custom `sidebar.json` or by walking the default order.
+ * Sections that are null/false/empty render nothing in both modes.
+ */
+export const resolveSidebarPages = <K extends string>(
+  sections: Record<K, NavNode | NavNode[] | null | undefined | false>,
+  defaultOrder: K[],
+  { sidebar, resource, context }: ResolveSidebarPagesOptions
+): ChildRef[] => {
+  if (sidebar) return applyCustomSidebar(sidebar, sections as SidebarSections, resource, context);
+  return defaultOrder.flatMap((key) => {
+    const value = sections[key];
+    if (!value) return [];
+    return Array.isArray(value) ? value : [value];
+  });
+};
+
+/**
+ * Pick the collections a custom sidebar can reference out of the builders' shared context.
+ * Builders pass their `ResourceGroupContext` here rather than spreading it by hand.
+ */
+export const toCustomSidebarContext = (context: {
+  resourceDocs?: ResourceDocEntry[];
+  domains?: unknown[];
+  services?: unknown[];
+  events?: unknown[];
+  commands?: unknown[];
+  queries?: unknown[];
+  schemas?: unknown[];
+}): CustomSidebarContext => ({
+  resourceDocs: context.resourceDocs,
+  domains: context.domains as EntryLike[] | undefined,
+  services: context.services as EntryLike[] | undefined,
+  events: context.events as EntryLike[] | undefined,
+  commands: context.commands as EntryLike[] | undefined,
+  queries: context.queries as EntryLike[] | undefined,
+  schemas: context.schemas as CustomSidebarContext['schemas'],
+});
+
+/**
+ * Index sidebar.json entries by the folder they live in, so a resource can look up
+ * its sidebar via `path.dirname(resource.filePath)`. The lookup is folder-keyed with no
+ * collection check: every sidebar-aware resource lives in its own folder (`index.mdx`), so
+ * two resources can never share a key. Sibling files like `ubiquitous-language.mdx` and
+ * `changelog.md` are not sidebar-aware and never perform this lookup.
+ */
+export const indexSidebarsByFolder = (entries: CollectionEntry<'sidebars'>[]): Map<string, SidebarSpec> => {
+  const byFolder = new Map<string, SidebarSpec>();
+  for (const entry of entries) {
+    if (!entry.filePath) continue;
+    byFolder.set(path.dirname(entry.filePath), { ...(entry.data as SidebarSpec), sourcePath: entry.filePath });
+  }
+  return byFolder;
+};
+
+export const getSidebarForResource = (
+  sidebarsByFolder: Map<string, SidebarSpec>,
+  resource: { filePath?: string }
+): SidebarSpec | undefined => {
+  if (!resource.filePath) return undefined;
+  const folder = path.dirname(resource.filePath);
+  const exact = sidebarsByFolder.get(folder);
+  if (exact) return exact;
+
+  // A versioned copy (…/OrderCreated/versioned/1.0.0/index.mdx) inherits the resource
+  // folder's sidebar.json unless its own versioned folder carries one, so both versions of
+  // a resource render the same structure. Version-specific links still resolve correctly:
+  // predefined sections are built per version and `{version}` placeholders interpolate it.
+  const versionedMatch = folder.match(/^(.*)\/versioned\/[^/]+$/);
+  return versionedMatch ? sidebarsByFolder.get(versionedMatch[1]) : undefined;
+};

--- a/packages/core/eventcatalog/src/stores/sidebar-store/state.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/state.ts
@@ -442,7 +442,12 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
     (acc, flow) => {
       const sidebar = getSidebarForResource(customSidebars, flow);
       const node = buildFlowNode(flow, context, { sidebar });
-      acc[`flow:${flow.data.id}:${flow.data.version}`] = sidebar ? node : withArchitectureDecisionsSection(node, flow, adrs);
+      const versionedKey = `flow:${flow.data.id}:${flow.data.version}`;
+      acc[versionedKey] = sidebar ? node : withArchitectureDecisionsSection(node, flow, adrs);
+      if (flow.data.latestVersion === flow.data.version) {
+        // Store reference to versioned key instead of duplicating the full node
+        acc[`flow:${flow.data.id}`] = versionedKey;
+      }
       return acc;
     },
     {} as Record<string, NavNode>

--- a/packages/core/eventcatalog/src/stores/sidebar-store/state.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/state.ts
@@ -41,7 +41,7 @@ import {
   shouldRenderSideBarSection,
   withArchitectureDecisionsSection,
 } from './builders/shared';
-import { isArchitectureGraphEnabled, isChangelogEnabled } from '@utils/feature';
+import { isArchitectureGraphEnabled, isChangelogEnabled, isResourceDocsEnabled } from '@utils/feature';
 
 export type { NavigationData, NavNode, ChildRef };
 
@@ -334,6 +334,7 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
   const messages = [...allEvents, ...allCommands, ...allQueries];
 
   const context = {
+    resourceDocsEnabled: isResourceDocsEnabled(),
     agents,
     services,
     domains,
@@ -678,6 +679,7 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
   );
 
   const dataProductContext = {
+    resourceDocsEnabled: isResourceDocsEnabled(),
     events,
     commands,
     queries,

--- a/packages/core/eventcatalog/src/stores/sidebar-store/state.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/state.ts
@@ -692,6 +692,16 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
     containers,
     channels,
     adrs,
+    // Included so data-product sidebar.json files resolve the same refs as every other
+    // resource (cross-resource specs, schema-existence checks, latest-only pins).
+    domains,
+    systems,
+    agents,
+    flows,
+    entities,
+    dataProducts,
+    diagrams,
+    schemas,
     resourceDocs,
     resourceDocCategories,
   };

--- a/packages/core/eventcatalog/src/stores/sidebar-store/state.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/state.ts
@@ -1,4 +1,5 @@
 import { getCollection } from 'astro:content';
+import { getSidebarForResource, indexSidebarsByFolder } from './custom-sidebar';
 import type { CollectionEntry } from 'astro:content';
 import { getAgents } from '@utils/collections/agents';
 import { getAdrAliasNodeKey, getAdrNodeKey, getAdrs, type Adr } from '@utils/collections/adrs';
@@ -296,6 +297,7 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
     ubiquitousLanguages,
     resourceDocs,
     resourceDocCategories,
+    customSidebarEntries,
   ] = await Promise.all([
     getDomains({ getAllVersions: false, includeServicesInSubdomains: false }),
     getSystems({ getAllVersions: false }),
@@ -316,7 +318,11 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
     getCollection('ubiquitousLanguages'),
     getResourceDocs(),
     getResourceDocCategories(),
+    getCollection('sidebars'),
   ]);
+
+  // Optional per-resource `sidebar.json` overrides, keyed by the folder they sit in.
+  const customSidebars = indexSidebarsByFolder(customSidebarEntries);
 
   // Calculate derived lists to avoid extra fetches
   const allSubDomainIds = new Set(domains.flatMap((d) => (d.data.domains || []).map((sd: any) => sd.data.id)));
@@ -433,11 +439,9 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
 
   const flowNodes = flows.reduce(
     (acc, flow) => {
-      acc[`flow:${flow.data.id}:${flow.data.version}`] = withArchitectureDecisionsSection(
-        buildFlowNode(flow, context),
-        flow,
-        adrs
-      );
+      const sidebar = getSidebarForResource(customSidebars, flow);
+      const node = buildFlowNode(flow, context, { sidebar });
+      acc[`flow:${flow.data.id}:${flow.data.version}`] = sidebar ? node : withArchitectureDecisionsSection(node, flow, adrs);
       return acc;
     },
     {} as Record<string, NavNode>
@@ -446,7 +450,10 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
   const domainNodes = domainsWithOwners.reduce(
     (acc, { domain, owners }) => {
       const versionedKey = `domain:${domain.data.id}:${domain.data.version}`;
-      acc[versionedKey] = withArchitectureDecisionsSection(buildDomainNode(domain, owners, context), domain, adrs);
+      const sidebar = getSidebarForResource(customSidebars, domain);
+      const domainNode = buildDomainNode(domain, owners, context, { sidebar });
+      // A custom sidebar decides for itself whether (and where) `$decision-records` renders.
+      acc[versionedKey] = sidebar ? domainNode : withArchitectureDecisionsSection(domainNode, domain, adrs);
       if (domain.data.latestVersion === domain.data.version) {
         // Store reference to versioned key instead of duplicating the full node
         acc[`domain:${domain.data.id}`] = versionedKey;
@@ -538,11 +545,9 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
     (acc, { agent, owners }) => {
       const versionedKey = `agent:${agent.data.id}:${agent.data.version}`;
       const agentChannels = agentChannelsMap.get(`${agent.data.id}:${agent.data.version}`) || [];
-      acc[versionedKey] = withArchitectureDecisionsSection(
-        buildAgentNode(agent, owners, context, agentChannels, flowRefsByAgent.get(versionedKey) || []),
-        agent,
-        adrs
-      );
+      const sidebar = getSidebarForResource(customSidebars, agent);
+      const node = buildAgentNode(agent, owners, context, agentChannels, flowRefsByAgent.get(versionedKey) || [], { sidebar });
+      acc[versionedKey] = sidebar ? node : withArchitectureDecisionsSection(node, agent, adrs);
       if (agent.data.latestVersion === agent.data.version) {
         acc[`agent:${agent.data.id}`] = versionedKey;
       }
@@ -555,11 +560,11 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
     (acc, { service, owners }) => {
       const versionedKey = `service:${service.data.id}:${service.data.version}`;
       const serviceChannels = serviceChannelsMap.get(`${service.data.id}:${service.data.version}`) || [];
-      acc[versionedKey] = withArchitectureDecisionsSection(
-        buildServiceNode(service, owners, context, serviceChannels, flowRefsByService.get(versionedKey) || []),
-        service,
-        adrs
-      );
+      const sidebar = getSidebarForResource(customSidebars, service);
+      const node = buildServiceNode(service, owners, context, serviceChannels, flowRefsByService.get(versionedKey) || [], {
+        sidebar,
+      });
+      acc[versionedKey] = sidebar ? node : withArchitectureDecisionsSection(node, service, adrs);
       if (service.data.latestVersion === service.data.version) {
         // Store reference to versioned key instead of duplicating the full node
         acc[`service:${service.data.id}`] = versionedKey;
@@ -612,14 +617,17 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
       const hasFieldUsage = messagesWithFieldUsage.has(message.data.id);
       const triggers = getTriggersOfMessage(messageReceivers, message, messages);
       const triggeredBy = getTriggeredByOfMessage(messageReceivers, message, messages);
-      acc[versionedKey] = withArchitectureDecisionsSection(
-        buildMessageNode(message, owners, context, hasFieldUsage, flowRefsByMessage.get(versionedKey) || [], {
-          triggers,
-          triggeredBy,
-        }),
+      const sidebar = getSidebarForResource(customSidebars, message);
+      const node = buildMessageNode(
         message,
-        adrs
+        owners,
+        context,
+        hasFieldUsage,
+        flowRefsByMessage.get(versionedKey) || [],
+        { triggers, triggeredBy },
+        { sidebar }
       );
+      acc[versionedKey] = sidebar ? node : withArchitectureDecisionsSection(node, message, adrs);
       if (message.data.latestVersion === message.data.version) {
         // Store reference to versioned key instead of duplicating the full node
         acc[`${type}:${message.data.id}`] = versionedKey;
@@ -634,11 +642,9 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
   const containerNodes = containerWithOwners.reduce(
     (acc, { container, owners }) => {
       const versionedKey = `container:${container.data.id}:${container.data.version}`;
-      acc[versionedKey] = withArchitectureDecisionsSection(
-        buildContainerNode(container, owners, context, flowRefsByContainer.get(versionedKey) || []),
-        container,
-        adrs
-      );
+      const sidebar = getSidebarForResource(customSidebars, container);
+      const node = buildContainerNode(container, owners, context, flowRefsByContainer.get(versionedKey) || [], { sidebar });
+      acc[versionedKey] = sidebar ? node : withArchitectureDecisionsSection(node, container, adrs);
       if (container.data.latestVersion === container.data.version) {
         // Store reference to versioned key instead of duplicating the full node
         acc[`container:${container.data.id}`] = versionedKey;
@@ -651,7 +657,9 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
   const systemNodes = systemWithOwners.reduce(
     (acc, { system, owners }) => {
       const versionedKey = `system:${system.data.id}:${system.data.version}`;
-      acc[versionedKey] = withArchitectureDecisionsSection(buildSystemNode(system, owners, context), system, adrs);
+      const sidebar = getSidebarForResource(customSidebars, system);
+      const node = buildSystemNode(system, owners, context, { sidebar });
+      acc[versionedKey] = sidebar ? node : withArchitectureDecisionsSection(node, system, adrs);
       if (system.data.latestVersion === system.data.version) {
         // Store reference to versioned key instead of duplicating the full node
         acc[`system:${system.data.id}`] = versionedKey;
@@ -676,6 +684,7 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
     services,
     containers,
     channels,
+    adrs,
     resourceDocs,
     resourceDocCategories,
   };
@@ -685,11 +694,11 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
   const dataProductNodes = dataProductWithOwners.reduce(
     (acc, { dataProduct, owners }) => {
       const versionedKey = `data-product:${dataProduct.data.id}:${dataProduct.data.version}`;
-      acc[versionedKey] = withArchitectureDecisionsSection(
-        buildDataProductNode(dataProduct, owners, dataProductContext, flowRefsByDataProduct.get(versionedKey) || []),
-        dataProduct,
-        adrs
-      );
+      const sidebar = getSidebarForResource(customSidebars, dataProduct);
+      const node = buildDataProductNode(dataProduct, owners, dataProductContext, flowRefsByDataProduct.get(versionedKey) || [], {
+        sidebar,
+      });
+      acc[versionedKey] = sidebar ? node : withArchitectureDecisionsSection(node, dataProduct, adrs);
       if (dataProduct.data.latestVersion === dataProduct.data.version) {
         acc[`data-product:${dataProduct.data.id}`] = versionedKey;
       }
@@ -701,7 +710,9 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
   const adrNodes = adrsWithOwners.reduce(
     (acc, { adr, owners, decisionMakers }) => {
       const versionedKey = getAdrNodeKey(adr);
-      acc[versionedKey] = buildAdrNode(adr, owners, decisionMakers, context);
+      acc[versionedKey] = buildAdrNode(adr, owners, decisionMakers, context, {
+        sidebar: getSidebarForResource(customSidebars, adr),
+      });
       if (adr.data.latestVersion === adr.data.version) {
         acc[getAdrAliasNodeKey(adr)] = versionedKey;
       }
@@ -713,7 +724,9 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
   const entityNodes = entitiesWithOwners.reduce(
     (acc, { entity, owners }) => {
       const versionedKey = `entity:${entity.data.id}:${entity.data.version}`;
-      acc[versionedKey] = withArchitectureDecisionsSection(buildEntityNode(entity, owners, context), entity, adrs);
+      const sidebar = getSidebarForResource(customSidebars, entity);
+      const node = buildEntityNode(entity, owners, context, { sidebar });
+      acc[versionedKey] = sidebar ? node : withArchitectureDecisionsSection(node, entity, adrs);
       if (entity.data.latestVersion === entity.data.version) {
         acc[`entity:${entity.data.id}`] = versionedKey;
       }

--- a/packages/core/eventcatalog/src/styles/tailwind.css
+++ b/packages/core/eventcatalog/src/styles/tailwind.css
@@ -20,6 +20,88 @@
   font-weight: 400;
 }
 
+/*
+ * Docs typography scale.
+ *
+ * Tailwind Typography's defaults are tuned for long-form articles: 1.75 line-height,
+ * paragraph gaps of 1.25em and heading gaps of 2em. Reference documentation (Stripe,
+ * GitHub, Vercel, Mintlify) measures at ~1.6 line-height, 1em paragraph gaps and heading
+ * gaps of ~1.5em with 500–600 weight headings. Tighten to match so pages read as reference
+ * material rather than essays.
+ *
+ * Scoped to `.docs-layout` (resource, resource-doc, resources, language pages) and
+ * `.custom-docs-shell` (custom documentation) so other
+ * prose surfaces — chat panel, admonitions on custom pages, the homepage — keep the plugin
+ * defaults. These rules are unlayered, so they win over the plugin's `@layer utilities`
+ * output regardless of source order; `h2 + *` etc. are restated because the plugin's
+ * zero-specificity `:where()` versions would otherwise lose to the rules above them.
+ */
+.docs-layout .prose,
+.custom-docs-shell .prose {
+  line-height: 1.6;
+}
+
+.docs-layout .prose p,
+.custom-docs-shell .prose p,
+.docs-layout .prose ul,
+.custom-docs-shell .prose ul,
+.docs-layout .prose ol,
+.custom-docs-shell .prose ol,
+.docs-layout .prose blockquote,
+.custom-docs-shell .prose blockquote,
+.docs-layout .prose table,
+.custom-docs-shell .prose table {
+  margin-top: 1em;
+  margin-bottom: 1em;
+}
+
+.docs-layout .prose li,
+.custom-docs-shell .prose li {
+  margin-top: 0.25em;
+  margin-bottom: 0.25em;
+}
+
+.docs-layout .prose h2,
+.custom-docs-shell .prose h2 {
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin-top: 1.6em;
+  margin-bottom: 0.6em;
+}
+
+.docs-layout .prose h3,
+.custom-docs-shell .prose h3 {
+  font-weight: 600;
+  margin-top: 1.5em;
+  margin-bottom: 0.5em;
+}
+
+.docs-layout .prose h4,
+.custom-docs-shell .prose h4 {
+  font-weight: 600;
+  margin-top: 1.4em;
+  margin-bottom: 0.4em;
+}
+
+.docs-layout .prose h2 + *,
+.custom-docs-shell .prose h2 + *,
+.docs-layout .prose h3 + *,
+.custom-docs-shell .prose h3 + *,
+.docs-layout .prose h4 + *,
+.custom-docs-shell .prose h4 + * {
+  margin-top: 0;
+}
+
+.docs-layout .prose > :first-child,
+.custom-docs-shell .prose > :first-child {
+  margin-top: 0;
+}
+
+.docs-layout .prose > :last-child,
+.custom-docs-shell .prose > :last-child {
+  margin-bottom: 0;
+}
+
 /* Dark mode uses data-theme attribute, not prefers-color-scheme */
 @custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *));
 

--- a/packages/core/eventcatalog/src/utils/collections/resource-docs.ts
+++ b/packages/core/eventcatalog/src/utils/collections/resource-docs.ts
@@ -6,6 +6,7 @@ export {
   getResourceDocCategoriesForResource,
   getResourceDocsForResource,
   getGroupedResourceDocsByType,
+  getResourceDocTypeLabel,
   type ResourceCollection,
   type ResourceDocEntry,
   type ResourceDocCategoryEntry,

--- a/packages/sdk/src/test/fixtures/build-index/default-catalog-index.json
+++ b/packages/sdk/src/test/fixtures/build-index/default-catalog-index.json
@@ -630,6 +630,42 @@
       "owners": ["product-platform"],
       "sidecars": [
         {
+          "path": "domains/Catalog/docs/guides/01-integrating-with-the-catalog.mdx",
+          "hash": "sha256:2bdac247ff8291af94cc576d939e2acf7024c7e6b862371a86408916009efdf2"
+        },
+        {
+          "path": "domains/Catalog/docs/guides/02-product-data-model.mdx",
+          "hash": "sha256:e0c429d72c592247a60b140ee30cfcf7731ccc342fb22062c2ff43b7a1b8f8ea"
+        },
+        {
+          "path": "domains/Catalog/docs/guides/03-event-versioning.mdx",
+          "hash": "sha256:fb1802cd11c693dfdd1e271a3ca8f0ef79f648ffdc50e831c5cf2bb85895bee0"
+        },
+        {
+          "path": "domains/Catalog/docs/guides/_category_.json",
+          "hash": "sha256:7387b6db78dc0aed63e1d654109db682d8d47213470bdd71dcbd5888590e0c21"
+        },
+        {
+          "path": "domains/Catalog/docs/runbooks/00-on-call.mdx",
+          "hash": "sha256:5f16c9267eac8c75ca58625eee5f25329fe939f98da32f49ee1744ec64d8f124"
+        },
+        {
+          "path": "domains/Catalog/docs/runbooks/01-search-index-lag.mdx",
+          "hash": "sha256:97c2b2c002bae7002ccaaba815efd1e04784839a0da5c93654321fa8ccb431b9"
+        },
+        {
+          "path": "domains/Catalog/docs/runbooks/02-reindexing-products.mdx",
+          "hash": "sha256:8efde565238ec0393971d09882f02854fdb5b711f8d60d4b7e31a7545ebf9c12"
+        },
+        {
+          "path": "domains/Catalog/docs/runbooks/_category_.json",
+          "hash": "sha256:efd0c585c3b7d6406b58ac9d5462cd91ff5ce25a4b9c98a4e130a5aa90143011"
+        },
+        {
+          "path": "domains/Catalog/sidebar.json",
+          "hash": "sha256:955f15ce2c9d8dbf196d606d18f539f1388d14f07b70848b1e03a7e64745bef4"
+        },
+        {
           "path": "domains/Catalog/ubiquitous-language.mdx",
           "hash": "sha256:8905dfccffdfc950d1f5aec2fda7c67045a3d3d536b972f1d835297a1284da3a"
         }
@@ -669,9 +705,45 @@
       "version": "1.0.0",
       "name": "Customer",
       "contentPath": "domains/Customer/index.mdx",
-      "contentHash": "sha256:df6811c1a5e418757516b27c54d30cd473af7bf5a017b58ba46e38d00d8f18c6",
+      "contentHash": "sha256:946e2c37e3b11a6693f41049d226764d86fb345c6e50e9f4898c1bed4d4659bb",
       "owners": ["customer-platform"],
       "sidecars": [
+        {
+          "path": "domains/Customer/docs/guides/01-integrating-with-customers.mdx",
+          "hash": "sha256:61542bd2acd4f30bd06a39a349b826fcee0a987db9f4069a092e0dceb84dff13"
+        },
+        {
+          "path": "domains/Customer/docs/guides/02-customer-data-model.mdx",
+          "hash": "sha256:2d46138a00d5e8a79232a2d67778d330bd440d98a91ef721790e0358b224e08d"
+        },
+        {
+          "path": "domains/Customer/docs/guides/03-account-status-lifecycle.mdx",
+          "hash": "sha256:33ac50b6cfb38f1bb14f5ccba0f381121b5338c34c2036dc5cfda1f32992049d"
+        },
+        {
+          "path": "domains/Customer/docs/guides/_category_.json",
+          "hash": "sha256:7387b6db78dc0aed63e1d654109db682d8d47213470bdd71dcbd5888590e0c21"
+        },
+        {
+          "path": "domains/Customer/docs/runbooks/00-on-call.mdx",
+          "hash": "sha256:d65a5b1b7921e38aebcdcd80519b80d79ee46729e05c8bfba517f41e0edee958"
+        },
+        {
+          "path": "domains/Customer/docs/runbooks/01-login-failures.mdx",
+          "hash": "sha256:b523d273f1c57c04a04aaaf55fed17d66ba9f97b9575add41a57101212477796"
+        },
+        {
+          "path": "domains/Customer/docs/runbooks/02-customer-events-lag.mdx",
+          "hash": "sha256:232652a2071afd241fde7705f1899f5d79da6d9a24c52d47007d934a9d060a79"
+        },
+        {
+          "path": "domains/Customer/docs/runbooks/_category_.json",
+          "hash": "sha256:efd0c585c3b7d6406b58ac9d5462cd91ff5ce25a4b9c98a4e130a5aa90143011"
+        },
+        {
+          "path": "domains/Customer/sidebar.json",
+          "hash": "sha256:d65edab1ae01531d840223c93b5e4a8e0e6df0d9d8625e6012e8a4247d160758"
+        },
         {
           "path": "domains/Customer/ubiquitous-language.mdx",
           "hash": "sha256:3e3c5f510f9807c7b83889b749414716a1669377aaa23ea79e13b38bca4237a4"
@@ -715,6 +787,38 @@
       "contentHash": "sha256:4c135222dcc67e7872a40668050b3056b98932a38cd21968b050c0f9bf37440a",
       "owners": ["fulfilment-platform"],
       "sidecars": [
+        {
+          "path": "domains/Fulfilment/docs/guides/01-integrating-with-fulfilment.mdx",
+          "hash": "sha256:966267510cc9374c522a37ece9bde47b7feca7222037a243f41e2bf45870511f"
+        },
+        {
+          "path": "domains/Fulfilment/docs/guides/02-fulfilment-data-model.mdx",
+          "hash": "sha256:a8b825a18ec86a1855715fbf74510bef3553ba5b5968b993f791ba617b9e8749"
+        },
+        {
+          "path": "domains/Fulfilment/docs/guides/03-order-lifecycle.mdx",
+          "hash": "sha256:75e4b03ad7df36ea443d6a29e274deda40b39d359cc260c174edbacd6fe5e54f"
+        },
+        {
+          "path": "domains/Fulfilment/docs/guides/_category_.json",
+          "hash": "sha256:7387b6db78dc0aed63e1d654109db682d8d47213470bdd71dcbd5888590e0c21"
+        },
+        {
+          "path": "domains/Fulfilment/docs/runbooks/00-on-call.mdx",
+          "hash": "sha256:8ad0ec20879dbf6e136b0074d42ef3464d332175bbf86f8be846f0666f786bf1"
+        },
+        {
+          "path": "domains/Fulfilment/docs/runbooks/01-shipments-not-dispatching.mdx",
+          "hash": "sha256:e620b9f34e3659575fbe67d9cd33692ad651528ce1c0f19fe257354d576a0a28"
+        },
+        {
+          "path": "domains/Fulfilment/docs/runbooks/_category_.json",
+          "hash": "sha256:efd0c585c3b7d6406b58ac9d5462cd91ff5ce25a4b9c98a4e130a5aa90143011"
+        },
+        {
+          "path": "domains/Fulfilment/sidebar.json",
+          "hash": "sha256:71fe44e57aaf5d3f9a0e015515c9194d19e0441a810ce7b25878810aeb2f0a5c"
+        },
         {
           "path": "domains/Fulfilment/ubiquitous-language.mdx",
           "hash": "sha256:513c1fd12c9612c7f8903004aeb8914408fa4355219bb4499f62636d55cc3f69"
@@ -767,6 +871,38 @@
       "owners": ["ordering-platform"],
       "sidecars": [
         {
+          "path": "domains/Ordering/docs/guides/01-integrating-with-ordering.mdx",
+          "hash": "sha256:4bfe58c11238664e4ecc663d3845ecc251322f88f3e9121c010b6a51cf2543de"
+        },
+        {
+          "path": "domains/Ordering/docs/guides/02-order-lifecycle.mdx",
+          "hash": "sha256:3acb26b86a0e281c8913315e43ea8b2e64ec7f43457048422f7cccb02a5fb4be"
+        },
+        {
+          "path": "domains/Ordering/docs/guides/03-checkout-saga-and-compensation.mdx",
+          "hash": "sha256:34af64e85effc7e2c23dd5b2c6a3dd23181d6dfb3663afdd8419c718d1052162"
+        },
+        {
+          "path": "domains/Ordering/docs/guides/_category_.json",
+          "hash": "sha256:7387b6db78dc0aed63e1d654109db682d8d47213470bdd71dcbd5888590e0c21"
+        },
+        {
+          "path": "domains/Ordering/docs/runbooks/00-on-call.mdx",
+          "hash": "sha256:afa0f14ad0ebcad428e3c86122cc45360493c8e291b564aff9df4ff8cc779169"
+        },
+        {
+          "path": "domains/Ordering/docs/runbooks/01-stuck-checkout-sessions.mdx",
+          "hash": "sha256:73069ba9765d63af40e59efa7e8ed0bcc756a6ef62ac6d0143254b57018e33aa"
+        },
+        {
+          "path": "domains/Ordering/docs/runbooks/_category_.json",
+          "hash": "sha256:efd0c585c3b7d6406b58ac9d5462cd91ff5ce25a4b9c98a4e130a5aa90143011"
+        },
+        {
+          "path": "domains/Ordering/sidebar.json",
+          "hash": "sha256:3f7bb1b0e385d707aced83503ddfb922c5d3a95bb66f55accd43ee78c6ae9510"
+        },
+        {
           "path": "domains/Ordering/ubiquitous-language.mdx",
           "hash": "sha256:3f5ece175b8fa2d82aa5f225095a505340a283470a14c5e05c95332a171d455b"
         }
@@ -815,6 +951,38 @@
       "contentHash": "sha256:82dcb892b91e5cec3d3abb0ef98f02637516314240070158adf365369ea009dc",
       "owners": ["payments-platform"],
       "sidecars": [
+        {
+          "path": "domains/Payments/docs/guides/01-reacting-to-payment-events.mdx",
+          "hash": "sha256:bb0e1a2495ff33d253eb2b8cdff3a016c43c6fbef0793bd1939cb98a1976803b"
+        },
+        {
+          "path": "domains/Payments/docs/guides/02-payment-and-fraud-model.mdx",
+          "hash": "sha256:0f7d55584eeda004ffef867abb5fc3346cd86495d81c052fff10a275fcb366eb"
+        },
+        {
+          "path": "domains/Payments/docs/guides/03-pci-what-you-must-never-log.mdx",
+          "hash": "sha256:95aae2c1680b6cfc39b2bec08b4f3bd9e9682d5aa6dbefea22a804f524e3d1a2"
+        },
+        {
+          "path": "domains/Payments/docs/guides/_category_.json",
+          "hash": "sha256:7387b6db78dc0aed63e1d654109db682d8d47213470bdd71dcbd5888590e0c21"
+        },
+        {
+          "path": "domains/Payments/docs/runbooks/01-payments-stuck-in-requested.mdx",
+          "hash": "sha256:b93b0d833a8ecd161dafd0e03e603bb3f195cdd983a975bd46db3cd9adb6aded"
+        },
+        {
+          "path": "domains/Payments/docs/runbooks/02-fraud-review-backlog.mdx",
+          "hash": "sha256:8880247506c547b57a3555787e23a94a6e77566fe6d2aada7ec49fde7f66a54e"
+        },
+        {
+          "path": "domains/Payments/docs/runbooks/_category_.json",
+          "hash": "sha256:efd0c585c3b7d6406b58ac9d5462cd91ff5ce25a4b9c98a4e130a5aa90143011"
+        },
+        {
+          "path": "domains/Payments/sidebar.json",
+          "hash": "sha256:99edb0bb15b1ed266140a67fca8588cd044ecc66cde0c62df89e97391983d713"
+        },
         {
           "path": "domains/Payments/ubiquitous-language.mdx",
           "hash": "sha256:37e3eff5e46d471656ac8b1f47a3168a8db31e411ce9ffbd2252df325003c07a"
@@ -873,6 +1041,40 @@
           "path": "asyncapi.yml",
           "name": "Reviews Eventing",
           "hash": "sha256:36358abda679dc19a2c22344a6b2eca4fc83a71a5485a31416356fda549e4fbb"
+        }
+      ],
+      "sidecars": [
+        {
+          "path": "domains/Reviews/docs/guides/01-integrating-with-reviews.mdx",
+          "hash": "sha256:9c3e476d7ae93a0d17fa77fe4b1c233142afcaed0d46afa65b3c54d5164dbddd"
+        },
+        {
+          "path": "domains/Reviews/docs/guides/02-moderation-lifecycle.mdx",
+          "hash": "sha256:ade1216baba1e77eeb805470a260717b8424766211b6932b0a6f5f0336dfc573"
+        },
+        {
+          "path": "domains/Reviews/docs/guides/03-rating-aggregation.mdx",
+          "hash": "sha256:d43f43f3827c5961b9acbe9686fc5fc08938d77a576aec17e001a1904a6681b6"
+        },
+        {
+          "path": "domains/Reviews/docs/guides/_category_.json",
+          "hash": "sha256:7387b6db78dc0aed63e1d654109db682d8d47213470bdd71dcbd5888590e0c21"
+        },
+        {
+          "path": "domains/Reviews/docs/runbooks/00-on-call.mdx",
+          "hash": "sha256:cdc42898321850e7ed16a8fdfa410bc41e8ffa9f01dfff1c19ad6117025bb029"
+        },
+        {
+          "path": "domains/Reviews/docs/runbooks/01-moderation-queue-stuck.mdx",
+          "hash": "sha256:9314016fec590982dff5ef330c1b24d19bb5b7d70cf55e8863db6ce7233c69c9"
+        },
+        {
+          "path": "domains/Reviews/docs/runbooks/_category_.json",
+          "hash": "sha256:efd0c585c3b7d6406b58ac9d5462cd91ff5ce25a4b9c98a4e130a5aa90143011"
+        },
+        {
+          "path": "domains/Reviews/sidebar.json",
+          "hash": "sha256:79744a37664c137194d27aab65f5b2b997f95200be17780a693adcd5528cb6ba"
         }
       ],
       "sends": [
@@ -978,6 +1180,38 @@
       "contentHash": "sha256:013ccf530b88fb9b343966f85b4fdc74062afab262dbc9bc5b306cfae046920e",
       "owners": ["shopping-platform"],
       "sidecars": [
+        {
+          "path": "domains/Shopping/docs/guides/01-integrating-with-shopping.mdx",
+          "hash": "sha256:c6652759755a5a928bf4ac6a3c12c167e098885b305e9e69c73d9eeb36425491"
+        },
+        {
+          "path": "domains/Shopping/docs/guides/02-cart-and-promotion-model.mdx",
+          "hash": "sha256:d3e5db6b8876723fd80a012c0c0266648cca4cff4423c7fdb1af763cec6e768d"
+        },
+        {
+          "path": "domains/Shopping/docs/guides/03-how-discounts-are-calculated.mdx",
+          "hash": "sha256:4ec75b1bf5f8d72c9849a651d830bd534a38bf9c693669d3231e12c86381def2"
+        },
+        {
+          "path": "domains/Shopping/docs/guides/_category_.json",
+          "hash": "sha256:7387b6db78dc0aed63e1d654109db682d8d47213470bdd71dcbd5888590e0c21"
+        },
+        {
+          "path": "domains/Shopping/docs/runbooks/01-discounts-not-applying.mdx",
+          "hash": "sha256:9160136e852f412e7b0969fae7b7b6f8844556653aeb01482933ea8990e0d3b2"
+        },
+        {
+          "path": "domains/Shopping/docs/runbooks/02-abandoned-cart-backlog.mdx",
+          "hash": "sha256:f02aaeb4967a12f46380f67f760d3a175b07ddc7d94d987b24ca544d5571d4ee"
+        },
+        {
+          "path": "domains/Shopping/docs/runbooks/_category_.json",
+          "hash": "sha256:efd0c585c3b7d6406b58ac9d5462cd91ff5ce25a4b9c98a4e130a5aa90143011"
+        },
+        {
+          "path": "domains/Shopping/sidebar.json",
+          "hash": "sha256:9c6bac91aa200aa95ab513bba9d0a7aa4af7907ea276d1f0fc9abf33f886ce14"
+        },
         {
           "path": "domains/Shopping/ubiquitous-language.mdx",
           "hash": "sha256:b8dd599829b78e570323150ad08bc65d01262413b9290a996ef63e9797e30f0d"
@@ -1718,6 +1952,12 @@
           "path": "schema.json",
           "default": true,
           "hash": "sha256:4e56f2f940f9736a0c3eb42d219813ae908402e93fe928cbe79b510cc9863308"
+        }
+      ],
+      "sidecars": [
+        {
+          "path": "domains/Catalog/systems/product-catalog-system/services/ProductAPI/events/ProductCreated/sidebar.json",
+          "hash": "sha256:cdb030836b21e5090c1dd8b09a889ea948e68f3b1ec4eda372ee5205dea7ae69"
         }
       ]
     },
@@ -2801,6 +3041,12 @@
           "path": "openapi.yml",
           "name": "Product API",
           "hash": "sha256:76d20efb09279ff1ccc0ea695f4b3a4c066bf5777a7b195bed66357a44468d18"
+        }
+      ],
+      "sidecars": [
+        {
+          "path": "domains/Catalog/systems/product-catalog-system/services/ProductAPI/sidebar.json",
+          "hash": "sha256:d11be81cac551fa3894c6a7c04e4a15ba0d02f78d1a757c15d7586c971000cd2"
         }
       ],
       "receives": [


### PR DESCRIPTION

## What This PR Does

Adds **resource sidebars**: drop a `sidebar.json` next to any resource's `index.mdx` and it fully defines that resource's sidebar. Works for every resource type — domains, systems, services, agents, events, commands, queries, flows, containers, entities, data products and ADRs. Alongside the feature, the sidebar renders as a consistent docs-style tree, the demo catalog is rebuilt to showcase it, and several standalone fixes ride along.

## Changes Overview

### Key Changes

- **`sidebar.json` per resource** — a small grammar: sections are predefined `$tokens` (kept live as the catalog changes), relabelled tokens (`{ "section": "$owners", "title": "Team" }`), or custom groups. Pages inside groups mix spliced `$tokens`, resource refs (`[[service|order-service@1.0.0]]`), resource docs (`[[doc|guides/onboarding]]`), specifications (`[[spec|service/order-service/openapi.yml]]`), schemas (`[[schema|order-placed]]`), plain links with `{id}`/`{version}`/`{collection}` placeholders, and nested groups. Any object entry takes `"collapsed": true|false`.
- **Builders refactored into named sections** — all ten builders now expose `build<Type>Sections()` + `DEFAULT_<TYPE>_SECTION_ORDER`; the 182-case snapshot suite guards that default output is unchanged. Versioned copies inherit the resource folder's sidebar unless they carry their own; `$decision-records` respects `detailsPanel.architectureDecisions`.
- **Fail-fast authoring** — unknown tokens and unresolvable doc/spec/schema refs fail the build with the offending file and the valid options; resource refs render nothing when missing.
- **Sidebar rendering** — docs-style tree: every group collapsible (explicit `collapsed` overrides the size heuristic; user toggles persisted in a new `{ expanded, collapsed }` storage shape, backwards compatible), carets on the right, nested groups under indent guides, item counts removed, active item scrolled into view and scroll offset persisted per drill-down level.
- **Demo catalog** — all seven domains get guides/runbooks (37 resource docs) and curated sidebars (integration events, contracts, collapsed internal sections); ProductAPI and ProductCreated demonstrate service/event sidebars.
- **Standalone fixes** (separate commit) — visualiser stylesheet ships in the page head so ClientRouter navigations keep React Flow styles; docs pages share one header anatomy and a reference-doc typography scale (scoped); wide tables no longer push the page under the sidebar; badge external-link arrow only for external hrefs; term descriptions use standard soft line breaks; schema pages sit flush against the sidebar.

## How It Works

A new `sidebars` content collection globs `**/sidebar.json` (Zod-validated, strict). At sidebar-store build time each resource looks up its folder's spec (`getSidebarForResource`, with versioned-folder inheritance) and passes it to its builder. Builders produce a map of named sections; `resolveSidebarPages` either walks the default order (no spec — output identical to before) or applies the custom spec, resolving tokens against the section map and refs against the catalog collections. The `withArchitectureDecisionsSection` wrapper is skipped when a custom sidebar is present, since `$decision-records` becomes an explicit token.

## Breaking Changes

None — catalogs without `sidebar.json` render the same sidebar contents. Visual changes to be aware of: all sidebar groups are now collapsible, item counts are removed, nested groups render as indented rows, and docs-page typography is tightened.

## Additional Notes

- Docs page for the feature is written in `website-2` (`docs/development/customization/05-resource-sidebar.md`), to be committed there.
- Follow-ups (not in this PR): `create-eventcatalog` template sync with the new demo content; editor support for the `sidebar.json` file type; linter rule for unresolvable resource refs; pre-existing triggers 404→500 on unknown paths.
- Full core suite passes (127 files / 1,384 tests); two independent review passes done, findings fixed or dispositioned.

https://claude.ai/code/session_01WywXCXG3B77BcP4CjBgFrv