### PR TITLE
Resolve core type errors and enforce type checking in CI

### DIFF
--- a/.changeset/quiet-lions-repeat.md
+++ b/.changeset/quiet-lions-repeat.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix type errors in sidebar builders and dictionary term edit URL resolution, and run type checks in CI

--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -29,13 +29,13 @@ jobs:
           key: turbo-${{ runner.os }}-${{ github.sha }}
           restore-keys: |
             turbo-${{ runner.os }}-
-      - name: Check Core Types
-        run: pnpm run check
-        working-directory: packages/core
       - name: Test All Packages
         run: pnpm run test:ci
       - name: Build All Packages
         run: pnpm run build:bin
+      - name: Check Core Types
+        run: pnpm run check
+        working-directory: packages/core
       - name: Package SDK
         run: pnpm pack
         working-directory: packages/sdk

--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -29,6 +29,9 @@ jobs:
           key: turbo-${{ runner.os }}-${{ github.sha }}
           restore-keys: |
             turbo-${{ runner.os }}-
+      - name: Check Core Types
+        run: pnpm run check
+        working-directory: packages/core
       - name: Test All Packages
         run: pnpm run test:ci
       - name: Build All Packages

--- a/packages/core/eventcatalog/src/components/SchemaExplorer/__tests__/useDarkMode.spec.ts
+++ b/packages/core/eventcatalog/src/components/SchemaExplorer/__tests__/useDarkMode.spec.ts
@@ -49,7 +49,9 @@ describe('useDarkMode', () => {
     });
 
     expect(container.textContent).toBe('light');
-    const hydrationWarnings = consoleError.mock.calls.filter((call) => String(call[0]).match(/did not match|hydrat/i));
+    const hydrationWarnings = consoleError.mock.calls.filter((call: Parameters<typeof console.error>) =>
+      String(call[0]).match(/did not match|hydrat/i)
+    );
     expect(hydrationWarnings).toEqual([]);
   });
 

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/language/[dictionaryId]/_index.data.ts
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/language/[dictionaryId]/_index.data.ts
@@ -13,7 +13,7 @@ export const resolveUbiquitousLanguageTermEditUrl = ({
   collection,
   configEditUrl,
 }: {
-  term: Pick<DictionaryTerm, 'editUrl'>;
+  term: Pick<DictionaryTerm, 'id' | 'editUrl'>;
   collection: Pick<UbiquitousLanguage, 'filePath'> & { data: Pick<UbiquitousLanguage['data'], 'editUrl'> };
   configEditUrl?: string;
 }) =>

--- a/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/custom-sidebar.spec.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/__tests__/custom-sidebar.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { applyCustomSidebar, indexSidebarsByFolder, getSidebarForResource, parseResourceRef } from '../custom-sidebar';
-import type { SidebarSections, SidebarSpec } from '../custom-sidebar';
+import type { CustomSidebarResource, SidebarSections, SidebarSpec } from '../custom-sidebar';
 import type { NavNode } from '../builders/shared';
 
 vi.mock('@utils/url-builder', () => ({
@@ -272,7 +272,7 @@ describe('applyCustomSidebar', () => {
       ],
     } as any;
 
-    const pagesOf = (entries: string[], res = ownResource) =>
+    const pagesOf = (entries: string[], res: CustomSidebarResource = ownResource) =>
       (applyCustomSidebar(spec([{ title: 'X', pages: entries }]), sections, res, context)[0] as NavNode).pages;
 
     it("resolves this resource's own specification by filename", () => {

--- a/packages/core/eventcatalog/src/stores/sidebar-store/builders/domain.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/builders/domain.ts
@@ -327,7 +327,7 @@ export const buildDomainSections = (
                 `/docs/domains/${domain.data.id}/${domain.data.version}/graphql/${specification.filenameWithoutExtension}`
               ),
             })),
-          ],
+          ] as ChildRef[],
         }
       : null,
     systems: renderSystems

--- a/packages/core/eventcatalog/src/stores/sidebar-store/builders/service.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/builders/service.ts
@@ -195,7 +195,7 @@ export const buildServiceSections = (
               leftIcon: '/icons/graphql-black.svg',
               href: buildUrl(`${docsBasePath}/graphql/${specification.filenameWithoutExtension}`),
             })),
-          ],
+          ] as ChildRef[],
         }
       : null,
     'resource-groups': renderResourceGroups

