### PR TITLE
Fix embedded architecture graphs not rendering and domain System Diagram 404s

### DIFF
--- a/.changeset/lucky-donuts-reply.md
+++ b/.changeset/lucky-donuts-reply.md
@@ -1,0 +1,8 @@
+---
+'@eventcatalog/core': patch
+---
+
+fix(core): embedded `<ArchitectureGraph/>` not rendering in static builds and 404s on domain System Diagram visualiser pages
+
+- The MDX `<ArchitectureGraph/>` placeholder and its island are now paired by document order instead of a render-time occurrence counter — Astro can invoke MDX component functions more than once per tag, which drifted the counter and left the island unable to find its portal div (the graph silently rendered nothing).
+- `/visualiser/domains/:id/:version/systems-context` pages were never generated because the guard looked systems up by their hydrated entry id — it now reads the hydrated system entries directly, matching the sidebar's guard.

--- a/packages/core/eventcatalog/src/components/MDX/ArchitectureGraph/ArchitectureGraph.astro
+++ b/packages/core/eventcatalog/src/components/MDX/ArchitectureGraph/ArchitectureGraph.astro
@@ -15,9 +15,9 @@ interface Props {
   showLegend?: boolean;
   /** Off by default — embedded graphs pin a lens rather than offer the picker */
   showLensPicker?: boolean;
-  // Override the DOM portal the graph mounts into. Defaults to
-  // `${id}-architecture-graph-portal` (or `catalog-architecture-graph-portal`).
-  portalId?: string;
+  // Position of this embed among the page's <ArchitectureGraph/> tags — pairs
+  // the island with its placeholder div by document order.
+  occurrenceIndex?: number;
   href?: {
     label: string;
     url: string;
@@ -32,7 +32,7 @@ const {
   showSearch = true,
   showLegend = true,
   showLensPicker = false,
-  portalId,
+  occurrenceIndex = 0,
   href,
 } = Astro.props;
 
@@ -47,7 +47,7 @@ const focusKey =
 
 <AstroArchitectureGraph
   client:only="react"
-  portalId={portalId ?? `${id ?? 'catalog'}-architecture-graph-portal`}
+  occurrenceIndex={occurrenceIndex}
   nodes={wire.nodes}
   links={wire.links}
   linkLabels={wire.linkLabels}

--- a/packages/core/eventcatalog/src/components/MDX/ArchitectureGraph/ArchitectureGraphPortal.tsx
+++ b/packages/core/eventcatalog/src/components/MDX/ArchitectureGraph/ArchitectureGraphPortal.tsx
@@ -1,17 +1,18 @@
-// The portal id pairs each scanner-rendered island with its MDX placeholder.
-// The occurrence index keeps multiple no-id embeds on one page from colliding
-// (the first occurrence keeps the unsuffixed id).
-export const architectureGraphPortalId = (id: string | undefined, occurrenceIndex: number) =>
-  `${id ?? 'catalog'}-architecture-graph-portal${occurrenceIndex > 0 ? `-${occurrenceIndex}` : ''}`;
+// Placeholders are matched to their islands positionally (nth placeholder in
+// document order ↔ nth <ArchitectureGraph/> tag in the host page's body scan).
+// The pairing must not rely on a render-time counter in the element id — Astro
+// can invoke MDX component functions more than once per tag (renderer probing),
+// which drifts such a counter out of sync with the body scan.
+export const ARCHITECTURE_GRAPH_PORTAL_SELECTOR = '[data-architecture-graph-portal]';
 
 // Empty placeholder rendered by the MDX component map. The real graph is
 // rendered by ArchitectureGraph.astro (which builds the data server-side) and
-// portals itself into this div by id — same pattern as NodeGraphPortal.
+// portals itself into this div — same pattern as NodeGraphPortal.
 const ArchitectureGraphPortal = (props: any) => {
   return (
     <div
       className="not-prose h-[30em] my-6 mb-12 w-full relative border! border-[rgb(var(--ec-page-border))]! rounded-md overflow-hidden"
-      id={architectureGraphPortalId(props.id, props.occurrenceIndex ?? 0)}
+      data-architecture-graph-portal={props.id ?? 'catalog'}
       style={{
         maxHeight: props.maxHeight ? `${props.maxHeight}em` : `30em`,
       }}

--- a/packages/core/eventcatalog/src/components/MDX/ArchitectureGraph/AstroArchitectureGraph.tsx
+++ b/packages/core/eventcatalog/src/components/MDX/ArchitectureGraph/AstroArchitectureGraph.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import CatalogForceGraph from '@components/CatalogGraph/CatalogForceGraph';
+import { ARCHITECTURE_GRAPH_PORTAL_SELECTOR } from '@components/MDX/ArchitectureGraph/ArchitectureGraphPortal';
 import type { CatalogGraphWireLink, CatalogGraphWireNode } from '@utils/node-graphs/catalog-force-graph';
 
 interface Props {
-  /** DOM id of the placeholder div ArchitectureGraphPortal rendered into the MDX content */
-  portalId: string;
+  /** Position of this island among the page's <ArchitectureGraph/> embeds — it
+   * mounts into the placeholder div at the same position in document order */
+  occurrenceIndex?: number;
   nodes: CatalogGraphWireNode[];
   links: CatalogGraphWireLink[];
   linkLabels: string[];
@@ -24,12 +26,13 @@ interface Props {
 // The island mounts outside the MDX content, finds the placeholder div the MDX
 // component map emitted, and portals the graph into it — same pattern as the
 // visualiser's NodeGraph.
-const AstroArchitectureGraph = ({ portalId, href, hrefLabel, ...graphProps }: Props) => {
+const AstroArchitectureGraph = ({ occurrenceIndex = 0, href, hrefLabel, ...graphProps }: Props) => {
   const [container, setContainer] = useState<HTMLElement | null>(null);
 
   useEffect(() => {
-    setContainer(document.getElementById(portalId));
-  }, [portalId]);
+    const portals = document.querySelectorAll<HTMLElement>(ARCHITECTURE_GRAPH_PORTAL_SELECTOR);
+    setContainer(portals[occurrenceIndex] ?? null);
+  }, [occurrenceIndex]);
 
   if (!container) return null;
 

--- a/packages/core/eventcatalog/src/components/MDX/components.tsx
+++ b/packages/core/eventcatalog/src/components/MDX/components.tsx
@@ -51,10 +51,6 @@ const getEntityMapCollection = (props: any, mdxProp: any) => {
 };
 
 const components = (props: any) => {
-  // Occurrence counter so multiple <ArchitectureGraph/> tags on one page each get
-  // their own portal — MDX renders in document order, matching the body scan order
-  // the host pages use to render the islands.
-  let architectureGraphOccurrence = 0;
   return {
     Attachments: (mdxProp: any) => jsx(Attachments, { ...props, ...mdxProp }),
     CustomProperties: (mdxProp: any) => jsx(CustomProperties, { ...props, ...mdxProp }),
@@ -74,14 +70,7 @@ const components = (props: any) => {
     ADRTable: (mdxProp: any) => jsx(ADRTable, { ...props, ...mdxProp }),
     EntityPropertiesTable: (mdxProp: any) => jsx(EntityPropertiesTable, { ...props, ...mdxProp }),
     NodeGraph: (mdxProp: any) => jsx(NodeGraphPortal, { ...props.data, ...mdxProp, props, mdxProp }),
-    ArchitectureGraph: (mdxProp: any) =>
-      jsx(ArchitectureGraphPortal, {
-        ...props.data,
-        ...mdxProp,
-        occurrenceIndex: architectureGraphOccurrence++,
-        props,
-        mdxProp,
-      }),
+    ArchitectureGraph: (mdxProp: any) => jsx(ArchitectureGraphPortal, { ...props.data, ...mdxProp, props, mdxProp }),
     ComponentDiagram: (mdxProp: any) => jsx(NodeGraphPortal, { ...props.data, ...mdxProp, props, mdxProp }),
     ContextDiagram: (mdxProp: any) => jsx(ContextDiagramPortal, { ...props.data, ...mdxProp, props, mdxProp }),
     SystemContextMap: (mdxProp: any) => jsx(SystemContextMapPortal, { ...mdxProp }),

--- a/packages/core/eventcatalog/src/enterprise/custom-documentation/pages/docs/custom/index.astro
+++ b/packages/core/eventcatalog/src/enterprise/custom-documentation/pages/docs/custom/index.astro
@@ -15,7 +15,6 @@ import { getAdjacentPages, getNavigationItems } from '@enterprise/custom-documen
 import CustomDocsNav from '@enterprise/custom-documentation/components/CustomDocsNav/CustomDocsNav.astro';
 import NodeGraph from '@components/MDX/NodeGraph/NodeGraph.astro';
 import ArchitectureGraph from '@components/MDX/ArchitectureGraph/ArchitectureGraph.astro';
-import { architectureGraphPortalId } from '@components/MDX/ArchitectureGraph/ArchitectureGraphPortal';
 import CopyAsMarkdown from '@components/CopyAsMarkdown';
 
 import {
@@ -202,7 +201,7 @@ const editUrl =
                   showSearch={graph.search}
                   showLegend={graph.legend}
                   showLensPicker={graph.lensPicker}
-                  portalId={architectureGraphPortalId(graph.id ?? (doc as any).id, occurrenceIndex)}
+                  occurrenceIndex={occurrenceIndex}
                   href={
                     isArchitectureGraphEnabled()
                       ? {

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/index.astro
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/index.astro
@@ -11,7 +11,6 @@ import Footer from '@layouts/Footer.astro';
 import components from '@components/MDX/components';
 import NodeGraph from '@components/MDX/NodeGraph/NodeGraph.astro';
 import ArchitectureGraph from '@components/MDX/ArchitectureGraph/ArchitectureGraph.astro';
-import { architectureGraphPortalId } from '@components/MDX/ArchitectureGraph/ArchitectureGraphPortal';
 import SchemaViewer from '@components/MDX/SchemaViewer/SchemaViewerRoot.astro';
 import Admonition from '@components/MDX/Admonition';
 import VersionList from '@components/Lists/VersionList.astro';
@@ -681,7 +680,7 @@ if (!isAdrPage && !hasCurrentFlowEmbed && !hasCurrentPageNodeGraph) {
                   showSearch={graph.search}
                   showLegend={graph.legend}
                   showLensPicker={graph.lensPicker}
-                  portalId={architectureGraphPortalId(graph.id, occurrenceIndex)}
+                  occurrenceIndex={occurrenceIndex}
                   href={
                     isArchitectureGraphEnabled()
                       ? {

--- a/packages/core/eventcatalog/src/pages/index.astro
+++ b/packages/core/eventcatalog/src/pages/index.astro
@@ -1,7 +1,6 @@
 ---
 import VerticalSideBarLayout from '@layouts/VerticalSideBarLayout.astro';
 import { getMDXComponentsByName, parseMdxBooleanProp } from '@utils/markdown';
-import { architectureGraphPortalId } from '@components/MDX/ArchitectureGraph/ArchitectureGraphPortal';
 import { resourceToCollectionMap } from '@utils/collections/util';
 import { buildUrl } from '@utils/url-builder';
 import { isCustomLandingPageEnabled, isVisualiserEnabled, isArchitectureGraphEnabled } from '@utils/feature';
@@ -125,7 +124,7 @@ if (config.landingPage) {
               showSearch={parseMdxBooleanProp(graph.search, true)}
               showLegend={parseMdxBooleanProp(graph.legend, true)}
               showLensPicker={parseMdxBooleanProp(graph.lensPicker, false)}
-              portalId={architectureGraphPortalId(graph.id, occurrenceIndex)}
+              occurrenceIndex={occurrenceIndex}
               href={
                 isArchitectureGraphEnabled()
                   ? {

--- a/packages/core/eventcatalog/src/pages/visualiser/domains/[id]/[version]/systems-context/_index.data.ts
+++ b/packages/core/eventcatalog/src/pages/visualiser/domains/[id]/[version]/systems-context/_index.data.ts
@@ -1,26 +1,21 @@
 import { HybridPage } from '@utils/page-loaders/hybrid-page';
 import { isAuthEnabled, isVisualiserEnabled } from '@utils/feature';
 import { getDomains } from '@utils/collections/domains';
-import { getSystems } from '@utils/collections/systems';
 
 /**
  * A domain gets a System Diagram when it has systems and at least one of those
  * systems takes part in a context graph — i.e. it declares relationships or actors. A
  * domain whose systems have neither has nothing to show, so we don't generate a page.
+ * `getDomains` hydrates `data.systems` into full system entries, so read each
+ * system's data directly — this must stay in sync with the sidebar's
+ * `hasSystemContext` guard so we never link to a page that wasn't generated.
  */
-const domainHasSystemContext = (
-  domain: Awaited<ReturnType<typeof getDomains>>[number],
-  systemMap: Map<string, { data: { relationships?: unknown[]; actors?: unknown[] } }>
-) => {
-  const systemRefs = (domain.data.systems || []) as { id: string }[];
-  if (systemRefs.length === 0) return false;
+const domainHasSystemContext = (domain: Awaited<ReturnType<typeof getDomains>>[number]) => {
+  const systems = (domain.data.systems || []) as any[];
 
-  return systemRefs.some((ref) => {
-    const system = systemMap.get(ref.id);
-    if (!system) return false;
-    const relationships = (system.data.relationships || []) as unknown[];
-    const actors = (system.data.actors || []) as unknown[];
-    return relationships.length > 0 || actors.length > 0;
+  return systems.some((system) => {
+    const data = system?.data ?? system;
+    return ((data?.relationships as unknown[]) || []).length > 0 || ((data?.actors as unknown[]) || []).length > 0;
   });
 };
 
@@ -30,11 +25,10 @@ export class Page extends HybridPage {
       return [];
     }
 
-    const [domains, systems] = await Promise.all([getDomains({ getAllVersions: false }), getSystems()]);
-    const systemMap = new Map(systems.map((system) => [system.data.id, system]));
+    const domains = await getDomains({ getAllVersions: false });
 
     return domains
-      .filter((domain) => domainHasSystemContext(domain, systemMap))
+      .filter((domain) => domainHasSystemContext(domain))
       .map((domain) => ({
         params: {
           id: domain.data.id,


### PR DESCRIPTION

## What This PR Does

Fixes two bugs visible on the demo site (and any static build):

1. `<ArchitectureGraph/>` embeds (docs pages, custom landing page, custom docs) render nothing — silently, with no console errors.
2. `/visualiser/domains/:id/:version/systems-context` returns 404 for every domain, while the sidebar still links to it ("System Diagram").

## Changes Overview

### Key Changes

- Pair the MDX `<ArchitectureGraph/>` placeholder with its island **by document order** instead of an element id built from a render-time occurrence counter
- `ArchitectureGraphPortal` now emits a `data-architecture-graph-portal` attribute (no id, no counter); `AstroArchitectureGraph` mounts into the nth matching div using the `occurrenceIndex` host pages already derive from scanning the raw body
- Remove the `architectureGraphPortalId` helper and the counter in the MDX component map; host pages pass `occurrenceIndex` instead of `portalId`
- Fix `domainHasSystemContext` in the systems-context page loader to read the hydrated system entries on `domain.data.systems` directly, instead of looking systems up in a map by an id that never matches
- Add a patch changeset for `@eventcatalog/core`

## How It Works

**Bug 1:** the MDX component map incremented an occurrence counter as a side effect of the component function being invoked, and used it as a suffix on the placeholder div's id. Astro invokes MDX component functions more than once per tag during renderer probing (`check()` passes before the real render), so the counter drifted: with a single `<ArchitectureGraph />` tag the emitted div was `payments-architecture-graph-portal-2` (or `-4` on the homepage) while the island looked for `payments-architecture-graph-portal`. `getElementById` missed and the island returned `null` — hence no graph and no errors. Only the final render's HTML survives, so document order of the placeholder divs always matches the body-scan order of the tags — positional pairing is immune to the extra invocations.

**Bug 2:** `getDomains()` hydrates `domain.data.systems` into full collection entries, so the old guard's `ref.id` was the Astro entry id (`product-catalog-system-1.0.0`) which never matched a map keyed by `system.data.id` (`product-catalog-system`). Every domain failed the check, `getStaticPaths` returned no paths, and every System Diagram page 404'd. The sidebar builder does the equivalent check correctly against the hydrated entries, which is why it still rendered links to the missing pages. The guard now mirrors the sidebar's check (with a raw-ref fallback).

## Breaking Changes

None. The placeholder div no longer carries an `id` attribute — the id was internal pairing plumbing, not documented API.

## Additional Notes

- Verified against the live demo HTML: the mismatched ids (`…-portal-2` div vs `…-portal` island prop) are present on both the landing page and docs pages, and all three domains' systems-context URLs 404 while per-system context pages work.
- The graph is `client:only`, so built HTML still shows an empty portal div — verification is in the browser.
- No editor-repo change needed; both are core rendering/routing bugs.

https://claude.ai/code/session_01TKqF7S2xUYdkYFq8P3gyMg