### PR TITLE
Ignore MDX components inside code fences when scanning the page body

### DIFF
--- a/.changeset/witty-badgers-scan.md
+++ b/.changeset/witty-badgers-scan.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/core': patch
+---
+
+fix(core): ignore MDX components inside fenced code blocks and inline code when scanning the page body — example snippets no longer produce phantom graph islands that shift the placeholder pairing

--- a/packages/core/eventcatalog/src/utils/__tests__/markdown.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/markdown.spec.ts
@@ -11,6 +11,21 @@ describe('markdown', () => {
       const components = getMDXComponentsByName(markdown, 'SchemaViewer');
       expect(components).toEqual([{ id: 'test' }, { id: 'test2' }, {}]);
     });
+
+    it('ignores components inside fenced code blocks and inline code', () => {
+      const markdown = [
+        '<ArchitectureGraph id="real" />',
+        '```mdx',
+        '<ArchitectureGraph id="example" />',
+        '```',
+        '~~~',
+        '<ArchitectureGraph id="tilde-example" />',
+        '~~~',
+        'Use `<ArchitectureGraph id="inline" />` to embed the graph.',
+      ].join('\n');
+      const components = getMDXComponentsByName(markdown, 'ArchitectureGraph');
+      expect(components).toEqual([{ id: 'real' }]);
+    });
   });
 
   describe('parseMdxBooleanProp', () => {

--- a/packages/core/eventcatalog/src/utils/markdown.ts
+++ b/packages/core/eventcatalog/src/utils/markdown.ts
@@ -2,11 +2,19 @@
 // rarely used, but useful for components that need to know how many times
 // the user wants to render a component in a markdown file
 export const getMDXComponentsByName = (document: string, componentName: string) => {
+  // Fenced code blocks and inline code are documentation, not rendered
+  // components — strip them so example snippets don't count as occurrences
+  // (hosts pair islands with rendered placeholders by occurrence).
+  const renderedContent = document
+    .replace(/```[\s\S]*?```/g, '')
+    .replace(/~~~[\s\S]*?~~~/g, '')
+    .replace(/`[^`\n]*`/g, '');
+
   // Define regex pattern to match self-closing MDX components with or without props.
   const pattern = new RegExp(`<${componentName}(\\s+[^>]*)?\\s*\\/>`, 'g');
 
   // Find all matches of the pattern
-  const matches = [...document.matchAll(pattern)];
+  const matches = [...renderedContent.matchAll(pattern)];
 
   // Extract the properties of each SchemaViewer
   const components = matches.map((match) => {


### PR DESCRIPTION

Follow-up to #2839 (this commit was pushed to that PR's branch, but a GitHub sync failure dropped it from the merge — the branch had it, the PR never registered it).

## What This PR Does

Hardens the `<ArchitectureGraph/>` placeholder/island pairing shipped in #2839, addressing the Codex review comment on that PR: `getMDXComponentsByName` scanned the raw body with a regex, so an example snippet inside a fenced code block (or inline code) counted as a real component occurrence. With the positional pairing from #2839, such a phantom occurrence would render an extra island and shift the pairing, mounting a graph with the wrong config into a later placeholder.

## Changes Overview

### Key Changes

- `getMDXComponentsByName` strips fenced code blocks (``` ``` ``` and `~~~`) and inline code spans before scanning
- Benefits every scan consumer (`ArchitectureGraph`, `NodeGraph`, `SystemContextMap`, `ContextDiagram`, `SchemaViewer`)
- Adds a unit test covering both fence styles and inline code
- Adds a patch changeset for `@eventcatalog/core`

## How It Works

Documentation examples are not rendered components — MDX doesn't execute JSX inside code fences — so the scan now removes those regions first and only counts occurrences that actually render. MDX has no indented code blocks, so fence and inline-code stripping covers the code cases.

## Breaking Changes

None.

## Additional Notes

The `<Visibility>`-hidden-embed case discussed on the #2839 review thread remains a known limitation of scan-based pairing (pre-existing, shared by the old id-counter approach); a DOM-driven design is a possible follow-up if that becomes a real usage pattern.

https://claude.ai/code/session_01TKqF7S2xUYdkYFq8P3gyMg