### PR TITLE
Fix embed mode chrome, sizing and theme support

### DIFF
--- a/.changeset/quiet-moons-embed-chrome.md
+++ b/.changeset/quiet-moons-embed-chrome.md
@@ -1,0 +1,9 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix(embed): hide catalog chrome and fill the viewport when embedding pages
+
+- Hide the vertical nav, header and resource sidebar on any page rendered with `?embed=true`
+- Give the visualiser, architecture graph, system context map, schema explorer, schema detail and discover pages a full-height embedded viewport (CSS driven, replacing the old post-load inline height scripts)
+- Support `?theme=light` / `?theme=dark` alongside `embed=true` so an embed can pick its own theme without overwriting the user's saved catalog preference

--- a/packages/core/eventcatalog/src/components/SchemaExplorer/SchemaExplorer.tsx
+++ b/packages/core/eventcatalog/src/components/SchemaExplorer/SchemaExplorer.tsx
@@ -384,6 +384,7 @@ export default function SchemaExplorer({ schemas, apiAccessEnabled = false }: Sc
       />
       <div className="flex flex-1 min-h-0 gap-0 overflow-hidden">
         <div
+          id="schema-explorer-sidebar"
           className="fixed top-0 z-20 flex h-screen flex-col overflow-hidden border-r border-[rgb(var(--ec-page-border))] bg-linear-to-b from-[rgb(var(--ec-page-bg))] via-[rgb(var(--ec-page-bg))] to-[rgb(var(--ec-accent)/0.06)]"
           style={{ left: 'var(--ec-vertical-nav-width)', width: 'var(--ec-schema-sidebar-width, 360px)' }}
         >
@@ -583,6 +584,7 @@ export default function SchemaExplorer({ schemas, apiAccessEnabled = false }: Sc
         </div>
 
         <div
+          id="schema-explorer-content"
           className="flex-1 min-h-0 min-w-0 overflow-hidden bg-[rgb(var(--ec-card-bg,var(--ec-page-bg)))]"
           style={{ marginLeft: 'var(--ec-schema-sidebar-width, 360px)' }}
         >

--- a/packages/core/eventcatalog/src/components/Tables/Discover/DiscoverTable.tsx
+++ b/packages/core/eventcatalog/src/components/Tables/Discover/DiscoverTable.tsx
@@ -812,6 +812,7 @@ export function DiscoverTable<T extends DiscoverTableData>({
     <div className="flex h-full min-h-0" style={{ ['--ec-discover-sidebar-width' as any]: '320px' }}>
       {/* Filter Sidebar */}
       <div
+        id="discover-filter-sidebar"
         className="fixed left-[var(--ec-vertical-nav-width)] top-0 z-20 flex h-screen w-[320px] flex-shrink-0 flex-col border-r border-[rgb(var(--ec-content-border))] bg-[rgb(var(--ec-rail-bg))]"
         style={{ width: 'var(--ec-discover-sidebar-width, 320px)' }}
       >
@@ -1180,6 +1181,7 @@ export function DiscoverTable<T extends DiscoverTableData>({
 
       {/* Main Table */}
       <div
+        id="discover-results"
         className="flex-1 min-w-0 flex flex-col overflow-hidden"
         style={{ marginLeft: 'var(--ec-discover-sidebar-width, 320px)' }}
       >

--- a/packages/core/eventcatalog/src/layouts/BaseLayout.astro
+++ b/packages/core/eventcatalog/src/layouts/BaseLayout.astro
@@ -25,10 +25,18 @@ const catalogTheme = config.theme || 'default';
           return 'dark';
         }
 
+        function getEmbeddedTheme() {
+          const params = new URLSearchParams(window.location.search);
+          const requestedTheme = params.get('theme');
+          const embedded = params.get('embed') === 'true';
+          return embedded && (requestedTheme === 'light' || requestedTheme === 'dark') ? requestedTheme : null;
+        }
+
         function applyTheme() {
-          // Check localStorage first, fall back to dark mode
+          // An embed can request its own theme without changing the user's saved catalog preference.
+          const embeddedTheme = getEmbeddedTheme();
           const stored = localStorage.getItem('eventcatalog-theme');
-          const theme = stored === 'light' || stored === 'dark' ? stored : getDefaultTheme();
+          const theme = embeddedTheme || (stored === 'light' || stored === 'dark' ? stored : getDefaultTheme());
           document.documentElement.setAttribute('data-theme', theme);
           // Also ensure catalog theme is set (for page transitions)
           document.documentElement.setAttribute('data-catalog-theme', catalogTheme);

--- a/packages/core/eventcatalog/src/layouts/VerticalSideBarLayout.astro
+++ b/packages/core/eventcatalog/src/layouts/VerticalSideBarLayout.astro
@@ -432,6 +432,10 @@ const verticalNavAutoCollapsePaths = [buildUrl('/discover', true), buildUrl('/do
     <script is:inline define:vars={{ verticalNavAutoCollapsePaths }}>
       (() => {
         const verticalNavStorageKey = 'eventcatalog-vertical-nav-collapsed';
+        const embedded = new URLSearchParams(window.location.search).get('embed') === 'true';
+
+        document.documentElement.setAttribute('data-embedded', embedded ? 'true' : 'false');
+
         const routeShouldAutoCollapseVerticalNav = (pathname) =>
           verticalNavAutoCollapsePaths.some((path) => pathname === path || pathname.startsWith(`${path}/`));
 
@@ -513,6 +517,15 @@ const verticalNavAutoCollapsePaths = [buildUrl('/discover', true), buildUrl('/do
       }
       .app-shell--with-sidebar {
         margin-left: calc(var(--ec-vertical-nav-width) + var(--ec-sidebar-panel-width));
+      }
+      :root[data-embedded='true'] #eventcatalog-vertical-nav,
+      :root[data-embedded='true'] #eventcatalog-header,
+      :root[data-embedded='true'] #eventcatalog-header-spacer,
+      :root[data-embedded='true'] #sidebar {
+        display: none !important;
+      }
+      :root[data-embedded='true'] .app-shell {
+        margin-left: 0 !important;
       }
       .vertical-nav-rail {
         width: var(--ec-vertical-nav-width);
@@ -1087,6 +1100,7 @@ const verticalNavAutoCollapsePaths = [buildUrl('/discover', true), buildUrl('/do
     const urlSearchParams = new URLSearchParams(window.location.search);
     const params = Object.fromEntries(urlSearchParams.entries());
     const embeded = params.embed === 'true' ? true : false;
+    document.documentElement.setAttribute('data-embedded', embeded ? 'true' : 'false');
     const content = document.getElementById('content');
     const shell = document.querySelector('.app-shell');
     const app = document.getElementById('eventcatalog-application');
@@ -1130,6 +1144,7 @@ const verticalNavAutoCollapsePaths = [buildUrl('/discover', true), buildUrl('/do
         'eventcatalog-vertical-nav',
         'eventcatalog-header',
         'eventcatalog-header-spacer',
+        'sidebar',
         'visualiser-footer',
         // /discover page elements
         'discover-collection-tabs',

--- a/packages/core/eventcatalog/src/pages/discover/[type]/index.astro
+++ b/packages/core/eventcatalog/src/pages/discover/[type]/index.astro
@@ -444,8 +444,18 @@ const title = `${currentTypeConfig.label} (${data.length})`;
     #eventcatalog-header {
       left: calc(var(--ec-vertical-nav-width, 14rem) + var(--ec-discover-sidebar-width, 320px)) !important;
     }
+    :root[data-embedded='true'] #discover-filter-sidebar {
+      display: none !important;
+    }
+    :root[data-embedded='true'] #discover-results {
+      margin-left: 0 !important;
+    }
+    :root[data-embedded='true'] #discover-page {
+      height: 100dvh !important;
+    }
   </style>
   <main
+    id="discover-page"
     class="ml-0 flex h-full min-h-0 flex-col overflow-hidden bg-[rgb(var(--ec-page-bg))]"
     style={`--ec-discover-sidebar-width: 320px; margin-left: calc(var(--ec-app-content-padding-left, 5rem) * -1); margin-right: calc(var(--ec-app-content-padding-right, 5rem) * -1); height: calc(100dvh - 60px);`}
   >

--- a/packages/core/eventcatalog/src/pages/schemas/[type]/[id]/[version]/index.astro
+++ b/packages/core/eventcatalog/src/pages/schemas/[type]/[id]/[version]/index.astro
@@ -130,8 +130,14 @@ const apiAccessEnabled = isEventCatalogScaleEnabled();
 ---
 
 <VerticalSideBarLayout title={pageTitle}>
+  <style is:global>
+    :root[data-embedded='true'] #schema-detail-page {
+      height: 100dvh !important;
+    }
+  </style>
   {/* The schema viewer is an app-style surface: pull it out of the content gutter so it sits flush against the sidebar. */}
   <div
+    id="schema-detail-page"
     class="h-[calc(100vh-4rem)] overflow-hidden flex flex-col"
     style="margin-left: calc(var(--ec-app-content-padding-left, 5rem) * -1); margin-right: calc(var(--ec-app-content-padding-right, 5rem) * -1);"
   >

--- a/packages/core/eventcatalog/src/pages/schemas/explorer/index.astro
+++ b/packages/core/eventcatalog/src/pages/schemas/explorer/index.astro
@@ -17,8 +17,18 @@ const apiAccessEnabled = isEventCatalogScaleEnabled();
     #eventcatalog-header {
       left: calc(var(--ec-vertical-nav-width, 14rem) + var(--ec-schema-sidebar-width, 360px)) !important;
     }
+    :root[data-embedded='true'] #schema-explorer-sidebar {
+      display: none !important;
+    }
+    :root[data-embedded='true'] #schema-explorer-content {
+      margin-left: 0 !important;
+    }
+    :root[data-embedded='true'] #schema-explorer-page {
+      height: 100dvh !important;
+    }
   </style>
   <main
+    id="schema-explorer-page"
     class="min-h-0 overflow-hidden bg-[rgb(var(--ec-page-bg))]"
     style={`--ec-schema-sidebar-width: 360px; margin-left: calc(var(--ec-app-content-padding-left, 5rem) * -1); margin-right: calc(var(--ec-app-content-padding-right, 5rem) * -1); height: calc(100dvh - 60px);`}
   >

--- a/packages/core/eventcatalog/src/pages/visualiser/[type]/[id]/[version]/index.astro
+++ b/packages/core/eventcatalog/src/pages/visualiser/[type]/[id]/[version]/index.astro
@@ -20,9 +20,9 @@ const {
 ---
 
 <VisualiserLayout title={`Visualiser | ${props.data.name} (${props.collection})`} description={props.data.summary}>
-  <div class="p-2">
+  <div id="visualiser-page" class="p-2">
     <div
-      class="h-[calc(100vh-5rem)] w-full relative border border-[rgb(var(--ec-page-border))]"
+      class="visualiser-viewport h-[calc(100vh-5rem)] w-full relative border border-[rgb(var(--ec-page-border))]"
       id={`${id}-portal`}
       transition:name="visualiser-graph"
     >
@@ -45,15 +45,13 @@ const {
   <ClientRouter />
 </VisualiserLayout>
 
-<script define:vars={{ id }}>
-  document.addEventListener('DOMContentLoaded', () => {
-    const urlSearchParams = new URLSearchParams(window.location.search);
-    const params = Object.fromEntries(urlSearchParams.entries());
-    const embeded = params.embed === 'true' ? true : false;
-    const viewport = document.getElementById(`${id}-portal`);
+<style is:global>
+  html[data-embedded='true'] #visualiser-page {
+    box-sizing: border-box;
+    height: 100vh;
+  }
 
-    if (embeded) {
-      viewport.style.height = 'calc(100vh - 30px)';
-    }
-  });
-</script>
+  html[data-embedded='true'] #visualiser-page .visualiser-viewport {
+    height: 100%;
+  }
+</style>

--- a/packages/core/eventcatalog/src/pages/visualiser/graph/index.astro
+++ b/packages/core/eventcatalog/src/pages/visualiser/graph/index.astro
@@ -16,9 +16,25 @@ const { nodes: wireNodes, links: wireLinks, linkLabels } = toCatalogForceGraphWi
 ---
 
 <VisualiserLayout title="Visualiser | Architecture Graph" description="Force-directed graph of every resource in the catalog">
-  <div class="m-4">
-    <div class="h-[calc(100vh-130px)] w-full relative border border-[rgb(var(--ec-page-border))] rounded-md overflow-hidden">
+  <div id="architecture-graph-page" class="m-4">
+    <div
+      id="architecture-graph-container"
+      class="h-[calc(100vh-130px)] w-full relative border border-[rgb(var(--ec-page-border))] rounded-md overflow-hidden"
+    >
       <CatalogForceGraph nodes={wireNodes} links={wireLinks} linkLabels={linkLabels} client:only="react" />
     </div>
   </div>
 </VisualiserLayout>
+
+<style is:global>
+  html[data-embedded='true'] #architecture-graph-page {
+    box-sizing: border-box;
+    height: 100vh;
+    margin: 0;
+    padding: 1rem;
+  }
+
+  html[data-embedded='true'] #architecture-graph-container {
+    height: 100%;
+  }
+</style>

--- a/packages/core/eventcatalog/src/pages/visualiser/system-context-map/index.astro
+++ b/packages/core/eventcatalog/src/pages/visualiser/system-context-map/index.astro
@@ -7,9 +7,9 @@ const id = 'system-context-map';
 ---
 
 <VisualiserLayout title={`Visualiser | System context map`}>
-  <div class="p-2">
+  <div id="system-context-map-page" class="p-2">
     <div
-      class="h-[calc(100vh-5rem)] w-full relative border border-[rgb(var(--ec-page-border))]"
+      class="system-context-map-viewport h-[calc(100vh-5rem)] w-full relative border border-[rgb(var(--ec-page-border))]"
       id={`${id}-portal`}
       transition:name="visualiser-graph"
     >
@@ -27,15 +27,13 @@ const id = 'system-context-map';
   <ClientRouter />
 </VisualiserLayout>
 
-<script define:vars={{ id }}>
-  document.addEventListener('DOMContentLoaded', () => {
-    const urlSearchParams = new URLSearchParams(window.location.search);
-    const params = Object.fromEntries(urlSearchParams.entries());
-    const embeded = params.embed === 'true' ? true : false;
-    const viewport = document.getElementById(`${id}-portal`);
+<style is:global>
+  html[data-embedded='true'] #system-context-map-page {
+    box-sizing: border-box;
+    height: 100vh;
+  }
 
-    if (embeded && viewport) {
-      viewport.style.height = 'calc(100vh - 30px)';
-    }
-  });
-</script>
+  html[data-embedded='true'] #system-context-map-page .system-context-map-viewport {
+    height: 100%;
+  }
+</style>

--- a/packages/core/eventcatalog/src/pages/visualiser/systems/[id]/[version]/context/index.astro
+++ b/packages/core/eventcatalog/src/pages/visualiser/systems/[id]/[version]/context/index.astro
@@ -17,9 +17,9 @@ const {
 ---
 
 <VisualiserLayout title={`Visualiser | ${props.data.name} - System Context`} description={props.data.summary}>
-  <div class="p-2">
+  <div id="system-context-map-page" class="p-2">
     <div
-      class="h-[calc(100vh-5rem)] w-full relative border border-[rgb(var(--ec-page-border))]"
+      class="system-context-map-viewport h-[calc(100vh-5rem)] w-full relative border border-[rgb(var(--ec-page-border))]"
       id={`${id}-portal`}
       transition:name="visualiser-graph"
     >
@@ -37,15 +37,13 @@ const {
   <ClientRouter />
 </VisualiserLayout>
 
-<script define:vars={{ id }}>
-  document.addEventListener('DOMContentLoaded', () => {
-    const urlSearchParams = new URLSearchParams(window.location.search);
-    const params = Object.fromEntries(urlSearchParams.entries());
-    const embeded = params.embed === 'true' ? true : false;
-    const viewport = document.getElementById(`${id}-portal`);
+<style is:global>
+  html[data-embedded='true'] #system-context-map-page {
+    box-sizing: border-box;
+    height: 100vh;
+  }
 
-    if (embeded) {
-      viewport.style.height = 'calc(100vh - 30px)';
-    }
-  });
-</script>
+  html[data-embedded='true'] #system-context-map-page .system-context-map-viewport {
+    height: 100%;
+  }
+</style>

--- a/packages/core/eventcatalog/src/stores/theme-store.ts
+++ b/packages/core/eventcatalog/src/stores/theme-store.ts
@@ -14,6 +14,15 @@ const getDefaultTheme = (): Theme => {
   return DEFAULT_THEME;
 };
 
+const getEmbeddedTheme = (): Theme | null => {
+  if (typeof window === 'undefined') return null;
+
+  const params = new URLSearchParams(window.location.search);
+  const requestedTheme = params.get('theme');
+  const embedded = params.get('embed') === 'true';
+  return embedded && (requestedTheme === 'light' || requestedTheme === 'dark') ? requestedTheme : null;
+};
+
 // Apply theme to document via data-theme attribute
 const applyTheme = (theme: Theme) => {
   if (typeof document !== 'undefined') {
@@ -25,6 +34,13 @@ const applyTheme = (theme: Theme) => {
 const initStore = () => {
   if (typeof window !== 'undefined') {
     try {
+      const embeddedTheme = getEmbeddedTheme();
+      if (embeddedTheme) {
+        themeStore.set(embeddedTheme);
+        applyTheme(embeddedTheme);
+        return;
+      }
+
       const stored = localStorage.getItem(THEME_KEY) as Theme | null;
       if (stored && (stored === 'light' || stored === 'dark')) {
         // User has explicitly chosen a theme, use that
@@ -49,6 +65,8 @@ if (typeof window !== 'undefined') {
   // Listen for system preference changes
   if (window.matchMedia) {
     window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
+      if (getEmbeddedTheme()) return;
+
       // Only follow system preference if user hasn't explicitly set a theme
       const stored = localStorage.getItem(THEME_KEY);
       if (!stored) {


### PR DESCRIPTION
## What This PR Does

Makes `?embed=true` behave consistently across the catalog. Previously some pages still rendered the vertical nav, header or resource sidebar when embedded, and several app-style pages did not fill the iframe height. This PR hides all catalog chrome in embed mode, gives the visualiser, schema and discover surfaces a full-height embedded viewport, and adds a `?theme=` parameter so an embed can render light or dark without changing the user's saved catalog preference.

## Changes Overview

### Key Changes

- `VerticalSideBarLayout.astro` sets a `data-embedded` attribute on `<html>` as early as possible, and CSS hides the vertical nav, header, header spacer and resource sidebar when it is `true`. `sidebar` is also added to the list of elements the existing embed script hides.
- Visualiser pages (resource visualiser, architecture graph, system context map, system context) replace their `DOMContentLoaded` inline-height scripts with `data-embedded` scoped CSS, so the viewport is sized before first paint rather than after hydration.
- Discover and Schema Explorer pages hide their filter/tree sidebars in embed mode and drop the left margin on the results panel, so the content uses the full iframe width. Schema detail and discover pages get `100dvh` heights when embedded (no header to subtract).
- Stable ids added to the Discover and Schema Explorer sidebar/content containers so page-level CSS can target them.
- `BaseLayout.astro` and `stores/theme-store.ts` read a `theme` query parameter when `embed=true`. The embed theme is applied but never written to `localStorage`, and the system `prefers-color-scheme` listener ignores changes while an embed theme is active.

## How It Works

The embed state is expressed once, as `data-embedded="true"` on the document element, and everything else is plain CSS keyed off that attribute. This replaces the previous approach of imperatively setting inline styles after `DOMContentLoaded`, which caused a visible layout shift while the page settled and did not run at all on Astro view transitions.

For theming, `getEmbeddedTheme()` only honours `theme` when `embed=true` and only accepts the literal values `light` and `dark`. When it returns a theme, `initStore` applies it and returns early — so the stored preference is read but never overwritten, and a user who visits the catalog normally afterwards still sees the theme they chose.

## Breaking Changes

None. All behaviour is gated behind `embed=true`, so non-embedded pages are unaffected.

## Additional Notes

- The old inline embed-height scripts are removed rather than kept alongside the CSS, so there is a single source of truth for embedded sizing.
- No editor repository (`eventcatalog/eventcatalog-editor`) change is needed for this — it is entirely catalog-side layout and theming behaviour.

https://claude.ai/code/session_01TvEr6E5umY439pbubQLnMR