--- a/packages/core/eventcatalog/src/stores/sidebar-store/state.ts
+++ b/packages/core/eventcatalog/src/stores/sidebar-store/state.ts
@@ -450,7 +450,7 @@ export const getNestedSideBarData = async (): Promise<NavigationData> => {
       }
       return acc;
     },
-    {} as Record<string, NavNode>
+    {} as Record<string, NavNode | string>
   );
 
   const domainNodes = domainsWithOwners.reduce(

--- a/packages/core/scripts/check-types.js
+++ b/packages/core/scripts/check-types.js
@@ -3,6 +3,7 @@
 // Run astro check with proper catalog directory setup
 import { join } from 'node:path';
 import { spawn } from 'node:child_process';
+import fs from 'node:fs';
 const __dirname = import.meta.dirname;
 
 const args = process.argv.slice(2);
@@ -70,6 +71,13 @@ const runWithFilteredOutput = async ({ command, cwd, env }) => {
     });
   });
 };
+
+// astro check needs the catalog's config/styles in the app directory. These are
+// generated at build time and absent on a clean checkout (both are gitignored),
+// so copy them across the same way scripts/ci/test.js does.
+for (const file of ['eventcatalog.config.js', 'eventcatalog.styles.css']) {
+  fs.copyFileSync(join(projectDIR, file), join(catalogDir, file));
+}
 
 await runWithFilteredOutput({
   command: `pnpm exec astro check --minimumSeverity error  --root ${catalogDir}`,


### PR DESCRIPTION
## What This PR Does

Fixes a handful of TypeScript errors in `@eventcatalog/core` that were not being caught because type checking never ran in CI. Adds a `Check Core Types` step to the `verify-build` workflow so these regressions are caught on every PR going forward. `pnpm run check` now reports 0 errors across 565 files.

## Changes Overview

### Key Changes

- **CI**: new `Check Core Types` step in `.github/workflows/verify-build.yml`, running `pnpm run check` in `packages/core`. It runs *after* `Build All Packages`, because the type check resolves `@eventcatalog/sdk` and `@eventcatalog/visualiser` from their built `dist` output.
- **`scripts/check-types.js`**: copies `eventcatalog.config.js` and `eventcatalog.styles.css` from the example catalog into the app directory before running `astro check`, mirroring `scripts/ci/test.js`. Both are gitignored build artifacts, so without this the check cannot load the Astro config on a clean checkout.
- **Sidebar builders** (`builders/domain.ts`, `builders/service.ts`): annotate the GraphQL specification child arrays as `ChildRef[]` so the mixed-shape array widens correctly instead of narrowing to the first element's type.
- **Sidebar state** (`state.ts`): the reducer accumulator is `Record<string, NavNode | string>`, matching the values actually written into it.
- **Ubiquitous language** (`_index.data.ts`): `resolveUbiquitousLanguageTermEditUrl` now takes `Pick<DictionaryTerm, 'id' | 'editUrl'>`, matching the shape the `index.astro` call site actually passes.
- **Tests**: type the `console.error` mock call parameter in `useDarkMode.spec.ts`, and the `res` parameter in `custom-sidebar.spec.ts` as `CustomSidebarResource`.

## How It Works

Most of these are annotation-only fixes with no runtime behaviour change. The two `as ChildRef[]` assertions address TypeScript inferring an overly narrow element type for arrays built from spread conditionals; widening to the declared union matches what the consuming code already expects. The `DictionaryTerm` pick widens the parameter type to match the object the caller supplies; the function body itself only reads `term.editUrl`, so behaviour is unchanged.

The CI step ordering matters: `astro check` needs both the generated catalog config and the workspace packages' `dist` output, neither of which exists on a fresh checkout. Making `check-types.js` generate the config itself also means `pnpm run check` now works locally from a clean clone, not just after a build.

## Breaking Changes

None.

## Additional Notes

- No editor-repo change needed — these are internal type annotations in core, with no change to public API or component contracts.
- Reviewers may want to consider whether the two `as ChildRef[]` assertions can be replaced with a properly typed builder helper as a follow-up; that felt out of scope for a type-fix PR.
- The first push of this branch failed CI exactly as described above (config not found on a clean runner); the second commit fixes it. Verified locally by deleting the generated config and re-running `pnpm run check` — 0 errors across 565 files.