### PR TITLE
New `<ArchitectureGraph/>` component to embed the architecture graph in documentation pages

### DIFF
--- a/.changeset/spotty-buses-shake.md
+++ b/.changeset/spotty-buses-shake.md
@@ -1,0 +1,6 @@
+---
+'@eventcatalog/core': patch
+'@eventcatalog/create-eventcatalog': patch
+---
+
+feat(core): new `<ArchitectureGraph/>` MDX component to embed the D3 architecture graph in resource and custom documentation pages, focused on the page's resource

--- a/examples/default/domains/Catalog/index.mdx
+++ b/examples/default/domains/Catalog/index.mdx
@@ -54,4 +54,10 @@ The **Catalog** domain is responsible for the lifecycle of every product Acme In
 
 The **Product Catalog System** is the authoritative source of product data. Whenever a product is created, updated or deleted it publishes a domain event. The **Search System** subscribes to those events, keeps its search index in sync, and exposes a search API so other teams never have to query the catalog database directly.
 
+## Architecture Graph
+
+Where Catalog sits in the wider architecture — its systems and messages, and the neighbouring domains it talks to.
+
+<ArchitectureGraph />
+
 The diagram below shows the domain's systems, how they relate, and the people who interact with them.

--- a/examples/default/domains/Ordering/index.mdx
+++ b/examples/default/domains/Ordering/index.mdx
@@ -68,3 +68,9 @@ The systems in this domain, how they relate, and the people who interact with th
 The components that make up this domain.
 
 <NodeGraph />
+
+## Architecture Graph
+
+Where Ordering sits in the wider architecture — its systems and messages, and the neighbouring domains it talks to.
+
+<ArchitectureGraph />

--- a/examples/default/domains/Ordering/systems/checkout-system/index.mdx
+++ b/examples/default/domains/Ordering/systems/checkout-system/index.mdx
@@ -55,3 +55,9 @@ The services and messages that make up this system.
 - [[command\|reserve-inventory]] — reserve stock for the items in the cart.
 - [[command\|authorize-payment]] — authorize payment for the order total.
 - [[command\|create-order]] — create the order in the Order Management System.
+
+## Architecture Graph
+
+The checkout system's neighbourhood in the wider architecture.
+
+<ArchitectureGraph />

--- a/examples/default/domains/Payments/index.mdx
+++ b/examples/default/domains/Payments/index.mdx
@@ -73,3 +73,9 @@ The **Payment Processing System** is the internal orchestrator. When the Orderin
 The systems in this domain, how they relate, and the people who interact with them.
 
 <ContextDiagram />
+
+## Architecture Graph
+
+Where Payments sits in the wider architecture — its systems and messages, and the neighbouring domains it talks to.
+
+<ArchitectureGraph />

--- a/examples/default/domains/Payments/systems/payment-processing-system/services/PaymentAPI/index.mdx
+++ b/examples/default/domains/Payments/systems/payment-processing-system/services/PaymentAPI/index.mdx
@@ -48,6 +48,12 @@ The **Payment API** is the entry point to the Payment Processing System. It rece
 
 <NodeGraph />
 
+## Architecture Graph
+
+How PaymentAPI connects to the rest of the catalog — the messages it exchanges and the systems around it.
+
+<ArchitectureGraph />
+
 <MessageTable format="all" limit={8} />
 
 <Footer />

--- a/examples/default/pages/homepage.astro
+++ b/examples/default/pages/homepage.astro
@@ -2,8 +2,8 @@
 import { getCollection } from 'astro:content';
 
 // EventCatalog injects its components via Astro.props.components. Destructure the ones
-// this landing page uses (including the SystemContextMap embed).
-const { Tile, Tiles, SystemContextMap } = Astro.props.components;
+// this landing page uses (including the ArchitectureGraph and SystemContextMap embeds).
+const { Tile, Tiles, SystemContextMap, ArchitectureGraph } = Astro.props.components;
 
 // Count the catalog's top-level resources. We filter out versioned/ entries so each
 // resource is counted once (by its latest version).
