### PR TITLE
Pin issuer on GitHub auth provider for RFC 9207 iss validation

### DIFF
--- a/.changeset/github-auth-issuer.md
+++ b/.changeset/github-auth-issuer.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/core': patch
+---
+
+fix(auth): pin issuer on the GitHub auth provider so RFC 9207 `iss` validation no longer fails with `unexpected "iss" (issuer) response parameter value` when an older @auth/core copy is hoisted in user projects

--- a/packages/core/eventcatalog/auth.config.ts
+++ b/packages/core/eventcatalog/auth.config.ts
@@ -22,8 +22,13 @@ const getAuthProviders = async () => {
     // GitHub provider
     if (authConfig.providers?.github) {
       const githubConfig = authConfig.providers.github;
+      // GitHub sends an RFC 9207 `iss` parameter on OAuth callbacks. Pin the issuer so
+      // validation works even when the resolved @auth/core copy predates the upstream
+      // default (auth-astro's peer range can hoist an older @auth/core in user projects).
+      const githubBaseUrl = githubConfig?.enterprise?.baseUrl ?? 'https://github.com';
       providers.push(
         GitHub({
+          issuer: `${githubBaseUrl}/login/oauth`,
           ...githubConfig,
         })
       );


### PR DESCRIPTION
## What This PR Does

Fixes GitHub sign-in failing with `/auth/error?error=Configuration` after GitHub enabled RFC 9207. OAuth callbacks from GitHub now include an `iss=https://github.com/login/oauth` parameter, which `oauth4webapi` validates against the provider's configured issuer. When no issuer is set, Auth.js falls back to the `https://authjs.dev` placeholder and throws:

```
[auth][cause] OperationProcessingError: unexpected "iss" (issuer) response parameter value
[auth][details] { "expected": "https://authjs.dev", "provider": "github" }
```

## Changes Overview

### Key Changes
- `packages/core/eventcatalog/auth.config.ts`: the bundled GitHub provider now sets `issuer` by default — `https://github.com/login/oauth`, or `${enterprise.baseUrl}/login/oauth` for GitHub Enterprise Server. User config is spread after the default, so an explicit `issuer` in `eventcatalog.auth.js` still wins.
- Adds a patch changeset.

## How It Works

Auth.js fixed this upstream in `@auth/core@0.41.2` (the GitHub provider now defaults its issuer), and core depends on `^0.41.3` — but that fix often never reaches users. `auth-astro@4.2.0` (latest) declares a stale peer dependency of `@auth/core@^0.37.3`, so npm hoists `@auth/core@0.37.4` to the root of user projects and nests `0.41.3` under `@eventcatalog/core`. Since `eventcatalog dev` symlinks `.eventcatalog-core/node_modules` to the user's root `node_modules`, `auth.config.ts` resolves the old `0.37.4` provider with no issuer default.

Pinning the issuer in our own provider config makes the behavior correct regardless of which `@auth/core` copy hoisting resolves.

## Breaking Changes

None. Users who already worked around this by setting `issuer` manually keep working — their value overrides the default.

## Additional Notes

- Docs updated separately in `website-2` (`docs/development/authentication/providers/03-setting-up-github.md`): troubleshooting entry for the error plus a note that the issuer is set automatically from 4.10.3.
- Longer term we could chase the stale `auth-astro` peer range upstream, but this fix is independent of that.