### PR TITLE
Interactive diagram controls with fullscreen modal

### DIFF
--- a/.changeset/mermaid-diagram-controls.md
+++ b/.changeset/mermaid-diagram-controls.md
@@ -2,4 +2,4 @@
 '@eventcatalog/core': patch
 ---
 
-feat(core): redesigned mermaid and PlantUML diagram controls. Diagrams now have Mintlify-style pan/zoom/reset controls with smooth transitions, a fullscreen modal viewer (drag, scroll and pinch to zoom, keyboard shortcuts) and `placement` / `actions` options for code blocks and `<MermaidFileLoader />`
+feat(core): redesigned mermaid and PlantUML diagram controls. Diagrams now have hover-revealed pan/zoom/reset controls with smooth transitions, a fullscreen modal viewer (drag, scroll and pinch to zoom, keyboard shortcuts) and `placement` / `actions` options for code blocks and `<MermaidFileLoader />`

--- a/.changeset/mermaid-diagram-controls.md
+++ b/.changeset/mermaid-diagram-controls.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/core': patch
+---
+
+feat(core): redesigned mermaid and PlantUML diagram controls. Diagrams now have Mintlify-style pan/zoom/reset controls with smooth transitions, a fullscreen modal viewer (drag, scroll and pinch to zoom, keyboard shortcuts) and `placement` / `actions` options for code blocks and `<MermaidFileLoader />`

--- a/examples/default/domains/Catalog/index.mdx
+++ b/examples/default/domains/Catalog/index.mdx
@@ -54,6 +54,43 @@ The **Catalog** domain is responsible for the lifecycle of every product Acme In
 
 The **Product Catalog System** is the authoritative source of product data. Whenever a product is created, updated or deleted it publishes a domain event. The **Search System** subscribes to those events, keeps its search index in sync, and exposes a search API so other teams never have to query the catalog database directly.
 
+## Value Chain
+
+A Wardley map of the Catalog domain. Product search is where we differentiate, so it sits closest to the shopper and furthest from commodity. The data stores and compute underneath are bought, not built.
+
+```mermaid
+wardley-beta
+title Catalog value chain
+
+anchor Shopper [0.96, 0.66]
+anchor Merchant [0.96, 0.34]
+component Product Search [0.84, 0.60]
+component Product Catalog [0.76, 0.42]
+component Search Index [0.60, 0.58]
+component Product Data Model [0.60, 0.30]
+component Event Bus [0.44, 0.74]
+component Search Engine [0.34, 0.78]
+component Catalog Database [0.24, 0.86]
+component Cloud Compute [0.10, 0.94]
+
+Shopper -> Product Search
+Merchant -> Product Catalog
+Product Search -> Search Index
+Product Catalog -> Product Data Model
+Product Catalog -> Event Bus
+Search Index -> Event Bus
+Search Index -> Search Engine
+Product Catalog -> Catalog Database
+Search Engine -> Cloud Compute
+Catalog Database -> Cloud Compute
+
+evolve Search Engine 0.90
+evolve Product Data Model 0.48
+
+note "Search relevance is our differentiator, keep it custom" [0.90, 0.40]
+note "Move self hosted search to a managed service" [0.28, 0.52]
+```
+
 ## Architecture Graph
 
 Where Catalog sits in the wider architecture — its systems and messages, and the neighbouring domains it talks to.

--- a/examples/default/domains/Fulfilment/index.mdx
+++ b/examples/default/domains/Fulfilment/index.mdx
@@ -70,14 +70,42 @@ The **Fulfilment** domain is responsible for the physical side of an order — m
 
 When an order is completed, the **Warehouse System** picks and packs it, having relied on the **Inventory System** to reserve stock earlier in checkout. Once packed, the **Shipping System** creates a shipment with an external **Carrier**, which delivers it to the customer and reports progress back.
 
+## Value Chain
+
+A Wardley map of the Fulfilment domain. Delivery is the promise customers see, carriers are a commodity we rent, and warehouse automation is the most novel part of the chain.
+
+```mermaid
+wardley-beta
+title Fulfilment value chain
+
+anchor Customer [0.96, 0.62]
+component Delivery Promise [0.86, 0.50]
+component Stock Reservation [0.72, 0.46]
+component Pick and Pack [0.64, 0.34]
+component Shipment Booking [0.56, 0.60]
+component Warehouse Automation [0.36, 0.22]
+component Carrier Network [0.40, 0.88]
+component Inventory Database [0.26, 0.86]
+component Cloud Compute [0.10, 0.94]
+
+Customer -> Delivery Promise
+Delivery Promise -> Stock Reservation
+Delivery Promise -> Shipment Booking
+Stock Reservation -> Inventory Database
+Shipment Booking -> Pick and Pack
+Shipment Booking -> Carrier Network
+Pick and Pack -> Warehouse Automation
+Inventory Database -> Cloud Compute
+
+evolve Warehouse Automation 0.52
+evolve Shipment Booking 0.82
+
+note "Robotic picking pilot in the main warehouse" [0.30, 0.06]
+note "Consolidate carriers behind a multi carrier aggregator" [0.50, 0.70]
+```
+
 ## System Diagram
 
 The systems in this domain, how they relate, and the people who interact with them.
 
 <ContextDiagram />
-
-## Resource Diagram
-
-The components that make up this domain.
-
-<NodeGraph />

--- a/examples/default/domains/Ordering/index.mdx
+++ b/examples/default/domains/Ordering/index.mdx
@@ -57,6 +57,41 @@ The **Ordering** domain is responsible for everything that happens once a custom
 
 When the [[domain|shopping]] domain checks out a cart, the **Checkout System** takes over. It orchestrates the steps needed to place an order — reserving inventory, authorizing payment, and finally asking the **Order Management System** to create the order. The Order Management System then owns that order for the rest of its life, publishing events as it is created, completed or cancelled.
 
+## Value Chain
+
+A Wardley map of the Ordering domain. Placing an order is the most visible need in the business, the checkout orchestration behind it is custom, and the workflow tooling it runs on is evolving towards a product.
+
+```mermaid
+wardley-beta
+title Ordering value chain
+
+anchor Customer [0.96, 0.56]
+component Place Order [0.88, 0.52]
+component Checkout Orchestration [0.76, 0.40]
+component Order Management [0.66, 0.52]
+component Inventory Reservation [0.54, 0.50]
+component Payment Authorization [0.54, 0.64]
+component Workflow Engine [0.38, 0.46]
+component Event Bus [0.40, 0.76]
+component Order Database [0.24, 0.86]
+component Cloud Compute [0.10, 0.94]
+
+Customer -> Place Order
+Place Order -> Checkout Orchestration
+Checkout Orchestration -> Inventory Reservation
+Checkout Orchestration -> Payment Authorization
+Checkout Orchestration -> Order Management
+Checkout Orchestration -> Workflow Engine
+Order Management -> Event Bus
+Order Management -> Order Database
+Workflow Engine -> Cloud Compute
+Order Database -> Cloud Compute
+
+evolve Workflow Engine 0.74
+
+note "Replace bespoke saga code with a managed workflow engine" [0.32, 0.24]
+```
+
 ## System Diagram
 
 The systems in this domain, how they relate, and the people who interact with them.

--- a/examples/default/domains/Payments/index.mdx
+++ b/examples/default/domains/Payments/index.mdx
@@ -68,6 +68,42 @@ The **Payments** domain is responsible for moving money. It authorizes and captu
 
 The **Payment Processing System** is the internal orchestrator. When the Ordering domain authorizes a payment, it requests payment via the external **Stripe** system and, in parallel, asks **Fraud Detection** to screen the payment. Stripe reports back whether the payment succeeded or failed, and the Payment Processing System records the outcome.
 
+## Value Chain
+
+A Wardley map of the Payments domain. Card processing and fraud screening are commodities we buy from providers, so the value we add is in orchestration, refunds and the compliance posture around them.
+
+```mermaid
+wardley-beta
+title Payments value chain
+
+anchor Shopper [0.96, 0.60]
+anchor Finance Team [0.96, 0.30]
+component Pay for Order [0.86, 0.58]
+component Refund Order [0.80, 0.34]
+component Payment Orchestration [0.70, 0.44]
+component Fraud Screening [0.56, 0.64]
+component Card Processing [0.46, 0.86]
+component PCI Compliance [0.38, 0.72]
+component Payment Ledger [0.26, 0.60]
+component Cloud Compute [0.10, 0.94]
+
+Shopper -> Pay for Order
+Finance Team -> Refund Order
+Pay for Order -> Payment Orchestration
+Refund Order -> Payment Orchestration
+Payment Orchestration -> Fraud Screening
+Payment Orchestration -> Card Processing
+Payment Orchestration -> Payment Ledger
+Card Processing -> PCI Compliance
+Payment Ledger -> Cloud Compute
+
+evolve Fraud Screening 0.82
+evolve Payment Ledger 0.80
+
+note "In house rules engine is being replaced by a managed fraud provider" [0.62, 0.30]
+note "Ledger moving to a hosted double entry service" [0.20, 0.36]
+```
+
 ## System Diagram
 
 The systems in this domain, how they relate, and the people who interact with them.

--- a/examples/default/domains/Shopping/index.mdx
+++ b/examples/default/domains/Shopping/index.mdx
@@ -59,9 +59,3 @@ The **Cart System** owns the customer's cart and the checkout flow. When pricing
 The systems in this domain, how they relate, and the people who interact with them.
 
 <ContextDiagram />
-
-## Resource Diagram
-
-The components that make up this domain.
-
-<NodeGraph />

--- a/packages/core/eventcatalog/src/components/MDX/MermaidFileLoader/MermaidFileLoader.astro
+++ b/packages/core/eventcatalog/src/components/MDX/MermaidFileLoader/MermaidFileLoader.astro
@@ -3,7 +3,9 @@ import fs from 'fs';
 import { getAbsoluteFilePathForAstroFile } from '@utils/files';
 import Admonition from '@components/MDX/Admonition';
 
-const { file: mermaidFile, filePath } = Astro.props;
+// `placement` and `actions` configure the interactive controls, e.g.
+// <MermaidFileLoader file="diagram.mmd" placement="top-left" actions={false} />
+const { file: mermaidFile, filePath, placement, actions } = Astro.props;
 
 // const escapeHtml = (str: string) => str.replace(/[&<>"']/g, (c) => escapeMap[c]);
 let isValidMermaidFile = mermaidFile.endsWith('.mmd') || mermaidFile.endsWith('.mermaid');