@@ -27,28 +27,26 @@ const stats = [
   <div class="pb-8 border-b border-[rgb(var(--ec-page-border))]">
     <h1 class="text-4xl md:text-5xl font-bold text-[rgb(var(--ec-page-text))]">Acme Inc Catalog</h1>
     <p class="mt-3 text-lg text-[rgb(var(--ec-page-text-muted))] max-w-3xl font-light">
-      Discover, explore and document the event-driven architecture that powers Acme Inc — our
+      Discover, explore our architecture that powers Acme Inc — our
       domains, the systems inside them, and the services and messages that connect everything.
     </p>
   </div>
 
-  {/* Stat cards */}
-  <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mt-8">
-    {
-      stats.map((stat) => (
-        <a
-          href={stat.href}
-          class="group rounded-xl border border-[rgb(var(--ec-page-border))] bg-[rgb(var(--ec-card-bg,var(--ec-page-bg)))] p-6 shadow-xs hover:shadow-md hover:border-[rgb(var(--ec-accent)/0.5)] transition-all"
-        >
-          <div class="text-4xl font-bold text-[rgb(var(--ec-page-text))]">{stat.value}</div>
-          <div class="mt-1 text-sm font-medium uppercase tracking-wide text-[rgb(var(--ec-page-text-muted))]">
-            {stat.label}
-          </div>
-        </a>
-      ))
-    }
-  </div>
+ 
 
+  {/* Architecture graph */}
+  <!-- <h2 class="text-2xl font-semibold text-[rgb(var(--ec-page-text))] mt-12 mb-2">Architecture</h2>
+  <p class="text-[rgb(var(--ec-page-text-muted))] font-light mb-2">
+    Every resource in the catalog and the relationships between them.
+  </p> -->
+
+
+</div>
+
+
+<ArchitectureGraph lens="domains" lensPicker="true" />
+
+<div class="not-prose">
   {/* System context map */}
   <h2 class="text-2xl font-semibold text-[rgb(var(--ec-page-text))] mt-12 mb-2">System context map</h2>
   <p class="text-[rgb(var(--ec-page-text-muted))] font-light mb-2">
@@ -60,7 +58,7 @@ const stats = [
 
 <div class="not-prose">
   {/* Domains */}
-  <h2 class="text-2xl font-semibold text-[rgb(var(--ec-page-text))] mt-12 mb-4">Explore the domains</h2>
+  <h2 class="text-2xl font-semibold text-[rgb(var(--ec-page-text))] mt-12 mb-4">Explore business domains</h2>
 </div>
 
 <Tiles columns={3}>

--- a/packages/core/eventcatalog/astro.config.mjs
+++ b/packages/core/eventcatalog/astro.config.mjs
@@ -190,6 +190,12 @@ export default defineConfig({
         'semver',
         'diff',
         'diff2html',
+        // Used by the ArchitectureGraph embeds — discovering these lazily mid-session
+        // triggers a re-optimize that 504s every already-loaded chunk
+        'd3-force',
+        'd3-selection',
+        'd3-zoom',
+        'd3-drag',
       ],
     },
   },

--- a/packages/core/eventcatalog/src/components/CatalogGraph/CatalogForceGraph.tsx
+++ b/packages/core/eventcatalog/src/components/CatalogGraph/CatalogForceGraph.tsx
@@ -30,23 +30,40 @@ import { drag } from 'd3-drag';
 import { getColorForCollection, tailwind500RgbByColor } from '@utils/collection-colors';
 import { getIconForCollection } from '@utils/collections/icons';
 import { buildUrl } from '@utils/url-builder';
+import type { CatalogGraphWireLink, CatalogGraphWireNode } from '@utils/node-graphs/catalog-force-graph';
 
-/** Compact wire format — expanded client-side to keep the serialised page payload small. */
-export interface CatalogGraphWireNode {
-  /** Resource id, e.g. `InventoryService` */
-  id: string;
-  label: string;
-  collection: string;
-  version?: string;
-}
-
-/** [sourceIndex, targetIndex, labelIndex] into the nodes / linkLabels arrays */
-export type CatalogGraphWireLink = [number, number, number];
+export type { CatalogGraphWireLink, CatalogGraphWireNode };
 
 interface Props {
   nodes: CatalogGraphWireNode[];
   links: CatalogGraphWireLink[];
   linkLabels: string[];
+  /** Seed the initial lens. URL state wins when `syncUrl` is on. */
+  initialLens?: string;
+  /** Seed the initial focused node key, e.g. `domains/Orders`. URL state wins when `syncUrl` is on. */
+  initialFocus?: string;
+  /** Seed the initial focus depth (1–3). URL state wins when `syncUrl` is on. */
+  initialFocusDepth?: number;
+  /**
+   * Read the view state from the URL and mirror changes back into it — the
+   * standalone /visualiser/graph page. Off for graphs embedded in docs pages,
+   * which must not rewrite their host page's query string.
+   */
+  syncUrl?: boolean;
+  /** Show the lens picker / detail slider (hidden on embedded graphs, which pin a lens) */
+  showLensPicker?: boolean;
+  showSearch?: boolean;
+  showLegend?: boolean;
+  /** When off, plain scrolling over the canvas scrolls the page — zooming needs ctrl/cmd+scroll */
+  zoomOnScroll?: boolean;
+  /**
+   * Base URL of the standalone /visualiser/graph page. When set, an "open"
+   * link is rendered whose query string carries the CURRENT view state (focus,
+   * depth, lens, hidden collections), so the full page opens on exactly the
+   * view the embedded graph is showing.
+   */
+  openInGraphUrl?: string;
+  openInGraphLabel?: string;
 }
 
 interface GraphNode extends CatalogGraphWireNode {
@@ -243,7 +260,21 @@ const distanceToHull = (px: number, py: number, hull: [number, number][]) => {
   return min;
 };
 
-const CatalogForceGraph = ({ nodes, links, linkLabels }: Props) => {
+const CatalogForceGraph = ({
+  nodes,
+  links,
+  linkLabels,
+  initialLens,
+  initialFocus,
+  initialFocusDepth,
+  syncUrl = true,
+  showLensPicker = true,
+  openInGraphUrl,
+  openInGraphLabel,
+  showSearch = true,
+  showLegend = true,
+  zoomOnScroll = true,
+}: Props) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const tooltipRef = useRef<HTMLDivElement>(null);
@@ -255,37 +286,51 @@ const CatalogForceGraph = ({ nodes, links, linkLabels }: Props) => {
   const iconSpritesRef = useRef(new Map<string, HTMLCanvasElement>());
   const drawRef = useRef<() => void>(() => {});
   // View state initialises from the URL so people can share what they're looking
-  // at (?lens=domains&focus=services/OrderService&depth=2&detail=3&hide=teams,entities)
+  // at (?lens=domains&focus=services/OrderService&depth=2&detail=3&hide=teams,entities).
+  // Embedded graphs (syncUrl off) seed from the initial* props instead — their
+  // host page's query string is not theirs to read or write.
+  const urlParam = (key: string) => (syncUrl ? new URLSearchParams(window.location.search).get(key) : null);
   const [hiddenCollections, setHiddenCollections] = useState<Set<string>>(() => {
-    const hide = new URLSearchParams(window.location.search).get('hide');
+    const hide = urlParam('hide');
     return new Set(hide ? hide.split(',').filter(Boolean) : []);
   });
   const [lensKey, setLensKey] = useState(() => {
-    const lens = new URLSearchParams(window.location.search).get('lens');
+    const lens = urlParam('lens') ?? initialLens;
     return lens && lens in LENSES ? lens : 'all';
   });
-  const [focusKey, setFocusKey] = useState<string | null>(() => new URLSearchParams(window.location.search).get('focus'));
+  const [focusKey, setFocusKey] = useState<string | null>(() => urlParam('focus') ?? initialFocus ?? null);
   const [focusDepth, setFocusDepth] = useState(() =>
-    Math.min(3, Math.max(1, Number(new URLSearchParams(window.location.search).get('depth')) || 1))
+    Math.min(3, Math.max(1, Number(urlParam('depth')) || initialFocusDepth || 1))
   );
   // How many hops of detail radiate out from a lens's anchor nodes (4 = everything)
-  const [lensDepth, setLensDepth] = useState(() =>
-    Math.min(MAX_LENS_DEPTH, Math.max(1, Number(new URLSearchParams(window.location.search).get('detail')) || 1))
-  );
+  const [lensDepth, setLensDepth] = useState(() => Math.min(MAX_LENS_DEPTH, Math.max(1, Number(urlParam('detail')) || 1)));
 
-  // Reflect the view state back into the URL (replaceState, so no history spam);
-  // unrelated params — e.g. the stress page's ?nodes — are preserved
-  useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
+  // Serialise the current view state into query params — shared between the
+  // URL sync below and the embedded graphs' "open in graph" link
+  const applyViewParams = (params: URLSearchParams) => {
     const setOrDelete = (key: string, value: string | null) => (value ? params.set(key, value) : params.delete(key));
     setOrDelete('lens', lensKey !== 'all' ? lensKey : null);
     setOrDelete('focus', focusKey);
     setOrDelete('depth', focusKey && focusDepth !== 1 ? String(focusDepth) : null);
     setOrDelete('detail', lensDepth !== 1 ? String(lensDepth) : null);
     setOrDelete('hide', hiddenCollections.size > 0 ? [...hiddenCollections].sort().join(',') : null);
-    const query = params.toString();
+    return params;
+  };
+
+  // Reflect the view state back into the URL (replaceState, so no history spam);
+  // unrelated params — e.g. the stress page's ?nodes — are preserved
+  useEffect(() => {
+    if (!syncUrl) return;
+    const query = applyViewParams(new URLSearchParams(window.location.search)).toString();
     window.history.replaceState(null, '', `${window.location.pathname}${query ? `?${query}` : ''}${window.location.hash}`);
   }, [lensKey, focusKey, focusDepth, lensDepth, hiddenCollections]);
+
+  // The "open in graph" link tracks the live view, so what opens is what's shown
+  const openInGraphHref = (() => {
+    if (!openInGraphUrl) return undefined;
+    const query = applyViewParams(new URLSearchParams()).toString();
+    return `${openInGraphUrl}${query ? `?${query}` : ''}`;
+  })();
   const [searchValue, setSearchValue] = useState('');
   const [showSuggestions, setShowSuggestions] = useState(false);
   const [selectedSuggestionIndex, setSelectedSuggestionIndex] = useState(-1);
@@ -989,6 +1034,8 @@ const CatalogForceGraph = ({ nodes, links, linkLabels }: Props) => {
           const [x, y] = pointerPosition(event);
           return !findNode(x, y);
         }
+        // Embedded graphs must not hijack page scrolling — zooming needs ctrl/cmd there
+        if (event.type === 'wheel' && !zoomOnScroll && !event.ctrlKey && !event.metaKey) return false;
         return !event.ctrlKey || event.type === 'wheel';
       })
       .on('zoom', (event) => {
@@ -1171,7 +1218,7 @@ const CatalogForceGraph = ({ nodes, links, linkLabels }: Props) => {
       resizeObserver.disconnect();
       themeObserver.disconnect();
     };
-  }, [viewNodes, viewLinks, lens, hiddenCollections, clusterAssignments, focusKey, focusAncestors]);
+  }, [viewNodes, viewLinks, lens, hiddenCollections, clusterAssignments, focusKey, focusAncestors, zoomOnScroll]);
 
   const toggleCollection = (collection: string) => {
     setHiddenCollections((current) => {
@@ -1205,138 +1252,158 @@ const CatalogForceGraph = ({ nodes, links, linkLabels }: Props) => {
         className="pointer-events-none absolute z-10 rounded-md border border-[rgb(var(--ec-page-border))] bg-[rgb(var(--ec-card-bg))] px-3 py-2 text-xs text-[rgb(var(--ec-page-text))] shadow-md transition-opacity duration-100"
         style={{ opacity: 0 }}
       />
-      <div className="absolute left-3 top-3 z-10 flex flex-col gap-2 rounded-md border border-[rgb(var(--ec-page-border))] bg-[rgb(var(--ec-card-bg))] px-3 py-2 text-xs shadow-xs">
-        <div className="flex items-center gap-2">
-          <label htmlFor="catalog-graph-lens" className="font-semibold text-[rgb(var(--ec-page-text))]">
-            Lens
-          </label>
-          <select
-            id="catalog-graph-lens"
-            value={lensKey}
-            onChange={(event) => {
-              // A new lens is a fresh view — drop any focus and legend filters
-              setLensKey(event.target.value);
-              setFocusKey(null);
-              setFocusDepth(1);
-              setHiddenCollections(new Set());
-            }}
-            title={lens.description}
-            className="rounded-sm border border-[rgb(var(--ec-input-border))] bg-[rgb(var(--ec-input-bg))] px-2 py-1 text-[rgb(var(--ec-input-text))]"
+      {/* Top-left chrome stacks in one column so the link and lens picker never overlap */}
+      <div className="absolute left-3 top-3 z-10 flex flex-col items-start gap-2">
+        {showLensPicker && (
+          <div className="flex flex-col gap-2 rounded-md border border-[rgb(var(--ec-page-border))] bg-[rgb(var(--ec-card-bg))] px-3 py-2 text-xs shadow-xs">
+            <div className="flex items-center gap-2">
+              <label htmlFor="catalog-graph-lens" className="font-semibold text-[rgb(var(--ec-page-text))]">
+                Lens
+              </label>
+              <select
+                id="catalog-graph-lens"
+                value={lensKey}
+                onChange={(event) => {
+                  // A new lens is a fresh view — drop any focus and legend filters
+                  setLensKey(event.target.value);
+                  setFocusKey(null);
+                  setFocusDepth(1);
+                  setHiddenCollections(new Set());
+                }}
+                title={lens.description}
+                className="rounded-sm border border-[rgb(var(--ec-input-border))] bg-[rgb(var(--ec-input-bg))] px-2 py-1 text-[rgb(var(--ec-input-text))]"
+              >
+                {Object.entries(LENSES).map(([key, { label }]) => (
+                  <option key={key} value={key}>
+                    {label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            {lens.hubCollections && !focusedNode && (
+              <label
+                className="flex items-center gap-2 text-[rgb(var(--ec-page-text-muted))]"
+                title="How many relationship hops to show around the anchor nodes"
+              >
+                Detail
+                <input
+                  type="range"
+                  min={1}
+                  max={MAX_LENS_DEPTH}
+                  step={1}
+                  value={lensDepth}
+                  onChange={(event) => setLensDepth(Number(event.target.value))}
+                  className="w-24 accent-[rgb(var(--ec-accent))]"
+                />
+                <span className="w-5 text-[rgb(var(--ec-page-text))]">{lensDepth >= MAX_LENS_DEPTH ? 'All' : lensDepth}</span>
+              </label>
+            )}
+          </div>
+        )}
+        {openInGraphHref && (
+          <a
+            href={openInGraphHref}
+            className="rounded-md border border-[rgb(var(--ec-page-border))] bg-[rgb(var(--ec-card-bg))] px-3 py-2 text-xs text-[rgb(var(--ec-page-text))] shadow-xs hover:bg-[rgb(var(--ec-accent-subtle))]"
           >
-            {Object.entries(LENSES).map(([key, { label }]) => (
-              <option key={key} value={key}>
-                {label}
-              </option>
-            ))}
-          </select>
-        </div>
-        {lens.hubCollections && !focusedNode && (
-          <label
-            className="flex items-center gap-2 text-[rgb(var(--ec-page-text-muted))]"
-            title="How many relationship hops to show around the anchor nodes"
-          >
-            Detail
-            <input
-              type="range"
-              min={1}
-              max={MAX_LENS_DEPTH}
-              step={1}
-              value={lensDepth}
-              onChange={(event) => setLensDepth(Number(event.target.value))}
-              className="w-24 accent-[rgb(var(--ec-accent))]"
-            />
-            <span className="w-5 text-[rgb(var(--ec-page-text))]">{lensDepth >= MAX_LENS_DEPTH ? 'All' : lensDepth}</span>
-          </label>
+            {openInGraphLabel ?? 'Open full screen'} →
+          </a>
         )}
       </div>
-      <div className="absolute right-3 top-3 z-10 flex flex-col gap-2 rounded-md border border-[rgb(var(--ec-page-border))] bg-[rgb(var(--ec-card-bg))] px-3 py-2 text-xs shadow-xs">
-        <div ref={searchContainerRef} className="relative">
-          <input
-            type="text"
-            placeholder="Search &amp; focus…"
-            value={searchValue}
-            onChange={(event) => {
-              setSearchValue(event.target.value);
-              setShowSuggestions(true);
-              setSelectedSuggestionIndex(-1);
-            }}
-            onFocus={() => setShowSuggestions(true)}
-            onKeyDown={handleSearchKeyDown}
-            className="w-56 rounded-sm border border-[rgb(var(--ec-input-border))] bg-[rgb(var(--ec-input-bg))] py-1 pl-2 pr-7 text-[rgb(var(--ec-input-text))] placeholder:text-[rgb(var(--ec-page-text-muted))] focus:outline-none focus:ring-2 focus:ring-[rgb(var(--ec-accent))]"
-          />
-          {searchValue && (
-            <button
-              type="button"
-              onClick={() => setSearchValue('')}
-              aria-label="Clear search"
-              className="absolute right-1.5 top-1/2 -translate-y-1/2 text-[rgb(var(--ec-page-text-muted))] hover:text-[rgb(var(--ec-page-text))]"
-            >
-              ×
-            </button>
-          )}
-          {showSuggestions && searchSuggestions.length > 0 && (
-            <div className="absolute left-0 right-0 top-full z-50 mt-1 max-h-64 overflow-y-auto rounded-md border border-[rgb(var(--ec-page-border))] bg-[rgb(var(--ec-card-bg))] shadow-lg">
-              {searchSuggestions.map((node, index) => {
-                const Icon = getIconForCollection(node.collection);
-                const chipStyle = collectionChipStyle(node.collection);
-                const isSelected = index === selectedSuggestionIndex;
-                return (
-                  <button
-                    key={node.key}
-                    type="button"
-                    onClick={() => selectSuggestion(node)}
-                    onMouseEnter={() => setSelectedSuggestionIndex(index)}
-                    className={`flex w-full items-center gap-2 px-2 py-1.5 text-left ${isSelected ? 'bg-[rgb(var(--ec-accent-subtle))]' : ''}`}
-                  >
-                    <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md" style={chipStyle}>
-                      <Icon width={13} height={13} />
-                    </span>
-                    <span className="min-w-0 flex-1">
-                      <span className="block truncate font-medium text-[rgb(var(--ec-page-text))]">{node.label}</span>
-                      {node.version && (
-                        <span className="block truncate text-[10px] text-[rgb(var(--ec-page-text-muted))]">v{node.version}</span>
-                      )}
-                    </span>
-                    <span className="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium" style={chipStyle}>
-                      {COLLECTION_LABELS[node.collection] ?? node.collection}
-                    </span>
-                  </button>
-                );
-              })}
+      {(showSearch || focusedNode) && (
+        // z-20: the search dropdown must paint over the Resources legend below it
+        <div className="absolute right-3 top-3 z-20 flex flex-col gap-2 rounded-md border border-[rgb(var(--ec-page-border))] bg-[rgb(var(--ec-card-bg))] px-3 py-2 text-xs shadow-xs">
+          {showSearch && (
+            <div ref={searchContainerRef} className="relative">
+              <input
+                type="text"
+                placeholder="Search &amp; focus…"
+                value={searchValue}
+                onChange={(event) => {
+                  setSearchValue(event.target.value);
+                  setShowSuggestions(true);
+                  setSelectedSuggestionIndex(-1);
+                }}
+                onFocus={() => setShowSuggestions(true)}
+                onKeyDown={handleSearchKeyDown}
+                className="w-56 rounded-sm border border-[rgb(var(--ec-input-border))] bg-[rgb(var(--ec-input-bg))] py-1 pl-2 pr-7 text-[rgb(var(--ec-input-text))] placeholder:text-[rgb(var(--ec-page-text-muted))] focus:outline-none focus:ring-2 focus:ring-[rgb(var(--ec-accent))]"
+              />
+              {searchValue && (
+                <button
+                  type="button"
+                  onClick={() => setSearchValue('')}
+                  aria-label="Clear search"
+                  className="absolute right-1.5 top-1/2 -translate-y-1/2 text-[rgb(var(--ec-page-text-muted))] hover:text-[rgb(var(--ec-page-text))]"
+                >
+                  ×
+                </button>
+              )}
+              {showSuggestions && searchSuggestions.length > 0 && (
+                <div className="absolute left-0 right-0 top-full z-50 mt-1 max-h-64 overflow-y-auto rounded-md border border-[rgb(var(--ec-page-border))] bg-[rgb(var(--ec-card-bg))] shadow-lg">
+                  {searchSuggestions.map((node, index) => {
+                    const Icon = getIconForCollection(node.collection);
+                    const chipStyle = collectionChipStyle(node.collection);
+                    const isSelected = index === selectedSuggestionIndex;
+                    return (
+                      <button
+                        key={node.key}
+                        type="button"
+                        onClick={() => selectSuggestion(node)}
+                        onMouseEnter={() => setSelectedSuggestionIndex(index)}
+                        className={`flex w-full items-center gap-2 px-2 py-1.5 text-left ${isSelected ? 'bg-[rgb(var(--ec-accent-subtle))]' : ''}`}
+                      >
+                        <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md" style={chipStyle}>
+                          <Icon width={13} height={13} />
+                        </span>
+                        <span className="min-w-0 flex-1">
+                          <span className="block truncate font-medium text-[rgb(var(--ec-page-text))]">{node.label}</span>
+                          {node.version && (
+                            <span className="block truncate text-[10px] text-[rgb(var(--ec-page-text-muted))]">
+                              v{node.version}
+                            </span>
+                          )}
+                        </span>
+                        <span className="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium" style={chipStyle}>
+                          {COLLECTION_LABELS[node.collection] ?? node.collection}
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
             </div>
           )}
+          {focusedNode && (
+            <>
+              <button
+                type="button"
+                onClick={() => setFocusKey(null)}
+                className="flex items-center gap-1 self-start rounded-full border border-[rgb(var(--ec-page-border))] bg-[rgb(var(--ec-accent-subtle))] px-2 py-0.5 text-[rgb(var(--ec-page-text))] hover:opacity-80"
+                title="Clear focus"
+              >
+                <span
+                  className="inline-block h-2 w-2 rounded-full"
+                  style={{ backgroundColor: nodeColor(focusedNode.collection) }}
+                />
+                Focused: {focusedNode.label}
+                <span aria-hidden="true">×</span>
+              </button>
+              <label className="flex items-center gap-2 text-[rgb(var(--ec-page-text-muted))]">
+                Depth
+                <input
+                  type="range"
+                  min={1}
+                  max={3}
+                  step={1}
+                  value={focusDepth}
+                  onChange={(event) => setFocusDepth(Number(event.target.value))}
+                  className="w-24 accent-[rgb(var(--ec-accent))]"
+                />
+                <span className="w-3 text-[rgb(var(--ec-page-text))]">{focusDepth}</span>
+              </label>
+            </>
+          )}
         </div>
-        {focusedNode && (
-          <>
-            <button
-              type="button"
-              onClick={() => setFocusKey(null)}
-              className="flex items-center gap-1 self-start rounded-full border border-[rgb(var(--ec-page-border))] bg-[rgb(var(--ec-accent-subtle))] px-2 py-0.5 text-[rgb(var(--ec-page-text))] hover:opacity-80"
-              title="Clear focus"
-            >
-              <span
-                className="inline-block h-2 w-2 rounded-full"
-                style={{ backgroundColor: nodeColor(focusedNode.collection) }}
-              />
-              Focused: {focusedNode.label}
-              <span aria-hidden="true">×</span>
-            </button>
-            <label className="flex items-center gap-2 text-[rgb(var(--ec-page-text-muted))]">
-              Depth
-              <input
-                type="range"
-                min={1}
-                max={3}
-                step={1}
-                value={focusDepth}
-                onChange={(event) => setFocusDepth(Number(event.target.value))}
-                className="w-24 accent-[rgb(var(--ec-accent))]"
-              />
-              <span className="w-3 text-[rgb(var(--ec-page-text))]">{focusDepth}</span>
-            </label>
-          </>
-        )}
-      </div>
+      )}
       {focusedNode && (
         <div className="absolute bottom-3 left-3 z-10 rounded-md border border-[rgb(var(--ec-page-border))] bg-[rgb(var(--ec-card-bg))] p-3 text-xs shadow-xs">
           <div className="mb-2 font-semibold text-[rgb(var(--ec-page-text))]">You are here</div>
@@ -1377,28 +1444,30 @@ const CatalogForceGraph = ({ nodes, links, linkLabels }: Props) => {
           </ul>
         </div>
       )}
-      <div className="absolute bottom-3 right-3 z-10 rounded-md border border-[rgb(var(--ec-page-border))] bg-[rgb(var(--ec-card-bg))] p-3 text-xs shadow-xs">
-        <div className="mb-2 font-semibold text-[rgb(var(--ec-page-text))]">Resources</div>
-        <ul className="space-y-1">
-          {collectionsInGraph.map(({ collection, count }) => {
-            const hidden = hiddenCollections.has(collection);
-            return (
-              <li key={collection}>
-                <button
-                  type="button"
-                  onClick={() => toggleCollection(collection)}
-                  className={`flex w-full items-center gap-2 rounded-sm px-1 py-0.5 text-left hover:bg-[rgb(var(--ec-accent-subtle))] ${hidden ? 'opacity-40' : ''}`}
-                >
-                  <span className="inline-block h-2.5 w-2.5 rounded-full" style={{ backgroundColor: nodeColor(collection) }} />
-                  <span className="text-[rgb(var(--ec-page-text))]">
-                    {COLLECTION_LABELS[collection] ?? collection} ({count})
-                  </span>
-                </button>
-              </li>
-            );
-          })}
-        </ul>
-      </div>
+      {showLegend && (
+        <div className="absolute bottom-3 right-3 z-10 rounded-md border border-[rgb(var(--ec-page-border))] bg-[rgb(var(--ec-card-bg))] p-3 text-xs shadow-xs">
+          <div className="mb-2 font-semibold text-[rgb(var(--ec-page-text))]">Resources</div>
+          <ul className="space-y-1">
+            {collectionsInGraph.map(({ collection, count }) => {
+              const hidden = hiddenCollections.has(collection);
+              return (
+                <li key={collection}>
+                  <button
+                    type="button"
+                    onClick={() => toggleCollection(collection)}
+                    className={`flex w-full items-center gap-2 rounded-sm px-1 py-0.5 text-left hover:bg-[rgb(var(--ec-accent-subtle))] ${hidden ? 'opacity-40' : ''}`}
+                  >
+                    <span className="inline-block h-2.5 w-2.5 rounded-full" style={{ backgroundColor: nodeColor(collection) }} />
+                    <span className="text-[rgb(var(--ec-page-text))]">
+                      {COLLECTION_LABELS[collection] ?? collection} ({count})
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
     </div>
   );
 };

--- a/packages/core/eventcatalog/src/components/CatalogGraph/CatalogForceGraph.tsx
+++ b/packages/core/eventcatalog/src/components/CatalogGraph/CatalogForceGraph.tsx
@@ -1030,6 +1030,9 @@ const CatalogForceGraph = ({
       .scaleExtent([0.1, 4])
       // Let node drags win over panning: ignore presses that start on a node
       .filter((event) => {
+        // Embedded graphs must not trap touch scrolling — a one-finger swipe over
+        // the canvas scrolls the page; a two-finger gesture pans/zooms the graph
+        if (event.type === 'touchstart' && !zoomOnScroll && event.touches.length < 2) return false;
         if (event.type === 'mousedown' || event.type === 'touchstart') {
           const [x, y] = pointerPosition(event);
           return !findNode(x, y);
@@ -1047,6 +1050,9 @@ const CatalogForceGraph = ({
       });
 
     const dragBehaviour = drag<HTMLCanvasElement, unknown>()
+      // On embeds, touch node-drags would also swallow page swipes that happen to
+      // start on a node — leave touch to the page there (tap-to-focus still works)
+      .filter((event) => (zoomOnScroll || event.type !== 'touchstart') && !event.ctrlKey && !event.button)
       .subject((event) => {
         const [x, y] = pointerPosition(event.sourceEvent);
         const node = findNode(x, y);

--- a/packages/core/eventcatalog/src/components/MDX/ArchitectureGraph/ArchitectureGraph.astro
+++ b/packages/core/eventcatalog/src/components/MDX/ArchitectureGraph/ArchitectureGraph.astro
@@ -1,0 +1,62 @@
+---
+import AstroArchitectureGraph from './AstroArchitectureGraph';
+import { getCatalogForceGraph, toCatalogForceGraphWire } from '@utils/node-graphs/catalog-force-graph';
+
+interface Props {
+  // Resource to focus the graph on (its neighbourhood fills the view). Omit both
+  // to render the whole catalog graph.
+  id?: string;
+  collection?: string;
+  /** Relationship hops rendered around the focused resource (1–3) */
+  depth?: number;
+  /** Lens to render: all | domains | systems | services | teams | messages */
+  lens?: string;
+  showSearch?: boolean;
+  showLegend?: boolean;
+  /** Off by default — embedded graphs pin a lens rather than offer the picker */
+  showLensPicker?: boolean;
+  // Override the DOM portal the graph mounts into. Defaults to
+  // `${id}-architecture-graph-portal` (or `catalog-architecture-graph-portal`).
+  portalId?: string;
+  href?: {
+    label: string;
+    url: string;
+  };
+}
+
+const {
+  id,
+  collection,
+  depth = 2,
+  lens,
+  showSearch = true,
+  showLegend = true,
+  showLensPicker = false,
+  portalId,
+  href,
+} = Astro.props;
+
+const graph = await getCatalogForceGraph();
+const wire = toCatalogForceGraphWire(graph);
+
+// Only focus a resource that exists in the graph — it holds latest versions
+// only, so e.g. an old-version page falls back to the whole catalog view
+const focusKey =
+  id && collection && graph.nodes.some((node) => node.id === `${collection}/${id}`) ? `${collection}/${id}` : undefined;
+---
+
+<AstroArchitectureGraph
+  client:only="react"
+  portalId={portalId ?? `${id ?? 'catalog'}-architecture-graph-portal`}
+  nodes={wire.nodes}
+  links={wire.links}
+  linkLabels={wire.linkLabels}
+  initialFocus={focusKey}
+  initialFocusDepth={depth}
+  initialLens={lens}
+  showSearch={showSearch}
+  showLegend={showLegend}
+  showLensPicker={showLensPicker}
+  href={href?.url}
+  hrefLabel={href?.label}
+/>

--- a/packages/core/eventcatalog/src/components/MDX/ArchitectureGraph/ArchitectureGraphPortal.tsx
+++ b/packages/core/eventcatalog/src/components/MDX/ArchitectureGraph/ArchitectureGraphPortal.tsx
@@ -1,3 +1,9 @@
+// The portal id pairs each scanner-rendered island with its MDX placeholder.
+// The occurrence index keeps multiple no-id embeds on one page from colliding
+// (the first occurrence keeps the unsuffixed id).
+export const architectureGraphPortalId = (id: string | undefined, occurrenceIndex: number) =>
+  `${id ?? 'catalog'}-architecture-graph-portal${occurrenceIndex > 0 ? `-${occurrenceIndex}` : ''}`;
+
 // Empty placeholder rendered by the MDX component map. The real graph is
 // rendered by ArchitectureGraph.astro (which builds the data server-side) and
 // portals itself into this div by id — same pattern as NodeGraphPortal.
@@ -5,7 +11,7 @@ const ArchitectureGraphPortal = (props: any) => {
   return (
     <div
       className="not-prose h-[30em] my-6 mb-12 w-full relative border! border-[rgb(var(--ec-page-border))]! rounded-md overflow-hidden"
-      id={`${props.id ?? 'catalog'}-architecture-graph-portal`}
+      id={architectureGraphPortalId(props.id, props.occurrenceIndex ?? 0)}
       style={{
         maxHeight: props.maxHeight ? `${props.maxHeight}em` : `30em`,
       }}

--- a/packages/core/eventcatalog/src/components/MDX/ArchitectureGraph/ArchitectureGraphPortal.tsx
+++ b/packages/core/eventcatalog/src/components/MDX/ArchitectureGraph/ArchitectureGraphPortal.tsx
@@ -1,0 +1,16 @@
+// Empty placeholder rendered by the MDX component map. The real graph is
+// rendered by ArchitectureGraph.astro (which builds the data server-side) and
+// portals itself into this div by id — same pattern as NodeGraphPortal.
+const ArchitectureGraphPortal = (props: any) => {
+  return (
+    <div
+      className="not-prose h-[30em] my-6 mb-12 w-full relative border! border-[rgb(var(--ec-page-border))]! rounded-md overflow-hidden"
+      id={`${props.id ?? 'catalog'}-architecture-graph-portal`}
+      style={{
+        maxHeight: props.maxHeight ? `${props.maxHeight}em` : `30em`,
+      }}
+    />
+  );
+};
+
+export default ArchitectureGraphPortal;

--- a/packages/core/eventcatalog/src/components/MDX/ArchitectureGraph/AstroArchitectureGraph.tsx
+++ b/packages/core/eventcatalog/src/components/MDX/ArchitectureGraph/AstroArchitectureGraph.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import CatalogForceGraph from '@components/CatalogGraph/CatalogForceGraph';
+import type { CatalogGraphWireLink, CatalogGraphWireNode } from '@utils/node-graphs/catalog-force-graph';
+
+interface Props {
+  /** DOM id of the placeholder div ArchitectureGraphPortal rendered into the MDX content */
+  portalId: string;
+  nodes: CatalogGraphWireNode[];
+  links: CatalogGraphWireLink[];
+  linkLabels: string[];
+  initialLens?: string;
+  initialFocus?: string;
+  initialFocusDepth?: number;
+  showSearch?: boolean;
+  showLegend?: boolean;
+  showLensPicker?: boolean;
+  /** Base URL of the standalone /visualiser/graph page — the graph renders an
+   * "open full screen" link carrying its live view state (focus, depth, lens) */
+  href?: string;
+  hrefLabel?: string;
+}
+
+// The island mounts outside the MDX content, finds the placeholder div the MDX
+// component map emitted, and portals the graph into it — same pattern as the
+// visualiser's NodeGraph.
+const AstroArchitectureGraph = ({ portalId, href, hrefLabel, ...graphProps }: Props) => {
+  const [container, setContainer] = useState<HTMLElement | null>(null);
+
+  useEffect(() => {
+    setContainer(document.getElementById(portalId));
+  }, [portalId]);
+
+  if (!container) return null;
+
+  return createPortal(
+    <CatalogForceGraph {...graphProps} syncUrl={false} zoomOnScroll={false} openInGraphUrl={href} openInGraphLabel={hrefLabel} />,
+    container
+  );
+};
+
+export default AstroArchitectureGraph;

--- a/packages/core/eventcatalog/src/components/MDX/components.tsx
+++ b/packages/core/eventcatalog/src/components/MDX/components.tsx
@@ -35,6 +35,7 @@ import MermaidFileLoader from '@components/MDX/MermaidFileLoader/MermaidFileLoad
 import LikeC4View from '@components/MDX/LikeC4View/LikeC4View.astro';
 //  Portals: required for server/client components
 import NodeGraphPortal from '@components/MDX/NodeGraph/NodeGraphPortal';
+import ArchitectureGraphPortal from '@components/MDX/ArchitectureGraph/ArchitectureGraphPortal';
 import ContextDiagramPortal from '@components/MDX/ContextDiagram/ContextDiagramPortal';
 import SystemContextMapPortal from '@components/MDX/SystemContextMap/SystemContextMapPortal';
 import SchemaViewerPortal from '@components/MDX/SchemaViewer/SchemaViewerPortal';
@@ -69,6 +70,7 @@ const components = (props: any) => {
     ADRTable: (mdxProp: any) => jsx(ADRTable, { ...props, ...mdxProp }),
     EntityPropertiesTable: (mdxProp: any) => jsx(EntityPropertiesTable, { ...props, ...mdxProp }),
     NodeGraph: (mdxProp: any) => jsx(NodeGraphPortal, { ...props.data, ...mdxProp, props, mdxProp }),
+    ArchitectureGraph: (mdxProp: any) => jsx(ArchitectureGraphPortal, { ...props.data, ...mdxProp, props, mdxProp }),
     ComponentDiagram: (mdxProp: any) => jsx(NodeGraphPortal, { ...props.data, ...mdxProp, props, mdxProp }),
     ContextDiagram: (mdxProp: any) => jsx(ContextDiagramPortal, { ...props.data, ...mdxProp, props, mdxProp }),
     SystemContextMap: (mdxProp: any) => jsx(SystemContextMapPortal, { ...mdxProp }),

--- a/packages/core/eventcatalog/src/components/MDX/components.tsx
+++ b/packages/core/eventcatalog/src/components/MDX/components.tsx
@@ -51,6 +51,10 @@ const getEntityMapCollection = (props: any, mdxProp: any) => {
 };
 
 const components = (props: any) => {
+  // Occurrence counter so multiple <ArchitectureGraph/> tags on one page each get
+  // their own portal — MDX renders in document order, matching the body scan order
+  // the host pages use to render the islands.
+  let architectureGraphOccurrence = 0;
   return {
     Attachments: (mdxProp: any) => jsx(Attachments, { ...props, ...mdxProp }),
     CustomProperties: (mdxProp: any) => jsx(CustomProperties, { ...props, ...mdxProp }),
@@ -70,7 +74,14 @@ const components = (props: any) => {
     ADRTable: (mdxProp: any) => jsx(ADRTable, { ...props, ...mdxProp }),
     EntityPropertiesTable: (mdxProp: any) => jsx(EntityPropertiesTable, { ...props, ...mdxProp }),
     NodeGraph: (mdxProp: any) => jsx(NodeGraphPortal, { ...props.data, ...mdxProp, props, mdxProp }),
-    ArchitectureGraph: (mdxProp: any) => jsx(ArchitectureGraphPortal, { ...props.data, ...mdxProp, props, mdxProp }),
+    ArchitectureGraph: (mdxProp: any) =>
+      jsx(ArchitectureGraphPortal, {
+        ...props.data,
+        ...mdxProp,
+        occurrenceIndex: architectureGraphOccurrence++,
+        props,
+        mdxProp,
+      }),
     ComponentDiagram: (mdxProp: any) => jsx(NodeGraphPortal, { ...props.data, ...mdxProp, props, mdxProp }),
     ContextDiagram: (mdxProp: any) => jsx(ContextDiagramPortal, { ...props.data, ...mdxProp, props, mdxProp }),
     SystemContextMap: (mdxProp: any) => jsx(SystemContextMapPortal, { ...mdxProp }),

--- a/packages/core/eventcatalog/src/enterprise/custom-documentation/pages/docs/custom/index.astro
+++ b/packages/core/eventcatalog/src/enterprise/custom-documentation/pages/docs/custom/index.astro
@@ -14,9 +14,16 @@ import { getMDXComponentsByName, parseMdxBooleanProp } from '@utils/markdown';
 import { getAdjacentPages, getNavigationItems } from '@enterprise/custom-documentation/utils/custom-docs';
 import CustomDocsNav from '@enterprise/custom-documentation/components/CustomDocsNav/CustomDocsNav.astro';
 import NodeGraph from '@components/MDX/NodeGraph/NodeGraph.astro';
+import ArchitectureGraph from '@components/MDX/ArchitectureGraph/ArchitectureGraph.astro';
 import CopyAsMarkdown from '@components/CopyAsMarkdown';
 
-import { isVisualiserEnabled, isMarkdownDownloadEnabled, isRSSEnabled, isEventCatalogChatEnabled } from '@utils/feature';
+import {
+  isVisualiserEnabled,
+  isMarkdownDownloadEnabled,
+  isRSSEnabled,
+  isEventCatalogChatEnabled,
+  isArchitectureGraphEnabled,
+} from '@utils/feature';
 
 const props = Astro.props;
 const doc = props.data;
@@ -47,6 +54,18 @@ const resolvedNodeGraphs = await Promise.all(
     };
   })
 );
+
+// Architecture graphs embedded via <ArchitectureGraph />. Custom docs have no
+// resource of their own, so with no `id` + `type` the whole catalog is rendered.
+const architectureGraphs = (getMDXComponentsByName(props.body, 'ArchitectureGraph') || []).map((graph: any) => ({
+  id: graph.id,
+  collection: graph.type ? resourceToCollectionMap[graph.type as keyof typeof resourceToCollectionMap] : undefined,
+  depth: graph.depth ? Number(graph.depth) : undefined,
+  lens: graph.lens,
+  search: parseMdxBooleanProp(graph.search, true),
+  legend: parseMdxBooleanProp(graph.legend, true),
+  lensPicker: parseMdxBooleanProp(graph.lensPicker, false),
+}));
 
 const { prev, next } = await getAdjacentPages(currentSlug);
 
@@ -169,6 +188,31 @@ const editUrl =
                   />
                 );
               })
+          }
+
+          {
+            architectureGraphs.length > 0 &&
+              architectureGraphs.map((graph: any) => (
+                <ArchitectureGraph
+                  id={graph.id}
+                  collection={graph.collection}
+                  depth={graph.depth}
+                  lens={graph.lens}
+                  showSearch={graph.search}
+                  showLegend={graph.legend}
+                  showLensPicker={graph.lensPicker}
+                  portalId={`${graph.id ?? (doc as any).id ?? 'catalog'}-architecture-graph-portal`}
+                  href={
+                    isArchitectureGraphEnabled()
+                      ? {
+                          label: 'Open full screen',
+                          // Base URL only — the graph appends its live view state (focus, depth, lens)
+                          url: buildUrl('/visualiser/graph'),
+                        }
+                      : undefined
+                  }
+                />
+              ))
           }
 
           <!-- Previous / Next Navigation -->

--- a/packages/core/eventcatalog/src/enterprise/custom-documentation/pages/docs/custom/index.astro
+++ b/packages/core/eventcatalog/src/enterprise/custom-documentation/pages/docs/custom/index.astro
@@ -15,6 +15,7 @@ import { getAdjacentPages, getNavigationItems } from '@enterprise/custom-documen
 import CustomDocsNav from '@enterprise/custom-documentation/components/CustomDocsNav/CustomDocsNav.astro';
 import NodeGraph from '@components/MDX/NodeGraph/NodeGraph.astro';
 import ArchitectureGraph from '@components/MDX/ArchitectureGraph/ArchitectureGraph.astro';
+import { architectureGraphPortalId } from '@components/MDX/ArchitectureGraph/ArchitectureGraphPortal';
 import CopyAsMarkdown from '@components/CopyAsMarkdown';
 
 import {
@@ -192,7 +193,7 @@ const editUrl =
 
           {
             architectureGraphs.length > 0 &&
-              architectureGraphs.map((graph: any) => (
+              architectureGraphs.map((graph: any, occurrenceIndex: number) => (
                 <ArchitectureGraph
                   id={graph.id}
                   collection={graph.collection}
@@ -201,7 +202,7 @@ const editUrl =
                   showSearch={graph.search}
                   showLegend={graph.legend}
                   showLensPicker={graph.lensPicker}
-                  portalId={`${graph.id ?? (doc as any).id ?? 'catalog'}-architecture-graph-portal`}
+                  portalId={architectureGraphPortalId(graph.id ?? (doc as any).id, occurrenceIndex)}
                   href={
                     isArchitectureGraphEnabled()
                       ? {

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/index.astro
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/index.astro
@@ -10,6 +10,7 @@ import Footer from '@layouts/Footer.astro';
 
 import components from '@components/MDX/components';
 import NodeGraph from '@components/MDX/NodeGraph/NodeGraph.astro';
+import ArchitectureGraph from '@components/MDX/ArchitectureGraph/ArchitectureGraph.astro';
 import SchemaViewer from '@components/MDX/SchemaViewer/SchemaViewerRoot.astro';
 import Admonition from '@components/MDX/Admonition';
 import VersionList from '@components/Lists/VersionList.astro';
@@ -65,6 +66,7 @@ import {
   isVisualiserEnabled,
   isRSSEnabled,
   isEventCatalogMCPEnabled,
+  isArchitectureGraphEnabled,
 } from '@utils/feature';
 import { getMDXComponentsByName, parseMdxBooleanProp } from '@utils/markdown';
 
@@ -361,6 +363,20 @@ const contextDiagrams = contextDiagramSupported
     })
   : [];
 
+// Architecture graphs embedded via <ArchitectureGraph />. Renders the D3
+// catalog-wide force graph focused on the current resource's neighbourhood;
+// `id` + `type` focus another resource instead. Each renders into its own
+// portal, so it never collides with the page's NodeGraph.
+const architectureGraphs = (getMDXComponentsByName(props.body || '', 'ArchitectureGraph') || []).map((graph: any) => ({
+  id: graph.id ?? props.data.id,
+  collection: graph.type ? resourceToCollectionMap[graph.type as keyof typeof resourceToCollectionMap] : props.collection,
+  depth: graph.depth ? Number(graph.depth) : undefined,
+  lens: graph.lens,
+  search: parseMdxBooleanProp(graph.search, true),
+  legend: parseMdxBooleanProp(graph.legend, true),
+  lensPicker: parseMdxBooleanProp(graph.lensPicker, false),
+}));
+
 // Get props for the node graph (when no id is passed, we assume its the current page)
 const hasCurrentFlowEmbed =
   props.collection === 'flows' &&
@@ -647,6 +663,30 @@ if (!isAdrPage && !hasCurrentFlowEmbed && !hasCurrentPageNodeGraph) {
                       ? {
                           label: 'Open Context Diagram',
                           url: diagram.visualiserUrl,
+                        }
+                      : undefined
+                  }
+                />
+              ))
+          }
+          {
+            architectureGraphs.length > 0 &&
+              architectureGraphs.map((graph: any) => (
+                <ArchitectureGraph
+                  id={graph.id}
+                  collection={graph.collection}
+                  depth={graph.depth}
+                  lens={graph.lens}
+                  showSearch={graph.search}
+                  showLegend={graph.legend}
+                  showLensPicker={graph.lensPicker}
+                  portalId={`${graph.id}-architecture-graph-portal`}
+                  href={
+                    isArchitectureGraphEnabled()
+                      ? {
+                          label: 'Open full screen',
+                          // Base URL only — the graph appends its live view state (focus, depth, lens)
+                          url: buildUrl('/visualiser/graph'),
                         }
                       : undefined
                   }

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/index.astro
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/index.astro
@@ -11,6 +11,7 @@ import Footer from '@layouts/Footer.astro';
 import components from '@components/MDX/components';
 import NodeGraph from '@components/MDX/NodeGraph/NodeGraph.astro';
 import ArchitectureGraph from '@components/MDX/ArchitectureGraph/ArchitectureGraph.astro';
+import { architectureGraphPortalId } from '@components/MDX/ArchitectureGraph/ArchitectureGraphPortal';
 import SchemaViewer from '@components/MDX/SchemaViewer/SchemaViewerRoot.astro';
 import Admonition from '@components/MDX/Admonition';
 import VersionList from '@components/Lists/VersionList.astro';
@@ -671,7 +672,7 @@ if (!isAdrPage && !hasCurrentFlowEmbed && !hasCurrentPageNodeGraph) {
           }
           {
             architectureGraphs.length > 0 &&
-              architectureGraphs.map((graph: any) => (
+              architectureGraphs.map((graph: any, occurrenceIndex: number) => (
                 <ArchitectureGraph
                   id={graph.id}
                   collection={graph.collection}
@@ -680,7 +681,7 @@ if (!isAdrPage && !hasCurrentFlowEmbed && !hasCurrentPageNodeGraph) {
                   showSearch={graph.search}
                   showLegend={graph.legend}
                   showLensPicker={graph.lensPicker}
-                  portalId={`${graph.id}-architecture-graph-portal`}
+                  portalId={architectureGraphPortalId(graph.id, occurrenceIndex)}
                   href={
                     isArchitectureGraphEnabled()
                       ? {

--- a/packages/core/eventcatalog/src/pages/index.astro
+++ b/packages/core/eventcatalog/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import VerticalSideBarLayout from '@layouts/VerticalSideBarLayout.astro';
 import { getMDXComponentsByName, parseMdxBooleanProp } from '@utils/markdown';
+import { architectureGraphPortalId } from '@components/MDX/ArchitectureGraph/ArchitectureGraphPortal';
 import { resourceToCollectionMap } from '@utils/collections/util';
 import { buildUrl } from '@utils/url-builder';
 import { isCustomLandingPageEnabled, isVisualiserEnabled, isArchitectureGraphEnabled } from '@utils/feature';
@@ -115,7 +116,7 @@ if (config.landingPage) {
             />
           ))}
         {ArchitectureGraph &&
-          architectureGraphs.map((graph: any) => (
+          architectureGraphs.map((graph: any, occurrenceIndex: number) => (
             <ArchitectureGraph
               id={graph.id}
               collection={graph.type ? resourceToCollectionMap[graph.type as keyof typeof resourceToCollectionMap] : undefined}
@@ -124,7 +125,7 @@ if (config.landingPage) {
               showSearch={parseMdxBooleanProp(graph.search, true)}
               showLegend={parseMdxBooleanProp(graph.legend, true)}
               showLensPicker={parseMdxBooleanProp(graph.lensPicker, false)}
-              portalId={`${graph.id ?? 'catalog'}-architecture-graph-portal`}
+              portalId={architectureGraphPortalId(graph.id, occurrenceIndex)}
               href={
                 isArchitectureGraphEnabled()
                   ? {

--- a/packages/core/eventcatalog/src/pages/index.astro
+++ b/packages/core/eventcatalog/src/pages/index.astro
@@ -1,16 +1,18 @@
 ---
 import VerticalSideBarLayout from '@layouts/VerticalSideBarLayout.astro';
-import { getMDXComponentsByName } from '@utils/markdown';
+import { getMDXComponentsByName, parseMdxBooleanProp } from '@utils/markdown';
 import { resourceToCollectionMap } from '@utils/collections/util';
 import { buildUrl } from '@utils/url-builder';
-import { isCustomLandingPageEnabled, isVisualiserEnabled } from '@utils/feature';
+import { isCustomLandingPageEnabled, isVisualiserEnabled, isArchitectureGraphEnabled } from '@utils/feature';
 import DefaultAstroLandingPage from './_index.astro';
 import config from '@config';
 
 let nodeGraphs: any[] = [];
 let systemContextMaps: any[] = [];
+let architectureGraphs: any[] = [];
 let CustomContent = null;
 let NodeGraph = null;
+let ArchitectureGraph = null;
 let customHomepageComponents: Record<string, any> = {};
 
 import path from 'path';
@@ -37,10 +39,18 @@ if (existsSync(pathToUserDefinedLandingPage) && isCustomLandingPageEnabled()) {
   // The homepage can also embed the global System Context Map via <SystemContextMap />.
   systemContextMaps = getMDXComponentsByName(rawContent, 'SystemContextMap') || [];
 
+  // …and the catalog-wide Architecture Graph via <ArchitectureGraph />. With no
+  // `id` + `type` the whole catalog is rendered.
+  architectureGraphs = getMDXComponentsByName(rawContent, 'ArchitectureGraph') || [];
+
   // Avoid pulling visualizer CSS into the default homepage bundle.
   // Only load the NodeGraph component when the custom homepage actually uses a graph.
   if (nodeGraphs.length > 0 || systemContextMaps.length > 0) {
     NodeGraph = (await import('@components/MDX/NodeGraph/NodeGraph.astro')).default;
+  }
+  // Only build the catalog-wide graph data when the homepage actually embeds it.
+  if (architectureGraphs.length > 0) {
+    ArchitectureGraph = (await import('@components/MDX/ArchitectureGraph/ArchitectureGraph.astro')).default;
   }
 }
 
@@ -99,6 +109,27 @@ if (config.landingPage) {
                   ? {
                       label: 'Open in Visualiser',
                       url: buildUrl('/visualiser/system-context-map'),
+                    }
+                  : undefined
+              }
+            />
+          ))}
+        {ArchitectureGraph &&
+          architectureGraphs.map((graph: any) => (
+            <ArchitectureGraph
+              id={graph.id}
+              collection={graph.type ? resourceToCollectionMap[graph.type as keyof typeof resourceToCollectionMap] : undefined}
+              depth={graph.depth ? Number(graph.depth) : undefined}
+              lens={graph.lens}
+              showSearch={parseMdxBooleanProp(graph.search, true)}
+              showLegend={parseMdxBooleanProp(graph.legend, true)}
+              showLensPicker={parseMdxBooleanProp(graph.lensPicker, false)}
+              portalId={`${graph.id ?? 'catalog'}-architecture-graph-portal`}
+              href={
+                isArchitectureGraphEnabled()
+                  ? {
+                      label: 'Open full screen',
+                      url: buildUrl('/visualiser/graph'),
                     }
                   : undefined
               }

--- a/packages/core/eventcatalog/src/pages/visualiser/graph/index.astro
+++ b/packages/core/eventcatalog/src/pages/visualiser/graph/index.astro
@@ -1,8 +1,7 @@
 ---
 import VisualiserLayout from '@layouts/VisualiserLayout.astro';
 import CatalogForceGraph from '@components/CatalogGraph/CatalogForceGraph';
-import type { CatalogGraphWireLink } from '@components/CatalogGraph/CatalogForceGraph';
-import { getCatalogForceGraph } from '@utils/node-graphs/catalog-force-graph';
+import { getCatalogForceGraph, toCatalogForceGraphWire } from '@utils/node-graphs/catalog-force-graph';
 import { isArchitectureGraphEnabled } from '@utils/feature';
 
 // Bail before building the graph — on very large catalogs the whole point of
@@ -11,29 +10,9 @@ if (!isArchitectureGraphEnabled()) {
   return new Response(null, { status: 404 });
 }
 
-const { nodes, links } = await getCatalogForceGraph();
-
 // Compact wire format: index-based links and client-derived URLs keep the
 // island props Astro serialises into the page small for large catalogs.
-const nodeIndexById = new Map(nodes.map((node, index) => [node.id, index]));
-const linkLabels = [...new Set(links.map((link) => link.label))];
-const labelIndexByLabel = new Map(linkLabels.map((label, index) => [label, index]));
-
-const wireNodes = nodes.map(({ id, label, collection, version }) => ({
-  // Node ids are `${collection}/${resourceId}` — send only the resource id, the client rebuilds the key
-  id: id.slice(collection.length + 1),
-  label,
-  collection,
-  version,
-}));
-
-const wireLinks = links.map(
-  (link): CatalogGraphWireLink => [
-    nodeIndexById.get(link.source)!,
-    nodeIndexById.get(link.target)!,
-    labelIndexByLabel.get(link.label)!,
-  ]
-);
+const { nodes: wireNodes, links: wireLinks, linkLabels } = toCatalogForceGraphWire(await getCatalogForceGraph());
 ---
 
 <VisualiserLayout title="Visualiser | Architecture Graph" description="Force-directed graph of every resource in the catalog">

--- a/packages/core/eventcatalog/src/utils/node-graphs/catalog-force-graph.ts
+++ b/packages/core/eventcatalog/src/utils/node-graphs/catalog-force-graph.ts
@@ -35,6 +35,47 @@ export interface CatalogGraphLink {
   label: string;
 }
 
+/** Compact wire format — index-based links keep the payload Astro serialises into the island small. */
+export interface CatalogGraphWireNode {
+  /** Resource id, e.g. `InventoryService` — the client rebuilds the `${collection}/${id}` key */
+  id: string;
+  label: string;
+  collection: string;
+  version?: string;
+}
+
+/** [sourceIndex, targetIndex, labelIndex] into the nodes / linkLabels arrays */
+export type CatalogGraphWireLink = [number, number, number];
+
+/**
+ * Compacts the built graph for serialisation into a client island: node ids are
+ * stripped of their `${collection}/` prefix, link labels are deduped into one
+ * array, and each link becomes an index tuple. URLs are dropped server-side and
+ * rebuilt client-side.
+ */
+export const toCatalogForceGraphWire = ({ nodes, links }: { nodes: CatalogGraphNode[]; links: CatalogGraphLink[] }) => {
+  const nodeIndexById = new Map(nodes.map((node, index) => [node.id, index]));
+  const linkLabels = [...new Set(links.map((link) => link.label))];
+  const labelIndexByLabel = new Map(linkLabels.map((label, index) => [label, index]));
+
+  const wireNodes: CatalogGraphWireNode[] = nodes.map(({ id, label, collection, version }) => ({
+    id: id.slice(collection.length + 1),
+    label,
+    collection,
+    version,
+  }));
+
+  const wireLinks = links.map(
+    (link): CatalogGraphWireLink => [
+      nodeIndexById.get(link.source)!,
+      nodeIndexById.get(link.target)!,
+      labelIndexByLabel.get(link.label)!,
+    ]
+  );
+
+  return { nodes: wireNodes, links: wireLinks, linkLabels };
+};
+
 type AnyEntry = {
   collection?: string;
   data: { id: string; name?: string; version?: string; latestVersion?: string; visualiser?: boolean };

--- a/packages/create-eventcatalog/templates/default/domains/Catalog/index.mdx
+++ b/packages/create-eventcatalog/templates/default/domains/Catalog/index.mdx
@@ -54,6 +54,12 @@ The **Catalog** domain is responsible for the lifecycle of every product Acme In
 
 The **Product Catalog System** is the authoritative source of product data. Whenever a product is created, updated or deleted it publishes a domain event. The **Search System** subscribes to those events, keeps its search index in sync, and exposes a search API so other teams never have to query the catalog database directly.
 
+## Architecture Graph
+
+Where Catalog sits in the wider architecture — its systems and messages, and the neighbouring domains it talks to.
+
+<ArchitectureGraph />
+
 The diagram below shows the domain's systems, how they relate, and the people who interact with them.
 
 <ContextDiagram />

--- a/packages/create-eventcatalog/templates/default/domains/Ordering/index.mdx
+++ b/packages/create-eventcatalog/templates/default/domains/Ordering/index.mdx
@@ -68,3 +68,9 @@ The systems in this domain, how they relate, and the people who interact with th
 The components that make up this domain.
 
 <NodeGraph />
+
+## Architecture Graph
+
+Where Ordering sits in the wider architecture — its systems and messages, and the neighbouring domains it talks to.
+
+<ArchitectureGraph />

--- a/packages/create-eventcatalog/templates/default/domains/Ordering/systems/checkout-system/index.mdx
+++ b/packages/create-eventcatalog/templates/default/domains/Ordering/systems/checkout-system/index.mdx
@@ -55,3 +55,9 @@ The services and messages that make up this system.
 - [[command\|reserve-inventory]] — reserve stock for the items in the cart.
 - [[command\|authorize-payment]] — authorize payment for the order total.
 - [[command\|create-order]] — create the order in the Order Management System.
+
+## Architecture Graph
+
+The checkout system's neighbourhood in the wider architecture.
+
+<ArchitectureGraph />

--- a/packages/create-eventcatalog/templates/default/domains/Payments/index.mdx
+++ b/packages/create-eventcatalog/templates/default/domains/Payments/index.mdx
@@ -67,3 +67,9 @@ The **Payment Processing System** is the internal orchestrator. When the Orderin
 The systems in this domain, how they relate, and the people who interact with them.
 
 <ContextDiagram />
+
+## Architecture Graph
+
+Where Payments sits in the wider architecture — its systems and messages, and the neighbouring domains it talks to.
+
+<ArchitectureGraph />

--- a/packages/create-eventcatalog/templates/default/domains/Payments/systems/payment-processing-system/services/PaymentAPI/index.mdx
+++ b/packages/create-eventcatalog/templates/default/domains/Payments/systems/payment-processing-system/services/PaymentAPI/index.mdx
@@ -46,6 +46,12 @@ The **Payment API** is the entry point to the Payment Processing System. It rece
 
 <NodeGraph />
 
+## Architecture Graph
+
+How PaymentAPI connects to the rest of the catalog — the messages it exchanges and the systems around it.
+
+<ArchitectureGraph />
+
 <MessageTable format="all" limit={8} />
 
 <Footer />

--- a/packages/create-eventcatalog/templates/default/pages/homepage.astro
+++ b/packages/create-eventcatalog/templates/default/pages/homepage.astro
@@ -2,8 +2,8 @@
 import { getCollection } from 'astro:content';
 
 // EventCatalog injects its components via Astro.props.components. Destructure the ones
-// this landing page uses (including the SystemContextMap embed).
-const { Tile, Tiles, SystemContextMap } = Astro.props.components;
+// this landing page uses (including the ArchitectureGraph and SystemContextMap embeds).
+const { Tile, Tiles, SystemContextMap, ArchitectureGraph } = Astro.props.components;
 
 // Count the catalog's top-level resources. We filter out versioned/ entries so each
 // resource is counted once (by its latest version).
@@ -49,6 +49,16 @@ const stats = [
     }
   </div>
 
+  {/* Architecture graph */}
+  <h2 class="text-2xl font-semibold text-[rgb(var(--ec-page-text))] mt-12 mb-2">Architecture</h2>
+  <p class="text-[rgb(var(--ec-page-text-muted))] font-light mb-2">
+    Every resource in the catalog and the relationships between them.
+  </p>
+</div>
+
+<ArchitectureGraph lens="domains" lensPicker="true" />
+
+<div class="not-prose">
   {/* System context map */}
   <h2 class="text-2xl font-semibold text-[rgb(var(--ec-page-text))] mt-12 mb-2">System context map</h2>
   <p class="text-[rgb(var(--ec-page-text-muted))] font-light mb-2">

--- a/packages/sdk/src/test/fixtures/build-index/default-catalog-index.json
+++ b/packages/sdk/src/test/fixtures/build-index/default-catalog-index.json
@@ -626,7 +626,7 @@
       "version": "1.0.0",
       "name": "Catalog",
       "contentPath": "domains/Catalog/index.mdx",
-      "contentHash": "sha256:1cb8e8ddd496e775dcc6d0e0a4eac85cc28066d248599a363d38c44f6c3a5801",
+      "contentHash": "sha256:f34e1362ab1fb1dfb9c3ed2836cd054f4858b6c764b0e0fe62185bb162bac779",
       "owners": ["product-platform"],
       "sidecars": [
         {
@@ -867,7 +867,7 @@
       "version": "1.0.0",
       "name": "Ordering",
       "contentPath": "domains/Ordering/index.mdx",
-      "contentHash": "sha256:b8897d88a778080bd1e00b8afba2566e855f59927a831e4e0197ce492401e07a",
+      "contentHash": "sha256:80d05ff89805888e594bdbea50854c8ae4b3e615ae0da6b8272e1e4de1d62249",
       "owners": ["ordering-platform"],
       "sidecars": [
         {
@@ -948,7 +948,7 @@
       "version": "1.0.0",
       "name": "Payments",
       "contentPath": "domains/Payments/index.mdx",
-      "contentHash": "sha256:82dcb892b91e5cec3d3abb0ef98f02637516314240070158adf365369ea009dc",
+      "contentHash": "sha256:271d5fc58b5ecdc3b02d1a1f3f3b9ed0fc4a1b48e07fb31a9bc0c726861464a9",
       "owners": ["payments-platform"],
       "sidecars": [
         {
@@ -2932,7 +2932,7 @@
       "version": "1.0.0",
       "name": "Payment API",
       "contentPath": "domains/Payments/systems/payment-processing-system/services/PaymentAPI/index.mdx",
-      "contentHash": "sha256:0678b124dbfa077a6f9957fb03f248ed4816dc25f5a8167c1fe17f0abf29144b",
+      "contentHash": "sha256:e6858bfb8b590d6cd310a33895cb7c864f04733148649b8bf5c829657cc377c5",
       "owners": ["payments-platform"],
       "receives": [
         {
@@ -3617,7 +3617,7 @@
       "version": "1.0.0",
       "name": "Checkout System",
       "contentPath": "domains/Ordering/systems/checkout-system/index.mdx",
-      "contentHash": "sha256:9df555d237da11df686f4346f18d7964902d39d5ca34ef4430c01a195ed93d66",
+      "contentHash": "sha256:13691e780cf7b2aeea12779097583d1094f5f6f4814f576a4eba3b7d9a2e62b3",
       "owners": ["ordering-platform"],
       "services": [
         {


### PR DESCRIPTION

## What This PR Does

Adds a new `<ArchitectureGraph/>` MDX component that embeds the catalog-wide D3 force-directed graph (the one from `/visualiser/graph`) directly inside documentation pages, focused on the resource being documented. Users can now drop the architecture graph into domains, services, systems, messages, custom documentation pages, and custom landing pages — the same way they already embed `<NodeGraph/>`.

## Changes Overview

### Key Changes
- New `ArchitectureGraph` MDX component (portal placeholder + Astro server component + React island), registered in the MDX component map and wired into the resource docs page, custom documentation pages, and the custom landing page renderer
- `CatalogForceGraph` gains embed support: `initialFocus`/`initialFocusDepth`/`initialLens` seed the view, `syncUrl={false}` stops embedded graphs reading/rewriting the host page's query string, `showLensPicker`/`showSearch`/`showLegend` toggle the chrome, and `zoomOnScroll={false}` keeps page scrolling working (ctrl/cmd+scroll zooms)
- An "Open full screen" link on embedded graphs opens `/visualiser/graph` carrying the live view state (focused node, selected depth, lens, hidden collections), shown when `visualiser.architectureGraph.enabled` is on
- New `lensPicker` prop (off by default) lets readers switch lenses on an embedded graph
- The wire-format compaction is extracted from the graph page into a shared `toCatalogForceGraphWire()` helper
- Fixes a z-index bug where the search suggestions dropdown rendered underneath the Resources legend (also affected the standalone graph page)
- Pre-bundles the d3 modules in `optimizeDeps` so dev-mode no longer 504s ("Outdated Optimize Dep") when a page first loads the graph island
- Example catalog and `create-eventcatalog` default template updated: `<ArchitectureGraph/>` on the Catalog, Ordering, and Payments domains, the checkout system, the PaymentAPI service, and the landing page (domains lens with the lens picker enabled)

## How It Works

The component follows the same portal pattern as `<NodeGraph/>`: the MDX component map renders an empty placeholder div, each host page scans the raw markdown body for `<ArchitectureGraph/>` tags and renders an Astro component per tag, which builds the catalog graph server-side via `getCatalogForceGraph()`, compacts it with the shared wire format, and hydrates a `client:only` React island that portals `CatalogForceGraph` into the placeholder.

With no props the graph focuses the current page's resource at depth 2. `id` + `type` focus another resource, `depth` widens the neighbourhood (1–3 hops), and `lens` pins a lens. Focus falls back to the whole-catalog view when the resource is not in the graph (it holds latest versions only). Each embed serialises the full catalog graph into the page so client-side refocus and search work — the wire format (index-based links, deduped labels) keeps that payload small.

## Breaking Changes

None. The standalone `/visualiser/graph` page behaves exactly as before (defaults preserve URL sync and full chrome), and pages that do not use the new component are unaffected.

## Additional Notes

- Like `<NodeGraph/>`, props must be quoted strings (`depth="3"`, `search="false"`) — the body scanner only matches quoted key/value pairs on self-closing tags
- One `<ArchitectureGraph/>` per page is the sensible pattern: each tag embeds its own copy of the catalog graph payload
- Website docs (component reference, guide cross-links, screenshot) are prepared separately in the website-2 repository

https://claude.ai/code/session_01CAeK9ZZXiDLfrbbLGZkKfM