@@ -48,8 +50,13 @@ if (isValidMermaidFile) {
 {
   mermaidFileContent && isValidMermaidFile && (
     <div class="mermaid-block pb-4">
-      <div class="mermaid border border-gray-200 rounded-lg p-1" data-content={mermaidFileContent}>
-        <p>Loading graph...</p>
+      <div
+        class="mermaid border border-[rgb(var(--ec-page-border))] rounded-lg p-1"
+        data-content={mermaidFileContent}
+        data-placement={placement}
+        data-actions={actions !== undefined ? String(actions) : undefined}
+      >
+        <p class="text-[rgb(var(--ec-page-text-muted))]">Loading graph...</p>
       </div>
     </div>
   )

--- a/packages/core/eventcatalog/src/pages/diagrams/[id]/[version]/embed.astro
+++ b/packages/core/eventcatalog/src/pages/diagrams/[id]/[version]/embed.astro
@@ -73,16 +73,6 @@ const diagramId = props.data.id;
         display: block;
       }
 
-      /* Zoom controls styling - must stay as CSS since svg-pan-zoom injects them */
-      .svg-pan-zoom-control {
-        fill: rgb(var(--ec-page-text-muted)) !important;
-        cursor: pointer;
-      }
-
-      .svg-pan-zoom-control:hover {
-        fill: rgb(var(--ec-page-text)) !important;
-      }
-
       /* Prose styles */
       .prose {
         max-width: none;
@@ -216,351 +206,702 @@ const diagramId = props.data.id;
       // Store zoom instances for cleanup
       const zoomInstances = new Map();
 
-      function createZoomControls(onZoomIn, onZoomOut, onFitView) {
-        // Detect dark mode
-        const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+      // ---------------------------------------------------------------------------
+      // Diagram pan/zoom, controls and fullscreen modal
+      // (kept in sync with eventcatalog/src/utils/mermaid-zoom.ts)
+      // ---------------------------------------------------------------------------
+      const CONTROLS_PLACEMENTS = ['top-left', 'top-right', 'bottom-left', 'bottom-right'];
+      const DEFAULT_PLACEMENT = 'top-right';
+      const CONTROLS_MIN_HEIGHT = 120;
+      const PAN_STEP = 60;
+      const ZOOM_STEP = 1.2;
+      const TRANSITION_MS = 150;
+      const FIT_PADDING = 16;
+      const STYLE_ID = 'ec-diagram-styles';
+      let closeOpenModal = null;
 
-        // Use explicit colors based on theme
-        const bgColor = isDark ? '#161b22' : '#ffffff';
-        const borderColor = isDark ? '#30363d' : '#e2e8f0';
-        const iconColor = isDark ? '#8b949e' : '#64748b';
-        const iconHoverColor = isDark ? '#f0f6fc' : '#0f172a';
-        const hoverBgColor = isDark ? '#21262d' : '#f1f5f9';
+      const DIAGRAM_STYLES = `
+.mermaid-zoom-container {
+  position: relative;
+  width: 100%;
+  overflow: hidden;
+}
+.ec-diagram-viewport {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  cursor: grab;
+  touch-action: pan-y pinch-zoom;
+  user-select: none;
+  -webkit-user-select: none;
+  outline: none;
+}
+.ec-diagram-viewport.is-panning {
+  cursor: grabbing;
+}
+.ec-diagram-viewport--modal {
+  touch-action: none;
+  background-image: radial-gradient(rgb(var(--ec-page-text, 15 23 42) / 0.08) 1px, transparent 1px);
+  background-size: 16px 16px;
+}
+.ec-diagram-content {
+  position: absolute;
+  left: 0;
+  top: 0;
+  transform-origin: 0 0;
+  transition: transform ${TRANSITION_MS}ms ease-out;
+  will-change: transform;
+}
+/* Element selectors bump specificity above the page's global ".mermaid svg" rules */
+div.ec-diagram-content > svg {
+  display: block;
+  margin: 0;
+  max-width: none !important;
+}
+.ec-diagram-btn {
+  all: unset;
+  box-sizing: border-box;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  cursor: pointer;
+  background: rgb(var(--ec-card-bg, 255 255 255));
+  color: rgb(var(--ec-page-text, 15 23 42));
+  border: 1px solid rgb(var(--ec-page-border, 226 232 240));
+  transition: background-color 0.15s, transform 0.1s;
+}
+.ec-diagram-btn:hover {
+  background: rgb(var(--ec-content-hover, 241 245 249));
+}
+.ec-diagram-btn:active {
+  transform: scale(0.95);
+}
+.ec-diagram-btn:focus-visible {
+  outline: 2px solid rgb(var(--ec-accent, 59 130 246));
+  outline-offset: 1px;
+}
+button.ec-diagram-btn svg {
+  display: block;
+  width: 16px;
+  height: 16px;
+  margin: 0;
+  flex-shrink: 0;
+}
+.ec-diagram-btn.ec-diagram-btn--success {
+  color: #10b981;
+}
+.ec-diagram-controls {
+  position: absolute;
+  z-index: 10;
+  display: grid;
+  grid-template-columns: repeat(3, 28px);
+  gap: 4px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease;
+}
+.ec-diagram-controls[data-placement="top-left"] { top: 8px; left: 8px; }
+.ec-diagram-controls[data-placement="top-right"] { top: 8px; right: 8px; }
+.ec-diagram-controls[data-placement="bottom-left"] { bottom: 8px; left: 8px; }
+.ec-diagram-controls[data-placement="bottom-right"] { bottom: 8px; right: 8px; }
+.mermaid-zoom-container:hover .ec-diagram-controls,
+.mermaid-zoom-container:focus-within .ec-diagram-controls {
+  opacity: 1;
+  pointer-events: auto;
+}
+@media (pointer: coarse) {
+  .ec-diagram-controls { opacity: 1; pointer-events: auto; }
+}
+@media print {
+  .ec-diagram-controls { display: none; }
+}
+.ec-diagram-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 9998;
+  background: rgb(0 0 0 / 0.4);
+  opacity: 0;
+  transition: opacity 250ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+.ec-diagram-modal-backdrop.is-open {
+  opacity: 1;
+}
+.ec-diagram-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  padding: 16px;
+}
+@media (min-width: 640px) {
+  .ec-diagram-modal { padding: 24px; }
+}
+.ec-diagram-modal__dialog {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  border-radius: 16px;
+  background: rgb(var(--ec-page-bg, 255 255 255));
+  box-shadow:
+    0 0 0 1px rgb(var(--ec-page-border, 226 232 240)),
+    0 25px 50px -12px rgb(0 0 0 / 0.25);
+  transform: scale(0.96);
+  opacity: 0;
+  transition:
+    transform 250ms cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 250ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+.ec-diagram-modal.is-open .ec-diagram-modal__dialog {
+  transform: none;
+  opacity: 1;
+}
+.ec-diagram-modal.is-closing .ec-diagram-modal__dialog,
+.ec-diagram-modal-backdrop.is-closing {
+  transition-duration: 150ms;
+}
+.ec-diagram-modal__toolbar {
+  position: absolute;
+  left: 12px;
+  top: 12px;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.ec-diagram-modal__zoom {
+  box-sizing: border-box;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 28px;
+  min-width: 56px;
+  padding: 0 6px;
+  border-radius: 6px;
+  border: 1px solid rgb(var(--ec-page-border, 226 232 240));
+  background: rgb(var(--ec-card-bg, 255 255 255));
+  color: rgb(var(--ec-page-text, 15 23 42));
+  font-family: inherit;
+  font-size: 12px;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+.ec-diagram-modal__close {
+  position: absolute;
+  right: 12px;
+  top: 12px;
+  z-index: 10;
+}
+@media (prefers-reduced-motion: reduce) {
+  .ec-diagram-content,
+  .ec-diagram-controls,
+  .ec-diagram-modal-backdrop,
+  .ec-diagram-modal__dialog {
+    transition: none;
+  }
+}
+`;
 
-        const controls = document.createElement('div');
-        controls.className = 'mermaid-zoom-controls';
-        controls.style.cssText = `
-          position: absolute;
-          bottom: 12px;
-          left: 12px;
-          display: flex;
-          flex-direction: column;
-          background: ${bgColor};
-          border-radius: 6px;
-          box-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
-          border: 1px solid ${borderColor};
-          overflow: hidden;
-          z-index: 10;
-        `;
+      function ensureDiagramStyles() {
+        if (document.getElementById(STYLE_ID)) return;
+        const style = document.createElement('style');
+        style.id = STYLE_ID;
+        style.textContent = DIAGRAM_STYLES;
+        document.head.appendChild(style);
+      }
 
-        const createButton = (svg, title, onClick, isLast = false) => {
-          const btn = document.createElement('button');
-          btn.type = 'button';
-          btn.title = title;
-          btn.innerHTML = svg;
-          btn.onclick = onClick;
-          btn.style.cssText = `
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            width: 26px;
-            height: 26px;
-            padding: 0;
-            margin: 0;
-            border: none;
-            background: ${bgColor};
-            color: ${iconColor};
-            cursor: pointer;
-            transition: background-color 0.15s, color 0.15s;
-            line-height: 1;
-            ${!isLast ? `border-bottom: 1px solid ${borderColor};` : ''}
-          `;
-          // Ensure SVG is properly centered
-          const svgEl = btn.querySelector('svg');
-          if (svgEl) {
-            svgEl.style.display = 'block';
-          }
-          btn.onmouseenter = () => {
-            btn.style.backgroundColor = hoverBgColor;
-            btn.style.color = iconHoverColor;
-          };
-          btn.onmouseleave = () => {
-            btn.style.backgroundColor = bgColor;
-            btn.style.color = iconColor;
-          };
-          return btn;
+      const icon = (paths, strokeWidth = 2) =>
+        `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="${strokeWidth}" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${paths}</svg>`;
+
+      const ICONS = {
+        fullscreen: icon('<path d="M15 3h6v6"/><path d="M9 21H3v-6"/><path d="M21 3l-7 7"/><path d="M3 21l7-7"/>'),
+        close: icon('<path d="M18 6 6 18"/><path d="m6 6 12 12"/>'),
+        panUp: icon('<path d="m18 15-6-6-6 6"/>', 2.5),
+        panDown: icon('<path d="m6 9 6 6 6-6"/>', 2.5),
+        panLeft: icon('<path d="m15 18-6-6 6-6"/>', 2.5),
+        panRight: icon('<path d="m9 18 6-6-6-6"/>', 2.5),
+        zoomIn: icon('<circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/><path d="M11 8v6"/><path d="M8 11h6"/>'),
+        zoomOut: icon('<circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/><path d="M8 11h6"/>'),
+        reset: icon('<path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/>', 2.5),
+        copy: icon(
+          '<rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/>'
+        ),
+        check: icon('<path d="M20 6 9 17l-5-5"/>', 2.5),
+      };
+
+      function createControlButton(svg, label, onClick) {
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'ec-diagram-btn';
+        btn.title = label;
+        btn.setAttribute('aria-label', label);
+        btn.innerHTML = svg;
+        btn.onclick = onClick;
+        return btn;
+      }
+
+      function createCopyButton(diagramContent) {
+        let copyTimeout;
+        const button = createControlButton(ICONS.copy, 'Copy diagram code', () => {
+          navigator.clipboard.writeText(diagramContent).catch((err) => {
+            console.warn('Failed to copy diagram code:', err);
+          });
+          button.innerHTML = ICONS.check;
+          button.classList.add('ec-diagram-btn--success');
+          button.title = 'Copied!';
+          if (copyTimeout) clearTimeout(copyTimeout);
+          copyTimeout = setTimeout(() => {
+            button.innerHTML = ICONS.copy;
+            button.classList.remove('ec-diagram-btn--success');
+            button.title = 'Copy diagram code';
+          }, 2000);
+        });
+        return button;
+      }
+
+      function resolvePlacement(value) {
+        return CONTROLS_PLACEMENTS.includes(value) ? value : DEFAULT_PLACEMENT;
+      }
+
+      function resolveActions(value) {
+        if (value === 'true') return true;
+        if (value === 'false') return false;
+        return undefined;
+      }
+
+      function getControlOptionsFromElement(element) {
+        return {
+          placement: resolvePlacement(element.getAttribute('data-placement')),
+          actions: resolveActions(element.getAttribute('data-actions')),
+        };
+      }
+
+      /**
+       * Pan/zoom engine: applies translate/scale to the content element. Button/keyboard changes
+       * are animated with a CSS transition; drag, wheel and pinch changes are instant.
+       */
+      function createPanZoom(viewport, content, contentWidth, contentHeight, options = {}) {
+        const { minScale = 0.1, maxScale = 8, wheelZoom = false, onChange } = options;
+
+        let scale = 1;
+        let x = 0;
+        let y = 0;
+
+        const clamp = (value) => Math.min(maxScale, Math.max(minScale, value));
+
+        const apply = (animate) => {
+          content.style.transitionDuration = animate ? `${TRANSITION_MS}ms` : '0ms';
+          content.style.transform = `translate(${x}px, ${y}px) scale(${scale})`;
+          if (onChange) onChange(scale);
         };
 
-        const plusSvg = `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg>`;
-        const minusSvg = `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"></line></svg>`;
-        const fitSvg = `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 3H5a2 2 0 0 0-2 2v3m18 0V5a2 2 0 0 0-2-2h-3m0 18h3a2 2 0 0 0 2-2v-3M3 16v3a2 2 0 0 0 2 2h3"></path></svg>`;
+        const fit = (animate = false) => {
+          const vw = viewport.clientWidth;
+          const vh = viewport.clientHeight;
+          if (vw <= 0 || vh <= 0) return;
+          scale = clamp(Math.min((vw - FIT_PADDING * 2) / contentWidth, (vh - FIT_PADDING * 2) / contentHeight, 1));
+          x = (vw - contentWidth * scale) / 2;
+          y = (vh - contentHeight * scale) / 2;
+          apply(animate);
+        };
 
-        controls.appendChild(createButton(plusSvg, 'Zoom in', onZoomIn));
-        controls.appendChild(createButton(minusSvg, 'Zoom out', onZoomOut));
-        controls.appendChild(createButton(fitSvg, 'Fit view', onFitView, true));
+        const zoomTo = (next, ox, oy, animate) => {
+          const target = clamp(next);
+          const ratio = target / scale;
+          x = ox - (ox - x) * ratio;
+          y = oy - (oy - y) * ratio;
+          scale = target;
+          apply(animate);
+        };
+
+        const zoomAtCenter = (factor) => zoomTo(scale * factor, viewport.clientWidth / 2, viewport.clientHeight / 2, true);
+
+        const panBy = (dx, dy) => {
+          x += dx;
+          y += dy;
+          apply(true);
+        };
+
+        const pointers = new Map();
+        let dragStart = null;
+        let pinchStart = null;
+
+        const pointerDistance = () => {
+          const [a, b] = Array.from(pointers.values());
+          return Math.hypot(a.x - b.x, a.y - b.y);
+        };
+
+        const pointerMidpoint = () => {
+          const [a, b] = Array.from(pointers.values());
+          const rect = viewport.getBoundingClientRect();
+          return { x: (a.x + b.x) / 2 - rect.left, y: (a.y + b.y) / 2 - rect.top };
+        };
+
+        const onPointerDown = (event) => {
+          if (event.pointerType === 'mouse' && event.button !== 0) return;
+          if (event.target.closest('button')) return;
+          viewport.setPointerCapture(event.pointerId);
+          pointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
+
+          if (pointers.size === 1) {
+            dragStart = { px: event.clientX, py: event.clientY, x, y };
+            viewport.classList.add('is-panning');
+          } else if (pointers.size === 2) {
+            dragStart = null;
+            pinchStart = { distance: pointerDistance(), scale };
+          }
+        };
+
+        const onPointerMove = (event) => {
+          if (!pointers.has(event.pointerId)) return;
+          pointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
+
+          if (pointers.size === 2 && pinchStart) {
+            const mid = pointerMidpoint();
+            zoomTo((pinchStart.scale * pointerDistance()) / pinchStart.distance, mid.x, mid.y, false);
+          } else if (pointers.size === 1 && dragStart) {
+            x = dragStart.x + (event.clientX - dragStart.px);
+            y = dragStart.y + (event.clientY - dragStart.py);
+            apply(false);
+          }
+        };
+
+        const onPointerUp = (event) => {
+          if (!pointers.has(event.pointerId)) return;
+          pointers.delete(event.pointerId);
+          try {
+            viewport.releasePointerCapture(event.pointerId);
+          } catch (e) {}
+
+          if (pointers.size === 0) {
+            dragStart = null;
+            pinchStart = null;
+            viewport.classList.remove('is-panning');
+          } else if (pointers.size === 1) {
+            const [remaining] = Array.from(pointers.values());
+            pinchStart = null;
+            dragStart = { px: remaining.x, py: remaining.y, x, y };
+          }
+        };
+
+        const onWheel = (event) => {
+          if (!wheelZoom) return;
+          event.preventDefault();
+          const rect = viewport.getBoundingClientRect();
+          const delta = event.deltaMode === 1 ? event.deltaY * 16 : event.deltaY;
+          zoomTo(scale * Math.exp(-delta * 0.0015), event.clientX - rect.left, event.clientY - rect.top, false);
+        };
+
+        const onDoubleClick = (event) => {
+          if (event.target.closest('button')) return;
+          const rect = viewport.getBoundingClientRect();
+          zoomTo(scale * ZOOM_STEP * ZOOM_STEP, event.clientX - rect.left, event.clientY - rect.top, true);
+        };
+
+        viewport.addEventListener('pointerdown', onPointerDown);
+        viewport.addEventListener('pointermove', onPointerMove);
+        viewport.addEventListener('pointerup', onPointerUp);
+        viewport.addEventListener('pointercancel', onPointerUp);
+        viewport.addEventListener('wheel', onWheel, { passive: false });
+        viewport.addEventListener('dblclick', onDoubleClick);
+
+        return {
+          fit,
+          zoomIn: () => zoomAtCenter(ZOOM_STEP),
+          zoomOut: () => zoomAtCenter(1 / ZOOM_STEP),
+          panBy,
+          getScale: () => scale,
+          destroy: () => {
+            viewport.removeEventListener('pointerdown', onPointerDown);
+            viewport.removeEventListener('pointermove', onPointerMove);
+            viewport.removeEventListener('pointerup', onPointerUp);
+            viewport.removeEventListener('pointercancel', onPointerUp);
+            viewport.removeEventListener('wheel', onWheel);
+            viewport.removeEventListener('dblclick', onDoubleClick);
+            pointers.clear();
+          },
+        };
+      }
+
+      function createViewport(svgElement, width, height, modal = false) {
+        const viewport = document.createElement('div');
+        viewport.className = modal ? 'ec-diagram-viewport ec-diagram-viewport--modal' : 'ec-diagram-viewport';
+
+        const content = document.createElement('div');
+        content.className = 'ec-diagram-content';
+        content.style.width = `${width}px`;
+        content.style.height = `${height}px`;
+
+        svgElement.setAttribute('width', String(width));
+        svgElement.setAttribute('height', String(height));
+        svgElement.style.width = `${width}px`;
+        svgElement.style.height = `${height}px`;
+        svgElement.style.maxWidth = 'none';
+
+        content.appendChild(svgElement);
+        viewport.appendChild(content);
+        return { viewport, content };
+      }
+
+      /**
+       * Opens the diagram in a fullscreen modal viewer with its own zoom toolbar.
+       */
+      function openDiagramModal(source) {
+        ensureDiagramStyles();
+        if (closeOpenModal) closeOpenModal();
+
+        const previouslyFocused = document.activeElement;
+        const previousBodyOverflow = document.body.style.overflow;
+
+        const backdrop = document.createElement('div');
+        backdrop.className = 'ec-diagram-modal-backdrop';
+
+        const root = document.createElement('div');
+        root.className = 'ec-diagram-modal';
+
+        const dialog = document.createElement('div');
+        dialog.className = 'ec-diagram-modal__dialog';
+        dialog.setAttribute('role', 'dialog');
+        dialog.setAttribute('aria-modal', 'true');
+        dialog.setAttribute('aria-label', 'Diagram');
+
+        const { viewport, content } = createViewport(source.svg.cloneNode(true), source.width, source.height, true);
+        viewport.tabIndex = 0;
+        viewport.setAttribute('role', 'application');
+        viewport.setAttribute(
+          'aria-label',
+          'Diagram viewer. Use the arrow keys to pan, plus and minus to zoom, and zero to reset.'
+        );
+
+        const zoomStatus = document.createElement('span');
+        zoomStatus.className = 'ec-diagram-modal__zoom';
+        zoomStatus.setAttribute('role', 'status');
+        zoomStatus.textContent = '100%';
+
+        const panZoom = createPanZoom(viewport, content, source.width, source.height, {
+          wheelZoom: true,
+          onChange: (scale) => {
+            zoomStatus.textContent = `${Math.round(scale * 100)}%`;
+          },
+        });
+
+        let closed = false;
+        const close = () => {
+          if (closed) return;
+          closed = true;
+          closeOpenModal = null;
+          document.removeEventListener('keydown', onKeyDown);
+          panZoom.destroy();
+          root.classList.add('is-closing');
+          backdrop.classList.add('is-closing');
+          root.classList.remove('is-open');
+          backdrop.classList.remove('is-open');
+          document.body.style.overflow = previousBodyOverflow;
+          setTimeout(() => {
+            root.remove();
+            backdrop.remove();
+          }, 150);
+          if (previouslyFocused && previouslyFocused.focus) previouslyFocused.focus({ preventScroll: true });
+        };
+        closeOpenModal = close;
+
+        const onKeyDown = (event) => {
+          switch (event.key) {
+            case 'Escape':
+              close();
+              break;
+            case 'ArrowUp':
+              panZoom.panBy(0, PAN_STEP);
+              break;
+            case 'ArrowDown':
+              panZoom.panBy(0, -PAN_STEP);
+              break;
+            case 'ArrowLeft':
+              panZoom.panBy(PAN_STEP, 0);
+              break;
+            case 'ArrowRight':
+              panZoom.panBy(-PAN_STEP, 0);
+              break;
+            case '+':
+            case '=':
+              panZoom.zoomIn();
+              break;
+            case '-':
+            case '_':
+              panZoom.zoomOut();
+              break;
+            case '0':
+              panZoom.fit(true);
+              break;
+            default:
+              return;
+          }
+          event.preventDefault();
+        };
+
+        const toolbar = document.createElement('div');
+        toolbar.className = 'ec-diagram-modal__toolbar';
+        toolbar.appendChild(createControlButton(ICONS.zoomOut, 'Zoom out', () => panZoom.zoomOut()));
+        toolbar.appendChild(zoomStatus);
+        toolbar.appendChild(createControlButton(ICONS.zoomIn, 'Zoom in', () => panZoom.zoomIn()));
+        toolbar.appendChild(createControlButton(ICONS.reset, 'Reset view', () => panZoom.fit(true)));
+        if (source.diagramContent) {
+          toolbar.appendChild(createCopyButton(source.diagramContent));
+        }
+
+        const closeBtn = createControlButton(ICONS.close, 'Close fullscreen', close);
+        closeBtn.classList.add('ec-diagram-modal__close');
+
+        dialog.appendChild(viewport);
+        dialog.appendChild(toolbar);
+        dialog.appendChild(closeBtn);
+        root.appendChild(dialog);
+
+        backdrop.addEventListener('click', close);
+        root.addEventListener('click', (event) => {
+          if (event.target === root) close();
+        });
+        document.addEventListener('keydown', onKeyDown);
+
+        document.body.appendChild(backdrop);
+        document.body.appendChild(root);
+        document.body.style.overflow = 'hidden';
+
+        panZoom.fit(false);
+        viewport.focus({ preventScroll: true });
+
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => {
+            backdrop.classList.add('is-open');
+            root.classList.add('is-open');
+          });
+        });
+      }
+
+      /**
+       * 3x3 grid of inline controls:
+       *   [fullscreen] [pan up]   [zoom in]
+       *   [pan left]   [reset]    [pan right]
+       *   [copy]       [pan down] [zoom out]
+       */
+      function createDiagramControls(panZoom, { placement, source }) {
+        const controls = document.createElement('div');
+        controls.className = 'ec-diagram-controls';
+        controls.setAttribute('data-placement', placement);
+        controls.setAttribute('role', 'toolbar');
+        controls.setAttribute('aria-label', 'Diagram controls');
+
+        let copyBtn;
+        if (source.diagramContent) {
+          copyBtn = createCopyButton(source.diagramContent);
+        } else {
+          copyBtn = document.createElement('div');
+          copyBtn.setAttribute('aria-hidden', 'true');
+        }
+
+        [
+          createControlButton(ICONS.fullscreen, 'Open fullscreen', () => openDiagramModal(source)),
+          createControlButton(ICONS.panUp, 'Pan up', () => panZoom.panBy(0, PAN_STEP)),
+          createControlButton(ICONS.zoomIn, 'Zoom in', () => panZoom.zoomIn()),
+          createControlButton(ICONS.panLeft, 'Pan left', () => panZoom.panBy(PAN_STEP, 0)),
+          createControlButton(ICONS.reset, 'Reset view', () => panZoom.fit(true)),
+          createControlButton(ICONS.panRight, 'Pan right', () => panZoom.panBy(-PAN_STEP, 0)),
+          copyBtn,
+          createControlButton(ICONS.panDown, 'Pan down', () => panZoom.panBy(0, -PAN_STEP)),
+          createControlButton(ICONS.zoomOut, 'Zoom out', () => panZoom.zoomOut()),
+        ].forEach((btn) => controls.appendChild(btn));
 
         return controls;
       }
 
-      // Icons for toolbar
-      const ICONS = {
-        presentation: `<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3.75 3v11.25A2.25 2.25 0 006 16.5h2.25M3.75 3h-1.5m1.5 0h16.5m0 0h1.5m-1.5 0v11.25A2.25 2.25 0 0118 16.5h-2.25m-7.5 0h7.5m-7.5 0l-1 3m8.5-3l1 3m0 0l.5 1.5m-.5-1.5h-9.5m0 0l-.5 1.5m.75-9l3-3 2.148 2.148A12.061 12.061 0 0116.5 7.605"></path></svg>`,
-        copy: `<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8.25 7.5V6.108c0-1.135.845-2.098 1.976-2.192.373-.03.748-.057 1.123-.08M15.75 18H18a2.25 2.25 0 002.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 00-1.123-.08M15.75 18.75v-1.875a3.375 3.375 0 00-3.375-3.375h-1.5a1.125 1.125 0 01-1.125-1.125v-1.5A3.375 3.375 0 006.375 7.5H5.25m11.9-3.664A2.251 2.251 0 0015 2.25h-1.5a2.251 2.251 0 00-2.15 1.586m5.8 0c.065.21.1.433.1.664v.75h-6V4.5c0-.231.035-.454.1-.664M6.75 7.5H4.875c-.621 0-1.125.504-1.125 1.125v12c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V16.5a9 9 0 00-9-9z"></path></svg>`,
-        check: `<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>`,
-      };
+      const TRIM_PADDING = 8;
+      const TRIM_THRESHOLD = 16;
 
-      function createToolbarButton(icon, tooltipText, onClick, tooltipPosition = 'bottom') {
-        const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        const bgColor = isDark ? '#161b22' : '#ffffff';
-        const iconColor = isDark ? '#8b949e' : '#64748b';
-        const iconHoverColor = isDark ? '#f0f6fc' : '#0f172a';
-        const hoverBgColor = isDark ? '#21262d' : '#f1f5f9';
+      // Tighten over-allocated viewBoxes (e.g. mermaid C4 diagrams) around the drawn content
+      function trimSvgViewBox(svgElement) {
+        const viewBox = svgElement.getAttribute('viewBox');
+        if (!viewBox) return;
+        const [vx, vy, vw, vh] = viewBox.split(/[\s,]+/).map(Number);
+        if (!(vw > 0 && vh > 0)) return;
 
-        const wrapper = document.createElement('div');
-        wrapper.style.cssText = 'position: relative;';
-
-        const btn = document.createElement('button');
-        btn.type = 'button';
-        btn.innerHTML = icon;
-        btn.style.cssText = `
-          all: unset;
-          box-sizing: border-box;
-          display: flex;
-          justify-content: center;
-          align-items: center;
-          width: 40px;
-          height: 40px;
-          min-width: 40px;
-          min-height: 40px;
-          padding: 0;
-          margin: 0;
-          border: none;
-          border-radius: 6px;
-          background: ${bgColor};
-          color: ${iconColor};
-          cursor: pointer;
-          transition: background-color 0.15s, color 0.15s;
-          box-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
-        `;
-
-        const svgEl = btn.querySelector('svg');
-        if (svgEl) svgEl.style.cssText = 'display: block; width: 20px; height: 20px;';
-
-        btn.onmouseenter = () => {
-          btn.style.backgroundColor = hoverBgColor;
-          btn.style.color = iconHoverColor;
-        };
-        btn.onmouseleave = () => {
-          btn.style.backgroundColor = bgColor;
-          btn.style.color = iconColor;
-        };
-        btn.onclick = onClick;
-
-        const tooltip = document.createElement('div');
-        tooltip.textContent = tooltipText;
-
-        // Position tooltip based on tooltipPosition parameter
-        let tooltipStyles = `
-          position: absolute;
-          padding: 4px 8px;
-          background: #1f2937;
-          color: white;
-          font-size: 12px;
-          border-radius: 4px;
-          box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1);
-          white-space: nowrap;
-          pointer-events: none;
-          opacity: 0;
-          transition: opacity 0.15s;
-          z-index: 50;
-        `;
-
-        if (tooltipPosition === 'right') {
-          tooltipStyles += `
-            top: 50%;
-            left: 100%;
-            transform: translateY(-50%);
-            margin-left: 8px;
-          `;
-        } else if (tooltipPosition === 'left') {
-          tooltipStyles += `
-            top: 50%;
-            right: 100%;
-            transform: translateY(-50%);
-            margin-right: 8px;
-          `;
-        } else {
-          // Default: bottom
-          tooltipStyles += `
-            top: 100%;
-            left: 50%;
-            transform: translateX(-50%);
-            margin-top: 8px;
-          `;
+        let bbox;
+        try {
+          bbox = svgElement.getBBox();
+        } catch (e) {
+          return;
         }
+        if (!(bbox.width > 0 && bbox.height > 0)) return;
 
-        tooltip.style.cssText = tooltipStyles;
+        const slack = Math.max(bbox.x - vx, bbox.y - vy, vx + vw - (bbox.x + bbox.width), vy + vh - (bbox.y + bbox.height));
+        if (slack <= TRIM_THRESHOLD) return;
 
-        wrapper.onmouseenter = () => (tooltip.style.opacity = '1');
-        wrapper.onmouseleave = () => (tooltip.style.opacity = '0');
-
-        wrapper.appendChild(btn);
-        wrapper.appendChild(tooltip);
-        return { wrapper, btn, tooltip, iconColor };
+        const x = Math.max(vx, bbox.x - TRIM_PADDING);
+        const y = Math.max(vy, bbox.y - TRIM_PADDING);
+        const width = Math.min(vx + vw, bbox.x + bbox.width + TRIM_PADDING) - x;
+        const height = Math.min(vy + vh, bbox.y + bbox.height + TRIM_PADDING) - y;
+        svgElement.setAttribute('viewBox', `${x} ${y} ${width} ${height}`);
       }
 
-      function createFullscreenButton(onClick) {
-        const { wrapper } = createToolbarButton(ICONS.presentation, 'Presentation Mode', onClick, 'right');
-        wrapper.style.cssText = 'position: absolute; top: 12px; left: 12px; z-index: 10;';
-        return wrapper;
-      }
-
-      function createCopyButton(onCopy) {
-        const copy = createToolbarButton(
-          ICONS.copy,
-          'Copy diagram code',
-          () => {
-            onCopy();
-            copy.btn.innerHTML = ICONS.check;
-            copy.btn.style.color = '#10b981';
-            copy.tooltip.textContent = 'Copied!';
-            const svgEl = copy.btn.querySelector('svg');
-            if (svgEl) svgEl.style.cssText = 'display: block; width: 20px; height: 20px;';
-
-            setTimeout(() => {
-              copy.btn.innerHTML = ICONS.copy;
-              copy.btn.style.color = copy.iconColor;
-              copy.tooltip.textContent = 'Copy diagram code';
-              const svgEl = copy.btn.querySelector('svg');
-              if (svgEl) svgEl.style.cssText = 'display: block; width: 20px; height: 20px;';
-            }, 2000);
-          },
-          'left'
-        );
-        copy.wrapper.style.cssText = 'position: absolute; top: 12px; right: 12px; z-index: 10;';
-        return copy.wrapper;
-      }
-
-      function toggleFullscreen(container) {
-        if (!document.fullscreenElement) {
-          container.requestFullscreen().catch((err) => console.warn('Fullscreen error:', err));
-        } else {
-          document.exitFullscreen();
-        }
-      }
-
-      async function initMermaidZoom(svgElement, container, id, diagramContent) {
-        const { default: svgPanZoom } = await import('https://cdn.jsdelivr.net/npm/svg-pan-zoom@3.6.2/+esm');
-
-        // Get the natural dimensions from viewBox or getBBox
-        let width, height;
+      function getSvgDimensions(svgElement) {
+        let width = 0;
+        let height = 0;
+        trimSvgViewBox(svgElement);
         const viewBox = svgElement.getAttribute('viewBox');
         if (viewBox) {
           const parts = viewBox.split(/[\s,]+/).map(Number);
           width = parts[2];
           height = parts[3];
-        } else {
-          const bbox = svgElement.getBBox();
-          width = bbox.width;
-          height = bbox.height;
-          if (width > 0 && height > 0) {
-            svgElement.setAttribute('viewBox', `${bbox.x} ${bbox.y} ${width} ${height}`);
-          }
         }
+        if (!(width > 0 && height > 0)) {
+          try {
+            const bbox = svgElement.getBBox();
+            width = bbox.width;
+            height = bbox.height;
+            if (width > 0 && height > 0 && !viewBox) {
+              svgElement.setAttribute('viewBox', `${bbox.x} ${bbox.y} ${width} ${height}`);
+            }
+          } catch (e) {}
+        }
+        if (!(width > 0 && height > 0)) {
+          width = svgElement.clientWidth || parseFloat(svgElement.getAttribute('width') || '0') || 800;
+          height = svgElement.clientHeight || parseFloat(svgElement.getAttribute('height') || '0') || 400;
+        }
+        return { width, height };
+      }
+
+      async function initMermaidZoom(svgElement, container, id, diagramContent, controlOptions = {}) {
+        ensureDiagramStyles();
+
+        const { placement = DEFAULT_PLACEMENT, actions } = controlOptions;
+        const { width, height } = getSvgDimensions(svgElement);
 
         // Set container height based on SVG aspect ratio, capped for usability
-        if (width > 0 && height > 0) {
-          const containerWidth = container.clientWidth || 800;
-          const aspectRatio = height / width;
-          const calculatedHeight = Math.min(Math.max(containerWidth * aspectRatio, 200), 500);
-          container.style.height = `${calculatedHeight}px`;
+        const containerWidth = container.clientWidth || 800;
+        container.style.height = `${Math.min(Math.max(containerWidth * (height / width), 200), 500)}px`;
+
+        const { viewport, content } = createViewport(svgElement, width, height);
+        container.innerHTML = '';
+        container.appendChild(viewport);
+
+        const panZoom = createPanZoom(viewport, content, width, height);
+        zoomInstances.set(id, panZoom);
+        panZoom.fit(false);
+
+        // Add interactive controls. By default they are only shown for diagrams taller than 120px.
+        const showControls = actions ?? height > CONTROLS_MIN_HEIGHT;
+        if (showControls) {
+          const source = { svg: svgElement, width, height, diagramContent };
+          container.appendChild(createDiagramControls(panZoom, { placement, source }));
         }
 
-        // SVG needs to fill the container for svg-pan-zoom
-        svgElement.style.width = '100%';
-        svgElement.style.height = '100%';
-        svgElement.removeAttribute('height');
-        svgElement.removeAttribute('width');
-
-        try {
-          const instance = svgPanZoom(svgElement, {
-            zoomEnabled: true,
-            controlIconsEnabled: false,
-            fit: true,
-            center: true,
-            minZoom: 0.5,
-            maxZoom: 10,
-            zoomScaleSensitivity: 0.15,
-            dblClickZoomEnabled: true,
-            mouseWheelZoomEnabled: false, // Disabled to avoid hijacking page scroll
-            preventMouseEventsDefault: true,
-            panEnabled: true,
-          });
-
-          zoomInstances.set(id, instance);
-
-          // Update cursor during pan
-          container.addEventListener('mousedown', () => {
-            container.style.cursor = 'grabbing';
-          });
-          container.addEventListener('mouseup', () => {
-            container.style.cursor = 'grab';
-          });
-          container.addEventListener('mouseleave', () => {
-            container.style.cursor = 'grab';
-          });
-
-          // Add custom controls
-          const controls = createZoomControls(
-            () => instance.zoomIn(),
-            () => instance.zoomOut(),
-            () => {
-              instance.fit();
-              instance.center();
-            }
-          );
-          container.appendChild(controls);
-
-          // Add fullscreen button (top-left)
-          const fullscreenBtn = createFullscreenButton(() => toggleFullscreen(container));
-          container.appendChild(fullscreenBtn);
-
-          // Add copy button (top-right) if diagram content is available
-          if (diagramContent) {
-            const copyBtn = createCopyButton(() => {
-              navigator.clipboard.writeText(diagramContent).catch((err) => {
-                console.warn('Failed to copy:', err);
-              });
-            });
-            container.appendChild(copyBtn);
+        const resizeObserver = new ResizeObserver(() => {
+          if (container.clientWidth > 0 && container.clientHeight > 0) {
+            panZoom.fit(false);
           }
-
-          // Handle fullscreen changes
-          document.addEventListener('fullscreenchange', () => {
-            const isFullscreen = document.fullscreenElement === container;
-            if (isFullscreen) {
-              instance.enableMouseWheelZoom();
-              const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-              container.style.background = isDark ? '#0d1117' : '#ffffff';
-            } else {
-              instance.disableMouseWheelZoom();
-              container.style.background = '';
-            }
-            setTimeout(() => {
-              if (container.clientWidth > 0 && container.clientHeight > 0) {
-                try {
-                  instance.resize();
-                  instance.fit();
-                  instance.center();
-                } catch (e) {}
-              }
-            }, 100);
-          });
-
-          // Resize handler for responsiveness
-          const resizeObserver = new ResizeObserver(() => {
-            if (container.clientWidth > 0 && container.clientHeight > 0) {
-              try {
-                instance.resize();
-                instance.fit();
-                instance.center();
-              } catch (e) {}
-            }
-          });
-          resizeObserver.observe(container);
-        } catch (e) {
-          console.warn('Failed to initialize zoom on mermaid diagram:', e);
-        }
+        });
+        resizeObserver.observe(container);
       }
 
       async function renderMermaid() {
@@ -608,8 +949,8 @@ const diagramId = props.data.id;
 
             // Create zoom container with inline styles (no Tailwind in embed)
             const container = document.createElement('div');
-            container.style.cssText =
-              'position: relative; width: 100%; min-height: 200px; overflow: hidden; margin: 1em 0; cursor: grab;';
+            container.className = 'mermaid-zoom-container';
+            container.style.cssText = 'min-height: 200px; margin: 1em 0;';
 
             // Insert the rendered SVG
             container.innerHTML = result.svg;
@@ -621,7 +962,7 @@ const diagramId = props.data.id;
             // Initialize zoom on the SVG
             const svgElement = container.querySelector('svg');
             if (svgElement) {
-              await initMermaidZoom(svgElement, container, id, content);
+              await initMermaidZoom(svgElement, container, id, content, getControlOptionsFromElement(graph));
             }
           } catch (e) {
             console.error('Mermaid render error:', e);
@@ -637,7 +978,6 @@ const diagramId = props.data.id;
         if (blocks.length === 0) return;
 
         const { deflate } = await import('https://cdn.jsdelivr.net/npm/pako@2.1.0/+esm');
-        const { default: svgPanZoom } = await import('https://cdn.jsdelivr.net/npm/svg-pan-zoom@3.6.2/+esm');
 
         function encode64(data) {
           const chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-_';
@@ -681,8 +1021,8 @@ const diagramId = props.data.id;
 
             // Create zoom container
             const container = document.createElement('div');
-            container.style.cssText =
-              'position: relative; width: 100%; min-height: 200px; overflow: hidden; margin: 1em 0; cursor: grab;';
+            container.className = 'mermaid-zoom-container';
+            container.style.cssText = 'min-height: 200px; margin: 1em 0;';
             container.innerHTML = svgText;
 
             block.innerHTML = '';

--- a/packages/core/eventcatalog/src/remark-plugins/__tests__/mermaid.spec.ts
+++ b/packages/core/eventcatalog/src/remark-plugins/__tests__/mermaid.spec.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { mermaid, parseMermaidMeta, buildControlAttributes } from '../mermaid';
+
+const createTree = (value: string, meta?: string) => ({
+  type: 'root',
+  children: [{ type: 'code', lang: 'mermaid', meta, value }],
+});
+
+const transform = (value: string, meta?: string) => {
+  const tree = createTree(value, meta);
+  // @ts-ignore - plugin only needs the tree
+  mermaid()(tree);
+  return tree.children[0] as unknown as { type: string; value: string };
+};
+
+describe('remark mermaid plugin', () => {
+  describe('parseMermaidMeta', () => {
+    it('returns no options when meta is empty', () => {
+      expect(parseMermaidMeta(undefined)).toEqual({});
+      expect(parseMermaidMeta('')).toEqual({});
+    });
+
+    it('parses placement with double or single quotes', () => {
+      expect(parseMermaidMeta('placement="top-left"')).toEqual({ placement: 'top-left' });
+      expect(parseMermaidMeta("placement='bottom-right'")).toEqual({ placement: 'bottom-right' });
+    });
+
+    it('ignores invalid placements', () => {
+      expect(parseMermaidMeta('placement="middle"')).toEqual({});
+    });
+
+    it('parses actions in JSX or plain form', () => {
+      expect(parseMermaidMeta('actions={false}')).toEqual({ actions: false });
+      expect(parseMermaidMeta('actions={true}')).toEqual({ actions: true });
+      expect(parseMermaidMeta('actions=false')).toEqual({ actions: false });
+    });
+
+    it('parses both options together', () => {
+      expect(parseMermaidMeta('placement="top-left" actions={true}')).toEqual({ placement: 'top-left', actions: true });
+    });
+  });
+
+  describe('buildControlAttributes', () => {
+    it('returns an empty string when no options are set', () => {
+      expect(buildControlAttributes({})).toBe('');
+    });
+
+    it('builds data attributes for the set options', () => {
+      expect(buildControlAttributes({ placement: 'bottom-left' })).toBe(' data-placement="bottom-left"');
+      expect(buildControlAttributes({ actions: false })).toBe(' data-actions="false"');
+      expect(buildControlAttributes({ placement: 'top-right', actions: true })).toBe(
+        ' data-placement="top-right" data-actions="true"'
+      );
+    });
+  });
+
+  describe('plugin', () => {
+    it('converts mermaid code blocks into html with escaped content', () => {
+      const node = transform('graph LR\n  A --> B');
+      expect(node.type).toBe('html');
+      expect(node.value).toContain('class="mermaid');
+      expect(node.value).toContain('data-content="graph LR\n  A --&gt; B"');
+      expect(node.value).not.toContain('data-placement');
+      expect(node.value).not.toContain('data-actions');
+    });
+
+    it('adds placement and actions data attributes from the code fence meta', () => {
+      const node = transform('graph LR\n  A --> B', 'placement="top-left" actions={false}');
+      expect(node.value).toContain('data-placement="top-left"');
+      expect(node.value).toContain('data-actions="false"');
+    });
+
+    it('leaves non-mermaid code blocks untouched', () => {
+      const tree = { type: 'root', children: [{ type: 'code', lang: 'js', value: 'const a = 1;' }] };
+      // @ts-ignore
+      mermaid()(tree);
+      expect(tree.children[0].type).toBe('code');
+    });
+  });
+});

--- a/packages/core/eventcatalog/src/remark-plugins/mermaid.ts
+++ b/packages/core/eventcatalog/src/remark-plugins/mermaid.ts
@@ -11,15 +11,62 @@ const escapeMap: Record<string, string> = {
 
 const escapeHtml = (str: string) => str.replace(/[&<>"']/g, (c) => escapeMap[c]);
 
+const PLACEMENTS = ['top-left', 'top-right', 'bottom-left', 'bottom-right'] as const;
+
+export interface MermaidCodeBlockOptions {
+  /** Position of the interactive controls */
+  placement?: (typeof PLACEMENTS)[number];
+  /** Force the interactive controls on or off */
+  actions?: boolean;
+}
+
+/**
+ * Parses options from the code fence meta string, e.g.
+ *
+ *   ```mermaid placement="top-left" actions={false}
+ *
+ * Supports `placement="..."` / `placement='...'` and `actions={true|false}` / `actions=true|false`.
+ */
+export function parseMermaidMeta(meta: string | null | undefined): MermaidCodeBlockOptions {
+  const options: MermaidCodeBlockOptions = {};
+  if (!meta) return options;
+
+  const placementMatch = meta.match(/placement=(?:["']([^"']+)["']|\{["']([^"']+)["']\})/);
+  const placement = placementMatch?.[1] ?? placementMatch?.[2];
+  if (placement && (PLACEMENTS as readonly string[]).includes(placement)) {
+    options.placement = placement as MermaidCodeBlockOptions['placement'];
+  }
+
+  const actionsMatch = meta.match(/actions=\{?(true|false)\}?/);
+  if (actionsMatch) {
+    options.actions = actionsMatch[1] === 'true';
+  }
+
+  return options;
+}
+
+/**
+ * Builds the `data-*` attributes used by the client-side renderer to configure the controls
+ */
+export function buildControlAttributes(options: MermaidCodeBlockOptions): string {
+  const attributes: string[] = [];
+  if (options.placement) attributes.push(`data-placement="${options.placement}"`);
+  if (options.actions !== undefined) attributes.push(`data-actions="${options.actions}"`);
+  return attributes.length > 0 ? ` ${attributes.join(' ')}` : '';
+}
+
 export const mermaid: RemarkPlugin<[]> = () => (tree) => {
   visit(tree, 'code', (node) => {
     if (node.lang !== 'mermaid') return;
+
+    // @ts-ignore meta is present on code nodes
+    const controlAttributes = buildControlAttributes(parseMermaidMeta(node.meta));
 
     // @ts-ignore test
     node.type = 'html';
     node.value = `
     <div class="mermaid-block pb-4">
-      <div class="mermaid border border-[rgb(var(--ec-page-border))] rounded-lg p-1" data-content="${escapeHtml(node.value)}">
+      <div class="mermaid border border-[rgb(var(--ec-page-border))] rounded-lg p-1" data-content="${escapeHtml(node.value)}"${controlAttributes}>
         <p class="text-[rgb(var(--ec-page-text-muted))]">Loading graph...</p>
       </div>
     </div>

--- a/packages/core/eventcatalog/src/utils/mermaid-zoom.ts
+++ b/packages/core/eventcatalog/src/utils/mermaid-zoom.ts
@@ -1,6 +1,6 @@
 /**
  * Diagram Zoom Utility
- * Provides pan/zoom functionality for Mermaid and PlantUML diagrams with Mintlify-style controls,
+ * Provides pan/zoom functionality for Mermaid and PlantUML diagrams with hover-revealed controls,
  * smooth (CSS transform) transitions and a fullscreen modal viewer.
  *
  * NOTE: A standalone version of this code also exists in the embed page at:
@@ -68,7 +68,7 @@ export function destroyZoomInstances(): void {
 }
 
 /**
- * Diagram control options (Mintlify-style)
+ * Diagram control options
  */
 export type ControlsPlacement = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
 

--- a/packages/core/eventcatalog/src/utils/mermaid-zoom.ts
+++ b/packages/core/eventcatalog/src/utils/mermaid-zoom.ts
@@ -1,6 +1,7 @@
 /**
  * Diagram Zoom Utility
- * Provides pan/zoom functionality for Mermaid and PlantUML diagrams with React Flow-style controls
+ * Provides pan/zoom functionality for Mermaid and PlantUML diagrams with Mintlify-style controls,
+ * smooth (CSS transform) transitions and a fullscreen modal viewer.
  *
  * NOTE: A standalone version of this code also exists in the embed page at:
  * src/pages/diagrams/[id]/[version]/embed.astro
@@ -10,15 +11,37 @@
  */
 
 // Store zoom instances for cleanup
-const zoomInstances = new Map<string, any>();
+const zoomInstances = new Map<string, PanZoomInstance>();
 const resizeObservers = new Map<string, ResizeObserver>();
-const fullscreenHandlers = new Map<string, () => void>();
 
 // Track registered icon pack names to avoid re-registering on subsequent renders
 const registeredIconPacks = new Set<string>();
 
 // Abort flag for cancelling in-progress renders during cleanup
 let renderingAborted = false;
+
+// Closer for the currently open fullscreen modal (only one can be open at a time)
+let closeOpenModal: (() => void) | null = null;
+
+// Mermaid renders are generation-tracked so a re-render (e.g. on theme change) supersedes in-flight ones
+let mermaidRenderGeneration = 0;
+let lastMermaidConfig: any;
+let themeObserver: MutationObserver | null = null;
+
+/**
+ * Mermaid bakes the theme into the rendered SVG, so diagrams are re-rendered whenever the
+ * `data-theme` attribute on <html> changes (light/dark toggle).
+ */
+function ensureThemeObserver(): void {
+  if (themeObserver) return;
+  themeObserver = new MutationObserver(() => {
+    const graphs = document.getElementsByClassName('mermaid');
+    if (graphs.length === 0) return;
+    destroyZoomInstances();
+    renderMermaidWithZoom(graphs, lastMermaidConfig);
+  });
+  themeObserver.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
+}
 
 /**
  * Destroys all zoom instances and cleans up observers
@@ -41,368 +64,776 @@ export function destroyZoomInstances(): void {
   });
   resizeObservers.clear();
 
-  // Clean up fullscreen event listeners
-  fullscreenHandlers.forEach((handler) => {
-    document.removeEventListener('fullscreenchange', handler);
-  });
-  fullscreenHandlers.clear();
+  closeOpenModal?.();
 }
 
 /**
- * Gets an RGB color string from a CSS variable
- * CSS variables store RGB values as "R G B" format, so we convert to "rgb(R, G, B)"
+ * Diagram control options (Mintlify-style)
  */
-function getCssVariableColor(variableName: string, fallback: string): string {
-  const value = getComputedStyle(document.documentElement).getPropertyValue(variableName).trim();
-  if (value) {
-    // Convert "R G B" format to "rgb(R, G, B)"
-    return `rgb(${value.split(' ').join(', ')})`;
+export type ControlsPlacement = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+
+const CONTROLS_PLACEMENTS: ControlsPlacement[] = ['top-left', 'top-right', 'bottom-left', 'bottom-right'];
+const DEFAULT_PLACEMENT: ControlsPlacement = 'top-right';
+
+/** Controls are shown by default only when the diagram's natural height exceeds this value */
+const CONTROLS_MIN_HEIGHT = 120;
+
+/** Pixels moved per pan button click / arrow key */
+const PAN_STEP = 60;
+
+/** Zoom factor per zoom button click / keyboard press */
+const ZOOM_STEP = 1.2;
+
+/** Duration of animated pan/zoom transitions */
+const TRANSITION_MS = 150;
+
+/** Padding around the diagram when fitting it into its viewport */
+const FIT_PADDING = 16;
+
+const STYLE_ID = 'ec-diagram-styles';
+
+/**
+ * Styles for the diagram viewport, controls and fullscreen modal. Uses EventCatalog theme
+ * variables with sensible fallbacks so the same styles work inside the isolated embed page.
+ */
+const DIAGRAM_STYLES = `
+.mermaid-zoom-container {
+  position: relative;
+  width: 100%;
+  overflow: hidden;
+}
+.ec-diagram-viewport {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  cursor: grab;
+  touch-action: pan-y pinch-zoom;
+  user-select: none;
+  -webkit-user-select: none;
+  outline: none;
+}
+.ec-diagram-viewport.is-panning {
+  cursor: grabbing;
+}
+.ec-diagram-viewport--modal {
+  touch-action: none;
+  background-image: radial-gradient(rgb(var(--ec-page-text, 15 23 42) / 0.08) 1px, transparent 1px);
+  background-size: 16px 16px;
+}
+.ec-diagram-content {
+  position: absolute;
+  left: 0;
+  top: 0;
+  transform-origin: 0 0;
+  transition: transform ${TRANSITION_MS}ms ease-out;
+  will-change: transform;
+}
+/* Element selectors bump specificity above the page's global ".mermaid svg" rules */
+div.ec-diagram-content > svg {
+  display: block;
+  margin: 0;
+  max-width: none !important;
+}
+.ec-diagram-btn {
+  all: unset;
+  box-sizing: border-box;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  cursor: pointer;
+  background: rgb(var(--ec-card-bg, 255 255 255));
+  color: rgb(var(--ec-page-text, 15 23 42));
+  border: 1px solid rgb(var(--ec-page-border, 226 232 240));
+  transition: background-color 0.15s, transform 0.1s;
+}
+.ec-diagram-btn:hover {
+  background: rgb(var(--ec-content-hover, 241 245 249));
+}
+.ec-diagram-btn:active {
+  transform: scale(0.95);
+}
+.ec-diagram-btn:focus-visible {
+  outline: 2px solid rgb(var(--ec-accent, 59 130 246));
+  outline-offset: 1px;
+}
+button.ec-diagram-btn svg {
+  display: block;
+  width: 16px;
+  height: 16px;
+  margin: 0;
+  flex-shrink: 0;
+}
+.ec-diagram-btn.ec-diagram-btn--success {
+  color: #10b981;
+}
+.ec-diagram-controls {
+  position: absolute;
+  z-index: 10;
+  display: grid;
+  grid-template-columns: repeat(3, 28px);
+  gap: 4px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease;
+}
+.ec-diagram-controls[data-placement="top-left"] { top: 8px; left: 8px; }
+.ec-diagram-controls[data-placement="top-right"] { top: 8px; right: 8px; }
+.ec-diagram-controls[data-placement="bottom-left"] { bottom: 8px; left: 8px; }
+.ec-diagram-controls[data-placement="bottom-right"] { bottom: 8px; right: 8px; }
+.mermaid-zoom-container:hover .ec-diagram-controls,
+.mermaid-zoom-container:focus-within .ec-diagram-controls {
+  opacity: 1;
+  pointer-events: auto;
+}
+@media (pointer: coarse) {
+  .ec-diagram-controls { opacity: 1; pointer-events: auto; }
+}
+@media print {
+  .ec-diagram-controls { display: none; }
+}
+.ec-diagram-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 9998;
+  background: rgb(0 0 0 / 0.4);
+  opacity: 0;
+  transition: opacity 250ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+.ec-diagram-modal-backdrop.is-open {
+  opacity: 1;
+}
+.ec-diagram-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  padding: 16px;
+}
+@media (min-width: 640px) {
+  .ec-diagram-modal { padding: 24px; }
+}
+.ec-diagram-modal__dialog {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  border-radius: 16px;
+  background: rgb(var(--ec-page-bg, 255 255 255));
+  box-shadow:
+    0 0 0 1px rgb(var(--ec-page-border, 226 232 240)),
+    0 25px 50px -12px rgb(0 0 0 / 0.25);
+  transform: scale(0.96);
+  opacity: 0;
+  transition:
+    transform 250ms cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 250ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+.ec-diagram-modal.is-open .ec-diagram-modal__dialog {
+  transform: none;
+  opacity: 1;
+}
+.ec-diagram-modal.is-closing .ec-diagram-modal__dialog,
+.ec-diagram-modal-backdrop.is-closing {
+  transition-duration: 150ms;
+}
+.ec-diagram-modal__toolbar {
+  position: absolute;
+  left: 12px;
+  top: 12px;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.ec-diagram-modal__zoom {
+  box-sizing: border-box;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 28px;
+  min-width: 56px;
+  padding: 0 6px;
+  border-radius: 6px;
+  border: 1px solid rgb(var(--ec-page-border, 226 232 240));
+  background: rgb(var(--ec-card-bg, 255 255 255));
+  color: rgb(var(--ec-page-text, 15 23 42));
+  font-family: inherit;
+  font-size: 12px;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+.ec-diagram-modal__close {
+  position: absolute;
+  right: 12px;
+  top: 12px;
+  z-index: 10;
+}
+@media (prefers-reduced-motion: reduce) {
+  .ec-diagram-content,
+  .ec-diagram-controls,
+  .ec-diagram-modal-backdrop,
+  .ec-diagram-modal__dialog {
+    transition: none;
   }
-  return fallback;
+}
+`;
+
+/**
+ * Injects the diagram stylesheet once per document
+ */
+function ensureDiagramStyles(): void {
+  if (document.getElementById(STYLE_ID)) return;
+  const style = document.createElement('style');
+  style.id = STYLE_ID;
+  style.textContent = DIAGRAM_STYLES;
+  document.head.appendChild(style);
 }
 
 /**
- * Gets theme colors based on current mode using CSS variables
+ * SVG icons (Lucide-style, 24px viewBox). Stroke widths are tuned for rendering at 16px.
  */
-function getThemeColors() {
-  const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-  return {
-    isDark,
-    bgColor: getCssVariableColor('--ec-card-bg', isDark ? '#161b22' : '#ffffff'),
-    borderColor: getCssVariableColor('--ec-page-border', isDark ? '#30363d' : '#e2e8f0'),
-    iconColor: getCssVariableColor('--ec-icon-color', isDark ? '#8b949e' : '#64748b'),
-    iconHoverColor: getCssVariableColor('--ec-icon-hover', isDark ? '#f0f6fc' : '#0f172a'),
-    hoverBgColor: getCssVariableColor('--ec-content-hover', isDark ? '#21262d' : '#f1f5f9'),
-    overlayBg: getCssVariableColor('--ec-page-bg', isDark ? '#0d1117' : '#ffffff'),
-  };
-}
+const icon = (paths: string, strokeWidth = 2) =>
+  `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="${strokeWidth}" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${paths}</svg>`;
+
+const ICONS = {
+  fullscreen: icon('<path d="M15 3h6v6"/><path d="M9 21H3v-6"/><path d="M21 3l-7 7"/><path d="M3 21l7-7"/>'),
+  close: icon('<path d="M18 6 6 18"/><path d="m6 6 12 12"/>'),
+  panUp: icon('<path d="m18 15-6-6-6 6"/>', 2.5),
+  panDown: icon('<path d="m6 9 6 6 6-6"/>', 2.5),
+  panLeft: icon('<path d="m15 18-6-6 6-6"/>', 2.5),
+  panRight: icon('<path d="m9 18 6-6-6-6"/>', 2.5),
+  zoomIn: icon('<circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/><path d="M11 8v6"/><path d="M8 11h6"/>'),
+  zoomOut: icon('<circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/><path d="M8 11h6"/>'),
+  reset: icon('<path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/>', 2.5),
+  copy: icon(
+    '<rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/>'
+  ),
+  check: icon('<path d="M20 6 9 17l-5-5"/>', 2.5),
+};
 
 /**
- * Creates a styled button with inline CSS
+ * Creates a single control button
  */
-function createStyledButton(
-  svg: string,
-  title: string,
-  onClick: () => void,
-  colors: ReturnType<typeof getThemeColors>,
-  options: { isLast?: boolean; isRound?: boolean } = {}
-): HTMLButtonElement {
-  const { isLast = false, isRound = false } = options;
+function createControlButton(svg: string, label: string, onClick: () => void): HTMLButtonElement {
   const btn = document.createElement('button');
   btn.type = 'button';
-  btn.title = title;
+  btn.className = 'ec-diagram-btn';
+  btn.title = label;
+  btn.setAttribute('aria-label', label);
   btn.innerHTML = svg;
   btn.onclick = onClick;
-
-  btn.style.cssText = `
-    all: unset;
-    box-sizing: border-box;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    width: 26px;
-    height: 26px;
-    min-width: 26px;
-    min-height: 26px;
-    padding: 0;
-    margin: 0;
-    border: none;
-    background: ${colors.bgColor};
-    color: ${colors.iconColor};
-    cursor: pointer;
-    transition: background-color 0.15s, color 0.15s;
-    line-height: 1;
-    font-size: 12px;
-    ${!isLast && !isRound ? `border-bottom: 1px solid ${colors.borderColor};` : ''}
-    ${isRound ? 'border-radius: 6px;' : ''}
-  `;
-
-  const svgEl = btn.querySelector('svg');
-  if (svgEl) {
-    svgEl.style.cssText = 'display: block; width: 12px; height: 12px;';
-  }
-
-  btn.onmouseenter = () => {
-    btn.style.backgroundColor = colors.hoverBgColor;
-    btn.style.color = colors.iconHoverColor;
-  };
-  btn.onmouseleave = () => {
-    btn.style.backgroundColor = colors.bgColor;
-    btn.style.color = colors.iconColor;
-  };
-
   return btn;
 }
 
 /**
- * SVG icons
+ * Creates a "copy diagram code" button with success feedback
  */
-const ICONS = {
-  plus: `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg>`,
-  minus: `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"></line></svg>`,
-  fit: `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 3H5a2 2 0 0 0-2 2v3m18 0V5a2 2 0 0 0-2-2h-3m0 18h3a2 2 0 0 0 2-2v-3M3 16v3a2 2 0 0 0 2 2h3"></path></svg>`,
-  // Heroicons PresentationChartLineIcon (outline)
-  presentation: `<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3.75 3v11.25A2.25 2.25 0 006 16.5h2.25M3.75 3h-1.5m1.5 0h16.5m0 0h1.5m-1.5 0v11.25A2.25 2.25 0 0118 16.5h-2.25m-7.5 0h7.5m-7.5 0l-1 3m8.5-3l1 3m0 0l.5 1.5m-.5-1.5h-9.5m0 0l-.5 1.5m.75-9l3-3 2.148 2.148A12.061 12.061 0 0116.5 7.605"></path></svg>`,
-  // Heroicons ClipboardDocumentIcon (outline)
-  copy: `<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8.25 7.5V6.108c0-1.135.845-2.098 1.976-2.192.373-.03.748-.057 1.123-.08M15.75 18H18a2.25 2.25 0 002.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 00-1.123-.08M15.75 18.75v-1.875a3.375 3.375 0 00-3.375-3.375h-1.5a1.125 1.125 0 01-1.125-1.125v-1.5A3.375 3.375 0 006.375 7.5H5.25m11.9-3.664A2.251 2.251 0 0015 2.25h-1.5a2.251 2.251 0 00-2.15 1.586m5.8 0c.065.21.1.433.1.664v.75h-6V4.5c0-.231.035-.454.1-.664M6.75 7.5H4.875c-.621 0-1.125.504-1.125 1.125v12c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V16.5a9 9 0 00-9-9z"></path></svg>`,
-  // Heroicons CheckIcon (outline)
-  check: `<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>`,
-};
+function createCopyButton(diagramContent: string): HTMLButtonElement {
+  let copyTimeout: ReturnType<typeof setTimeout> | undefined;
+  const button = createControlButton(ICONS.copy, 'Copy diagram code', () => {
+    navigator.clipboard.writeText(diagramContent).catch((err) => {
+      console.warn('Failed to copy diagram code:', err);
+    });
+    button.innerHTML = ICONS.check;
+    button.classList.add('ec-diagram-btn--success');
+    button.title = 'Copied!';
+    if (copyTimeout) clearTimeout(copyTimeout);
+    copyTimeout = setTimeout(() => {
+      button.innerHTML = ICONS.copy;
+      button.classList.remove('ec-diagram-btn--success');
+      button.title = 'Copy diagram code';
+    }, 2000);
+  });
+  return button;
+}
 
 /**
- * Creates React Flow-style zoom controls
+ * Resolves the controls placement from a raw attribute/config value
  */
-function createZoomControls(onZoomIn: () => void, onZoomOut: () => void, onFitView: () => void): HTMLElement {
-  const colors = getThemeColors();
+export function resolvePlacement(value: string | null | undefined): ControlsPlacement {
+  return CONTROLS_PLACEMENTS.includes(value as ControlsPlacement) ? (value as ControlsPlacement) : DEFAULT_PLACEMENT;
+}
+
+/**
+ * Resolves the `actions` option from a raw attribute value ("true" / "false" / undefined)
+ */
+export function resolveActions(value: string | null | undefined): boolean | undefined {
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  return undefined;
+}
+
+/**
+ * Reads diagram control options from the `data-*` attributes of a diagram element
+ */
+export function getControlOptionsFromElement(element: Element): Pick<ZoomOptions, 'placement' | 'actions'> {
+  return {
+    placement: resolvePlacement(element.getAttribute('data-placement')),
+    actions: resolveActions(element.getAttribute('data-actions')),
+  };
+}
+
+/**
+ * Pan/zoom engine
+ *
+ * Applies `translate(x, y) scale(s)` to a content element inside a viewport. Button/keyboard
+ * driven changes are animated with a CSS transition; drag, wheel and pinch changes are instant.
+ */
+export interface PanZoomInstance {
+  fit: (animate?: boolean) => void;
+  zoomIn: () => void;
+  zoomOut: () => void;
+  panBy: (dx: number, dy: number) => void;
+  getScale: () => number;
+  destroy: () => void;
+}
+
+interface PanZoomOptions {
+  minScale?: number;
+  maxScale?: number;
+  /** Zoom with the mouse wheel / trackpad. Disabled inline so the page keeps scrolling. */
+  wheelZoom?: boolean;
+  onChange?: (scale: number) => void;
+}
+
+export function createPanZoom(
+  viewport: HTMLElement,
+  content: HTMLElement,
+  contentWidth: number,
+  contentHeight: number,
+  options: PanZoomOptions = {}
+): PanZoomInstance {
+  const { minScale = 0.1, maxScale = 8, wheelZoom = false, onChange } = options;
+
+  let scale = 1;
+  let x = 0;
+  let y = 0;
+
+  const clamp = (value: number) => Math.min(maxScale, Math.max(minScale, value));
+
+  const apply = (animate: boolean) => {
+    content.style.transitionDuration = animate ? `${TRANSITION_MS}ms` : '0ms';
+    content.style.transform = `translate(${x}px, ${y}px) scale(${scale})`;
+    onChange?.(scale);
+  };
+
+  /** Fits the diagram inside the viewport (never scaling it above 100%) and centers it */
+  const fit = (animate = false) => {
+    const vw = viewport.clientWidth;
+    const vh = viewport.clientHeight;
+    if (vw <= 0 || vh <= 0) return;
+    scale = clamp(Math.min((vw - FIT_PADDING * 2) / contentWidth, (vh - FIT_PADDING * 2) / contentHeight, 1));
+    x = (vw - contentWidth * scale) / 2;
+    y = (vh - contentHeight * scale) / 2;
+    apply(animate);
+  };
+
+  /** Zooms to `next` keeping the viewport point (ox, oy) fixed */
+  const zoomTo = (next: number, ox: number, oy: number, animate: boolean) => {
+    const target = clamp(next);
+    const ratio = target / scale;
+    x = ox - (ox - x) * ratio;
+    y = oy - (oy - y) * ratio;
+    scale = target;
+    apply(animate);
+  };
+
+  const zoomAtCenter = (factor: number) => zoomTo(scale * factor, viewport.clientWidth / 2, viewport.clientHeight / 2, true);
+
+  const panBy = (dx: number, dy: number) => {
+    x += dx;
+    y += dy;
+    apply(true);
+  };
+
+  // Pointer handling (drag to pan, two-finger pinch to zoom)
+  const pointers = new Map<number, { x: number; y: number }>();
+  let dragStart: { px: number; py: number; x: number; y: number } | null = null;
+  let pinchStart: { distance: number; scale: number } | null = null;
+
+  const pointerDistance = () => {
+    const [a, b] = Array.from(pointers.values());
+    return Math.hypot(a.x - b.x, a.y - b.y);
+  };
+
+  const pointerMidpoint = () => {
+    const [a, b] = Array.from(pointers.values());
+    const rect = viewport.getBoundingClientRect();
+    return { x: (a.x + b.x) / 2 - rect.left, y: (a.y + b.y) / 2 - rect.top };
+  };
+
+  const onPointerDown = (event: PointerEvent) => {
+    if (event.pointerType === 'mouse' && event.button !== 0) return;
+    if ((event.target as HTMLElement).closest('button')) return;
+    viewport.setPointerCapture(event.pointerId);
+    pointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
+
+    if (pointers.size === 1) {
+      dragStart = { px: event.clientX, py: event.clientY, x, y };
+      viewport.classList.add('is-panning');
+    } else if (pointers.size === 2) {
+      dragStart = null;
+      pinchStart = { distance: pointerDistance(), scale };
+    }
+  };
+
+  const onPointerMove = (event: PointerEvent) => {
+    if (!pointers.has(event.pointerId)) return;
+    pointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
+
+    if (pointers.size === 2 && pinchStart) {
+      const mid = pointerMidpoint();
+      zoomTo((pinchStart.scale * pointerDistance()) / pinchStart.distance, mid.x, mid.y, false);
+    } else if (pointers.size === 1 && dragStart) {
+      x = dragStart.x + (event.clientX - dragStart.px);
+      y = dragStart.y + (event.clientY - dragStart.py);
+      apply(false);
+    }
+  };
+
+  const onPointerUp = (event: PointerEvent) => {
+    if (!pointers.has(event.pointerId)) return;
+    pointers.delete(event.pointerId);
+    try {
+      viewport.releasePointerCapture(event.pointerId);
+    } catch (e) {
+      // Pointer may already be released
+    }
+
+    if (pointers.size === 0) {
+      dragStart = null;
+      pinchStart = null;
+      viewport.classList.remove('is-panning');
+    } else if (pointers.size === 1) {
+      const [remaining] = Array.from(pointers.values());
+      pinchStart = null;
+      dragStart = { px: remaining.x, py: remaining.y, x, y };
+    }
+  };
+
+  const onWheel = (event: WheelEvent) => {
+    if (!wheelZoom) return;
+    event.preventDefault();
+    const rect = viewport.getBoundingClientRect();
+    const delta = event.deltaMode === 1 ? event.deltaY * 16 : event.deltaY;
+    zoomTo(scale * Math.exp(-delta * 0.0015), event.clientX - rect.left, event.clientY - rect.top, false);
+  };
+
+  const onDoubleClick = (event: MouseEvent) => {
+    if ((event.target as HTMLElement).closest('button')) return;
+    const rect = viewport.getBoundingClientRect();
+    zoomTo(scale * ZOOM_STEP * ZOOM_STEP, event.clientX - rect.left, event.clientY - rect.top, true);
+  };
+
+  viewport.addEventListener('pointerdown', onPointerDown);
+  viewport.addEventListener('pointermove', onPointerMove);
+  viewport.addEventListener('pointerup', onPointerUp);
+  viewport.addEventListener('pointercancel', onPointerUp);
+  viewport.addEventListener('wheel', onWheel, { passive: false });
+  viewport.addEventListener('dblclick', onDoubleClick);
+
+  return {
+    fit,
+    zoomIn: () => zoomAtCenter(ZOOM_STEP),
+    zoomOut: () => zoomAtCenter(1 / ZOOM_STEP),
+    panBy,
+    getScale: () => scale,
+    destroy: () => {
+      viewport.removeEventListener('pointerdown', onPointerDown);
+      viewport.removeEventListener('pointermove', onPointerMove);
+      viewport.removeEventListener('pointerup', onPointerUp);
+      viewport.removeEventListener('pointercancel', onPointerUp);
+      viewport.removeEventListener('wheel', onWheel);
+      viewport.removeEventListener('dblclick', onDoubleClick);
+      pointers.clear();
+    },
+  };
+}
+
+/**
+ * Builds the viewport + content wrapper around an SVG and sizes the SVG to its natural dimensions
+ */
+function createViewport(svgElement: SVGElement, width: number, height: number, modal = false) {
+  const viewport = document.createElement('div');
+  viewport.className = modal ? 'ec-diagram-viewport ec-diagram-viewport--modal' : 'ec-diagram-viewport';
+
+  const content = document.createElement('div');
+  content.className = 'ec-diagram-content';
+  content.style.width = `${width}px`;
+  content.style.height = `${height}px`;
+
+  svgElement.setAttribute('width', String(width));
+  svgElement.setAttribute('height', String(height));
+  svgElement.style.width = `${width}px`;
+  svgElement.style.height = `${height}px`;
+  svgElement.style.maxWidth = 'none';
+
+  content.appendChild(svgElement);
+  viewport.appendChild(content);
+  return { viewport, content };
+}
+
+interface DiagramSource {
+  svg: SVGElement;
+  width: number;
+  height: number;
+  diagramContent?: string;
+}
+
+/**
+ * Opens the diagram in a fullscreen modal viewer with its own zoom toolbar.
+ * Supports drag/wheel/pinch, arrow keys to pan, +/- to zoom, 0 to reset and Escape to close.
+ */
+export function openDiagramModal(source: DiagramSource): void {
+  ensureDiagramStyles();
+  closeOpenModal?.();
+
+  const previouslyFocused = document.activeElement as HTMLElement | null;
+  const previousBodyOverflow = document.body.style.overflow;
+
+  const backdrop = document.createElement('div');
+  backdrop.className = 'ec-diagram-modal-backdrop';
+
+  const root = document.createElement('div');
+  root.className = 'ec-diagram-modal';
+
+  const dialog = document.createElement('div');
+  dialog.className = 'ec-diagram-modal__dialog';
+  dialog.setAttribute('role', 'dialog');
+  dialog.setAttribute('aria-modal', 'true');
+  dialog.setAttribute('aria-label', 'Diagram');
+
+  const { viewport, content } = createViewport(source.svg.cloneNode(true) as SVGElement, source.width, source.height, true);
+  viewport.tabIndex = 0;
+  viewport.setAttribute('role', 'application');
+  viewport.setAttribute('aria-label', 'Diagram viewer. Use the arrow keys to pan, plus and minus to zoom, and zero to reset.');
+
+  const zoomStatus = document.createElement('span');
+  zoomStatus.className = 'ec-diagram-modal__zoom';
+  zoomStatus.setAttribute('role', 'status');
+  zoomStatus.textContent = '100%';
+
+  const panZoom = createPanZoom(viewport, content, source.width, source.height, {
+    wheelZoom: true,
+    onChange: (scale) => {
+      zoomStatus.textContent = `${Math.round(scale * 100)}%`;
+    },
+  });
+
+  let closed = false;
+  const close = () => {
+    if (closed) return;
+    closed = true;
+    closeOpenModal = null;
+    document.removeEventListener('keydown', onKeyDown);
+    panZoom.destroy();
+    root.classList.add('is-closing');
+    backdrop.classList.add('is-closing');
+    root.classList.remove('is-open');
+    backdrop.classList.remove('is-open');
+    document.body.style.overflow = previousBodyOverflow;
+    setTimeout(() => {
+      root.remove();
+      backdrop.remove();
+    }, 150);
+    previouslyFocused?.focus?.({ preventScroll: true });
+  };
+  closeOpenModal = close;
+
+  const onKeyDown = (event: KeyboardEvent) => {
+    switch (event.key) {
+      case 'Escape':
+        close();
+        break;
+      case 'ArrowUp':
+        panZoom.panBy(0, PAN_STEP);
+        break;
+      case 'ArrowDown':
+        panZoom.panBy(0, -PAN_STEP);
+        break;
+      case 'ArrowLeft':
+        panZoom.panBy(PAN_STEP, 0);
+        break;
+      case 'ArrowRight':
+        panZoom.panBy(-PAN_STEP, 0);
+        break;
+      case '+':
+      case '=':
+        panZoom.zoomIn();
+        break;
+      case '-':
+      case '_':
+        panZoom.zoomOut();
+        break;
+      case '0':
+        panZoom.fit(true);
+        break;
+      default:
+        return;
+    }
+    event.preventDefault();
+  };
+
+  const toolbar = document.createElement('div');
+  toolbar.className = 'ec-diagram-modal__toolbar';
+  toolbar.appendChild(createControlButton(ICONS.zoomOut, 'Zoom out', () => panZoom.zoomOut()));
+  toolbar.appendChild(zoomStatus);
+  toolbar.appendChild(createControlButton(ICONS.zoomIn, 'Zoom in', () => panZoom.zoomIn()));
+  toolbar.appendChild(createControlButton(ICONS.reset, 'Reset view', () => panZoom.fit(true)));
+  if (source.diagramContent) {
+    toolbar.appendChild(createCopyButton(source.diagramContent));
+  }
+
+  const closeBtn = createControlButton(ICONS.close, 'Close fullscreen', close);
+  closeBtn.classList.add('ec-diagram-modal__close');
+
+  dialog.appendChild(viewport);
+  dialog.appendChild(toolbar);
+  dialog.appendChild(closeBtn);
+  root.appendChild(dialog);
+
+  backdrop.addEventListener('click', close);
+  root.addEventListener('click', (event) => {
+    // Clicks on the padding around the dialog close the modal
+    if (event.target === root) close();
+  });
+  document.addEventListener('keydown', onKeyDown);
+
+  document.body.appendChild(backdrop);
+  document.body.appendChild(root);
+  document.body.style.overflow = 'hidden';
+
+  panZoom.fit(false);
+  viewport.focus({ preventScroll: true });
+
+  // Let the starting styles paint before transitioning in
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      backdrop.classList.add('is-open');
+      root.classList.add('is-open');
+    });
+  });
+}
+
+interface DiagramControlsOptions {
+  placement: ControlsPlacement;
+  source: DiagramSource;
+}
+
+/**
+ * Creates the inline interactive diagram controls, laid out as a 3x3 grid:
+ *
+ *   [fullscreen] [pan up]   [zoom in]
+ *   [pan left]   [reset]    [pan right]
+ *   [copy]       [pan down] [zoom out]
+ */
+function createDiagramControls(panZoom: PanZoomInstance, options: DiagramControlsOptions): HTMLElement {
+  const { placement, source } = options;
 
   const controls = document.createElement('div');
-  controls.style.cssText = `
-    position: absolute;
-    bottom: 12px;
-    left: 12px;
-    display: flex;
-    flex-direction: column;
-    background: ${colors.bgColor};
-    border-radius: 6px;
-    box-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
-    border: 1px solid ${colors.borderColor};
-    overflow: hidden;
-    z-index: 10;
-  `;
+  controls.className = 'ec-diagram-controls';
+  controls.setAttribute('data-placement', placement);
+  controls.setAttribute('role', 'toolbar');
+  controls.setAttribute('aria-label', 'Diagram controls');
 
-  controls.appendChild(createStyledButton(ICONS.plus, 'Zoom in', onZoomIn, colors));
-  controls.appendChild(createStyledButton(ICONS.minus, 'Zoom out', onZoomOut, colors));
-  controls.appendChild(createStyledButton(ICONS.fit, 'Fit view', onFitView, colors, { isLast: true }));
+  let copyBtn: HTMLElement;
+  if (source.diagramContent) {
+    copyBtn = createCopyButton(source.diagramContent);
+  } else {
+    // Keep the grid shape when there is nothing to copy
+    copyBtn = document.createElement('div');
+    copyBtn.setAttribute('aria-hidden', 'true');
+  }
+
+  const buttons: HTMLElement[] = [
+    createControlButton(ICONS.fullscreen, 'Open fullscreen', () => openDiagramModal(source)),
+    createControlButton(ICONS.panUp, 'Pan up', () => panZoom.panBy(0, PAN_STEP)),
+    createControlButton(ICONS.zoomIn, 'Zoom in', () => panZoom.zoomIn()),
+    createControlButton(ICONS.panLeft, 'Pan left', () => panZoom.panBy(PAN_STEP, 0)),
+    createControlButton(ICONS.reset, 'Reset view', () => panZoom.fit(true)),
+    createControlButton(ICONS.panRight, 'Pan right', () => panZoom.panBy(-PAN_STEP, 0)),
+    copyBtn,
+    createControlButton(ICONS.panDown, 'Pan down', () => panZoom.panBy(0, -PAN_STEP)),
+    createControlButton(ICONS.zoomOut, 'Zoom out', () => panZoom.zoomOut()),
+  ];
+  buttons.forEach((btn) => controls.appendChild(btn));
 
   return controls;
 }
 
 /**
- * Creates a toolbar button with tooltip
- */
-function createToolbarButton(
-  icon: string,
-  tooltipText: string,
-  onClick: () => void,
-  colors: ReturnType<typeof getThemeColors>,
-  tooltipPosition: 'left' | 'right' | 'bottom' = 'bottom'
-): { wrapper: HTMLElement; btn: HTMLButtonElement; tooltip: HTMLElement } {
-  const wrapper = document.createElement('div');
-  wrapper.style.cssText = `position: relative;`;
-
-  const btn = document.createElement('button');
-  btn.type = 'button';
-  btn.innerHTML = icon;
-  btn.style.cssText = `
-    all: unset;
-    box-sizing: border-box;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    width: 40px;
-    height: 40px;
-    min-width: 40px;
-    min-height: 40px;
-    padding: 0;
-    margin: 0;
-    border: none;
-    border-radius: 6px;
-    background: ${colors.bgColor};
-    color: ${colors.iconColor};
-    cursor: pointer;
-    transition: background-color 0.15s, color 0.15s;
-    box-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
-  `;
-
-  const svgEl = btn.querySelector('svg');
-  if (svgEl) {
-    svgEl.style.cssText = 'display: block; width: 20px; height: 20px;';
-  }
-
-  btn.onmouseenter = () => {
-    btn.style.backgroundColor = colors.hoverBgColor;
-    btn.style.color = colors.iconHoverColor;
-  };
-  btn.onmouseleave = () => {
-    btn.style.backgroundColor = colors.bgColor;
-    btn.style.color = colors.iconColor;
-  };
-  btn.onclick = onClick;
-
-  // Tooltip with position-based styling
-  const tooltip = document.createElement('div');
-  tooltip.textContent = tooltipText;
-
-  let tooltipStyles = `
-    position: absolute;
-    padding: 4px 8px;
-    background: #1f2937;
-    color: white;
-    font-size: 12px;
-    border-radius: 4px;
-    box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1);
-    white-space: nowrap;
-    pointer-events: none;
-    opacity: 0;
-    transition: opacity 0.15s;
-    z-index: 50;
-  `;
-
-  if (tooltipPosition === 'right') {
-    tooltipStyles += `
-      top: 50%;
-      left: 100%;
-      transform: translateY(-50%);
-      margin-left: 8px;
-    `;
-  } else if (tooltipPosition === 'left') {
-    tooltipStyles += `
-      top: 50%;
-      right: 100%;
-      transform: translateY(-50%);
-      margin-right: 8px;
-    `;
-  } else {
-    // Default: bottom
-    tooltipStyles += `
-      top: 100%;
-      left: 50%;
-      transform: translateX(-50%);
-      margin-top: 8px;
-    `;
-  }
-
-  tooltip.style.cssText = tooltipStyles;
-
-  wrapper.onmouseenter = () => {
-    tooltip.style.opacity = '1';
-  };
-  wrapper.onmouseleave = () => {
-    tooltip.style.opacity = '0';
-  };
-
-  wrapper.appendChild(btn);
-  wrapper.appendChild(tooltip);
-
-  return { wrapper, btn, tooltip };
-}
-
-/**
- * Creates the fullscreen button for top-left (tooltip shows to the right)
- */
-function createFullscreenButton(onClick: () => void): HTMLElement {
-  const colors = getThemeColors();
-  const { wrapper } = createToolbarButton(ICONS.presentation, 'Presentation Mode', onClick, colors, 'right');
-  wrapper.style.cssText = `
-    position: absolute;
-    top: 12px;
-    left: 12px;
-    z-index: 10;
-  `;
-  return wrapper;
-}
-
-/**
- * Creates the copy button for top-right (tooltip shows to the left)
- */
-function createCopyButton(onCopy: () => void): HTMLElement {
-  const colors = getThemeColors();
-  const copy = createToolbarButton(
-    ICONS.copy,
-    'Copy diagram code',
-    () => {
-      onCopy();
-      // Show feedback
-      copy.btn.innerHTML = ICONS.check;
-      copy.btn.style.color = '#10b981'; // Green color for success
-      copy.tooltip.textContent = 'Copied!';
-
-      const svgEl = copy.btn.querySelector('svg');
-      if (svgEl) {
-        svgEl.style.cssText = 'display: block; width: 20px; height: 20px;';
-      }
-
-      setTimeout(() => {
-        copy.btn.innerHTML = ICONS.copy;
-        copy.btn.style.color = colors.iconColor;
-        copy.tooltip.textContent = 'Copy diagram code';
-        const svgEl = copy.btn.querySelector('svg');
-        if (svgEl) {
-          svgEl.style.cssText = 'display: block; width: 20px; height: 20px;';
-        }
-      }, 2000);
-    },
-    colors,
-    'left'
-  );
-
-  copy.wrapper.style.cssText = `
-    position: absolute;
-    top: 12px;
-    right: 12px;
-    z-index: 10;
-  `;
-
-  return copy.wrapper;
-}
-
-/**
- * Toggles native fullscreen mode on a container
- */
-function toggleFullscreen(container: HTMLElement): void {
-  if (!document.fullscreenElement) {
-    container.requestFullscreen().catch((err) => {
-      console.warn(`Error entering fullscreen: ${err.message}`);
-    });
-  } else {
-    document.exitFullscreen();
-  }
-}
-
-/**
- * Creates the zoom container with React Flow-style appearance
+ * Creates the zoom container that wraps a rendered diagram
  */
 export function createZoomContainer(): HTMLElement {
+  ensureDiagramStyles();
   const container = document.createElement('div');
   container.className = 'mermaid-zoom-container';
-  container.style.cssText = `
-    position: relative;
-    width: 100%;
-    min-height: 200px;
-    overflow: hidden;
-    margin: 0;
-    cursor: grab;
-  `;
+  container.style.minHeight = '200px';
   return container;
 }
 
 interface ZoomOptions {
   minZoom?: number;
   maxZoom?: number;
-  zoomScaleSensitivity?: number;
   maxHeight?: number;
   minHeight?: number;
   diagramContent?: string;
+  /** Where to place the interactive controls. Defaults to `top-right`. */
+  placement?: ControlsPlacement;
+  /** Force the controls on/off. By default they are shown when the diagram is taller than 120px. */
+  actions?: boolean;
+}
+
+/** Padding kept around the content when a viewBox is trimmed */
+const TRIM_PADDING = 8;
+
+/** Only trim a viewBox when it has more than this much empty space on a side */
+const TRIM_THRESHOLD = 16;
+
+/**
+ * Some renderers (notably mermaid C4 diagrams) declare a viewBox much larger than the drawn
+ * content, which makes the diagram appear small and heavily padded. When the SVG is rendered
+ * we can measure the real content bounds and tighten the viewBox around them.
+ */
+function trimSvgViewBox(svgElement: SVGElement): void {
+  const viewBox = svgElement.getAttribute('viewBox');
+  if (!viewBox) return;
+  const [vx, vy, vw, vh] = viewBox.split(/[\s,]+/).map(Number);
+  if (!(vw > 0 && vh > 0)) return;
+
+  let bbox: DOMRect;
+  try {
+    bbox = (svgElement as unknown as SVGGraphicsElement).getBBox();
+  } catch (e) {
+    return;
+  }
+  // getBBox returns zeros when the SVG is not rendered (e.g. inside a collapsed section)
+  if (!(bbox.width > 0 && bbox.height > 0)) return;
+
+  const slack = {
+    left: bbox.x - vx,
+    top: bbox.y - vy,
+    right: vx + vw - (bbox.x + bbox.width),
+    bottom: vy + vh - (bbox.y + bbox.height),
+  };
+  if (Math.max(slack.left, slack.top, slack.right, slack.bottom) <= TRIM_THRESHOLD) return;
+
+  const x = Math.max(vx, bbox.x - TRIM_PADDING);
+  const y = Math.max(vy, bbox.y - TRIM_PADDING);
+  const width = Math.min(vx + vw, bbox.x + bbox.width + TRIM_PADDING) - x;
+  const height = Math.min(vy + vh, bbox.y + bbox.height + TRIM_PADDING) - y;
+  svgElement.setAttribute('viewBox', `${x} ${y} ${width} ${height}`);
 }
 
 /**
- * Initializes zoom on a Mermaid SVG element
+ * Reads the natural dimensions of an SVG from its viewBox, bounding box or attributes
  */
-export async function initMermaidZoom(
-  svgElement: SVGElement,
-  container: HTMLElement,
-  id: string,
-  options: ZoomOptions = {}
-): Promise<void> {
-  // Lower zoomScaleSensitivity = smoother but slower zoom
-  const { minZoom = 0.5, maxZoom = 10, zoomScaleSensitivity = 0.15, maxHeight = 500, minHeight = 200, diagramContent } = options;
-
-  // Dynamic import for performance
-  const { default: svgPanZoom } = await import('svg-pan-zoom');
-
-  // Get the natural dimensions from viewBox or getBBox
-  let width: number = 0;
-  let height: number = 0;
+function getSvgDimensions(svgElement: SVGElement): { width: number; height: number } {
+  let width = 0;
+  let height = 0;
+  trimSvgViewBox(svgElement);
   const viewBox = svgElement.getAttribute('viewBox');
 
   if (viewBox) {
@@ -412,7 +843,7 @@ export async function initMermaidZoom(
   }
 
   // If viewBox didn't give us dimensions, try getBBox
-  if (width <= 0 || height <= 0) {
+  if (!(width > 0 && height > 0)) {
     try {
       // Cast to SVGGraphicsElement which has getBBox method
       const bbox = (svgElement as unknown as SVGGraphicsElement).getBBox();
@@ -427,130 +858,66 @@ export async function initMermaidZoom(
   }
 
   // Fallback to element dimensions if still no size
-  if (width <= 0 || height <= 0) {
+  if (!(width > 0 && height > 0)) {
     width = svgElement.clientWidth || parseFloat(svgElement.getAttribute('width') || '0') || 800;
     height = svgElement.clientHeight || parseFloat(svgElement.getAttribute('height') || '0') || 400;
   }
 
+  return { width, height };
+}
+
+/**
+ * Initializes pan/zoom (and the interactive controls) on a rendered SVG element
+ */
+export async function initMermaidZoom(
+  svgElement: SVGElement,
+  container: HTMLElement,
+  id: string,
+  options: ZoomOptions = {}
+): Promise<void> {
+  const {
+    minZoom = 0.1,
+    maxZoom = 8,
+    maxHeight = 500,
+    minHeight = 200,
+    diagramContent,
+    placement = DEFAULT_PLACEMENT,
+    actions,
+  } = options;
+
+  ensureDiagramStyles();
+
+  const { width, height } = getSvgDimensions(svgElement);
+
   // Set container height based on SVG aspect ratio, capped for usability
-  if (width > 0 && height > 0) {
-    const containerWidth = container.clientWidth || 800;
-    const aspectRatio = height / width;
-    const calculatedHeight = Math.min(Math.max(containerWidth * aspectRatio, minHeight), maxHeight);
-    container.style.height = `${calculatedHeight}px`;
-  } else {
-    container.style.height = `${minHeight}px`;
+  const containerWidth = container.clientWidth || 800;
+  const calculatedHeight = Math.min(Math.max(containerWidth * (height / width), minHeight), maxHeight);
+  container.style.height = `${calculatedHeight}px`;
+
+  // Wrap the SVG in a viewport + transformable content element
+  const { viewport, content } = createViewport(svgElement, width, height);
+  container.innerHTML = '';
+  container.appendChild(viewport);
+
+  const panZoom = createPanZoom(viewport, content, width, height, { minScale: minZoom, maxScale: maxZoom });
+  zoomInstances.set(id, panZoom);
+  panZoom.fit(false);
+
+  // Add interactive controls. By default they are only shown for diagrams taller than 120px.
+  const showControls = actions ?? height > CONTROLS_MIN_HEIGHT;
+  if (showControls) {
+    const source: DiagramSource = { svg: svgElement, width, height, diagramContent };
+    container.appendChild(createDiagramControls(panZoom, { placement, source }));
   }
 
-  // SVG needs to fill the container for svg-pan-zoom
-  svgElement.style.width = '100%';
-  svgElement.style.height = '100%';
-  svgElement.removeAttribute('height');
-  svgElement.removeAttribute('width');
-
-  try {
-    const instance = svgPanZoom(svgElement, {
-      zoomEnabled: true,
-      controlIconsEnabled: false, // We use custom controls
-      fit: true,
-      center: true,
-      minZoom,
-      maxZoom,
-      zoomScaleSensitivity,
-      dblClickZoomEnabled: true,
-      mouseWheelZoomEnabled: false, // Disabled to avoid hijacking page scroll
-      preventMouseEventsDefault: true,
-      panEnabled: true,
-    });
-
-    zoomInstances.set(id, instance);
-
-    // Update cursor during pan
-    container.addEventListener('mousedown', () => {
-      container.style.cursor = 'grabbing';
-    });
-    container.addEventListener('mouseup', () => {
-      container.style.cursor = 'grab';
-    });
-    container.addEventListener('mouseleave', () => {
-      container.style.cursor = 'grab';
-    });
-
-    // Add custom controls
-    const controls = createZoomControls(
-      () => instance.zoomIn(),
-      () => instance.zoomOut(),
-      () => {
-        instance.fit();
-        instance.center();
-      }
-    );
-    container.appendChild(controls);
-
-    // Add fullscreen button (top-left)
-    const fullscreenBtn = createFullscreenButton(() => toggleFullscreen(container));
-    container.appendChild(fullscreenBtn);
-
-    // Add copy button (top-right) if diagram content is available
-    if (diagramContent) {
-      const copyBtn = createCopyButton(() => {
-        navigator.clipboard.writeText(diagramContent).catch((err) => {
-          console.warn('Failed to copy diagram code:', err);
-        });
-      });
-      container.appendChild(copyBtn);
+  // Refit on resize for responsiveness
+  const resizeObserver = new ResizeObserver(() => {
+    if (container.clientWidth > 0 && container.clientHeight > 0) {
+      panZoom.fit(false);
     }
-
-    // Handle fullscreen changes - enable scroll zoom in fullscreen, disable when exiting
-    const handleFullscreenChange = () => {
-      const isFullscreen = document.fullscreenElement === container;
-
-      if (isFullscreen) {
-        // Enable scroll zoom in fullscreen
-        instance.enableMouseWheelZoom();
-        // Update container styles for fullscreen
-        container.style.background = getThemeColors().overlayBg;
-      } else {
-        // Disable scroll zoom when not fullscreen
-        instance.disableMouseWheelZoom();
-        // Reset container background
-        container.style.background = '';
-      }
-
-      // Fit and center after transition
-      setTimeout(() => {
-        if (container.clientWidth > 0 && container.clientHeight > 0) {
-          try {
-            instance.resize();
-            instance.fit();
-            instance.center();
-          } catch (e) {
-            // Ignore matrix inversion errors
-          }
-        }
-      }, 100);
-    };
-    document.addEventListener('fullscreenchange', handleFullscreenChange);
-    fullscreenHandlers.set(id, handleFullscreenChange);
-
-    // Resize handler for responsiveness
-    const resizeObserver = new ResizeObserver(() => {
-      // Guard against zero-dimension containers which cause matrix inversion errors
-      if (container.clientWidth > 0 && container.clientHeight > 0) {
-        try {
-          instance.resize();
-          instance.fit();
-          instance.center();
-        } catch (e) {
-          // Ignore matrix inversion errors during resize
-        }
-      }
-    });
-    resizeObserver.observe(container);
-    resizeObservers.set(id, resizeObserver);
-  } catch (e) {
-    console.warn('Failed to initialize zoom on mermaid diagram:', e);
-  }
+  });
+  resizeObserver.observe(container);
+  resizeObservers.set(id, resizeObserver);
 }
 
 /**
@@ -590,8 +957,12 @@ export async function renderMermaidWithZoom(graphs: HTMLCollectionOf<Element>, m
 
   // Reset abort flag at the start of rendering
   renderingAborted = false;
+  const generation = ++mermaidRenderGeneration;
+  lastMermaidConfig = mermaidConfig;
+  ensureThemeObserver();
 
   const { default: mermaid } = await import('mermaid');
+  if (generation !== mermaidRenderGeneration) return;
 
   // Apply any custom mermaid configuration
   if (mermaidConfig) {
@@ -652,7 +1023,7 @@ export async function renderMermaidWithZoom(graphs: HTMLCollectionOf<Element>, m
 
   for (const graph of graphsArray) {
     // Check if rendering was aborted (e.g., user navigated away)
-    if (renderingAborted) return;
+    if (renderingAborted || generation !== mermaidRenderGeneration) return;
 
     const content = graph.getAttribute('data-content');
     if (!content) continue;
@@ -663,7 +1034,7 @@ export async function renderMermaidWithZoom(graphs: HTMLCollectionOf<Element>, m
       const result = await mermaid.render(id, content);
 
       // Check again after async operation
-      if (renderingAborted) return;
+      if (renderingAborted || generation !== mermaidRenderGeneration) return;
 
       // Create zoom container
       const container = createZoomContainer();
@@ -676,7 +1047,10 @@ export async function renderMermaidWithZoom(graphs: HTMLCollectionOf<Element>, m
       // Initialize zoom on the SVG
       const svgElement = container.querySelector('svg');
       if (svgElement) {
-        await initMermaidZoom(svgElement as SVGElement, container, id, { diagramContent: content });
+        await initMermaidZoom(svgElement as SVGElement, container, id, {
+          diagramContent: content,
+          ...getControlOptionsFromElement(graph),
+        });
       }
     } catch (e) {
       console.error('Mermaid render error:', e);
@@ -743,7 +1117,7 @@ export async function renderPlantUMLWithZoom(blocks: HTMLCollectionOf<Element>):
     const svgUrl = `https://www.plantuml.com/plantuml/svg/~1${encoded}`;
 
     try {
-      // Fetch SVG content so we can use svg-pan-zoom
+      // Fetch SVG content so we can pan/zoom it
       const response = await fetch(svgUrl);
 
       // Check again after async operation
@@ -769,7 +1143,10 @@ export async function renderPlantUMLWithZoom(blocks: HTMLCollectionOf<Element>):
       // Initialize zoom on the SVG
       const svgElement = container.querySelector('svg');
       if (svgElement) {
-        await initMermaidZoom(svgElement as SVGElement, container, id, { diagramContent: content });
+        await initMermaidZoom(svgElement as SVGElement, container, id, {
+          diagramContent: content,
+          ...getControlOptionsFromElement(block),
+        });
       }
     } catch (e) {
       // Fallback to img tag if fetch fails (e.g., CORS issues)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -140,7 +140,6 @@
     "shelljs": "^0.9.0",
     "sonner": "^2.0.7",
     "sql.js": "^1.12.0",
-    "svg-pan-zoom": "^3.6.2",
     "tailwindcss": "^4.3.1",
     "typescript": "^5.4.5",
     "unist-util-visit": "^5.0.0",

--- a/packages/create-eventcatalog/templates/default/domains/Customer/index.mdx
+++ b/packages/create-eventcatalog/templates/default/domains/Customer/index.mdx
@@ -59,9 +59,3 @@ The **Customer Management System** owns customer profile data — it accepts reg
 The systems in this domain, how they relate, and the people who interact with them.
 
 <ContextDiagram />
-
-## Resource Diagram
-
-The components that make up this domain.
-
-<NodeGraph />

--- a/packages/create-eventcatalog/templates/default/domains/Fulfilment/index.mdx
+++ b/packages/create-eventcatalog/templates/default/domains/Fulfilment/index.mdx
@@ -75,9 +75,3 @@ When an order is completed, the **Warehouse System** picks and packs it, having 
 The systems in this domain, how they relate, and the people who interact with them.
 
 <ContextDiagram />
-
-## Resource Diagram
-
-The components that make up this domain.
-
-<NodeGraph />

--- a/packages/create-eventcatalog/templates/default/domains/Shopping/index.mdx
+++ b/packages/create-eventcatalog/templates/default/domains/Shopping/index.mdx
@@ -59,9 +59,3 @@ The **Cart System** owns the customer's cart and the checkout flow. When pricing
 The systems in this domain, how they relate, and the people who interact with them.
 
 <ContextDiagram />
-
-## Resource Diagram
-
-The components that make up this domain.
-
-<NodeGraph />

--- a/packages/sdk/src/test/fixtures/build-index/default-catalog-index.json
+++ b/packages/sdk/src/test/fixtures/build-index/default-catalog-index.json
@@ -626,7 +626,7 @@
       "version": "1.0.0",
       "name": "Catalog",
       "contentPath": "domains/Catalog/index.mdx",
-      "contentHash": "sha256:f34e1362ab1fb1dfb9c3ed2836cd054f4858b6c764b0e0fe62185bb162bac779",
+      "contentHash": "sha256:d981afe5b9957e4e76ada79a294f5b520c992a152b8e9b947085f40d653c001b",
       "owners": ["product-platform"],
       "sidecars": [
         {
@@ -784,7 +784,7 @@
       "version": "1.0.0",
       "name": "Fulfilment",
       "contentPath": "domains/Fulfilment/index.mdx",
-      "contentHash": "sha256:4c135222dcc67e7872a40668050b3056b98932a38cd21968b050c0f9bf37440a",
+      "contentHash": "sha256:7d93fe273b2b35f6bba4d03748e2e41a969d1d95264e4e4a4c7c6a942a85e187",
       "owners": ["fulfilment-platform"],
       "sidecars": [
         {
@@ -867,7 +867,7 @@
       "version": "1.0.0",
       "name": "Ordering",
       "contentPath": "domains/Ordering/index.mdx",
-      "contentHash": "sha256:80d05ff89805888e594bdbea50854c8ae4b3e615ae0da6b8272e1e4de1d62249",
+      "contentHash": "sha256:b343c252eebe8d3d4afb0b7963da18ba66496f4854022036784fcb9eab38fdc4",
       "owners": ["ordering-platform"],
       "sidecars": [
         {
@@ -948,7 +948,7 @@
       "version": "1.0.0",
       "name": "Payments",
       "contentPath": "domains/Payments/index.mdx",
-      "contentHash": "sha256:271d5fc58b5ecdc3b02d1a1f3f3b9ed0fc4a1b48e07fb31a9bc0c726861464a9",
+      "contentHash": "sha256:3af19203a35d7d45a5b9bd26d2e97cdab085d63143c77f0a4d26477b38c85b02",
       "owners": ["payments-platform"],
       "sidecars": [
         {
@@ -1177,7 +1177,7 @@
       "version": "1.0.0",
       "name": "Shopping",
       "contentPath": "domains/Shopping/index.mdx",
-      "contentHash": "sha256:013ccf530b88fb9b343966f85b4fdc74062afab262dbc9bc5b306cfae046920e",
+      "contentHash": "sha256:0977f45bb05ff1d8b85c9229f0440d69620bbe3fedfb1d0fd099dcdaaa3d3bcd",
       "owners": ["shopping-platform"],
       "sidecars": [
         {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -263,14 +263,14 @@ importers:
         specifier: ^4.0.3
         version: 4.0.3
       hono:
-        specifier: 4.13.0
-        version: 4.13.0
+        specifier: 4.13.5
+        version: 4.13.5
       html-to-image:
         specifier: ^1.11.11
         version: 1.11.13
       js-yaml:
-        specifier: ^4.3.1
-        version: 4.3.1
+        specifier: ^4.3.2
+        version: 4.3.2
       jsonpath-plus:
         specifier: ^10.4.0
         version: 10.4.0
@@ -361,9 +361,6 @@ importers:
       sql.js:
         specifier: ^1.12.0
         version: 1.14.1
-      svg-pan-zoom:
-        specifier: ^3.6.2
-        version: 3.6.2
       tailwindcss:
         specifier: ^4.3.1
         version: 4.3.1
@@ -5456,8 +5453,8 @@ packages:
   highlightjs-vue@1.0.0:
     resolution: {integrity: sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==}
 
-  hono@4.13.0:
-    resolution: {integrity: sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==}
+  hono@4.13.5:
+    resolution: {integrity: sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==}
     engines: {node: '>=16.9.0'}
 
   hookable@6.1.0:
@@ -5822,8 +5819,8 @@ packages:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
-  js-yaml@4.3.1:
-    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
+  js-yaml@4.3.2:
+    resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
     hasBin: true
 
   jsdom@27.0.0:
@@ -9013,7 +9010,7 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       picomatch: 4.0.4
       retext-smartypants: 6.2.0
       shiki: 4.0.2
@@ -9219,7 +9216,7 @@ snapshots:
       ajv-errors: 3.0.0(ajv@8.17.1)
       ajv-formats: 2.1.1(ajv@8.17.1)
       avsc: 5.7.9
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       jsonpath-plus: 10.4.0
       node-fetch: 2.6.7
     transitivePeerDependencies:
@@ -9549,7 +9546,7 @@ snapshots:
   '@changesets/parse@0.4.2':
     dependencies:
       '@changesets/types': 6.1.0
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
 
   '@changesets/pre@2.0.2':
     dependencies:
@@ -10110,9 +10107,9 @@ snapshots:
     dependencies:
       react: 18.3.1
 
-  '@hono/node-server@1.19.9(hono@4.13.0)':
+  '@hono/node-server@1.19.9(hono@4.13.5)':
     dependencies:
-      hono: 4.13.0
+      hono: 4.13.5
 
   '@iconify-json/logos@1.2.9':
     dependencies:
@@ -10423,7 +10420,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 1.19.9(hono@4.13.0)
+      '@hono/node-server': 1.19.9(hono@4.13.5)
       ajv: 8.17.1
       ajv-formats: 3.0.1(ajv@8.17.1)
       content-type: 1.0.5
@@ -10433,7 +10430,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.2.1(express@5.2.1)
-      hono: 4.13.0
+      hono: 4.13.5
       jose: 6.1.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -12633,7 +12630,7 @@ snapshots:
       github-slugger: 2.0.0
       html-escaper: 3.0.3
       http-cache-semantics: 4.2.0
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       jsonc-parser: 3.3.1
       magic-string: 1.1.0
       magicast: 0.5.2
@@ -14392,7 +14389,7 @@ snapshots:
 
   highlightjs-vue@1.0.0: {}
 
-  hono@4.13.0: {}
+  hono@4.13.5: {}
 
   hookable@6.1.0: {}
 
@@ -14707,7 +14704,7 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  js-yaml@4.3.1:
+  js-yaml@4.3.2:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION

## What This PR Does

Redesigns the interactive controls for Mermaid and PlantUML diagrams rendered in EventCatalog. Diagrams now get a compact, hover-revealed control grid, smooth animated pan and zoom, and a fullscreen modal viewer. It also adds per-diagram `placement` and `actions` options, fixes diagrams not re-rendering on light/dark toggle, and removes the `svg-pan-zoom` dependency from core.

## Changes Overview

### Key Changes

- **New control grid.** A 3x3 grid of 28px bordered buttons in the diagram corner: fullscreen, pan up, zoom in / pan left, reset, pan right / copy, pan down, zoom out. Controls fade in on hover or focus, are always visible on touch devices, and are hidden when printing.
- **Smooth pan and zoom.** Replaces `svg-pan-zoom` with a small CSS transform engine. Button, keyboard and double-click changes animate over 150ms ease-out; drag, wheel and pinch stay instant. Respects `prefers-reduced-motion`.
- **Fullscreen modal.** The fullscreen button opens a dialog over a dimmed backdrop with a dotted grid, a toolbar showing zoom out / current zoom % / zoom in / reset / copy, and a close button. Supports drag, scroll and pinch to zoom, arrow keys to pan, `+` / `-` to zoom, `0` to reset and `Escape` to close. Locks page scroll while open and restores focus on close.
- **Per-diagram options.** Code fences accept `placement="top-left|top-right|bottom-left|bottom-right"` and `actions={true|false}`. The same props work on `<MermaidFileLoader />`. Controls show by default only when the diagram is taller than 120px.
- **Theme switching.** Mermaid bakes its theme into the SVG, so diagrams are now re-rendered when `data-theme` changes. A render generation counter stops a stale in-flight render from overwriting the new one.
- **Tighter fit.** Over-allocated SVG viewBoxes (notably mermaid C4 diagrams) are trimmed to the drawn content before fitting, so diagrams no longer render small with large empty margins.
- **Icon centering fix.** The page's global `.mermaid svg` margin rule was offsetting the icon SVGs inside the buttons. Element-qualified selectors now override it.
- **Embed page.** `/diagrams/{id}/{version}/embed` carries a plain-JS port of the same engine and modal, and no longer loads `svg-pan-zoom` from the CDN.
- **Dependency cleanup.** `svg-pan-zoom` removed from `@eventcatalog/core` (the visualiser package keeps its own copy).
- **Example catalog.** Adds a "Value Chain" Wardley map to the Catalog, Payments, Fulfilment and Ordering domains, built from each domain's actual systems.

### Files

- `packages/core/eventcatalog/src/utils/mermaid-zoom.ts` – engine, controls, modal, theme observer, viewBox trimming
- `packages/core/eventcatalog/src/pages/diagrams/[id]/[version]/embed.astro` – standalone JS port
- `packages/core/eventcatalog/src/remark-plugins/mermaid.ts` – parses `placement` / `actions` from fence meta, plus new tests
- `packages/core/eventcatalog/src/components/MDX/MermaidFileLoader/MermaidFileLoader.astro` – accepts `placement` / `actions` props
- `examples/default/domains/*/index.mdx` – Wardley maps

## How It Works

The renderer wraps each diagram SVG in a viewport and a transformable content element. A `createPanZoom` helper tracks `x`, `y` and `scale` and applies `translate() scale()` to the content element, toggling the transition duration between 150ms and 0ms depending on whether the change came from a button or a pointer gesture. Fit is computed from the SVG's natural size, capped at 100%.

The modal reuses the same engine on a cloned SVG. Styles are injected once per document from the module so the isolated embed page works without the app's stylesheet, and every colour comes from the `--ec-*` theme variables with fallbacks.

## Breaking Changes

None. Existing `mermaid` and `plantuml` code blocks and `<MermaidFileLoader />` usages render as before, with the new controls.

## Additional Notes

- Verified in the browser: inline controls, smooth zoom transitions, modal open/close and keyboard handling, light/dark re-rendering, icon centering, PlantUML rendering, and all four example Wardley maps.
- The embed page port was not exercised in a browser because the example catalog has no diagram resources. Worth a quick manual check on a catalog that has one.
- The lockfile diff also bumps `hono` and `js-yaml` because the lockfile was already out of sync with `package.json` specifiers.
- Controls are hover-only on desktop. Keyboard users get them via focus and touch devices always show them.

https://claude.ai/code/session_01QVPc2tUt3DBt3acYhRcr71