### PR TITLE
Add @eventcatalog/diff for architecture and schema compatibility diffs

### DIFF
--- a/.changeset/diff-package-scaffold.md
+++ b/.changeset/diff-package-scaffold.md
@@ -1,0 +1,11 @@
+---
+'@eventcatalog/diff': minor
+'@eventcatalog/sdk': minor
+---
+
+feat(diff): new `@eventcatalog/diff` package that compares two catalog indexes and returns an `ArchitectureDiff`
+
+- Compares two SDK `Index` documents (from `buildIndex`) and reports resources added / removed / changed, edges added / removed across every direction the SDK resolves, schema changes with a compatibility verdict, and impact naming the producers and consumers hurt by each breaking change, with owners.
+- JSON Schema compatibility under `backward`, `forward`, `full` (default) and `none` strategies, following Confluent Schema Registry semantics: properties and required (with `default`), types, enums and const, min/max constraints, pattern, format, multipleOf, uniqueItems, open and closed content models, arrays and tuples, oneOf / anyOf / allOf, local `$ref`, boolean schemas. Keywords it cannot reason about are reported as breaking rather than silently passed.
+- Unknown verdicts (unsupported formats, missing content, added or removed schema files) are counted in `summary.schemaUnknown` so they are never silent.
+- `buildIndex` in `@eventcatalog/sdk` gains an `includeSchemaContent` option that embeds raw schema text alongside its hash. Off by default.

--- a/packages/diff/.gitignore
+++ b/packages/diff/.gitignore
@@ -1,0 +1,3 @@
+dist
+node_modules
+.turbo

--- a/packages/diff/.prettierignore
+++ b/packages/diff/.prettierignore
@@ -1,0 +1,4 @@
+dist
+node_modules
+pnpm-lock.yaml
+CHANGELOG.md

--- a/packages/diff/.prettierrc
+++ b/packages/diff/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "printWidth": 130,
+  "tabWidth": 2,
+  "useTabs": false,
+  "trailingComma": "es5",
+  "bracketSpacing": true
+}

--- a/packages/diff/COMPATIBILITY.md
+++ b/packages/diff/COMPATIBILITY.md
@@ -1,0 +1,257 @@
+# Schema compatibility, explained
+
+This guide is for anyone who has been told "your change is breaking" and wants to know why, or who wants to change a schema and know in advance whether it is safe. No prior knowledge of schema registries is assumed.
+
+It covers JSON Schema, which is the first format `@eventcatalog/diff` understands. The ideas apply to any schema format.
+
+---
+
+## The one idea behind everything
+
+A message has two sides. Something **writes** it, something **reads** it.
+
+- A **producer** writes a message using the schema it was built with.
+- A **consumer** reads a message using the schema it was built with.
+
+The two sides are usually different services, owned by different teams, deployed at different times. So at any moment there might be messages in flight, in a queue, in a topic, or in a database, written with one version of the schema and read with another.
+
+A change is **safe** when the reader's schema accepts everything the writer's schema could have produced.
+
+A change is **breaking** when it doesn't.
+
+Every rule in this document is that one sentence applied to one keyword.
+
+---
+
+## The running example
+
+Throughout, we use one event.
+
+**Orders Service** publishes `OrderCreated`. **Payment Service** subscribes to it.
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "orderId": { "type": "string" },
+    "customerId": { "type": "string" },
+    "status": { "type": "string", "enum": ["pending", "paid"] }
+  },
+  "required": ["orderId", "customerId"]
+}
+```
+
+Orders wants to change this schema. Payment is still running on the old one. What happens?
+
+---
+
+## Two directions
+
+Because there are two sides, there are two questions you can ask.
+
+### Forward: does the old consumer survive the new messages?
+
+Orders ships the new schema. Payment has not been touched. New `OrderCreated` messages start arriving at Payment, which is still validating with the **old** schema.
+
+> **Forward compatible** means a consumer on the **old** schema can read messages written with the **new** schema.
+
+This is the question most people mean when they ask "will my change break anyone?". In EventCatalog terms: **will this pull request break the consumers in the graph?**
+
+### Backward: does the new consumer survive the old messages?
+
+Now the other way round. Payment upgrades to the new schema. But there are old messages still in the queue, or Payment replays a week of history from the topic, or reads an event store. Those messages were written with the **old** schema, and Payment is now validating with the **new** one.
+
+> **Backward compatible** means a consumer on the **new** schema can read messages written with the **old** schema.
+
+This matters whenever old messages can meet a new reader: Kafka replays, event sourcing, dead letter queues, long retention.
+
+### A naming trap
+
+In the REST API world, "backward compatible" means "old clients keep working". That is the **forward** direction in schema terms. The names come from schema registries like Confluent's, and we use the registry meaning so the tool agrees with the registry. If you only care whether existing consumers keep working, the word you want is **forward**.
+
+---
+
+## Strategies
+
+A strategy tells the diff which questions to ask.
+
+| Strategy   | Question asked                                        | Use it when                                                                  |
+| ---------- | ----------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `forward`  | Will old consumers survive new messages?              | Producers ship first, consumers catch up later. You never replay old data.   |
+| `backward` | Will new consumers survive old messages?              | Consumers ship first, or consumers replay history. Confluent's default.      |
+| `full`     | Both of the above                                     | Different teams deploy independently and you want no surprises. **Default.** |
+| `none`     | Neither. Report changes, never call anything breaking | You want the report, but you coordinate upgrades yourself.                   |
+
+**Why `full` is the default.** EventCatalog runs the diff on a pull request. The person changing the schema usually owns the producer. The consumers belong to other teams and might deploy tomorrow or next month, and might replay data. A review tool should flag anything that could hurt either of them. If your organisation has settled on one direction, set it explicitly.
+
+---
+
+## The rules, with reasons
+
+Every change makes the schema accept **more** values, accept **fewer** values, accept a **different** set of values, or accept the **same** values.
+
+|                       | Backward (new reader, old data) | Forward (old reader, new data) |
+| --------------------- | ------------------------------- | ------------------------------ |
+| Accepts **more**      | safe                            | **breaking**                   |
+| Accepts **fewer**     | **breaking**                    | safe                           |
+| Accepts **different** | **breaking**                    | **breaking**                   |
+| Accepts the **same**  | safe                            | safe                           |
+
+Why? If the new schema accepts more, old data still fits inside it (backward safe), but new data might fall outside the old schema (forward breaking). Accepting fewer is the mirror image.
+
+That table is the whole rules engine. The sections below just say which bucket each keyword change lands in.
+
+### Properties
+
+| Change                                       | Bucket    | Why                                                                                                               |
+| -------------------------------------------- | --------- | ----------------------------------------------------------------------------------------------------------------- |
+| Add an optional property                     | same      | Old messages don't have it and don't need it. New messages carry an extra field that old readers ignore.          |
+| Remove an optional property                  | same      | Nobody was relying on it being there.                                                                             |
+| Add a required property                      | fewer     | Old messages don't have it, so a new reader rejects them. Old readers ignore the extra field, so forward is fine. |
+| Add a required property that has a `default` | same      | The new reader fills the gap with the default when reading old messages.                                          |
+| Remove a required property                   | more      | New messages may omit a field the old reader insists on.                                                          |
+| Rename a required property                   | different | It is a removal and an addition at once. Both directions break.                                                   |
+
+**Example, forward breaking.** Orders removes `customerId` from `required`. Payment, on the old schema, receives an `OrderCreated` without a `customerId` and rejects it, or crashes reading `undefined`.
+
+**Example, backward breaking.** Orders adds `placedAt` to `required`. Payment upgrades and then replays last week's events, none of which have `placedAt`. Every one is rejected.
+
+**Fix.** New fields should be optional, or required with a `default`. Removing a field should be done in two steps: make it optional, wait for consumers to stop depending on it, then remove it.
+
+### Types
+
+| Change                                      | Bucket    | Why                                                          |
+| ------------------------------------------- | --------- | ------------------------------------------------------------ |
+| `integer` to `number`                       | more      | Every integer is a number. New messages may now carry `2.5`. |
+| `number` to `integer`                       | fewer     | Old messages may have carried `2.5`.                         |
+| `string` to `["string", "null"]` (nullable) | more      | New messages may carry `null`.                               |
+| `["string", "null"]` to `string`            | fewer     | Old messages may have carried `null`.                        |
+| Remove `type` entirely                      | more      | The property now accepts anything.                           |
+| Add a `type` where there was none           | fewer     | Old messages could have carried anything.                    |
+| `string` to `number`, or any other swap     | different | Neither side accepts the other's values.                     |
+
+**Example.** Orders changes `orderId` from `string` to `integer`. Payment on the old schema receives `12345` where it expected `"ord_12345"`. Both directions break, because old messages have strings and new messages have integers.
+
+### Enums and `const`
+
+| Change                            | Bucket    | Why                                                           |
+| --------------------------------- | --------- | ------------------------------------------------------------- |
+| Add an enum value                 | more      | New messages may carry a value the old reader has never seen. |
+| Remove an enum value              | fewer     | Old messages may carry it.                                    |
+| Restrict a free string to an enum | fewer     | Old messages could have carried any string.                   |
+| Lift an enum restriction          | more      | New messages may carry any string.                            |
+| Change a `const`                  | different | The old value is gone and a new one appears.                  |
+
+**Example.** Orders adds `"refunded"` to `status`. Payment on the old schema has a `switch` over `pending` and `paid` with no default branch. The first refunded order hits code that was never written. That is forward breaking, and it is one of the most common real-world breakages.
+
+### Constraints
+
+`minLength`, `maxLength`, `minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`, `minItems`, `maxItems`, `minProperties`, `maxProperties`, `pattern`, `format`, `multipleOf`, `uniqueItems`.
+
+| Change                                                                                        | Bucket    |
+| --------------------------------------------------------------------------------------------- | --------- |
+| Tighten (raise a minimum, lower a maximum, add a pattern, add a format, require unique items) | fewer     |
+| Loosen (the reverse of any of the above, or remove the keyword)                               | more      |
+| Change `pattern`, `format` or `multipleOf` to a different value                               | different |
+
+**Why is a changed pattern "different" rather than tighter or looser?** Because working out whether one regular expression accepts everything another one does is not something we can do reliably. Rather than guess, we treat it as breaking in both directions and let a human look.
+
+### Additional properties, and closed objects
+
+By default a JSON Schema object is **open**: properties not listed in `properties` are allowed. Setting `"additionalProperties": false` makes it **closed**.
+
+| Change                                         | Bucket | Why                                                    |
+| ---------------------------------------------- | ------ | ------------------------------------------------------ |
+| Open to closed (`additionalProperties: false`) | fewer  | Old messages may have carried extra fields.            |
+| Closed to open                                 | more   | New messages may carry fields the old reader rejects.  |
+| Add a schema for additional properties         | fewer  | Extra fields used to be anything, now they must match. |
+
+**Closed objects change the property rules.** The property table above assumes an open object, where a reader shrugs at fields it does not know. A closed reader does not shrug. It rejects the whole message.
+
+| Change on a closed object   | Bucket | Why                                                                                            |
+| --------------------------- | ------ | ---------------------------------------------------------------------------------------------- |
+| Add an optional property    | more   | New messages carry a field the **old** closed reader has never heard of. Forward breaks.       |
+| Remove an optional property | fewer  | Old messages still carry the field, and the **new** closed reader rejects it. Backward breaks. |
+
+**Example.** Payment validates `OrderCreated` with `additionalProperties: false`. Orders adds an optional `placedAt`. Under an open schema this is the safest change there is. Under the closed schema, every new message is rejected by Payment. If you use closed objects, adding fields needs a two-step rollout: consumers first, then producers.
+
+### Arrays
+
+The schema for array items is walked like any other schema, so a change to `items.type` follows the type rules above, with a path like `/properties/lines/items/type`.
+
+Tuples (`items` as an array in draft-07, `prefixItems` in 2020-12) describe positions. Constraining a new position accepts fewer; dropping one accepts more.
+
+### Composition: `oneOf`, `anyOf`, `allOf`
+
+| Change                            | Bucket | Why                                                                  |
+| --------------------------------- | ------ | -------------------------------------------------------------------- |
+| Add a `oneOf` / `anyOf` branch    | more   | New messages may match a shape the old reader has never seen.        |
+| Remove a `oneOf` / `anyOf` branch | fewer  | Old messages may have matched it.                                    |
+| Add an `allOf` branch             | fewer  | Every message must now satisfy one more constraint.                  |
+| Remove an `allOf` branch          | more   | A constraint is gone.                                                |
+| Change inside a branch            | walked | Reported at the branch path, e.g. `/properties/payment/oneOf/0/...`. |
+
+**Example.** Orders adds an `apple_pay` branch to `payment.oneOf`. Payment on the old schema receives a payment shape it cannot validate. Forward breaking.
+
+### `$ref` and definitions
+
+References to `#/definitions/...` and `#/$defs/...` are followed before comparing, including a ref that points at another ref. A change inside a definition is reported **once**, at the definition's path, no matter how many properties use it. Moving an inline object into a definition, or renaming a definition, with identical content is not a change at all.
+
+A `$ref` to **another file** cannot be followed, because the diff only sees the one schema. If such a ref changes, it is reported as `keyword.changed` and treated as breaking both ways. If it is unchanged, nothing is reported.
+
+### Things that are never breaking
+
+Changing `title`, `description`, `examples`, `$comment`, `$id`, `$schema` or `default`. Reordering `properties`, `required` entries, `enum` values or `oneOf` branches. None of these change what values are accepted, so none of them produce any ops.
+
+One annotation is reported without being breaking: `"deprecated": true`. Catalogs care about deprecation, so it appears as a `schema.deprecated` op that a UI can show.
+
+### Things we refuse to judge
+
+`patternProperties`, `propertyNames`, `not`, `if` / `then` / `else`, `dependentRequired`, `dependentSchemas`, `dependencies`, `contains`, `minContains`, `maxContains`, `unevaluatedProperties`, `unevaluatedItems`, `additionalItems`.
+
+These keywords can express almost anything, and deciding compatibility for them properly is a research problem. When one of them changes, the diff reports it as `keyword.changed` and treats it as breaking in **both** directions. That is deliberate. A false alarm costs a human a minute. A silent pass costs an outage.
+
+---
+
+## Reading a diff result
+
+For every changed schema the diff gives you:
+
+- **`breaking`**: `true`, `false`, or `null` when the index was built without schema content and no verdict was possible.
+- **`direction`**: which side breaks. `forward` means existing consumers are hurt. `backward` means consumers replaying old data are hurt. `both` means both.
+- **`ops`**: every change found, each with a JSON pointer path, a stable `kind`, a human `reason`, and its own `breaking` flag under the chosen strategy.
+
+And for every breaking change, an **impact** entry naming the producers and consumers of that message, with their owners, taken from the catalog graph.
+
+So "Orders removed `customerId` from `OrderCreated`" comes back as: breaking, direction forward, one op at `/properties/customerId` saying the property is no longer required, and an impact entry saying Payment Service, owned by team-payments, consumes this message.
+
+---
+
+## Frequently asked questions
+
+**I added an optional field and the diff says breaking under `full`. Why?**
+Check the ops. An optional field alone is safe. Usually something else changed in the same commit, often a description tidy-up that also touched an enum, or a field that was made required at the same time.
+
+**Adding an enum value is breaking? Everybody does that.**
+Under `forward`, yes, and it is genuinely the cause of real incidents: consumers with an exhaustive switch and no default. Under `backward` it is safe. If your consumers are all written defensively, run with `backward` and the diff will agree with you.
+
+**My schema uses `if` / `then`. Every change is flagged.**
+Only changes to the `if` / `then` blocks themselves. Changes elsewhere in the schema are judged normally. If the conditional logic changes, a human should look.
+
+**What does a version bump do?**
+If the baseline has `OrderCreated` 1.0.0 and the candidate adds 2.0.0, then 1.0.0 is compared against 2.0.0 and both versions are recorded on the change. A version bump does not make a breaking change safe. It just makes it visible and intentional. Separately, every version that exists on both sides is compared against itself, so editing 1.0.0 in place while 2.0.0 exists is still found.
+
+**I renamed the schema file. Will the diff lose track of it?**
+No. Schema files are paired by `id`, then `path`, then the `default` flag, and if exactly one file is left on each side they are paired by elimination. A file that genuinely appears or disappears is reported as an added or removed schema.
+
+**My messages use Avro, not JSON Schema.**
+The diff sees that the file changed, because the hash differs, but cannot judge it yet. The change is reported with `breaking: null` and counted in `summary.schemaUnknown`. Nothing marks the diff as breaking, so make sure your policy treats a non-zero unknown count as "a human needs to look". Silently passing an unjudged change is the one thing this tool must never do.
+
+**Why doesn't a schema with no consumers still count as breaking?**
+It does. The diff reports facts. The impact entry will show an empty `consumers` list, and the policy layer, for example the CLI, can decide that nobody is hurt and downgrade it to a warning.
+
+**Where do these rules come from?**
+The definitions of backward, forward and full match [Confluent Schema Registry](https://docs.confluent.io/platform/current/schema-registry/fundamentals/schema-evolution.html). The per-keyword reasoning follows Confluent's [JSON Schema compatibility notes](https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/serdes-json.html), using their lenient reading of the open content model.
+
+**A rule looks wrong to me.**
+Open `src/test/json-schema/json-schema.test.ts`, find the strategy you run, copy the closest test, paste your before and after schema, and state the verdict you expect. That is the fastest way to have the conversation.

--- a/packages/diff/README.md
+++ b/packages/diff/README.md
@@ -1,0 +1,210 @@
+# @eventcatalog/diff
+
+Compare two EventCatalog indexes and return a single, versioned `ArchitectureDiff` document.
+
+This is a pure library. It has no knowledge of git, CI, webhooks or policy. Those are consumers that build on top of the diff document.
+
+## Usage
+
+```ts
+import createSDK from '@eventcatalog/sdk';
+import { diff } from '@eventcatalog/diff';
+
+// Build an index for each side. Include schema content so the diff can
+// compute compatibility verdicts, not just detect that a schema changed.
+const a = await createSDK(baselineDir).buildIndex({ source: 'acme/catalog', commit: 'abc1234', includeSchemaContent: true });
+const b = await createSDK(candidateDir).buildIndex({ source: 'acme/catalog', commit: 'def5678', includeSchemaContent: true });
+
+const result = diff(a, b, { strategy: 'backward' });
+
+if (result.summary.breaking) {
+  // apply your own policy: fail, warn, notify...
+}
+```
+
+`a` is the baseline (for example `main`) and `b` is the candidate (for example a PR branch).
+
+### Options
+
+| Option                 | Default  | What it does                                                                                                                               |
+| ---------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `strategy`             | `'full'` | Compatibility strategy used to judge schema changes. See below.                                                                            |
+| `includeSchemaContent` | `false`  | Copy the raw before and after schema text onto each schema change, so a UI can render a side-by-side diff without going back to the index. |
+
+## Input: the SDK `Index`
+
+The input is the `Index` document returned by `buildIndex()` in `@eventcatalog/sdk`, the same document used for federation. The diff resolves each side with the SDK resolver so pointers such as `version: latest` become concrete edges. The diff engine never touches the filesystem.
+
+Schema content is opt in. Build with `includeSchemaContent: true` to embed the raw schema text next to its hash. Without it the diff still reports which schemas changed, but the compatibility verdict is `null`.
+
+### Which schemas get compared
+
+- **Versions.** Every version of a message that exists on both sides is compared against itself, so a patch to `OrderCreated` 1.0.0 is found even when 2.0.0 exists. When the latest versions differ, the latest on each side are also compared, so a bump from 1.0.0 to 2.0.0 is reported as one change with both versions recorded.
+- **Files.** A message can carry several schema files. They are paired by `id`, then by `path`, then by the `default` flag, and finally, when exactly one file is left unmatched on each side, by elimination. So renaming `schema.json` to `order-created.json` in the same change does not hide what changed inside it. A file that exists on only one side is reported as `change: 'added'` or `change: 'removed'`.
+- **Formats.** `format: 'json-schema'` is compared. A `.json` file with no declared format is compared only when its content uses JSON Schema keywords, so an example payload stored as `schema.json` is not walked as if it were a schema. Everything else gets a `null` verdict.
+
+### Unknown verdicts are never silent
+
+A schema change with no verdict, because the format is not supported yet, the content was not in the index, the JSON did not parse, or the file was added or removed, has `breaking: null` and is counted in `summary.schemaUnknown`. `summary.breaking` stays `false` for these. A policy layer should treat a non-zero `schemaUnknown` as "a human needs to look", and probably fail the build for it until the format is supported.
+
+## Output: `ArchitectureDiff`
+
+- `resources` added / removed / changed
+- `edges` added / removed, across every direction the SDK resolves
+- `schemaChanges` with a compatibility verdict, the direction that broke, and the operations that caused it
+- `impact` derived from `sends` / `receives` edges, so callers do not need to walk the graph again
+
+### Resources
+
+A resource is identified by its `type` and `id`, so an event and a service with the same id are different resources. Because an index carries every version of a resource:
+
+- an id only in the candidate is **added**, an id only in the baseline is **removed**, every version listed
+- an id on both sides whose latest version differs is **changed** with `version: { a, b }`, not removed plus added
+- an id on both sides with the same latest version but a different `name`, `owners` or `deprecated` is **changed**, with the differing `fields` named
+- an individual old version that appears or disappears while the id survives is added or removed on its own, so deleting 0.6.0 while 1.0.0 stays is visible
+
+Markdown content and schema files are not resource changes. Schemas are covered by `schemaChanges`; markdown is documentation.
+
+### Edges
+
+Every direction the SDK resolves is compared: `sends`, `receives`, `writesTo`, `readsFrom`, `contains`, `references`, `appliesTo`, `relatesTo`. Edge identity is direction, `via`, from id and to id. Versions are left out on purpose, so bumping a message does not churn every edge that points at it. A consumer on `latest` is resolved before comparing.
+
+An edge whose target disappears from the catalog, so that the pointer no longer resolves, is reported as removed. A pointer to something not in the catalog is still reported, with no `type` on that end.
+
+### Impact
+
+`impact` names who is hurt. Producers and consumers always come from the **baseline** graph: the services that exist today, on the message that is about to change or disappear, with their owners.
+
+| Reason                   | When                                                                 | Makes the diff breaking    |
+| ------------------------ | -------------------------------------------------------------------- | -------------------------- |
+| `schema_breaking_change` | A message schema broke under the strategy                            | yes                        |
+| `message_removed`        | A message, or one version of it, is gone while services still use it | yes                        |
+| `consumer_removed`       | A service stopped receiving a message that still exists              | no, that is its own choice |
+| `producer_removed`       | A service stopped sending a message that still exists                | no                         |
+
+A removed message nobody used any more is a tidy-up and gets no impact entry.
+
+Producers and consumers are whatever declares `sends` or `receives` in the catalog: services, domains and agents all appear, each with its own `type`.
+
+```json
+{
+  "message": { "type": "event", "id": "order-created", "version": "1.0.0" },
+  "reason": "schema_breaking_change",
+  "direction": "forward",
+  "producers": [{ "type": "service", "id": "orders-service", "version": "3.1.0", "owners": ["team-orders"] }],
+  "consumers": [{ "type": "service", "id": "payment-service", "version": "2.0.0", "owners": ["team-payments"] }]
+}
+```
+
+`direction` tells a consumer of the diff how to read the lists:
+
+| Direction  | Who is hurt                                                                                   |
+| ---------- | --------------------------------------------------------------------------------------------- |
+| `forward`  | The consumers listed are on the old schema and will fail to read new messages                 |
+| `backward` | The consumers listed will fail to read old messages once they move to the new schema (replay) |
+| `both`     | Both of the above. Only possible under the `full` strategy                                    |
+
+Only direct edges to the compared version count, after the SDK has resolved them against the baseline. In practice:
+
+- A consumer on `latest`, or with no version at all, resolves to the latest version in the baseline. It is listed when that version is edited in place, and when the message is bumped, because a latest subscriber moves to the new version automatically. It is not listed when an older, non-latest version is patched.
+- A consumer on a semver range such as `^1.0.0` resolves to the highest matching version and is listed when that version changes, even for a major bump. The catalog cannot know whether the producer keeps publishing the old line, so it errs on inclusion.
+- A consumer pinned to an exact older version is not listed for a change to a newer one.
+- A message nobody consumes still gets an entry with an empty `consumers` list, so policy can decide that nobody is affected.
+
+The diff reports facts. Whether an impact fails a build, warns, or only matters when the consumer belongs to another team is policy, and belongs in the CLI.
+
+## Compatibility strategies
+
+> New to schema compatibility? Read [COMPATIBILITY.md](./COMPATIBILITY.md) first. It explains the two directions, every rule, and why, using one running example.
+
+The strategy answers one question: **which side upgrades first?** The definitions follow [Confluent Schema Registry](https://docs.confluent.io/platform/current/schema-registry/fundamentals/schema-evolution.html), so they match what teams running Kafka already expect.
+
+| Strategy   | Meaning                                                                         | Upgrade order                                |
+| ---------- | ------------------------------------------------------------------------------- | -------------------------------------------- |
+| `backward` | A consumer on the **new** schema can read messages written with the **old** one | Upgrade consumers first, then producers      |
+| `forward`  | A consumer on the **old** schema can read messages written with the **new** one | Upgrade producers first, then consumers      |
+| `full`     | Both of the above                                                               | Upgrade producers and consumers in any order |
+| `none`     | Compatibility is not checked. Changes are still reported, nothing is breaking   | Coordinate the upgrade yourself              |
+
+**The default is `full`.** Confluent defaults to `backward` because a Kafka consumer may rewind and replay old messages. EventCatalog runs the diff on a pull request where a producer changes an event that other services already consume. Those consumers are on the old schema, which is the `forward` direction, so a `backward` default would pass changes that break every consumer in the graph. Checking both directions is the safe default for a review tool. Set `backward` or `forward` to match the setting on your schema registry.
+
+> **Naming warning.** In REST API terms, "backward compatible" means old clients keep working. In schema registry terms that is `forward`. We use the schema registry meaning. If you only want to know whether existing consumers keep working, use `forward`.
+
+Every rule below comes from the same test: does the reader's schema accept everything the writer's schema could have produced? A change that makes a schema accept **more** is safe for `backward` and breaking for `forward`. A change that makes it accept **less** is the reverse.
+
+### JSON Schema rules
+
+Objects are open by default in JSON Schema: unknown properties are accepted. We take Confluent's lenient reading of that: adding a property to an open object is safe, on the basis that producers do not emit undeclared properties. Objects with `additionalProperties: false` are closed, and get their own stricter rows below. A schema-valued `additionalProperties` is treated as open.
+
+| Change                                                                                                             | `backward` | `forward` | Kind                                  |
+| ------------------------------------------------------------------------------------------------------------------ | ---------- | --------- | ------------------------------------- |
+| Add an optional property to an open object                                                                         | ok         | ok        | `property.added`                      |
+| Add an optional property to a closed object (old readers reject unknown properties)                                | ok         | breaking  | `property.added-to-closed-object`     |
+| Remove an optional property from an open object                                                                    | ok         | ok        | `property.removed`                    |
+| Remove an optional property from a closed object (new readers reject old messages still carrying it)               | breaking   | ok        | `property.removed-from-closed-object` |
+| Make a property required / add a required property                                                                 | breaking   | ok        | `required.added`                      |
+| Make a property required when it has a `default`                                                                   | ok         | ok        | `required.added-with-default`         |
+| Make a required property optional / remove a required property                                                     | ok         | breaking  | `required.removed`                    |
+| Widen a type (`integer` to `number`, `string` to `["string","null"]`, type removed)                                | ok         | breaking  | `type.widened`                        |
+| Narrow a type (`number` to `integer`, nullable to not, type added)                                                 | breaking   | ok        | `type.narrowed`                       |
+| Change a type outright (`string` to `number`)                                                                      | breaking   | breaking  | `type.changed`                        |
+| Add an enum value                                                                                                  | ok         | breaking  | `enum.value.added`                    |
+| Remove an enum value                                                                                               | breaking   | ok        | `enum.value.removed`                  |
+| Restrict a free value to an enum or `const`                                                                        | breaking   | ok        | `enum.added`                          |
+| Lift an enum restriction                                                                                           | ok         | breaking  | `enum.removed`                        |
+| Tighten a constraint (`min*` up, `max*` down, `pattern`/`format`/`multipleOf`/`uniqueItems`/`oneOf`/`allOf` added) | breaking   | ok        | `constraint.tightened`                |
+| Loosen a constraint (the reverse)                                                                                  | ok         | breaking  | `constraint.loosened`                 |
+| Change `pattern`, `format` or `multipleOf` to a different value                                                    | breaking   | breaking  | `constraint.changed`                  |
+| Close an open model (`additionalProperties: false`)                                                                | breaking   | ok        | `additionalProperties.closed`         |
+| Open a closed model                                                                                                | ok         | breaking  | `additionalProperties.opened`         |
+| Constrain a new tuple position (`items` array or `prefixItems`)                                                    | breaking   | ok        | `tuple.item.added`                    |
+| Drop a tuple position                                                                                              | ok         | breaking  | `tuple.item.removed`                  |
+| Add a `oneOf` / `anyOf` branch                                                                                     | ok         | breaking  | `union.branch.added`                  |
+| Remove a `oneOf` / `anyOf` branch                                                                                  | breaking   | ok        | `union.branch.removed`                |
+| Add an `allOf` branch                                                                                              | breaking   | ok        | `allOf.branch.added`                  |
+| Remove an `allOf` branch                                                                                           | ok         | breaking  | `allOf.branch.removed`                |
+| Replace `true` (anything) with a schema, or a schema with `false`                                                  | breaking   | ok        | `schema.restricted`                   |
+| Replace a schema with `true`, or `false` with a schema                                                             | ok         | breaking  | `schema.relaxed`                      |
+| Mark a node `deprecated: true`                                                                                     | ok         | ok        | `schema.deprecated`                   |
+| Change a keyword we do not reason about (see below)                                                                | breaking   | breaking  | `keyword.changed`                     |
+
+`full` is breaking when either column is breaking. `none` is never breaking.
+
+Also handled:
+
+- **Nesting.** `properties`, `items`, `additionalProperties` (when it is a schema), and every `oneOf` / `anyOf` / `allOf` branch are walked recursively. Paths are JSON pointers straight to the node, e.g. `/properties/lines/items/properties/sku`.
+- **Local `$ref`.** `#/definitions/...` and `#/$defs/...` are resolved before comparing, following chains of refs. A change inside a definition is reported once, at the definition's own path, no matter how many properties use it. Recursive definitions terminate. Extracting an inline object into a definition, or renaming a definition, with identical content is not a change.
+- **External `$ref`.** A ref to another file (`./common.json#/Address`) cannot be followed. If it changes it is reported as `keyword.changed`, breaking both ways. If it is unchanged it is not a change.
+- **Branch matching.** `oneOf` / `anyOf` / `allOf` branches are matched by content first, so reordering is not a change. Remaining branches are paired by position and walked, so an edit inside one branch is reported at that branch's path.
+- **Annotations.** `title`, `description`, `examples`, `$comment`, `$id`, `$schema` and `default` changes produce no ops. Reordering `properties`, `required` or `enum` entries is not a change. `deprecated: true` is the one annotation that is reported, as a non-breaking `schema.deprecated` op, because catalogs care about it.
+- **`format`.** Treated as a constraint. In draft-07 validators it is, but in 2020-12 it is an annotation unless the validator opts in, so a new `format` on a 2020-12 schema may be flagged more strictly than your validator enforces.
+- **Keywords we do not reason about.** `patternProperties`, `propertyNames`, `not`, `if` / `then` / `else`, `dependentRequired`, `dependentSchemas`, `dependencies`, `contains`, `minContains`, `maxContains`, `unevaluatedProperties`, `unevaluatedItems`, `additionalItems`. A change to any of these is reported as `keyword.changed` and treated as breaking in both directions, because refusing to call it safe is better than a silent pass.
+
+The table above is the intent. The source of truth is the rules table in [`src/json-schema/rules.ts`](./src/json-schema/rules.ts) and the scenarios in [`src/test/json-schema/json-schema.test.ts`](./src/test/json-schema/json-schema.test.ts). When they disagree with this README, fix the README.
+
+### Other formats
+
+Avro, Protobuf and others are not compared yet. A change to their schema file is still reported by hash, with a `null` verdict.
+
+## Development
+
+```bash
+pnpm --filter @eventcatalog/diff run test
+pnpm --filter @eventcatalog/diff run build
+```
+
+### Adding a JSON Schema rule
+
+1. Add the change kind to `JsonSchemaChangeKind` in `src/json-schema/types.ts`.
+2. Emit it from the walker in `src/json-schema/compare.ts`.
+3. Add its row to the rules table in `src/json-schema/rules.ts`.
+4. Add a test under each strategy it affects in `src/test/json-schema/json-schema.test.ts`, with the before and after schema written out in full.
+5. Update the table in this README.
+
+### Reproducing a user-reported schema problem
+
+Open `src/test/json-schema/json-schema.test.ts`, find the strategy the user runs, copy the closest test, paste their before and after schema, and state the verdict you expect. Run the tests. Fix the rule. The test stays as a regression check.
+
+### Scenario fixtures
+
+End-to-end tests are data driven. Each folder under `src/test/fixtures/scenarios/` holds a baseline index (`a.json`), a candidate index (`b.json`), the expected diff (`expected.json`) and optional `options.json`. Indexes are validated with the SDK's `parseIndex` when loaded, so fixtures cannot drift from what `buildIndex` emits. The scenario runner loads every folder, so adding a case is just adding a folder.

--- a/packages/diff/package.json
+++ b/packages/diff/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@eventcatalog/diff",
+  "version": "0.0.0",
+  "description": "Compare two EventCatalog indexes and produce a versioned ArchitectureDiff document",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsup",
+    "build:bin": "tsup",
+    "dev": "tsup --watch",
+    "clean": "rimraf dist",
+    "test": "vitest --run",
+    "test:ci": "vitest --run",
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write .",
+    "format:diff": "prettier --list-different ."
+  },
+  "keywords": [
+    "eventcatalog",
+    "diff",
+    "event-driven-architecture",
+    "schema",
+    "breaking-changes"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/event-catalog/eventcatalog.git",
+    "directory": "packages/diff"
+  },
+  "author": "EventCatalog",
+  "license": "MIT",
+  "dependencies": {
+    "@eventcatalog/sdk": "workspace:*",
+    "semver": "^7.7.2"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.10",
+    "prettier": "^3.3.3",
+    "rimraf": "^6.0.1",
+    "tsup": "^8.1.0",
+    "typescript": "^5.5.3",
+    "vitest": "^3.2.4",
+    "@types/semver": "^7.5.8"
+  }
+}

--- a/packages/diff/src/diff.ts
+++ b/packages/diff/src/diff.ts
@@ -1,0 +1,73 @@
+import type { Index } from '@eventcatalog/sdk';
+import { resolve } from '@eventcatalog/sdk';
+import { diffEdges } from './edges';
+import { impactOf } from './impact';
+import { diffResources } from './resources';
+import { diffSchemas } from './schemas';
+import type { ArchitectureDiff, CompatibilityStrategy } from './types';
+import { ARCHITECTURE_DIFF_SCHEMA_VERSION } from './types';
+
+export type DiffOptions = {
+  /**
+   * Compatibility strategy used when comparing schemas. Defaults to `full`, so a
+   * change is breaking if it could break either producers or consumers.
+   */
+  strategy?: CompatibilityStrategy;
+  /**
+   * Copy the raw before and after schema text onto each schema change, so a
+   * consumer can render a side-by-side diff without going back to the index.
+   * Off by default to keep the document small.
+   */
+  includeSchemaContent?: boolean;
+};
+
+export const DEFAULT_STRATEGY: CompatibilityStrategy = 'full';
+
+/**
+ * Compare two catalog indexes and return a single ArchitectureDiff document.
+ *
+ * `a` is the baseline (e.g. `main`) and `b` is the candidate (e.g. a PR branch).
+ * Both are SDK `Index` documents as returned by `buildIndex()`. Build them with
+ * `includeSchemaContent: true` to get schema compatibility verdicts.
+ */
+export const diff = (a: Index, b: Index, options: DiffOptions = {}): ArchitectureDiff => {
+  const strategy = options.strategy ?? DEFAULT_STRATEGY;
+
+  // Each side is resolved on its own so pointers (e.g. `version: latest`) become concrete edges.
+  const graphA = resolve([a]);
+  const graphB = resolve([b]);
+
+  const resources = diffResources(a, b);
+  const edges = diffEdges(graphA, graphB);
+  const schemaChanges = diffSchemas(a, b, { strategy, includeSchemaContent: options.includeSchemaContent ?? false });
+  const impact = impactOf({ baseline: graphA, schemaChanges, resourcesRemoved: resources.removed, edgesRemoved: edges.removed });
+
+  const schemaBreaking = schemaChanges.filter((change) => change.breaking === true).length;
+  const schemaUnknown = schemaChanges.filter((change) => change.breaking === null).length;
+  // A message that disappears while services still produce or consume it is breaking, whatever the schema said.
+  const messageRemoved = impact.some((entry) => entry.reason === 'message_removed');
+
+  return {
+    schemaVersion: ARCHITECTURE_DIFF_SCHEMA_VERSION,
+    refs: {
+      a: { source: a.source, commit: a.commit },
+      b: { source: b.source, commit: b.commit },
+    },
+    compatibility: { strategy },
+    summary: {
+      breaking: schemaBreaking > 0 || messageRemoved,
+      resourcesAdded: resources.added.length,
+      resourcesRemoved: resources.removed.length,
+      resourcesChanged: resources.changed.length,
+      edgesAdded: edges.added.length,
+      edgesRemoved: edges.removed.length,
+      schemaChanges: schemaChanges.length,
+      schemaBreaking,
+      schemaUnknown,
+    },
+    resources,
+    edges,
+    schemaChanges,
+    impact,
+  };
+};

--- a/packages/diff/src/edges.ts
+++ b/packages/diff/src/edges.ts
@@ -1,0 +1,84 @@
+import type { ResolvedEdge, ResolvedGraph } from '@eventcatalog/sdk';
+import type { DiffEdge, EdgeEnd } from './types';
+import { indexEntities } from './utils/entities';
+import type { EntityIndex } from './utils/entities';
+
+export type EdgeDiff = {
+  added: DiffEdge[];
+  removed: DiffEdge[];
+};
+
+/**
+ * Compares the resolved edges of two graphs, across every direction the SDK
+ * resolves (sends, receives, writesTo, readsFrom, contains, references, appliesTo,
+ * relatesTo).
+ *
+ * Edge identity is direction + via + from id + to id. Versions are deliberately
+ * left out: they are already resolved, and including them would report a removed
+ * and an added edge every time a message is bumped, drowning the real changes.
+ * The versions shown on an edge are the ones from the side it came from.
+ *
+ * Resolution matters, though. When a message is deleted but a service still
+ * points at it, the SDK keeps the edge and marks it unresolved. That edge has
+ * effectively been removed, and is reported as such. The reverse, a dangling
+ * pointer that now resolves because the target was documented, is an added edge.
+ */
+export const diffEdges = (a: ResolvedGraph, b: ResolvedGraph): EdgeDiff => {
+  const before = byIdentity(a);
+  const after = byIdentity(b);
+  const entitiesA = indexEntities(a);
+  const entitiesB = indexEntities(b);
+  const added: DiffEdge[] = [];
+  const removed: DiffEdge[] = [];
+
+  for (const key of new Set([...before.keys(), ...after.keys()])) {
+    const edgeA = before.get(key);
+    const edgeB = after.get(key);
+
+    if (!edgeA) added.push(toDiffEdge(entitiesB, edgeB!));
+    else if (!edgeB) removed.push(toDiffEdge(entitiesA, edgeA));
+    else if (isResolved(edgeA) && !isResolved(edgeB)) removed.push(toDiffEdge(entitiesA, edgeA));
+    else if (!isResolved(edgeA) && isResolved(edgeB)) added.push(toDiffEdge(entitiesB, edgeB));
+  }
+
+  return { added: sort(added), removed: sort(removed) };
+};
+
+const identity = (edge: ResolvedEdge) => `${edge.direction}|${edge.via ?? ''}|${edge.from}|${edge.to}`;
+
+const isResolved = (edge: ResolvedEdge) => edge.status === 'resolved';
+
+const byIdentity = (graph: ResolvedGraph) => {
+  const map = new Map<string, ResolvedEdge>();
+  for (const edge of graph.edges) {
+    // Several versions of the same service can carry the same edge; a resolved one wins.
+    const existing = map.get(identity(edge));
+    if (!existing || (!isResolved(existing) && isResolved(edge))) map.set(identity(edge), edge);
+  }
+  return map;
+};
+
+const toDiffEdge = (entities: EntityIndex, edge: ResolvedEdge): DiffEdge => ({
+  direction: edge.direction,
+  from: end(entities, edge.from, edge.fromVersion),
+  to: end(entities, edge.to, edge.resolved),
+  ...(edge.via !== undefined ? { via: edge.via } : {}),
+});
+
+const end = (entities: EntityIndex, id: string, version: string | null): EdgeEnd => {
+  const entity = entities.find(id, version);
+  return {
+    ...(entity ? { type: entity.type } : {}),
+    id,
+    ...(version !== null ? { version } : {}),
+  };
+};
+
+const sort = (edges: DiffEdge[]) =>
+  [...edges].sort(
+    (left, right) =>
+      left.direction.localeCompare(right.direction) ||
+      left.from.id.localeCompare(right.from.id) ||
+      left.to.id.localeCompare(right.to.id) ||
+      (left.via ?? '').localeCompare(right.via ?? '')
+  );

--- a/packages/diff/src/impact.ts
+++ b/packages/diff/src/impact.ts
@@ -1,0 +1,143 @@
+import type { ResolvedEdge, ResolvedEntity, ResolvedGraph } from '@eventcatalog/sdk';
+import type { DiffEdge, Impact, ImpactedResource, MessageType, ResourceRemoved, SchemaChange } from './types';
+import { indexEntities } from './utils/entities';
+import type { EntityIndex } from './utils/entities';
+
+const MESSAGE_TYPES: ReadonlySet<string> = new Set<MessageType>(['event', 'command', 'query']);
+
+const isMessageType = (type: string | undefined): type is MessageType => type !== undefined && MESSAGE_TYPES.has(type);
+
+export type ImpactInput = {
+  /** The resolved baseline graph: who produces and consumes what today. */
+  baseline: ResolvedGraph;
+  schemaChanges: SchemaChange[];
+  resourcesRemoved: ResourceRemoved[];
+  edgesRemoved: DiffEdge[];
+};
+
+/**
+ * Works out who is hurt by the changes, so consumers of the diff never walk edges.
+ *
+ * Producers and consumers always come from the BASELINE graph: they are the services
+ * that exist today, on the message that is about to change or disappear.
+ *
+ *   schema_breaking_change  a message schema broke; lists everyone on the compared version
+ *   message_removed         a message (or one version of it) is gone; lists everyone still using it
+ *   consumer_removed        a service stopped receiving a message that still exists
+ *   producer_removed        a service stopped sending a message that still exists
+ */
+export const impactOf = ({ baseline, schemaChanges, resourcesRemoved, edgesRemoved }: ImpactInput): Impact[] => {
+  const graph: Graph = { edges: baseline.edges, entities: indexEntities(baseline) };
+  return [
+    ...impactOfSchemaChanges(graph, schemaChanges),
+    ...impactOfRemovedMessages(graph, resourcesRemoved),
+    ...impactOfRemovedEdges(graph, edgesRemoved, resourcesRemoved),
+  ];
+};
+
+/** The baseline edges plus a constant-time entity lookup. */
+type Graph = { edges: ResolvedEdge[]; entities: EntityIndex };
+
+// ---------------------------------------------------------------------------
+// schema_breaking_change
+// ---------------------------------------------------------------------------
+
+const impactOfSchemaChanges = (baseline: Graph, schemaChanges: SchemaChange[]): Impact[] =>
+  schemaChanges
+    .filter((change) => change.breaking === true && change.direction !== null)
+    .map((change) => ({
+      message: { type: change.message.type, id: change.message.id, version: change.message.version.a },
+      reason: 'schema_breaking_change' as const,
+      direction: change.direction!,
+      producers: partiesOf(baseline, change.message.id, change.message.version.a, 'sends'),
+      consumers: partiesOf(baseline, change.message.id, change.message.version.a, 'receives'),
+    }));
+
+// ---------------------------------------------------------------------------
+// message_removed
+// ---------------------------------------------------------------------------
+
+/** A removed message with nobody left pointing at it is a tidy-up, not an impact, so those are skipped. */
+const impactOfRemovedMessages = (baseline: Graph, resourcesRemoved: ResourceRemoved[]): Impact[] =>
+  resourcesRemoved
+    .filter((resource) => isMessageType(resource.type))
+    .map((resource) => ({
+      message: { type: resource.type as MessageType, id: resource.id, version: resource.version },
+      reason: 'message_removed' as const,
+      producers: partiesOf(baseline, resource.id, resource.version, 'sends'),
+      consumers: partiesOf(baseline, resource.id, resource.version, 'receives'),
+    }))
+    .filter((impact) => impact.producers.length > 0 || impact.consumers.length > 0);
+
+// ---------------------------------------------------------------------------
+// consumer_removed / producer_removed
+// ---------------------------------------------------------------------------
+
+/**
+ * A removed direct sends/receives edge whose message still exists. Edges lost because
+ * the message itself was removed are already covered by message_removed.
+ */
+const impactOfRemovedEdges = (baseline: Graph, edgesRemoved: DiffEdge[], resourcesRemoved: ResourceRemoved[]): Impact[] => {
+  const removedMessages = new Set(resourcesRemoved.filter((r) => isMessageType(r.type)).map((r) => r.id));
+  const byMessage = new Map<string, Impact>();
+
+  for (const edge of edgesRemoved) {
+    if (edge.via !== undefined || !isMessageType(edge.to.type) || removedMessages.has(edge.to.id)) continue;
+    if (edge.direction !== 'sends' && edge.direction !== 'receives') continue;
+
+    const reason = edge.direction === 'receives' ? 'consumer_removed' : 'producer_removed';
+    const key = `${reason}|${edge.to.type}:${edge.to.id}`;
+    const impact = byMessage.get(key) ?? {
+      message: { type: edge.to.type, id: edge.to.id },
+      reason,
+      producers: [],
+      consumers: [],
+    };
+
+    const party = baseline.entities.find(edge.from.id, edge.from.version ?? null);
+    if (party) (edge.direction === 'receives' ? impact.consumers : impact.producers).push(toImpactedResource(party));
+    byMessage.set(key, impact);
+  }
+
+  return [...byMessage.values()].map((impact) => ({
+    ...impact,
+    producers: sortParties(impact.producers),
+    consumers: sortParties(impact.consumers),
+  }));
+};
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+const partiesOf = (
+  graph: Graph,
+  messageId: string,
+  messageVersion: string | undefined,
+  direction: ResolvedEdge['direction']
+): ImpactedResource[] =>
+  sortParties(
+    graph.edges
+      // `via` edges are indirect (e.g. `sends.to` a channel, `receives.from` a service); only direct message edges count.
+      .filter(
+        (edge) =>
+          edge.direction === direction && edge.via === undefined && edge.to === messageId && pointsAt(edge, messageVersion)
+      )
+      .map((edge) => graph.entities.find(edge.from, edge.fromVersion))
+      .filter((entity): entity is ResolvedEntity => entity !== undefined)
+      .map(toImpactedResource)
+  );
+
+/** An edge counts when it resolved to the compared version, or could not be resolved at all. */
+const pointsAt = (edge: ResolvedEdge, version: string | undefined) =>
+  edge.resolved === null || version === undefined || edge.resolved === version;
+
+const toImpactedResource = (entity: ResolvedEntity): ImpactedResource => ({
+  type: entity.type,
+  id: entity.id,
+  ...(entity.version !== undefined ? { version: entity.version } : {}),
+  ...(entity.owners !== undefined ? { owners: entity.owners } : {}),
+});
+
+const sortParties = (parties: ImpactedResource[]) =>
+  [...parties].sort((left, right) => left.id.localeCompare(right.id) || (left.version ?? '').localeCompare(right.version ?? ''));

--- a/packages/diff/src/index.ts
+++ b/packages/diff/src/index.ts
@@ -1,0 +1,6 @@
+export { diff, DEFAULT_STRATEGY } from './diff';
+export type { DiffOptions } from './diff';
+export * from './types';
+export { checkJsonSchemaCompatibility, compareJsonSchemas } from './json-schema';
+export type { JsonSchema, JsonSchemaChange, JsonSchemaChangeKind, JsonSchemaCompatibility } from './json-schema';
+export type { Index, IndexResource, IndexResourceType, IndexSchema, EdgeDirection } from '@eventcatalog/sdk';

--- a/packages/diff/src/json-schema/compare.ts
+++ b/packages/diff/src/json-schema/compare.ts
@@ -1,0 +1,530 @@
+import type { JsonSchema, JsonSchemaChange, JsonSchemaChangeKind } from './types';
+
+/**
+ * Walks two JSON schemas side by side and emits every semantic change found.
+ *
+ * This is deliberately rule-free: it only says *what* changed, never whether
+ * that matters. `rules.ts` decides what is breaking under each strategy.
+ *
+ * Supported: properties, required (with `default`), type (including `integer`
+ * within `number` and nullable unions), enum and const, the min/max constraint
+ * families, pattern, format, multipleOf, uniqueItems, additionalProperties,
+ * items and tuples (`items` array or `prefixItems`), oneOf, anyOf, allOf, local
+ * `$ref` (changes reported once, at the definition), and boolean schemas.
+ *
+ * Annotations (title, description, examples, $comment, default ...) are ignored.
+ * Keywords we cannot reason about are reported as `keyword.changed` so they are
+ * never silently passed.
+ */
+export const compareJsonSchemas = (before: JsonSchema, after: JsonSchema): JsonSchemaChange[] => {
+  const context: Context = { rootBefore: before, rootAfter: after, changes: [], visitedRefs: new Set() };
+  walk(before, after, '', context);
+  return context.changes;
+};
+
+type ObjectSchema = { [keyword: string]: unknown };
+
+type Context = {
+  rootBefore: JsonSchema;
+  rootAfter: JsonSchema;
+  changes: JsonSchemaChange[];
+  visitedRefs: Set<string>;
+};
+
+// ---------------------------------------------------------------------------
+// walk
+// ---------------------------------------------------------------------------
+
+const walk = (beforeInput: JsonSchema, afterInput: JsonSchema, pointerInput: string, context: Context): void => {
+  const { before, after, pointer, skip } = dereference(beforeInput, afterInput, pointerInput, context);
+  if (skip) return;
+
+  if (typeof before === 'boolean' || typeof after === 'boolean') {
+    compareBooleanSchemas(before, after, pointer, context);
+    return;
+  }
+
+  compareDeprecated(before, after, pointer, context);
+  compareType(before, after, pointer, context);
+  compareEnum(before, after, pointer, context);
+  compareConstraints(before, after, pointer, context);
+  compareProperties(before, after, pointer, context);
+  compareRequired(before, after, pointer, context);
+  compareAdditionalProperties(before, after, pointer, context);
+  compareItems(before, after, pointer, context);
+  compareUnion(before, after, pointer, 'oneOf', context);
+  compareUnion(before, after, pointer, 'anyOf', context);
+  compareAllOf(before, after, pointer, context);
+  compareUnsupportedKeywords(before, after, pointer, context);
+};
+
+const emit = (context: Context, change: JsonSchemaChange) => {
+  context.changes.push(change);
+};
+
+// ---------------------------------------------------------------------------
+// $ref
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolves local `$ref`s on either side. When both sides are refs the changes are
+ * reported at the definition's own path, once, so a definition used by ten
+ * properties does not produce ten copies of the same change and recursive
+ * schemas terminate.
+ */
+const dereference = (before: JsonSchema, after: JsonSchema, pointer: string, context: Context) => {
+  const refBefore = refOf(before);
+  const refAfter = refOf(after);
+  if (refBefore === undefined && refAfter === undefined) return { before, after, pointer, skip: false };
+
+  if (refBefore !== undefined && refAfter !== undefined) {
+    const key = `${refBefore}|${refAfter}`;
+    if (context.visitedRefs.has(key)) return { before, after, pointer, skip: true };
+    context.visitedRefs.add(key);
+    return {
+      before: resolveRef(context.rootBefore, refBefore),
+      after: resolveRef(context.rootAfter, refAfter),
+      pointer: refAfter.slice(1),
+      skip: false,
+    };
+  }
+
+  return {
+    before: refBefore !== undefined ? resolveRef(context.rootBefore, refBefore) : before,
+    after: refAfter !== undefined ? resolveRef(context.rootAfter, refAfter) : after,
+    pointer,
+    skip: false,
+  };
+};
+
+/** Only local refs (`#/...`) are followed. Anything else is left in place and reported by the unsupported-keyword check. */
+const refOf = (schema: JsonSchema): string | undefined =>
+  isObjectSchema(schema) && typeof schema.$ref === 'string' && schema.$ref.startsWith('#/') ? schema.$ref : undefined;
+
+const MAX_REF_HOPS = 32;
+
+/**
+ * Follows a local JSON pointer such as `#/definitions/Address`, and keeps following
+ * if the target is itself a local ref. Unknown targets resolve to `true` (anything).
+ */
+const resolveRef = (root: JsonSchema, ref: string): JsonSchema => {
+  let target = resolvePointer(root, ref);
+  for (let hop = 0; hop < MAX_REF_HOPS; hop++) {
+    const next = refOf(target);
+    if (next === undefined) return target;
+    target = resolvePointer(root, next);
+  }
+  return true;
+};
+
+const resolvePointer = (root: JsonSchema, ref: string): JsonSchema => {
+  let current: unknown = root;
+  for (const segment of ref.slice(2).split('/')) {
+    if (!isObjectSchema(current as JsonSchema)) return true;
+    current = (current as ObjectSchema)[unescapePointer(segment)];
+  }
+  return current === undefined ? true : (current as JsonSchema);
+};
+
+// ---------------------------------------------------------------------------
+// boolean schemas: `true` accepts anything, `false` accepts nothing
+// ---------------------------------------------------------------------------
+
+const compareBooleanSchemas = (before: JsonSchema, after: JsonSchema, pointer: string, context: Context) => {
+  if (before === after) return;
+  const relaxed = before === false || after === true;
+  emit(context, { kind: relaxed ? 'schema.relaxed' : 'schema.restricted', path: pointer, before, after });
+};
+
+// ---------------------------------------------------------------------------
+// type
+// ---------------------------------------------------------------------------
+
+const compareType = (before: ObjectSchema, after: ObjectSchema, pointer: string, context: Context) => {
+  const typesBefore = typesOf(before);
+  const typesAfter = typesOf(after);
+  const path = `${pointer}/type`;
+
+  if (typesBefore === undefined && typesAfter === undefined) return;
+  if (typesBefore === undefined) {
+    emit(context, { kind: 'type.narrowed', path, before: 'any', after: after.type });
+    return;
+  }
+  if (typesAfter === undefined) {
+    emit(context, { kind: 'type.widened', path, before: before.type, after: 'any' });
+    return;
+  }
+
+  const afterCoversBefore = covers(typesAfter, typesBefore);
+  const beforeCoversAfter = covers(typesBefore, typesAfter);
+  if (afterCoversBefore && beforeCoversAfter) return;
+
+  const kind: JsonSchemaChangeKind = afterCoversBefore ? 'type.widened' : beforeCoversAfter ? 'type.narrowed' : 'type.changed';
+  emit(context, { kind, path, before: before.type, after: after.type });
+};
+
+const typesOf = (schema: ObjectSchema): Set<string> | undefined => {
+  if (schema.type === undefined) return undefined;
+  return new Set(Array.isArray(schema.type) ? (schema.type as string[]) : [schema.type as string]);
+};
+
+/** Does `outer` accept every value that `inner` accepts? `number` covers `integer`. */
+const covers = (outer: Set<string>, inner: Set<string>) =>
+  [...inner].every((type) => outer.has(type) || (type === 'integer' && outer.has('number')));
+
+// ---------------------------------------------------------------------------
+// enum and const
+// ---------------------------------------------------------------------------
+
+const compareEnum = (before: ObjectSchema, after: ObjectSchema, pointer: string, context: Context) => {
+  const valuesBefore = enumOf(before);
+  const valuesAfter = enumOf(after);
+  const path = `${pointer}/enum`;
+
+  if (valuesBefore === undefined && valuesAfter === undefined) return;
+  if (valuesBefore === undefined) {
+    emit(context, { kind: 'enum.added', path, after: valuesAfter });
+    return;
+  }
+  if (valuesAfter === undefined) {
+    emit(context, { kind: 'enum.removed', path, before: valuesBefore });
+    return;
+  }
+
+  const keysBefore = new Set(valuesBefore.map(stableStringify));
+  const keysAfter = new Set(valuesAfter.map(stableStringify));
+
+  for (const value of valuesAfter) {
+    if (!keysBefore.has(stableStringify(value))) emit(context, { kind: 'enum.value.added', path, after: value });
+  }
+  for (const value of valuesBefore) {
+    if (!keysAfter.has(stableStringify(value))) emit(context, { kind: 'enum.value.removed', path, before: value });
+  }
+};
+
+const enumOf = (schema: ObjectSchema): unknown[] | undefined => {
+  if (Array.isArray(schema.enum)) return schema.enum;
+  if ('const' in schema) return [schema.const];
+  return undefined;
+};
+
+// ---------------------------------------------------------------------------
+// constraints
+// ---------------------------------------------------------------------------
+
+/** A higher value accepts less. */
+const MIN_CONSTRAINTS = ['minLength', 'minimum', 'exclusiveMinimum', 'minItems', 'minProperties'];
+/** A lower value accepts less. */
+const MAX_CONSTRAINTS = ['maxLength', 'maximum', 'exclusiveMaximum', 'maxItems', 'maxProperties'];
+/** Present means constrained; a different value is a different constraint. */
+const PRESENCE_CONSTRAINTS = ['pattern', 'format', 'multipleOf'];
+/** `true` means constrained. */
+const FLAG_CONSTRAINTS = ['uniqueItems'];
+
+const compareConstraints = (before: ObjectSchema, after: ObjectSchema, pointer: string, context: Context) => {
+  for (const keyword of MIN_CONSTRAINTS) compareBound(before, after, pointer, keyword, 'higher-is-tighter', context);
+  for (const keyword of MAX_CONSTRAINTS) compareBound(before, after, pointer, keyword, 'lower-is-tighter', context);
+  for (const keyword of PRESENCE_CONSTRAINTS) comparePresence(before, after, pointer, keyword, context);
+  for (const keyword of FLAG_CONSTRAINTS) compareFlag(before, after, pointer, keyword, context);
+};
+
+const compareBound = (
+  before: ObjectSchema,
+  after: ObjectSchema,
+  pointer: string,
+  keyword: string,
+  mode: 'higher-is-tighter' | 'lower-is-tighter',
+  context: Context
+) => {
+  const valueBefore = numberOrUndefined(before[keyword]);
+  const valueAfter = numberOrUndefined(after[keyword]);
+  if (valueBefore === valueAfter) return;
+
+  const path = `${pointer}/${keyword}`;
+  const change = { path, keyword, before: valueBefore, after: valueAfter };
+
+  if (valueBefore === undefined) return emit(context, { kind: 'constraint.tightened', ...change });
+  if (valueAfter === undefined) return emit(context, { kind: 'constraint.loosened', ...change });
+
+  const tighter = mode === 'higher-is-tighter' ? valueAfter > valueBefore : valueAfter < valueBefore;
+  emit(context, { kind: tighter ? 'constraint.tightened' : 'constraint.loosened', ...change });
+};
+
+const comparePresence = (before: ObjectSchema, after: ObjectSchema, pointer: string, keyword: string, context: Context) => {
+  const valueBefore = before[keyword];
+  const valueAfter = after[keyword];
+  if (stableStringify(valueBefore) === stableStringify(valueAfter)) return;
+
+  const change = { path: `${pointer}/${keyword}`, keyword, before: valueBefore, after: valueAfter };
+  if (valueBefore === undefined) return emit(context, { kind: 'constraint.tightened', ...change });
+  if (valueAfter === undefined) return emit(context, { kind: 'constraint.loosened', ...change });
+  emit(context, { kind: 'constraint.changed', ...change });
+};
+
+const compareFlag = (before: ObjectSchema, after: ObjectSchema, pointer: string, keyword: string, context: Context) => {
+  const flagBefore = before[keyword] === true;
+  const flagAfter = after[keyword] === true;
+  if (flagBefore === flagAfter) return;
+
+  emit(context, {
+    kind: flagAfter ? 'constraint.tightened' : 'constraint.loosened',
+    path: `${pointer}/${keyword}`,
+    keyword,
+    before: flagBefore,
+    after: flagAfter,
+  });
+};
+
+// ---------------------------------------------------------------------------
+// properties and required
+// ---------------------------------------------------------------------------
+
+const compareProperties = (before: ObjectSchema, after: ObjectSchema, pointer: string, context: Context) => {
+  const propsBefore = propertiesOf(before);
+  const propsAfter = propertiesOf(after);
+  const names = new Set([...Object.keys(propsBefore), ...Object.keys(propsAfter)]);
+
+  for (const name of names) {
+    const path = `${pointer}/properties/${escapePointer(name)}`;
+    const inBefore = name in propsBefore;
+    const inAfter = name in propsAfter;
+
+    if (!inBefore && inAfter) {
+      // An old reader on a CLOSED schema rejects the unknown property in new messages.
+      const kind: JsonSchemaChangeKind = isClosed(before) ? 'property.added-to-closed-object' : 'property.added';
+      emit(context, { kind, path, after: propsAfter[name] });
+    } else if (inBefore && !inAfter) {
+      // A new reader on a CLOSED schema rejects old messages that still carry the property.
+      const kind: JsonSchemaChangeKind = isClosed(after) ? 'property.removed-from-closed-object' : 'property.removed';
+      emit(context, { kind, path, before: propsBefore[name] });
+    } else {
+      walk(propsBefore[name]!, propsAfter[name]!, path, context);
+    }
+  }
+};
+
+/** `additionalProperties: false`. A schema-valued additionalProperties is treated as open (lenient). */
+const isClosed = (schema: ObjectSchema) => schema.additionalProperties === false;
+
+// ---------------------------------------------------------------------------
+// deprecated: an annotation, never breaking, but worth surfacing
+// ---------------------------------------------------------------------------
+
+const compareDeprecated = (before: ObjectSchema, after: ObjectSchema, pointer: string, context: Context) => {
+  if (before.deprecated !== true && after.deprecated === true) {
+    emit(context, { kind: 'schema.deprecated', path: pointer, before: false, after: true });
+  }
+};
+
+const compareRequired = (before: ObjectSchema, after: ObjectSchema, pointer: string, context: Context) => {
+  const requiredBefore = requiredOf(before);
+  const requiredAfter = requiredOf(after);
+  const propsAfter = propertiesOf(after);
+
+  for (const name of requiredAfter) {
+    if (requiredBefore.has(name)) continue;
+    const property = propsAfter[name];
+    const hasDefault = isObjectSchema(property as JsonSchema) && (property as ObjectSchema).default !== undefined;
+    emit(context, {
+      kind: hasDefault ? 'required.added-with-default' : 'required.added',
+      path: `${pointer}/properties/${escapePointer(name)}`,
+      before: false,
+      after: true,
+    });
+  }
+  for (const name of requiredBefore) {
+    if (!requiredAfter.has(name)) {
+      emit(context, {
+        kind: 'required.removed',
+        path: `${pointer}/properties/${escapePointer(name)}`,
+        before: true,
+        after: false,
+      });
+    }
+  }
+};
+
+const propertiesOf = (schema: ObjectSchema): Record<string, JsonSchema> =>
+  isObjectSchema(schema.properties as JsonSchema) ? (schema.properties as Record<string, JsonSchema>) : {};
+
+const requiredOf = (schema: ObjectSchema): Set<string> =>
+  new Set(Array.isArray(schema.required) ? (schema.required as string[]) : []);
+
+// ---------------------------------------------------------------------------
+// additionalProperties: absent or `true` is open, `false` is closed, a schema is partially open
+// ---------------------------------------------------------------------------
+
+const compareAdditionalProperties = (before: ObjectSchema, after: ObjectSchema, pointer: string, context: Context) => {
+  const apBefore = (before.additionalProperties ?? true) as JsonSchema;
+  const apAfter = (after.additionalProperties ?? true) as JsonSchema;
+  const path = `${pointer}/additionalProperties`;
+
+  if (apBefore !== false && apAfter === false) return emit(context, { kind: 'additionalProperties.closed', path });
+  if (apBefore === false && apAfter !== false) return emit(context, { kind: 'additionalProperties.opened', path });
+  walk(apBefore, apAfter, path, context);
+};
+
+// ---------------------------------------------------------------------------
+// arrays: `items` (schema), tuples (`items` array in draft-07, `prefixItems` in 2020-12)
+// ---------------------------------------------------------------------------
+
+const compareItems = (before: ObjectSchema, after: ObjectSchema, pointer: string, context: Context) => {
+  const tupleBefore = tupleOf(before);
+  const tupleAfter = tupleOf(after);
+
+  if (tupleBefore || tupleAfter) {
+    const keyword = Array.isArray(after.items) || Array.isArray(before.items) ? 'items' : 'prefixItems';
+    const itemsBefore = tupleBefore ?? [];
+    const itemsAfter = tupleAfter ?? [];
+    const shared = Math.min(itemsBefore.length, itemsAfter.length);
+
+    for (let i = 0; i < shared; i++) walk(itemsBefore[i]!, itemsAfter[i]!, `${pointer}/${keyword}/${i}`, context);
+    for (let i = shared; i < itemsAfter.length; i++) {
+      emit(context, { kind: 'tuple.item.added', path: `${pointer}/${keyword}/${i}`, after: itemsAfter[i] });
+    }
+    for (let i = shared; i < itemsBefore.length; i++) {
+      emit(context, { kind: 'tuple.item.removed', path: `${pointer}/${keyword}/${i}`, before: itemsBefore[i] });
+    }
+  }
+
+  const schemaBefore = itemsSchemaOf(before);
+  const schemaAfter = itemsSchemaOf(after);
+  if (schemaBefore === undefined && schemaAfter === undefined) return;
+  walk(schemaBefore ?? true, schemaAfter ?? true, `${pointer}/items`, context);
+};
+
+const tupleOf = (schema: ObjectSchema): JsonSchema[] | undefined => {
+  if (Array.isArray(schema.items)) return schema.items as JsonSchema[];
+  if (Array.isArray(schema.prefixItems)) return schema.prefixItems as JsonSchema[];
+  return undefined;
+};
+
+const itemsSchemaOf = (schema: ObjectSchema): JsonSchema | undefined =>
+  schema.items !== undefined && !Array.isArray(schema.items) ? (schema.items as JsonSchema) : undefined;
+
+// ---------------------------------------------------------------------------
+// composition
+// ---------------------------------------------------------------------------
+
+const compareUnion = (
+  before: ObjectSchema,
+  after: ObjectSchema,
+  pointer: string,
+  keyword: 'oneOf' | 'anyOf',
+  context: Context
+) => {
+  compareBranches(before, after, pointer, keyword, 'union.branch.added', 'union.branch.removed', context);
+};
+
+const compareAllOf = (before: ObjectSchema, after: ObjectSchema, pointer: string, context: Context) => {
+  compareBranches(before, after, pointer, 'allOf', 'allOf.branch.added', 'allOf.branch.removed', context);
+};
+
+/**
+ * Identical branches are matched first, wherever they sit, so reordering is not a
+ * change. What is left is paired by position and walked when the counts agree, so
+ * an edit inside one branch is reported precisely. Otherwise the leftovers are
+ * reported as added or removed.
+ */
+const compareBranches = (
+  before: ObjectSchema,
+  after: ObjectSchema,
+  pointer: string,
+  keyword: 'oneOf' | 'anyOf' | 'allOf',
+  addedKind: JsonSchemaChangeKind,
+  removedKind: JsonSchemaChangeKind,
+  context: Context
+) => {
+  const branchesBefore = Array.isArray(before[keyword]) ? (before[keyword] as JsonSchema[]) : undefined;
+  const branchesAfter = Array.isArray(after[keyword]) ? (after[keyword] as JsonSchema[]) : undefined;
+  const path = `${pointer}/${keyword}`;
+
+  if (branchesBefore === undefined && branchesAfter === undefined) return;
+  if (branchesBefore === undefined) {
+    // A union that did not exist now restricts values to its branches; an allOf adds constraints. Both tighten.
+    return emit(context, { kind: 'constraint.tightened', path, keyword, after: branchesAfter });
+  }
+  if (branchesAfter === undefined) {
+    return emit(context, { kind: 'constraint.loosened', path, keyword, before: branchesBefore });
+  }
+
+  const keysBefore = branchesBefore.map(stableStringify);
+  const keysAfter = branchesAfter.map(stableStringify);
+  const matchedAfter = new Set<number>();
+  const unmatchedBefore: number[] = [];
+
+  branchesBefore.forEach((_branch, i) => {
+    const j = keysAfter.findIndex((key, index) => key === keysBefore[i] && !matchedAfter.has(index));
+    if (j >= 0) matchedAfter.add(j);
+    else unmatchedBefore.push(i);
+  });
+  const unmatchedAfter = branchesAfter.map((_branch, j) => j).filter((j) => !matchedAfter.has(j));
+
+  if (unmatchedBefore.length === unmatchedAfter.length) {
+    unmatchedBefore.forEach((i, n) => {
+      const j = unmatchedAfter[n]!;
+      walk(branchesBefore[i]!, branchesAfter[j]!, `${path}/${j}`, context);
+    });
+    return;
+  }
+
+  for (const j of unmatchedAfter) emit(context, { kind: addedKind, path: `${path}/${j}`, keyword, after: branchesAfter[j] });
+  for (const i of unmatchedBefore) emit(context, { kind: removedKind, path: `${path}/${i}`, keyword, before: branchesBefore[i] });
+};
+
+// ---------------------------------------------------------------------------
+// keywords we do not reason about: report, never silently pass
+// ---------------------------------------------------------------------------
+
+const UNSUPPORTED_KEYWORDS = [
+  // Any $ref still present here is external (local ones were resolved). We cannot see its target.
+  '$ref',
+  'patternProperties',
+  'propertyNames',
+  'not',
+  'if',
+  'then',
+  'else',
+  'dependentRequired',
+  'dependentSchemas',
+  'dependencies',
+  'contains',
+  'minContains',
+  'maxContains',
+  'unevaluatedProperties',
+  'unevaluatedItems',
+  'additionalItems',
+];
+
+const compareUnsupportedKeywords = (before: ObjectSchema, after: ObjectSchema, pointer: string, context: Context) => {
+  for (const keyword of UNSUPPORTED_KEYWORDS) {
+    if (stableStringify(before[keyword]) === stableStringify(after[keyword])) continue;
+    emit(context, {
+      kind: 'keyword.changed',
+      path: `${pointer}/${keyword}`,
+      keyword,
+      before: before[keyword],
+      after: after[keyword],
+    });
+  }
+};
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+const isObjectSchema = (schema: JsonSchema | undefined): schema is ObjectSchema => typeof schema === 'object' && schema !== null;
+
+const numberOrUndefined = (value: unknown): number | undefined => (typeof value === 'number' ? value : undefined);
+
+/** Deterministic JSON so two structurally equal values compare equal regardless of key order. */
+const stableStringify = (value: unknown): string =>
+  JSON.stringify(value, (_key, item) =>
+    item && typeof item === 'object' && !Array.isArray(item)
+      ? Object.fromEntries(Object.entries(item as Record<string, unknown>).sort(([a], [b]) => a.localeCompare(b)))
+      : item
+  ) ?? 'undefined';
+
+/** RFC 6901: `~` becomes `~0` and `/` becomes `~1` inside a pointer segment. */
+const escapePointer = (segment: string) => segment.replace(/~/g, '~0').replace(/\//g, '~1');
+const unescapePointer = (segment: string) => segment.replace(/~1/g, '/').replace(/~0/g, '~');

--- a/packages/diff/src/json-schema/index.ts
+++ b/packages/diff/src/json-schema/index.ts
@@ -1,0 +1,55 @@
+import type { BreakingDirection, CompatibilityStrategy, SchemaOp } from '../types';
+import { compareJsonSchemas } from './compare';
+import { isBreaking, reasonFor } from './rules';
+import type { JsonSchema, JsonSchemaChange, JsonSchemaChangeKind } from './types';
+
+export type { JsonSchema, JsonSchemaChange, JsonSchemaChangeKind } from './types';
+export { compareJsonSchemas } from './compare';
+
+export type JsonSchemaCompatibility = {
+  breaking: boolean;
+  /** Which side the change breaks under the strategy, or `null` when it is not breaking. */
+  direction: BreakingDirection | null;
+  ops: SchemaOp[];
+};
+
+/**
+ * Compare two JSON schemas and judge the result under a compatibility strategy.
+ *
+ * Returns every change as an op (so consumers can show what happened), a single
+ * verdict (breaking if at least one op is breaking under the strategy) and the
+ * direction that broke, so impact can say who is hurt.
+ */
+export const checkJsonSchemaCompatibility = (
+  before: JsonSchema,
+  after: JsonSchema,
+  strategy: CompatibilityStrategy
+): JsonSchemaCompatibility => {
+  const changes = compareJsonSchemas(before, after);
+  const ops = changes.map((change) => toOp(change, strategy));
+
+  const checksBackward = strategy === 'backward' || strategy === 'full';
+  const checksForward = strategy === 'forward' || strategy === 'full';
+  const breaksBackward = checksBackward && changes.some((change) => isBreaking(change, 'backward'));
+  const breaksForward = checksForward && changes.some((change) => isBreaking(change, 'forward'));
+
+  const direction: BreakingDirection | null =
+    breaksBackward && breaksForward ? 'both' : breaksBackward ? 'backward' : breaksForward ? 'forward' : null;
+
+  return { breaking: direction !== null, direction, ops };
+};
+
+/** `add` when only an after value exists, `remove` when only a before value exists, otherwise `replace`. */
+const opFor = (change: JsonSchemaChange): SchemaOp['op'] => {
+  if (change.before === undefined && change.after !== undefined) return 'add';
+  if (change.before !== undefined && change.after === undefined) return 'remove';
+  return 'replace';
+};
+
+const toOp = (change: JsonSchemaChange, strategy: CompatibilityStrategy): SchemaOp => ({
+  op: opFor(change),
+  path: change.path,
+  kind: change.kind,
+  reason: reasonFor(change),
+  breaking: isBreaking(change, strategy),
+});

--- a/packages/diff/src/json-schema/rules.ts
+++ b/packages/diff/src/json-schema/rules.ts
@@ -1,0 +1,140 @@
+import type { CompatibilityStrategy } from '../types';
+import type { JsonSchemaChange, JsonSchemaChangeKind } from './types';
+
+/**
+ * The business rules: which changes break which compatibility strategy.
+ *
+ * Definitions (as used by Confluent Schema Registry, which Kafka users expect):
+ *
+ *   backward  a consumer using the NEW schema can read messages written with the OLD schema
+ *             (consumers upgrade first)
+ *   forward   a consumer using the OLD schema can read messages written with the NEW schema
+ *             (producers upgrade first)
+ *   full      both of the above
+ *   none      nothing is ever breaking
+ *
+ * Every row answers one question per direction: does the reader's schema accept
+ * everything the writer's schema could have produced? A change that makes the
+ * schema accept MORE is safe for backward and breaking for forward. A change that
+ * makes it accept LESS is the reverse.
+ *
+ * Schemas are treated as having an open content model (`additionalProperties` not
+ * `false`), which is the JSON Schema default: unknown properties are accepted. We
+ * take Confluent's lenient reading of that model: adding a property is safe, on the
+ * assumption that producers do not emit undeclared properties.
+ * See https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/serdes-json.html
+ *
+ * To add a rule: add the kind to `JsonSchemaChangeKind`, emit it from `compare.ts`,
+ * add a row here, add explicit tests under each strategy in
+ * `src/test/json-schema/json-schema.test.ts`, and update the rules table in the
+ * package README.
+ */
+type Rule = {
+  backward: boolean;
+  forward: boolean;
+  reason: (change: JsonSchemaChange) => string;
+};
+
+/** Accepts more than before: safe for backward, breaking for forward. */
+const WIDENS = { backward: false, forward: true };
+/** Accepts less than before: breaking for backward, safe for forward. */
+const NARROWS = { backward: true, forward: false };
+/** Neither side can be trusted to read the other. */
+const INCOMPATIBLE = { backward: true, forward: true };
+/** Safe both ways. */
+const SAFE = { backward: false, forward: false };
+
+const RULES: Record<JsonSchemaChangeKind, Rule> = {
+  // --- properties -----------------------------------------------------------
+  // Old messages simply don't have the property; new messages carry an extra one.
+  'property.added': { ...SAFE, reason: () => 'property added' },
+  // The old schema was closed (additionalProperties: false), so an old reader rejects the new property.
+  'property.added-to-closed-object': {
+    ...WIDENS,
+    reason: () => 'property added to a closed object (old readers reject unknown properties)',
+  },
+  // Old messages still carry the property but the new schema ignores it; new messages lack
+  // a property the old schema knew about but did not require.
+  'property.removed': { ...SAFE, reason: () => 'property removed' },
+  // The new schema is closed, so a new reader rejects old messages that still carry the property.
+  'property.removed-from-closed-object': {
+    ...NARROWS,
+    reason: () => 'property removed from a closed object (new readers reject old messages that still carry it)',
+  },
+  // Old messages were written without the property, so a new consumer that requires it cannot read them.
+  'required.added': { ...NARROWS, reason: () => 'property became required' },
+  // The new consumer fills the gap with the default, so old messages still read.
+  'required.added-with-default': { ...SAFE, reason: () => 'property became required but has a default' },
+  // New messages may omit the property, so an old consumer that requires it cannot read them.
+  'required.removed': { ...WIDENS, reason: () => 'property is no longer required' },
+
+  // --- types ----------------------------------------------------------------
+  'type.widened': { ...WIDENS, reason: (c) => `type widened from ${show(c.before)} to ${show(c.after)}` },
+  'type.narrowed': { ...NARROWS, reason: (c) => `type narrowed from ${show(c.before)} to ${show(c.after)}` },
+  'type.changed': { ...INCOMPATIBLE, reason: (c) => `type changed from ${show(c.before)} to ${show(c.after)}` },
+
+  // --- enum and const -------------------------------------------------------
+  'enum.added': { ...NARROWS, reason: (c) => `values restricted to ${show(c.after)}` },
+  'enum.removed': { ...WIDENS, reason: () => 'enum restriction removed' },
+  'enum.value.added': { ...WIDENS, reason: (c) => `enum value ${show(c.after)} added` },
+  'enum.value.removed': { ...NARROWS, reason: (c) => `enum value ${show(c.before)} removed` },
+
+  // --- constraints ----------------------------------------------------------
+  'constraint.tightened': {
+    ...NARROWS,
+    reason: (c) =>
+      c.before === undefined
+        ? `${c.keyword} added (${show(c.after)})`
+        : `${c.keyword} tightened from ${show(c.before)} to ${show(c.after)}`,
+  },
+  'constraint.loosened': {
+    ...WIDENS,
+    reason: (c) =>
+      c.after === undefined ? `${c.keyword} removed` : `${c.keyword} loosened from ${show(c.before)} to ${show(c.after)}`,
+  },
+  'constraint.changed': { ...INCOMPATIBLE, reason: (c) => `${c.keyword} changed from ${show(c.before)} to ${show(c.after)}` },
+
+  // --- content model --------------------------------------------------------
+  'additionalProperties.closed': { ...NARROWS, reason: () => 'additional properties are no longer allowed' },
+  'additionalProperties.opened': { ...WIDENS, reason: () => 'additional properties are now allowed' },
+
+  // --- arrays ---------------------------------------------------------------
+  'tuple.item.added': { ...NARROWS, reason: () => 'tuple position is now constrained' },
+  'tuple.item.removed': { ...WIDENS, reason: () => 'tuple position is no longer constrained' },
+
+  // --- composition ----------------------------------------------------------
+  'union.branch.added': { ...WIDENS, reason: (c) => `${c.keyword} branch added` },
+  'union.branch.removed': { ...NARROWS, reason: (c) => `${c.keyword} branch removed` },
+  'allOf.branch.added': { ...NARROWS, reason: () => 'allOf branch added' },
+  'allOf.branch.removed': { ...WIDENS, reason: () => 'allOf branch removed' },
+
+  // --- boolean schemas ------------------------------------------------------
+  'schema.restricted': { ...NARROWS, reason: () => 'schema now accepts fewer values' },
+  'schema.relaxed': { ...WIDENS, reason: () => 'schema now accepts more values' },
+
+  // --- annotations ----------------------------------------------------------
+  // Changes nothing about accepted values, but consumers of the diff want to see it.
+  'schema.deprecated': { ...SAFE, reason: () => 'marked as deprecated' },
+
+  // --- unknown --------------------------------------------------------------
+  // We cannot reason about it, so we refuse to call it safe.
+  'keyword.changed': { ...INCOMPATIBLE, reason: (c) => `${c.keyword} changed, compatibility cannot be determined` },
+};
+
+export const isBreaking = (change: JsonSchemaChange, strategy: CompatibilityStrategy): boolean => {
+  const rule = RULES[change.kind];
+  switch (strategy) {
+    case 'backward':
+      return rule.backward;
+    case 'forward':
+      return rule.forward;
+    case 'full':
+      return rule.backward || rule.forward;
+    case 'none':
+      return false;
+  }
+};
+
+export const reasonFor = (change: JsonSchemaChange): string => RULES[change.kind].reason(change);
+
+const show = (value: unknown): string => (typeof value === 'string' ? value : JSON.stringify(value));

--- a/packages/diff/src/json-schema/types.ts
+++ b/packages/diff/src/json-schema/types.ts
@@ -1,0 +1,58 @@
+/** A JSON Schema document. Boolean schemas (`true` / `false`) are valid in draft-06 and later. */
+export type JsonSchema = boolean | { [keyword: string]: unknown };
+
+/**
+ * Every kind of change the comparer can detect. Each kind has exactly one row in
+ * the rules table, which decides whether it is breaking under each strategy.
+ */
+export type JsonSchemaChangeKind =
+  // properties
+  | 'property.added'
+  | 'property.added-to-closed-object'
+  | 'property.removed'
+  | 'property.removed-from-closed-object'
+  | 'required.added'
+  | 'required.added-with-default'
+  | 'required.removed'
+  // types
+  | 'type.widened'
+  | 'type.narrowed'
+  | 'type.changed'
+  // enums and const
+  | 'enum.added'
+  | 'enum.removed'
+  | 'enum.value.added'
+  | 'enum.value.removed'
+  // numeric, string, array and object constraints
+  | 'constraint.tightened'
+  | 'constraint.loosened'
+  | 'constraint.changed'
+  // content model
+  | 'additionalProperties.closed'
+  | 'additionalProperties.opened'
+  // arrays
+  | 'tuple.item.added'
+  | 'tuple.item.removed'
+  // composition
+  | 'union.branch.added'
+  | 'union.branch.removed'
+  | 'allOf.branch.added'
+  | 'allOf.branch.removed'
+  // boolean schemas
+  | 'schema.restricted'
+  | 'schema.relaxed'
+  // annotations worth surfacing
+  | 'schema.deprecated'
+  // anything we cannot reason about
+  | 'keyword.changed';
+
+/** A single semantic change between two schemas, with the values on both sides. */
+export type JsonSchemaChange = {
+  kind: JsonSchemaChangeKind;
+  /** JSON pointer to the affected node, e.g. `/properties/customerId`. */
+  path: string;
+  /** The keyword involved, when the kind is generic (e.g. `minLength`, `oneOf`). */
+  keyword?: string;
+  before?: unknown;
+  after?: unknown;
+};

--- a/packages/diff/src/resources.ts
+++ b/packages/diff/src/resources.ts
@@ -1,0 +1,97 @@
+import type { Index, IndexResource } from '@eventcatalog/sdk';
+import type { ResourceAdded, ResourceChanged, ResourceField, ResourceRemoved } from './types';
+import { compareVersions, latest } from './utils/versions';
+
+export type ResourceDiff = {
+  added: ResourceAdded[];
+  removed: ResourceRemoved[];
+  changed: ResourceChanged[];
+};
+
+/**
+ * Compares the resources of two indexes.
+ *
+ * A resource is identified by type and id. Because an index carries every version
+ * of a resource, the rules are:
+ *   - id only in the candidate: added (every version listed)
+ *   - id only in the baseline: removed (every version listed)
+ *   - id on both sides and the latest version differs: changed, with `version: { a, b }`
+ *   - id on both sides, same latest version, but name / owners / deprecated differ: changed
+ *   - an individual old version that appears or disappears while the id survives: added / removed
+ */
+export const diffResources = (a: Index, b: Index): ResourceDiff => {
+  const before = byKey(a);
+  const after = byKey(b);
+  const added: ResourceAdded[] = [];
+  const removed: ResourceRemoved[] = [];
+  const changed: ResourceChanged[] = [];
+
+  for (const key of new Set([...before.keys(), ...after.keys()])) {
+    const versionsA = before.get(key) ?? [];
+    const versionsB = after.get(key) ?? [];
+
+    if (versionsA.length === 0) {
+      added.push(...versionsB.map(ref));
+      continue;
+    }
+    if (versionsB.length === 0) {
+      removed.push(...versionsA.map(ref));
+      continue;
+    }
+
+    const latestA = latest(versionsA)!;
+    const latestB = latest(versionsB)!;
+    const fields = changedFields(latestA, latestB);
+    if (fields.length > 0) {
+      changed.push({ type: latestA.type, id: latestA.id, version: { a: latestA.version, b: latestB.version }, fields });
+    }
+
+    // Old versions that came or went while the id itself survived. The latest pair is
+    // already covered by `changed`, so skip those two.
+    const has = (list: IndexResource[], version: string | undefined) => list.some((resource) => resource.version === version);
+    for (const resource of versionsB) {
+      if (resource !== latestB && !has(versionsA, resource.version)) added.push(ref(resource));
+    }
+    for (const resource of versionsA) {
+      if (resource !== latestA && !has(versionsB, resource.version)) removed.push(ref(resource));
+    }
+  }
+
+  return { added: sort(added), removed: sort(removed), changed: sort(changed) };
+};
+
+const byKey = (index: Index) => {
+  const map = new Map<string, IndexResource[]>();
+  for (const resource of index.resources) {
+    const key = `${resource.type}:${resource.id}`;
+    map.set(key, [...(map.get(key) ?? []), resource]);
+  }
+  return map;
+};
+
+const ref = (resource: IndexResource): ResourceAdded => ({
+  type: resource.type,
+  id: resource.id,
+  ...(resource.version !== undefined ? { version: resource.version } : {}),
+});
+
+const changedFields = (before: IndexResource, after: IndexResource): ResourceField[] => {
+  const fields: ResourceField[] = [];
+  if (before.version !== after.version) fields.push('version');
+  if (before.name !== after.name) fields.push('name');
+  if (stable(before.owners) !== stable(after.owners)) fields.push('owners');
+  if (stable(before.deprecated) !== stable(after.deprecated)) fields.push('deprecated');
+  return fields;
+};
+
+const stable = (value: unknown) => JSON.stringify(value ?? null);
+
+const sort = <T extends { type: string; id: string; version?: string | { a?: string } }>(items: T[]): T[] =>
+  [...items].sort(
+    (left, right) =>
+      left.type.localeCompare(right.type) ||
+      left.id.localeCompare(right.id) ||
+      compareVersions(versionOf(left.version), versionOf(right.version))
+  );
+
+const versionOf = (version: string | { a?: string } | undefined) => (typeof version === 'object' ? version.a : version);

--- a/packages/diff/src/schemas.ts
+++ b/packages/diff/src/schemas.ts
@@ -1,0 +1,225 @@
+import type { Index, IndexResource, IndexSchema } from '@eventcatalog/sdk';
+import { checkJsonSchemaCompatibility } from './json-schema';
+import type { JsonSchema } from './json-schema';
+import type { CompatibilityStrategy, MessageType, SchemaChange, SchemaPointer } from './types';
+import { compareVersions, latest } from './utils/versions';
+
+const MESSAGE_TYPES: ReadonlySet<string> = new Set<MessageType>(['event', 'command', 'query']);
+
+type Message = IndexResource & { type: MessageType };
+
+const isMessage = (resource: IndexResource): resource is Message => MESSAGE_TYPES.has(resource.type);
+
+export type DiffSchemasOptions = {
+  strategy: CompatibilityStrategy;
+  /** Copy the raw schema text onto `before` and `after` of each change. */
+  includeSchemaContent: boolean;
+};
+
+/**
+ * Finds every message schema that changed between the two indexes and judges each
+ * change under the strategy.
+ *
+ * Which versions are compared:
+ *   - every version that exists on both sides, against itself (an in-place edit)
+ *   - the latest version on each side, when they differ (a version bump)
+ *
+ * Which schemas within a message are compared: see `pairSchemas`. A schema file
+ * that exists on only one side is reported as added or removed, with no verdict.
+ */
+export const diffSchemas = (a: Index, b: Index, options: DiffSchemasOptions): SchemaChange[] => {
+  const before = messagesByKey(a);
+  const after = messagesByKey(b);
+  const changes: SchemaChange[] = [];
+
+  for (const [key, versionsA] of before) {
+    const versionsB = after.get(key);
+    if (!versionsB) continue;
+
+    for (const [messageA, messageB] of pairVersions(versionsA, versionsB)) {
+      changes.push(...diffMessageSchemas(messageA, messageB, options));
+    }
+  }
+
+  return changes;
+};
+
+// ---------------------------------------------------------------------------
+// versions
+// ---------------------------------------------------------------------------
+
+/** Every version of each message, keyed by `type:id`. */
+const messagesByKey = (index: Index) => {
+  const byKey = new Map<string, Message[]>();
+  for (const resource of index.resources) {
+    if (!isMessage(resource)) continue;
+    const key = `${resource.type}:${resource.id}`;
+    byKey.set(key, [...(byKey.get(key) ?? []), resource]);
+  }
+  return byKey;
+};
+
+/** Exact version matches first (ordered by version), then the latest-to-latest bump if the latest versions differ. */
+const pairVersions = (versionsA: Message[], versionsB: Message[]): Array<[Message, Message]> => {
+  const byVersionB = new Map(versionsB.map((message) => [message.version, message]));
+  const pairs: Array<[Message, Message]> = [];
+
+  for (const messageA of [...versionsA].sort((left, right) => compareVersions(left.version, right.version))) {
+    const messageB = byVersionB.get(messageA.version);
+    if (messageB) pairs.push([messageA, messageB]);
+  }
+
+  const latestA = latest(versionsA);
+  const latestB = latest(versionsB);
+  if (latestA && latestB && latestA.version !== latestB.version) pairs.push([latestA, latestB]);
+
+  return pairs;
+};
+
+// ---------------------------------------------------------------------------
+// schemas within a message
+// ---------------------------------------------------------------------------
+
+const diffMessageSchemas = (messageA: Message, messageB: Message, options: DiffSchemasOptions): SchemaChange[] => {
+  const { strategy, includeSchemaContent } = options;
+  const message = { type: messageA.type, id: messageA.id, version: { a: messageA.version, b: messageB.version } };
+  const changes: SchemaChange[] = [];
+
+  for (const { before, after } of pairSchemas(messageA.schemas ?? [], messageB.schemas ?? [])) {
+    if (before && after) {
+      if (before.hash !== undefined && before.hash === after.hash) continue;
+      changes.push({
+        message,
+        change: 'modified',
+        before: pointer(before, includeSchemaContent),
+        after: pointer(after, includeSchemaContent),
+        strategy,
+        ...judge(before, after, strategy),
+      });
+    } else if (after) {
+      changes.push({ message, change: 'added', after: pointer(after, includeSchemaContent), strategy, ...UNKNOWN });
+    } else if (before) {
+      changes.push({ message, change: 'removed', before: pointer(before, includeSchemaContent), strategy, ...UNKNOWN });
+    }
+  }
+
+  return changes;
+};
+
+type SchemaPair = { before?: IndexSchema; after?: IndexSchema };
+
+/**
+ * Pairs the schema files of a message across the two sides. In order:
+ *   1. same `id`
+ *   2. same `path`
+ *   3. both flagged `default`
+ *   4. exactly one unmatched schema on each side (a renamed file)
+ * Anything still unmatched is an added or removed schema.
+ */
+const pairSchemas = (schemasA: IndexSchema[], schemasB: IndexSchema[]): SchemaPair[] => {
+  const pairs: SchemaPair[] = [];
+  let remainingA = [...schemasA];
+  let remainingB = [...schemasB];
+
+  const matchBy = (key: (schema: IndexSchema) => string | undefined) => {
+    for (const before of [...remainingA]) {
+      const keyA = key(before);
+      if (keyA === undefined) continue;
+      const after = remainingB.find((candidate) => key(candidate) === keyA);
+      if (!after) continue;
+      pairs.push({ before, after });
+      remainingA = remainingA.filter((schema) => schema !== before);
+      remainingB = remainingB.filter((schema) => schema !== after);
+    }
+  };
+
+  matchBy((schema) => schema.id);
+  matchBy((schema) => schema.path);
+  matchBy((schema) => (schema.default ? 'default' : undefined));
+
+  if (remainingA.length === 1 && remainingB.length === 1) {
+    pairs.push({ before: remainingA[0]!, after: remainingB[0]! });
+    remainingA = [];
+    remainingB = [];
+  }
+
+  for (const before of remainingA) pairs.push({ before });
+  for (const after of remainingB) pairs.push({ after });
+
+  return pairs;
+};
+
+const pointer = (schema: IndexSchema, includeContent: boolean): SchemaPointer => ({
+  path: schema.path ?? '',
+  hash: schema.hash,
+  ...(includeContent && schema.content !== undefined ? { content: schema.content } : {}),
+});
+
+// ---------------------------------------------------------------------------
+// verdict
+// ---------------------------------------------------------------------------
+
+const UNKNOWN: Pick<SchemaChange, 'breaking' | 'direction' | 'ops'> = { breaking: null, direction: null, ops: [] };
+
+/**
+ * Judge a changed schema. Returns `breaking: null` when no verdict is possible:
+ * the index was built without schema content, the content is not valid JSON, or
+ * the format is not one we can compare yet.
+ */
+const judge = (
+  before: IndexSchema,
+  after: IndexSchema,
+  strategy: CompatibilityStrategy
+): Pick<SchemaChange, 'breaking' | 'direction' | 'ops'> => {
+  const beforeContent = asJsonSchema(before);
+  const afterContent = asJsonSchema(after);
+  if (beforeContent === undefined || afterContent === undefined) return UNKNOWN;
+
+  return checkJsonSchemaCompatibility(beforeContent, afterContent, strategy);
+};
+
+/**
+ * The parsed schema, or undefined when this is not a JSON Schema we can compare.
+ * `format: 'json-schema'` is trusted. Without a format, a `.json` file counts only
+ * when its content uses JSON Schema keywords, so an example payload stored as
+ * `schema.json` is not walked as if it were a schema.
+ */
+const asJsonSchema = (schema: IndexSchema): JsonSchema | undefined => {
+  if (schema.format !== undefined && schema.format !== 'json-schema') return undefined;
+  if (schema.format === undefined && !(schema.path ?? '').endsWith('.json')) return undefined;
+
+  const parsed = parseJson(schema.content);
+  if (parsed === undefined) return undefined;
+  if (schema.format === undefined && !looksLikeJsonSchema(parsed)) return undefined;
+  return parsed;
+};
+
+const SCHEMA_KEYWORDS = [
+  '$schema',
+  'type',
+  'properties',
+  'items',
+  'required',
+  'enum',
+  'oneOf',
+  'anyOf',
+  'allOf',
+  '$ref',
+  'definitions',
+  '$defs',
+];
+
+const looksLikeJsonSchema = (value: JsonSchema): boolean =>
+  typeof value === 'boolean' || SCHEMA_KEYWORDS.some((keyword) => keyword in value);
+
+const parseJson = (content: string | undefined): JsonSchema | undefined => {
+  if (content === undefined) return undefined;
+  try {
+    const parsed: unknown = JSON.parse(content);
+    return typeof parsed === 'boolean' || (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed))
+      ? (parsed as JsonSchema)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+};

--- a/packages/diff/src/test/diff.test.ts
+++ b/packages/diff/src/test/diff.test.ts
@@ -1,0 +1,3571 @@
+import { describe, expect, it } from 'vitest';
+import { diff } from '../index';
+import { domain, event, index, receives, resource, schema, sends, service } from './fixtures/builders';
+
+/**
+ * Behavioural specification for @eventcatalog/diff.
+ *
+ * Each `describe` names a business rule. Each test reads as given / when / then and
+ * asserts the WHOLE ArchitectureDiff document, so you can see exactly what a consumer
+ * of the diff receives.
+ */
+
+// ---------------------------------------------------------------------------
+// A small catalog used throughout: Orders publishes OrderCreated, Payments subscribes.
+// ---------------------------------------------------------------------------
+
+const orderCreatedSchema = schema({
+  type: 'object',
+  required: ['customerId'],
+  properties: { customerId: { type: 'string' } },
+});
+
+const orderCreatedSchemaWithOptionalTotal = schema({
+  type: 'object',
+  required: ['customerId'],
+  properties: { customerId: { type: 'string' }, orderTotal: { type: 'number' } },
+});
+
+const orderCreatedSchemaWithRequiredTotal = schema({
+  type: 'object',
+  required: ['customerId', 'orderTotal'],
+  properties: { customerId: { type: 'string' }, orderTotal: { type: 'number' } },
+});
+
+const orderCreatedSchemaWithoutCustomerId = schema({
+  type: 'object',
+  required: [],
+  properties: {},
+});
+
+const ordersService = service('orders-service', '3.1.0', { owners: ['team-orders'], sends: [sends('order-created', '1.0.0')] });
+const paymentService = service('payment-service', '2.0.0', {
+  owners: ['team-payments'],
+  receives: [receives('order-created', '1.0.0')],
+});
+const orderCreated = event('order-created', '1.0.0', { owners: ['team-orders'], schemas: [orderCreatedSchema] });
+
+const catalog = [ordersService, paymentService, orderCreated];
+
+describe('@eventcatalog/diff', () => {
+  describe('the diff document', () => {
+    it('is versioned, records where each side came from, and defaults to the full strategy', () => {
+      // Given a baseline built from main and a candidate built from a PR commit
+      const a = index({ source: 'acme/catalog', commit: 'abc1234' });
+      const b = index({ source: 'acme/catalog', commit: 'def5678' });
+
+      // When they are compared with no options
+      const result = diff(a, b);
+
+      // Then this is the complete document a consumer receives
+      expect(result).toEqual({
+        schemaVersion: 1,
+        refs: {
+          a: { source: 'acme/catalog', commit: 'abc1234' },
+          b: { source: 'acme/catalog', commit: 'def5678' },
+        },
+        compatibility: { strategy: 'full' },
+        summary: {
+          breaking: false,
+          resourcesAdded: 0,
+          resourcesRemoved: 0,
+          resourcesChanged: 0,
+          edgesAdded: 0,
+          edgesRemoved: 0,
+          schemaChanges: 0,
+          schemaBreaking: 0,
+          schemaUnknown: 0,
+        },
+        resources: { added: [], removed: [], changed: [] },
+        edges: { added: [], removed: [] },
+        schemaChanges: [],
+        impact: [],
+      });
+    });
+
+    it('records the strategy the caller asks for', () => {
+      // Given the caller only cares that existing consumers keep working
+      // When two indexes are compared
+      const result = diff(index(), index(), { strategy: 'forward' });
+
+      // Then the strategy is on the document so consumers know how verdicts were reached
+      expect(result).toEqual({
+        schemaVersion: 1,
+        refs: {
+          a: { source: 'acme/catalog', commit: 'abc1234' },
+          b: { source: 'acme/catalog', commit: 'abc1234' },
+        },
+        compatibility: { strategy: 'forward' },
+        summary: {
+          breaking: false,
+          resourcesAdded: 0,
+          resourcesRemoved: 0,
+          resourcesChanged: 0,
+          edgesAdded: 0,
+          edgesRemoved: 0,
+          schemaChanges: 0,
+          schemaBreaking: 0,
+          schemaUnknown: 0,
+        },
+        resources: { added: [], removed: [], changed: [] },
+        edges: { added: [], removed: [] },
+        schemaChanges: [],
+        impact: [],
+      });
+    });
+
+    it('never modifies the indexes it is given', () => {
+      // Given two indexes
+      const a = index({ commit: 'abc1234', resources: catalog });
+      const b = index({ commit: 'def5678', resources: catalog });
+      const aBefore = structuredClone(a);
+      const bBefore = structuredClone(b);
+
+      // When they are compared
+      diff(a, b);
+
+      // Then the inputs are untouched
+      expect(a).toEqual(aBefore);
+      expect(b).toEqual(bBefore);
+    });
+  });
+
+  describe('when nothing has changed between the two catalogs', () => {
+    it('reports nothing added, removed, changed or breaking', () => {
+      // Given the same catalog indexed at two different commits
+      const a = index({ commit: 'abc1234', resources: catalog });
+      const b = index({ commit: 'def5678', resources: catalog });
+
+      // When they are compared
+      const result = diff(a, b);
+
+      // Then every section is empty and the diff is not breaking
+      expect(result).toEqual({
+        schemaVersion: 1,
+        refs: {
+          a: { source: 'acme/catalog', commit: 'abc1234' },
+          b: { source: 'acme/catalog', commit: 'def5678' },
+        },
+        compatibility: { strategy: 'full' },
+        summary: {
+          breaking: false,
+          resourcesAdded: 0,
+          resourcesRemoved: 0,
+          resourcesChanged: 0,
+          edgesAdded: 0,
+          edgesRemoved: 0,
+          schemaChanges: 0,
+          schemaBreaking: 0,
+          schemaUnknown: 0,
+        },
+        resources: { added: [], removed: [], changed: [] },
+        edges: { added: [], removed: [] },
+        schemaChanges: [],
+        impact: [],
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Schemas, end to end through diff(). The full set of JSON Schema rules lives in
+  // json-schema/json-schema.test.ts; these check that a schema change in a catalog
+  // surfaces in the diff document with the right verdict, and that impact names
+  // the producers and consumers who are hurt.
+  // ---------------------------------------------------------------------------
+
+  describe('schemas', () => {
+    describe('when a required property is removed from an event, in place, without a version bump', () => {
+      // Given OrderCreated 1.0.0 had a required customerId in the baseline
+      const a = index({ commit: 'abc1234', resources: catalog });
+
+      // And the candidate removes it from the same version
+      const b = index({
+        commit: 'def5678',
+        resources: [
+          ordersService,
+          paymentService,
+          event('order-created', '1.0.0', { owners: ['team-orders'], schemas: [orderCreatedSchemaWithoutCustomerId] }),
+        ],
+      });
+
+      it('is breaking under the default (full) strategy, and impact names Payments as the consumer that is hurt', () => {
+        // When they are compared with no strategy given
+        const result = diff(a, b);
+
+        // Then the document is breaking, says which op caused it, which direction broke,
+        // and who produces and consumes the message, with their owners
+        expect(result).toEqual({
+          schemaVersion: 1,
+          refs: {
+            a: { source: 'acme/catalog', commit: 'abc1234' },
+            b: { source: 'acme/catalog', commit: 'def5678' },
+          },
+          compatibility: { strategy: 'full' },
+          summary: {
+            breaking: true,
+            resourcesAdded: 0,
+            resourcesRemoved: 0,
+            resourcesChanged: 0,
+            edgesAdded: 0,
+            edgesRemoved: 0,
+            schemaChanges: 1,
+            schemaBreaking: 1,
+            schemaUnknown: 0,
+          },
+          resources: { added: [], removed: [], changed: [] },
+          edges: { added: [], removed: [] },
+          schemaChanges: [
+            {
+              message: { type: 'event', id: 'order-created', version: { a: '1.0.0', b: '1.0.0' } },
+              change: 'modified',
+              before: { path: 'schema.json', hash: orderCreatedSchema.hash },
+              after: { path: 'schema.json', hash: orderCreatedSchemaWithoutCustomerId.hash },
+              strategy: 'full',
+              breaking: true,
+              direction: 'forward',
+              ops: [
+                {
+                  op: 'remove',
+                  path: '/properties/customerId',
+                  kind: 'property.removed',
+                  reason: 'property removed',
+                  breaking: false,
+                },
+                {
+                  op: 'replace',
+                  path: '/properties/customerId',
+                  kind: 'required.removed',
+                  reason: 'property is no longer required',
+                  breaking: true,
+                },
+              ],
+            },
+          ],
+          impact: [
+            {
+              message: { type: 'event', id: 'order-created', version: '1.0.0' },
+              reason: 'schema_breaking_change',
+              direction: 'forward',
+              producers: [{ type: 'service', id: 'orders-service', version: '3.1.0', owners: ['team-orders'] }],
+              consumers: [{ type: 'service', id: 'payment-service', version: '2.0.0', owners: ['team-payments'] }],
+            },
+          ],
+        });
+      });
+
+      it('is breaking under forward, because a consumer on the old schema insists on the field', () => {
+        const result = diff(a, b, { strategy: 'forward' });
+
+        expect(result).toEqual({
+          schemaVersion: 1,
+          refs: {
+            a: { source: 'acme/catalog', commit: 'abc1234' },
+            b: { source: 'acme/catalog', commit: 'def5678' },
+          },
+          compatibility: { strategy: 'forward' },
+          summary: {
+            breaking: true,
+            resourcesAdded: 0,
+            resourcesRemoved: 0,
+            resourcesChanged: 0,
+            edgesAdded: 0,
+            edgesRemoved: 0,
+            schemaChanges: 1,
+            schemaBreaking: 1,
+            schemaUnknown: 0,
+          },
+          resources: { added: [], removed: [], changed: [] },
+          edges: { added: [], removed: [] },
+          schemaChanges: [
+            {
+              message: { type: 'event', id: 'order-created', version: { a: '1.0.0', b: '1.0.0' } },
+              change: 'modified',
+              before: { path: 'schema.json', hash: orderCreatedSchema.hash },
+              after: { path: 'schema.json', hash: orderCreatedSchemaWithoutCustomerId.hash },
+              strategy: 'forward',
+              breaking: true,
+              direction: 'forward',
+              ops: [
+                {
+                  op: 'remove',
+                  path: '/properties/customerId',
+                  kind: 'property.removed',
+                  reason: 'property removed',
+                  breaking: false,
+                },
+                {
+                  op: 'replace',
+                  path: '/properties/customerId',
+                  kind: 'required.removed',
+                  reason: 'property is no longer required',
+                  breaking: true,
+                },
+              ],
+            },
+          ],
+          impact: [
+            {
+              message: { type: 'event', id: 'order-created', version: '1.0.0' },
+              reason: 'schema_breaking_change',
+              direction: 'forward',
+              producers: [{ type: 'service', id: 'orders-service', version: '3.1.0', owners: ['team-orders'] }],
+              consumers: [{ type: 'service', id: 'payment-service', version: '2.0.0', owners: ['team-payments'] }],
+            },
+          ],
+        });
+      });
+
+      it('is not breaking under backward, because old messages still carry the field, so nobody is impacted', () => {
+        const result = diff(a, b, { strategy: 'backward' });
+
+        expect(result).toEqual({
+          schemaVersion: 1,
+          refs: {
+            a: { source: 'acme/catalog', commit: 'abc1234' },
+            b: { source: 'acme/catalog', commit: 'def5678' },
+          },
+          compatibility: { strategy: 'backward' },
+          summary: {
+            breaking: false,
+            resourcesAdded: 0,
+            resourcesRemoved: 0,
+            resourcesChanged: 0,
+            edgesAdded: 0,
+            edgesRemoved: 0,
+            schemaChanges: 1,
+            schemaBreaking: 0,
+            schemaUnknown: 0,
+          },
+          resources: { added: [], removed: [], changed: [] },
+          edges: { added: [], removed: [] },
+          schemaChanges: [
+            {
+              message: { type: 'event', id: 'order-created', version: { a: '1.0.0', b: '1.0.0' } },
+              change: 'modified',
+              before: { path: 'schema.json', hash: orderCreatedSchema.hash },
+              after: { path: 'schema.json', hash: orderCreatedSchemaWithoutCustomerId.hash },
+              strategy: 'backward',
+              breaking: false,
+              direction: null,
+              ops: [
+                {
+                  op: 'remove',
+                  path: '/properties/customerId',
+                  kind: 'property.removed',
+                  reason: 'property removed',
+                  breaking: false,
+                },
+                {
+                  op: 'replace',
+                  path: '/properties/customerId',
+                  kind: 'required.removed',
+                  reason: 'property is no longer required',
+                  breaking: false,
+                },
+              ],
+            },
+          ],
+          impact: [],
+        });
+      });
+
+      it('is still reported under none, but nothing is breaking and nobody is impacted', () => {
+        const result = diff(a, b, { strategy: 'none' });
+
+        expect(result).toEqual({
+          schemaVersion: 1,
+          refs: {
+            a: { source: 'acme/catalog', commit: 'abc1234' },
+            b: { source: 'acme/catalog', commit: 'def5678' },
+          },
+          compatibility: { strategy: 'none' },
+          summary: {
+            breaking: false,
+            resourcesAdded: 0,
+            resourcesRemoved: 0,
+            resourcesChanged: 0,
+            edgesAdded: 0,
+            edgesRemoved: 0,
+            schemaChanges: 1,
+            schemaBreaking: 0,
+            schemaUnknown: 0,
+          },
+          resources: { added: [], removed: [], changed: [] },
+          edges: { added: [], removed: [] },
+          schemaChanges: [
+            {
+              message: { type: 'event', id: 'order-created', version: { a: '1.0.0', b: '1.0.0' } },
+              change: 'modified',
+              before: { path: 'schema.json', hash: orderCreatedSchema.hash },
+              after: { path: 'schema.json', hash: orderCreatedSchemaWithoutCustomerId.hash },
+              strategy: 'none',
+              breaking: false,
+              direction: null,
+              ops: [
+                {
+                  op: 'remove',
+                  path: '/properties/customerId',
+                  kind: 'property.removed',
+                  reason: 'property removed',
+                  breaking: false,
+                },
+                {
+                  op: 'replace',
+                  path: '/properties/customerId',
+                  kind: 'required.removed',
+                  reason: 'property is no longer required',
+                  breaking: false,
+                },
+              ],
+            },
+          ],
+          impact: [],
+        });
+      });
+    });
+
+    describe('when an optional property is added to an event', () => {
+      it('is reported as a schema change but is not breaking, so nobody is impacted', () => {
+        // Given OrderCreated gains an optional orderTotal
+        const a = index({ commit: 'abc1234', resources: catalog });
+        const b = index({
+          commit: 'def5678',
+          resources: [
+            ordersService,
+            paymentService,
+            event('order-created', '1.0.0', { owners: ['team-orders'], schemas: [orderCreatedSchemaWithOptionalTotal] }),
+          ],
+        });
+
+        // When they are compared
+        const result = diff(a, b);
+
+        // Then the change is visible but safe
+        expect(result).toEqual({
+          schemaVersion: 1,
+          refs: {
+            a: { source: 'acme/catalog', commit: 'abc1234' },
+            b: { source: 'acme/catalog', commit: 'def5678' },
+          },
+          compatibility: { strategy: 'full' },
+          summary: {
+            breaking: false,
+            resourcesAdded: 0,
+            resourcesRemoved: 0,
+            resourcesChanged: 0,
+            edgesAdded: 0,
+            edgesRemoved: 0,
+            schemaChanges: 1,
+            schemaBreaking: 0,
+            schemaUnknown: 0,
+          },
+          resources: { added: [], removed: [], changed: [] },
+          edges: { added: [], removed: [] },
+          schemaChanges: [
+            {
+              message: { type: 'event', id: 'order-created', version: { a: '1.0.0', b: '1.0.0' } },
+              change: 'modified',
+              before: { path: 'schema.json', hash: orderCreatedSchema.hash },
+              after: { path: 'schema.json', hash: orderCreatedSchemaWithOptionalTotal.hash },
+              strategy: 'full',
+              breaking: false,
+              direction: null,
+              ops: [
+                {
+                  op: 'add',
+                  path: '/properties/orderTotal',
+                  kind: 'property.added',
+                  reason: 'property added',
+                  breaking: false,
+                },
+              ],
+            },
+          ],
+          impact: [],
+        });
+      });
+    });
+
+    describe('when a required property is added to an event', () => {
+      const a = index({ commit: 'abc1234', resources: catalog });
+      const b = index({
+        commit: 'def5678',
+        resources: [
+          ordersService,
+          paymentService,
+          event('order-created', '1.0.0', { owners: ['team-orders'], schemas: [orderCreatedSchemaWithRequiredTotal] }),
+        ],
+      });
+
+      it('is breaking under backward, and impact says the backward direction broke: consumers cannot replay old messages', () => {
+        const result = diff(a, b, { strategy: 'backward' });
+
+        expect(result).toEqual({
+          schemaVersion: 1,
+          refs: {
+            a: { source: 'acme/catalog', commit: 'abc1234' },
+            b: { source: 'acme/catalog', commit: 'def5678' },
+          },
+          compatibility: { strategy: 'backward' },
+          summary: {
+            breaking: true,
+            resourcesAdded: 0,
+            resourcesRemoved: 0,
+            resourcesChanged: 0,
+            edgesAdded: 0,
+            edgesRemoved: 0,
+            schemaChanges: 1,
+            schemaBreaking: 1,
+            schemaUnknown: 0,
+          },
+          resources: { added: [], removed: [], changed: [] },
+          edges: { added: [], removed: [] },
+          schemaChanges: [
+            {
+              message: { type: 'event', id: 'order-created', version: { a: '1.0.0', b: '1.0.0' } },
+              change: 'modified',
+              before: { path: 'schema.json', hash: orderCreatedSchema.hash },
+              after: { path: 'schema.json', hash: orderCreatedSchemaWithRequiredTotal.hash },
+              strategy: 'backward',
+              breaking: true,
+              direction: 'backward',
+              ops: [
+                {
+                  op: 'add',
+                  path: '/properties/orderTotal',
+                  kind: 'property.added',
+                  reason: 'property added',
+                  breaking: false,
+                },
+                {
+                  op: 'replace',
+                  path: '/properties/orderTotal',
+                  kind: 'required.added',
+                  reason: 'property became required',
+                  breaking: true,
+                },
+              ],
+            },
+          ],
+          impact: [
+            {
+              message: { type: 'event', id: 'order-created', version: '1.0.0' },
+              reason: 'schema_breaking_change',
+              direction: 'backward',
+              producers: [{ type: 'service', id: 'orders-service', version: '3.1.0', owners: ['team-orders'] }],
+              consumers: [{ type: 'service', id: 'payment-service', version: '2.0.0', owners: ['team-payments'] }],
+            },
+          ],
+        });
+      });
+
+      it('is not breaking under forward, because existing consumers ignore the new field, so nobody is impacted', () => {
+        const result = diff(a, b, { strategy: 'forward' });
+
+        expect(result).toEqual({
+          schemaVersion: 1,
+          refs: {
+            a: { source: 'acme/catalog', commit: 'abc1234' },
+            b: { source: 'acme/catalog', commit: 'def5678' },
+          },
+          compatibility: { strategy: 'forward' },
+          summary: {
+            breaking: false,
+            resourcesAdded: 0,
+            resourcesRemoved: 0,
+            resourcesChanged: 0,
+            edgesAdded: 0,
+            edgesRemoved: 0,
+            schemaChanges: 1,
+            schemaBreaking: 0,
+            schemaUnknown: 0,
+          },
+          resources: { added: [], removed: [], changed: [] },
+          edges: { added: [], removed: [] },
+          schemaChanges: [
+            {
+              message: { type: 'event', id: 'order-created', version: { a: '1.0.0', b: '1.0.0' } },
+              change: 'modified',
+              before: { path: 'schema.json', hash: orderCreatedSchema.hash },
+              after: { path: 'schema.json', hash: orderCreatedSchemaWithRequiredTotal.hash },
+              strategy: 'forward',
+              breaking: false,
+              direction: null,
+              ops: [
+                {
+                  op: 'add',
+                  path: '/properties/orderTotal',
+                  kind: 'property.added',
+                  reason: 'property added',
+                  breaking: false,
+                },
+                {
+                  op: 'replace',
+                  path: '/properties/orderTotal',
+                  kind: 'required.added',
+                  reason: 'property became required',
+                  breaking: false,
+                },
+              ],
+            },
+          ],
+          impact: [],
+        });
+      });
+    });
+
+    describe('when a change breaks both directions under the full strategy', () => {
+      it('reports the direction as both, and impact lists every producer and consumer', () => {
+        // Given OrderCreated drops the required customerId (breaks forward) and adds a required orderTotal (breaks backward)
+        const a = index({ commit: 'abc1234', resources: catalog });
+        const swappedRequired = schema({
+          type: 'object',
+          required: ['orderTotal'],
+          properties: { orderTotal: { type: 'number' } },
+        });
+        const b = index({
+          commit: 'def5678',
+          resources: [
+            ordersService,
+            paymentService,
+            event('order-created', '1.0.0', { owners: ['team-orders'], schemas: [swappedRequired] }),
+          ],
+        });
+
+        // When they are compared with the default strategy
+        const result = diff(a, b);
+
+        // Then both directions are reported as broken
+        expect(result).toEqual({
+          schemaVersion: 1,
+          refs: {
+            a: { source: 'acme/catalog', commit: 'abc1234' },
+            b: { source: 'acme/catalog', commit: 'def5678' },
+          },
+          compatibility: { strategy: 'full' },
+          summary: {
+            breaking: true,
+            resourcesAdded: 0,
+            resourcesRemoved: 0,
+            resourcesChanged: 0,
+            edgesAdded: 0,
+            edgesRemoved: 0,
+            schemaChanges: 1,
+            schemaBreaking: 1,
+            schemaUnknown: 0,
+          },
+          resources: { added: [], removed: [], changed: [] },
+          edges: { added: [], removed: [] },
+          schemaChanges: [
+            {
+              message: { type: 'event', id: 'order-created', version: { a: '1.0.0', b: '1.0.0' } },
+              change: 'modified',
+              before: { path: 'schema.json', hash: orderCreatedSchema.hash },
+              after: { path: 'schema.json', hash: swappedRequired.hash },
+              strategy: 'full',
+              breaking: true,
+              direction: 'both',
+              ops: [
+                {
+                  op: 'remove',
+                  path: '/properties/customerId',
+                  kind: 'property.removed',
+                  reason: 'property removed',
+                  breaking: false,
+                },
+                {
+                  op: 'add',
+                  path: '/properties/orderTotal',
+                  kind: 'property.added',
+                  reason: 'property added',
+                  breaking: false,
+                },
+                {
+                  op: 'replace',
+                  path: '/properties/orderTotal',
+                  kind: 'required.added',
+                  reason: 'property became required',
+                  breaking: true,
+                },
+                {
+                  op: 'replace',
+                  path: '/properties/customerId',
+                  kind: 'required.removed',
+                  reason: 'property is no longer required',
+                  breaking: true,
+                },
+              ],
+            },
+          ],
+          impact: [
+            {
+              message: { type: 'event', id: 'order-created', version: '1.0.0' },
+              reason: 'schema_breaking_change',
+              direction: 'both',
+              producers: [{ type: 'service', id: 'orders-service', version: '3.1.0', owners: ['team-orders'] }],
+              consumers: [{ type: 'service', id: 'payment-service', version: '2.0.0', owners: ['team-payments'] }],
+            },
+          ],
+        });
+      });
+    });
+
+    describe('when the caller asks for schema content to be included', () => {
+      it('copies the raw before and after schema text onto the change, so a UI can render a side-by-side diff', () => {
+        // Given OrderCreated gains an optional orderTotal
+        const a = index({ commit: 'abc1234', resources: catalog });
+        const b = index({
+          commit: 'def5678',
+          resources: [
+            ordersService,
+            paymentService,
+            event('order-created', '1.0.0', { owners: ['team-orders'], schemas: [orderCreatedSchemaWithOptionalTotal] }),
+          ],
+        });
+
+        // When they are compared with includeSchemaContent
+        const result = diff(a, b, { includeSchemaContent: true });
+
+        // Then both sides of the change carry the schema text exactly as it was in the index
+        expect(result).toEqual({
+          schemaVersion: 1,
+          refs: {
+            a: { source: 'acme/catalog', commit: 'abc1234' },
+            b: { source: 'acme/catalog', commit: 'def5678' },
+          },
+          compatibility: { strategy: 'full' },
+          summary: {
+            breaking: false,
+            resourcesAdded: 0,
+            resourcesRemoved: 0,
+            resourcesChanged: 0,
+            edgesAdded: 0,
+            edgesRemoved: 0,
+            schemaChanges: 1,
+            schemaBreaking: 0,
+            schemaUnknown: 0,
+          },
+          resources: { added: [], removed: [], changed: [] },
+          edges: { added: [], removed: [] },
+          schemaChanges: [
+            {
+              message: { type: 'event', id: 'order-created', version: { a: '1.0.0', b: '1.0.0' } },
+              change: 'modified',
+              before: {
+                path: 'schema.json',
+                hash: orderCreatedSchema.hash,
+                content: '{"type":"object","required":["customerId"],"properties":{"customerId":{"type":"string"}}}',
+              },
+              after: {
+                path: 'schema.json',
+                hash: orderCreatedSchemaWithOptionalTotal.hash,
+                content:
+                  '{"type":"object","required":["customerId"],"properties":{"customerId":{"type":"string"},"orderTotal":{"type":"number"}}}',
+              },
+              strategy: 'full',
+              breaking: false,
+              direction: null,
+              ops: [
+                {
+                  op: 'add',
+                  path: '/properties/orderTotal',
+                  kind: 'property.added',
+                  reason: 'property added',
+                  breaking: false,
+                },
+              ],
+            },
+          ],
+          impact: [],
+        });
+      });
+    });
+
+    describe('when a message is bumped to a new version with a different schema', () => {
+      it('compares the latest version on each side, records both versions, and impacts the consumers of the old version', () => {
+        // Given the baseline has OrderCreated 1.0.0
+        const a = index({ commit: 'abc1234', resources: catalog });
+
+        // And the candidate keeps 1.0.0 on disk and adds 2.0.0 with customerId removed
+        const b = index({
+          commit: 'def5678',
+          resources: [
+            ...catalog,
+            event('order-created', '2.0.0', { owners: ['team-orders'], schemas: [orderCreatedSchemaWithoutCustomerId] }),
+          ],
+        });
+
+        // When they are compared
+        const result = diff(a, b);
+
+        // Then 1.0.0 is compared against 2.0.0, not against the untouched 1.0.0 copy
+        expect(result).toEqual({
+          schemaVersion: 1,
+          refs: {
+            a: { source: 'acme/catalog', commit: 'abc1234' },
+            b: { source: 'acme/catalog', commit: 'def5678' },
+          },
+          compatibility: { strategy: 'full' },
+          summary: {
+            breaking: true,
+            resourcesAdded: 0,
+            resourcesRemoved: 0,
+            resourcesChanged: 1,
+            edgesAdded: 0,
+            edgesRemoved: 0,
+            schemaChanges: 1,
+            schemaBreaking: 1,
+            schemaUnknown: 0,
+          },
+          resources: {
+            added: [],
+            removed: [],
+            changed: [{ type: 'event', id: 'order-created', version: { a: '1.0.0', b: '2.0.0' }, fields: ['version'] }],
+          },
+          edges: { added: [], removed: [] },
+          schemaChanges: [
+            {
+              message: { type: 'event', id: 'order-created', version: { a: '1.0.0', b: '2.0.0' } },
+              change: 'modified',
+              before: { path: 'schema.json', hash: orderCreatedSchema.hash },
+              after: { path: 'schema.json', hash: orderCreatedSchemaWithoutCustomerId.hash },
+              strategy: 'full',
+              breaking: true,
+              direction: 'forward',
+              ops: [
+                {
+                  op: 'remove',
+                  path: '/properties/customerId',
+                  kind: 'property.removed',
+                  reason: 'property removed',
+                  breaking: false,
+                },
+                {
+                  op: 'replace',
+                  path: '/properties/customerId',
+                  kind: 'required.removed',
+                  reason: 'property is no longer required',
+                  breaking: true,
+                },
+              ],
+            },
+          ],
+          impact: [
+            {
+              message: { type: 'event', id: 'order-created', version: '1.0.0' },
+              reason: 'schema_breaking_change',
+              direction: 'forward',
+              producers: [{ type: 'service', id: 'orders-service', version: '3.1.0', owners: ['team-orders'] }],
+              consumers: [{ type: 'service', id: 'payment-service', version: '2.0.0', owners: ['team-payments'] }],
+            },
+          ],
+        });
+      });
+    });
+
+    describe('when the index was built without schema content', () => {
+      it('reports the change by hash with an unknown (null) verdict and no ops, does not mark the diff breaking, and impacts nobody', () => {
+        // Given both indexes only carry hashes, as buildIndex() does by default
+        const { content: _beforeContent, ...orderCreatedSchemaHashOnly } = orderCreatedSchema;
+        const { content: _afterContent, ...orderCreatedSchemaWithoutCustomerIdHashOnly } = orderCreatedSchemaWithoutCustomerId;
+
+        const a = index({
+          commit: 'abc1234',
+          resources: [
+            ordersService,
+            paymentService,
+            event('order-created', '1.0.0', { owners: ['team-orders'], schemas: [orderCreatedSchemaHashOnly] }),
+          ],
+        });
+        const b = index({
+          commit: 'def5678',
+          resources: [
+            ordersService,
+            paymentService,
+            event('order-created', '1.0.0', { owners: ['team-orders'], schemas: [orderCreatedSchemaWithoutCustomerIdHashOnly] }),
+          ],
+        });
+
+        // When they are compared
+        const result = diff(a, b);
+
+        // Then we know the schema changed but cannot say whether it is safe
+        expect(result).toEqual({
+          schemaVersion: 1,
+          refs: {
+            a: { source: 'acme/catalog', commit: 'abc1234' },
+            b: { source: 'acme/catalog', commit: 'def5678' },
+          },
+          compatibility: { strategy: 'full' },
+          summary: {
+            breaking: false,
+            resourcesAdded: 0,
+            resourcesRemoved: 0,
+            resourcesChanged: 0,
+            edgesAdded: 0,
+            edgesRemoved: 0,
+            schemaChanges: 1,
+            schemaBreaking: 0,
+            schemaUnknown: 1,
+          },
+          resources: { added: [], removed: [], changed: [] },
+          edges: { added: [], removed: [] },
+          schemaChanges: [
+            {
+              message: { type: 'event', id: 'order-created', version: { a: '1.0.0', b: '1.0.0' } },
+              change: 'modified',
+              before: { path: 'schema.json', hash: orderCreatedSchema.hash },
+              after: { path: 'schema.json', hash: orderCreatedSchemaWithoutCustomerId.hash },
+              strategy: 'full',
+              breaking: null,
+              direction: null,
+              ops: [],
+            },
+          ],
+          impact: [],
+        });
+      });
+    });
+
+    describe('when the schema file is renamed in the same change', () => {
+      it('still pairs the two files, because each side has exactly one schema, and reports the content change', () => {
+        // Given the schema moves from schema.json to order-created.json and loses customerId
+        const renamed = { ...orderCreatedSchemaWithoutCustomerId, path: 'order-created.json' };
+        const a = index({ commit: 'abc1234', resources: catalog });
+        const b = index({
+          commit: 'def5678',
+          resources: [
+            ordersService,
+            paymentService,
+            event('order-created', '1.0.0', { owners: ['team-orders'], schemas: [renamed] }),
+          ],
+        });
+
+        // When they are compared
+        const result = diff(a, b);
+
+        // Then the rename does not hide the breaking change
+        expect(result).toEqual({
+          schemaVersion: 1,
+          refs: {
+            a: { source: 'acme/catalog', commit: 'abc1234' },
+            b: { source: 'acme/catalog', commit: 'def5678' },
+          },
+          compatibility: { strategy: 'full' },
+          summary: {
+            breaking: true,
+            resourcesAdded: 0,
+            resourcesRemoved: 0,
+            resourcesChanged: 0,
+            edgesAdded: 0,
+            edgesRemoved: 0,
+            schemaChanges: 1,
+            schemaBreaking: 1,
+            schemaUnknown: 0,
+          },
+          resources: { added: [], removed: [], changed: [] },
+          edges: { added: [], removed: [] },
+          schemaChanges: [
+            {
+              message: { type: 'event', id: 'order-created', version: { a: '1.0.0', b: '1.0.0' } },
+              change: 'modified',
+              before: { path: 'schema.json', hash: orderCreatedSchema.hash },
+              after: { path: 'order-created.json', hash: orderCreatedSchemaWithoutCustomerId.hash },
+              strategy: 'full',
+              breaking: true,
+              direction: 'forward',
+              ops: [
+                {
+                  op: 'remove',
+                  path: '/properties/customerId',
+                  kind: 'property.removed',
+                  reason: 'property removed',
+                  breaking: false,
+                },
+                {
+                  op: 'replace',
+                  path: '/properties/customerId',
+                  kind: 'required.removed',
+                  reason: 'property is no longer required',
+                  breaking: true,
+                },
+              ],
+            },
+          ],
+          impact: [
+            {
+              message: { type: 'event', id: 'order-created', version: '1.0.0' },
+              reason: 'schema_breaking_change',
+              direction: 'forward',
+              producers: [{ type: 'service', id: 'orders-service', version: '3.1.0', owners: ['team-orders'] }],
+              consumers: [{ type: 'service', id: 'payment-service', version: '2.0.0', owners: ['team-payments'] }],
+            },
+          ],
+        });
+      });
+    });
+
+    describe('when a schema file is removed from a message', () => {
+      it('is reported as a removed schema with no verdict, and counted as unknown so it is never silent', () => {
+        // Given OrderCreated loses its schema entirely
+        const a = index({ commit: 'abc1234', resources: catalog });
+        const b = index({
+          commit: 'def5678',
+          resources: [ordersService, paymentService, event('order-created', '1.0.0', { owners: ['team-orders'] })],
+        });
+
+        // When they are compared
+        const result = diff(a, b);
+
+        // Then we cannot say it is safe, and the summary says so
+        expect(result).toEqual({
+          schemaVersion: 1,
+          refs: {
+            a: { source: 'acme/catalog', commit: 'abc1234' },
+            b: { source: 'acme/catalog', commit: 'def5678' },
+          },
+          compatibility: { strategy: 'full' },
+          summary: {
+            breaking: false,
+            resourcesAdded: 0,
+            resourcesRemoved: 0,
+            resourcesChanged: 0,
+            edgesAdded: 0,
+            edgesRemoved: 0,
+            schemaChanges: 1,
+            schemaBreaking: 0,
+            schemaUnknown: 1,
+          },
+          resources: { added: [], removed: [], changed: [] },
+          edges: { added: [], removed: [] },
+          schemaChanges: [
+            {
+              message: { type: 'event', id: 'order-created', version: { a: '1.0.0', b: '1.0.0' } },
+              change: 'removed',
+              before: { path: 'schema.json', hash: orderCreatedSchema.hash },
+              strategy: 'full',
+              breaking: null,
+              direction: null,
+              ops: [],
+            },
+          ],
+          impact: [],
+        });
+      });
+    });
+
+    describe('when a schema file is added to a message that had none', () => {
+      it('is reported as an added schema with no verdict', () => {
+        const a = index({
+          commit: 'abc1234',
+          resources: [ordersService, paymentService, event('order-created', '1.0.0', { owners: ['team-orders'] })],
+        });
+        const b = index({ commit: 'def5678', resources: catalog });
+
+        const result = diff(a, b);
+
+        expect(result).toEqual({
+          schemaVersion: 1,
+          refs: {
+            a: {
+              source: 'acme/catalog',
+              commit: 'abc1234',
+            },
+            b: {
+              source: 'acme/catalog',
+              commit: 'def5678',
+            },
+          },
+          compatibility: {
+            strategy: 'full',
+          },
+          summary: {
+            breaking: false,
+            resourcesAdded: 0,
+            resourcesRemoved: 0,
+            resourcesChanged: 0,
+            edgesAdded: 0,
+            edgesRemoved: 0,
+            schemaChanges: 1,
+            schemaBreaking: 0,
+            schemaUnknown: 1,
+          },
+          resources: {
+            added: [],
+            removed: [],
+            changed: [],
+          },
+          edges: {
+            added: [],
+            removed: [],
+          },
+          schemaChanges: [
+            {
+              message: {
+                type: 'event',
+                id: 'order-created',
+                version: {
+                  a: '1.0.0',
+                  b: '1.0.0',
+                },
+              },
+              change: 'added',
+              after: {
+                path: 'schema.json',
+                hash: orderCreatedSchema.hash,
+              },
+              strategy: 'full',
+              breaking: null,
+              direction: null,
+              ops: [],
+            },
+          ],
+          impact: [],
+        });
+      });
+    });
+
+    describe('when an older version is patched while a newer version exists', () => {
+      it('the older version is still compared against itself, so the change is not hidden behind the latest', () => {
+        // Given OrderCreated exists at 1.0.0 and 2.0.0, and the PR edits 1.0.0 only
+        const orderCreatedV2 = event('order-created', '2.0.0', {
+          owners: ['team-orders'],
+          schemas: [orderCreatedSchemaWithOptionalTotal],
+        });
+        const a = index({ commit: 'abc1234', resources: [ordersService, paymentService, orderCreated, orderCreatedV2] });
+        const b = index({
+          commit: 'def5678',
+          resources: [
+            ordersService,
+            paymentService,
+            event('order-created', '1.0.0', { owners: ['team-orders'], schemas: [orderCreatedSchemaWithoutCustomerId] }),
+            orderCreatedV2,
+          ],
+        });
+
+        // When they are compared
+        const result = diff(a, b);
+
+        // Then the 1.0.0 edit is reported, 2.0.0 is untouched, and Payments (on 1.0.0) is impacted
+        expect(result).toEqual({
+          schemaVersion: 1,
+          refs: {
+            a: {
+              source: 'acme/catalog',
+              commit: 'abc1234',
+            },
+            b: {
+              source: 'acme/catalog',
+              commit: 'def5678',
+            },
+          },
+          compatibility: {
+            strategy: 'full',
+          },
+          summary: {
+            breaking: true,
+            resourcesAdded: 0,
+            resourcesRemoved: 0,
+            resourcesChanged: 0,
+            edgesAdded: 0,
+            edgesRemoved: 0,
+            schemaChanges: 1,
+            schemaBreaking: 1,
+            schemaUnknown: 0,
+          },
+          resources: {
+            added: [],
+            removed: [],
+            changed: [],
+          },
+          edges: {
+            added: [],
+            removed: [],
+          },
+          schemaChanges: [
+            {
+              message: {
+                type: 'event',
+                id: 'order-created',
+                version: {
+                  a: '1.0.0',
+                  b: '1.0.0',
+                },
+              },
+              change: 'modified',
+              before: {
+                path: 'schema.json',
+                hash: orderCreatedSchema.hash,
+              },
+              after: {
+                path: 'schema.json',
+                hash: orderCreatedSchemaWithoutCustomerId.hash,
+              },
+              strategy: 'full',
+              breaking: true,
+              direction: 'forward',
+              ops: [
+                {
+                  op: 'remove',
+                  path: '/properties/customerId',
+                  kind: 'property.removed',
+                  reason: 'property removed',
+                  breaking: false,
+                },
+                {
+                  op: 'replace',
+                  path: '/properties/customerId',
+                  kind: 'required.removed',
+                  reason: 'property is no longer required',
+                  breaking: true,
+                },
+              ],
+            },
+          ],
+          impact: [
+            {
+              message: {
+                type: 'event',
+                id: 'order-created',
+                version: '1.0.0',
+              },
+              reason: 'schema_breaking_change',
+              direction: 'forward',
+              producers: [
+                {
+                  type: 'service',
+                  id: 'orders-service',
+                  version: '3.1.0',
+                  owners: ['team-orders'],
+                },
+              ],
+              consumers: [
+                {
+                  type: 'service',
+                  id: 'payment-service',
+                  version: '2.0.0',
+                  owners: ['team-payments'],
+                },
+              ],
+            },
+          ],
+        });
+      });
+    });
+
+    describe('when a .json schema file has no declared format and does not look like a schema', () => {
+      it('is reported by hash with no verdict rather than walked as if it were a schema', () => {
+        // Given an example payload stored as schema.json, with no `format` in frontmatter
+        const payloadBefore = schema('{"orderId":"ord_1","customerId":"cus_1"}', { format: undefined });
+        const payloadAfter = schema('{"orderId":"ord_1"}', { format: undefined });
+        const a = index({
+          commit: 'abc1234',
+          resources: [
+            ordersService,
+            paymentService,
+            event('order-created', '1.0.0', { owners: ['team-orders'], schemas: [payloadBefore] }),
+          ],
+        });
+        const b = index({
+          commit: 'def5678',
+          resources: [
+            ordersService,
+            paymentService,
+            event('order-created', '1.0.0', { owners: ['team-orders'], schemas: [payloadAfter] }),
+          ],
+        });
+
+        // When they are compared
+        const result = diff(a, b);
+
+        // Then we do not pretend to understand it
+        expect(result).toEqual({
+          schemaVersion: 1,
+          refs: {
+            a: {
+              source: 'acme/catalog',
+              commit: 'abc1234',
+            },
+            b: {
+              source: 'acme/catalog',
+              commit: 'def5678',
+            },
+          },
+          compatibility: {
+            strategy: 'full',
+          },
+          summary: {
+            breaking: false,
+            resourcesAdded: 0,
+            resourcesRemoved: 0,
+            resourcesChanged: 0,
+            edgesAdded: 0,
+            edgesRemoved: 0,
+            schemaChanges: 1,
+            schemaBreaking: 0,
+            schemaUnknown: 1,
+          },
+          resources: {
+            added: [],
+            removed: [],
+            changed: [],
+          },
+          edges: {
+            added: [],
+            removed: [],
+          },
+          schemaChanges: [
+            {
+              message: {
+                type: 'event',
+                id: 'order-created',
+                version: {
+                  a: '1.0.0',
+                  b: '1.0.0',
+                },
+              },
+              change: 'modified',
+              before: {
+                path: 'schema.json',
+                hash: payloadBefore.hash,
+              },
+              after: {
+                path: 'schema.json',
+                hash: payloadAfter.hash,
+              },
+              strategy: 'full',
+              breaking: null,
+              direction: null,
+              ops: [],
+            },
+          ],
+          impact: [],
+        });
+      });
+    });
+
+    describe('when a message only exists on one side', () => {
+      it('is not a schema change, because there is nothing to compare it against', () => {
+        // Given the candidate adds a brand new event
+        const a = index({ commit: 'abc1234', resources: catalog });
+        const b = index({
+          commit: 'def5678',
+          resources: [...catalog, event('order-shipped', '1.0.0', { schemas: [schema({ type: 'object' })] })],
+        });
+
+        // When they are compared
+        const result = diff(a, b);
+
+        // Then it is a resource addition, not a schema change
+        expect(result).toEqual({
+          schemaVersion: 1,
+          refs: {
+            a: { source: 'acme/catalog', commit: 'abc1234' },
+            b: { source: 'acme/catalog', commit: 'def5678' },
+          },
+          compatibility: { strategy: 'full' },
+          summary: {
+            breaking: false,
+            resourcesAdded: 1,
+            resourcesRemoved: 0,
+            resourcesChanged: 0,
+            edgesAdded: 0,
+            edgesRemoved: 0,
+            schemaChanges: 0,
+            schemaBreaking: 0,
+            schemaUnknown: 0,
+          },
+          resources: { added: [{ type: 'event', id: 'order-shipped', version: '1.0.0' }], removed: [], changed: [] },
+          edges: { added: [], removed: [] },
+          schemaChanges: [],
+          impact: [],
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Impact: who is hurt. Derived from the baseline graph so consumers of the diff
+  // never walk edges themselves.
+  // ---------------------------------------------------------------------------
+
+  describe('impact', () => {
+    describe('when a breaking change hits a message nobody consumes', () => {
+      it('still lists the producer, with an empty consumers list, so policy can decide that nobody is affected', () => {
+        // Given OrderCreated is published by Orders but nobody subscribes
+        const a = index({ commit: 'abc1234', resources: [ordersService, orderCreated] });
+        const b = index({
+          commit: 'def5678',
+          resources: [
+            ordersService,
+            event('order-created', '1.0.0', { owners: ['team-orders'], schemas: [orderCreatedSchemaWithoutCustomerId] }),
+          ],
+        });
+
+        // When they are compared
+        const result = diff(a, b);
+
+        // Then the change is still breaking, but the impact entry shows no consumers
+        expect(result).toEqual({
+          schemaVersion: 1,
+          refs: {
+            a: { source: 'acme/catalog', commit: 'abc1234' },
+            b: { source: 'acme/catalog', commit: 'def5678' },
+          },
+          compatibility: { strategy: 'full' },
+          summary: {
+            breaking: true,
+            resourcesAdded: 0,
+            resourcesRemoved: 0,
+            resourcesChanged: 0,
+            edgesAdded: 0,
+            edgesRemoved: 0,
+            schemaChanges: 1,
+            schemaBreaking: 1,
+            schemaUnknown: 0,
+          },
+          resources: { added: [], removed: [], changed: [] },
+          edges: { added: [], removed: [] },
+          schemaChanges: [
+            {
+              message: { type: 'event', id: 'order-created', version: { a: '1.0.0', b: '1.0.0' } },
+              change: 'modified',
+              before: { path: 'schema.json', hash: orderCreatedSchema.hash },
+              after: { path: 'schema.json', hash: orderCreatedSchemaWithoutCustomerId.hash },
+              strategy: 'full',
+              breaking: true,
+              direction: 'forward',
+              ops: [
+                {
+                  op: 'remove',
+                  path: '/properties/customerId',
+                  kind: 'property.removed',
+                  reason: 'property removed',
+                  breaking: false,
+                },
+                {
+                  op: 'replace',
+                  path: '/properties/customerId',
+                  kind: 'required.removed',
+                  reason: 'property is no longer required',
+                  breaking: true,
+                },
+              ],
+            },
+          ],
+          impact: [
+            {
+              message: { type: 'event', id: 'order-created', version: '1.0.0' },
+              reason: 'schema_breaking_change',
+              direction: 'forward',
+              producers: [{ type: 'service', id: 'orders-service', version: '3.1.0', owners: ['team-orders'] }],
+              consumers: [],
+            },
+          ],
+        });
+      });
+    });
+
+    describe('when a message has several consumers', () => {
+      it('lists every consumer, sorted by id, each with its own owners', () => {
+        // Given Payments, Shipping and Analytics all subscribe to OrderCreated
+        const shippingService = service('shipping-service', '1.2.0', {
+          owners: ['team-fulfilment'],
+          receives: [receives('order-created', '1.0.0')],
+        });
+        const analyticsService = service('analytics-service', '0.9.0', {
+          owners: ['team-data', 'team-platform'],
+          receives: [receives('order-created', '1.0.0')],
+        });
+        const a = index({
+          commit: 'abc1234',
+          resources: [ordersService, paymentService, shippingService, analyticsService, orderCreated],
+        });
+        const b = index({
+          commit: 'def5678',
+          resources: [
+            ordersService,
+            paymentService,
+            shippingService,
+            analyticsService,
+            event('order-created', '1.0.0', { owners: ['team-orders'], schemas: [orderCreatedSchemaWithoutCustomerId] }),
+          ],
+        });
+
+        // When they are compared with forward, the strategy that asks "do existing consumers keep working?"
+        const result = diff(a, b, { strategy: 'forward' });
+
+        // Then all three consumers are named
+        expect(result).toEqual({
+          schemaVersion: 1,
+          refs: {
+            a: { source: 'acme/catalog', commit: 'abc1234' },
+            b: { source: 'acme/catalog', commit: 'def5678' },
+          },
+          compatibility: { strategy: 'forward' },
+          summary: {
+            breaking: true,
+            resourcesAdded: 0,
+            resourcesRemoved: 0,
+            resourcesChanged: 0,
+            edgesAdded: 0,
+            edgesRemoved: 0,
+            schemaChanges: 1,
+            schemaBreaking: 1,
+            schemaUnknown: 0,
+          },
+          resources: { added: [], removed: [], changed: [] },
+          edges: { added: [], removed: [] },
+          schemaChanges: [
+            {
+              message: { type: 'event', id: 'order-created', version: { a: '1.0.0', b: '1.0.0' } },
+              change: 'modified',
+              before: { path: 'schema.json', hash: orderCreatedSchema.hash },
+              after: { path: 'schema.json', hash: orderCreatedSchemaWithoutCustomerId.hash },
+              strategy: 'forward',
+              breaking: true,
+              direction: 'forward',
+              ops: [
+                {
+                  op: 'remove',
+                  path: '/properties/customerId',
+                  kind: 'property.removed',
+                  reason: 'property removed',
+                  breaking: false,
+                },
+                {
+                  op: 'replace',
+                  path: '/properties/customerId',
+                  kind: 'required.removed',
+                  reason: 'property is no longer required',
+                  breaking: true,
+                },
+              ],
+            },
+          ],
+          impact: [
+            {
+              message: { type: 'event', id: 'order-created', version: '1.0.0' },
+              reason: 'schema_breaking_change',
+              direction: 'forward',
+              producers: [{ type: 'service', id: 'orders-service', version: '3.1.0', owners: ['team-orders'] }],
+              consumers: [
+                { type: 'service', id: 'analytics-service', version: '0.9.0', owners: ['team-data', 'team-platform'] },
+                { type: 'service', id: 'payment-service', version: '2.0.0', owners: ['team-payments'] },
+                { type: 'service', id: 'shipping-service', version: '1.2.0', owners: ['team-fulfilment'] },
+              ],
+            },
+          ],
+        });
+      });
+    });
+
+    describe('when a consumer subscribes to "latest" rather than a pinned version', () => {
+      // Given Payments follows whatever the latest OrderCreated is, and Shipping gives no version at all (same thing)
+      const paymentOnLatest = service('payment-service', '2.0.0', {
+        owners: ['team-payments'],
+        receives: [receives('order-created', 'latest')],
+      });
+      const shippingNoVersion = service('shipping-service', '1.2.0', {
+        owners: ['team-fulfilment'],
+        receives: [{ id: 'order-created' }],
+      });
+
+      it('is listed when the latest version is edited in place, because latest resolves to the version that changed', () => {
+        const a = index({ commit: 'abc1234', resources: [ordersService, paymentOnLatest, shippingNoVersion, orderCreated] });
+        const b = index({
+          commit: 'def5678',
+          resources: [
+            ordersService,
+            paymentOnLatest,
+            shippingNoVersion,
+            event('order-created', '1.0.0', { owners: ['team-orders'], schemas: [orderCreatedSchemaWithoutCustomerId] }),
+          ],
+        });
+
+        const result = diff(a, b);
+
+        expect(result).toEqual({
+          schemaVersion: 1,
+          refs: {
+            a: {
+              source: 'acme/catalog',
+              commit: 'abc1234',
+            },
+            b: {
+              source: 'acme/catalog',
+              commit: 'def5678',
+            },
+          },
+          compatibility: {
+            strategy: 'full',
+          },
+          summary: {
+            breaking: true,
+            resourcesAdded: 0,
+            resourcesRemoved: 0,
+            resourcesChanged: 0,
+            edgesAdded: 0,
+            edgesRemoved: 0,
+            schemaChanges: 1,
+            schemaBreaking: 1,
+            schemaUnknown: 0,
+          },
+          resources: {
+            added: [],
+            removed: [],
+            changed: [],
+          },
+          edges: {
+            added: [],
+            removed: [],
+          },
+          schemaChanges: [
+            {
+              message: {
+                type: 'event',
+                id: 'order-created',
+                version: {
+                  a: '1.0.0',
+                  b: '1.0.0',
+                },
+              },
+              change: 'modified',
+              before: {
+                path: 'schema.json',
+                hash: orderCreatedSchema.hash,
+              },
+              after: {
+                path: 'schema.json',
+                hash: orderCreatedSchemaWithoutCustomerId.hash,
+              },
+              strategy: 'full',
+              breaking: true,
+              direction: 'forward',
+              ops: [
+                {
+                  op: 'remove',
+                  path: '/properties/customerId',
+                  kind: 'property.removed',
+                  reason: 'property removed',
+                  breaking: false,
+                },
+                {
+                  op: 'replace',
+                  path: '/properties/customerId',
+                  kind: 'required.removed',
+                  reason: 'property is no longer required',
+                  breaking: true,
+                },
+              ],
+            },
+          ],
+          impact: [
+            {
+              message: {
+                type: 'event',
+                id: 'order-created',
+                version: '1.0.0',
+              },
+              reason: 'schema_breaking_change',
+              direction: 'forward',
+              producers: [
+                {
+                  type: 'service',
+                  id: 'orders-service',
+                  version: '3.1.0',
+                  owners: ['team-orders'],
+                },
+              ],
+              consumers: [
+                {
+                  type: 'service',
+                  id: 'payment-service',
+                  version: '2.0.0',
+                  owners: ['team-payments'],
+                },
+                {
+                  type: 'service',
+                  id: 'shipping-service',
+                  version: '1.2.0',
+                  owners: ['team-fulfilment'],
+                },
+              ],
+            },
+          ],
+        });
+      });
+
+      it('is listed when the message is bumped to a new version, because a latest subscriber moves to the new version automatically', () => {
+        // Given the candidate adds OrderCreated 2.0.0; a consumer on latest silently starts receiving 2.0.0
+        const a = index({ commit: 'abc1234', resources: [ordersService, paymentOnLatest, shippingNoVersion, orderCreated] });
+        const b = index({
+          commit: 'def5678',
+          resources: [
+            ordersService,
+            paymentOnLatest,
+            shippingNoVersion,
+            orderCreated,
+            event('order-created', '2.0.0', { owners: ['team-orders'], schemas: [orderCreatedSchemaWithoutCustomerId] }),
+          ],
+        });
+
+        const result = diff(a, b);
+
+        expect(result).toEqual({
+          schemaVersion: 1,
+          refs: {
+            a: {
+              source: 'acme/catalog',
+              commit: 'abc1234',
+            },
+            b: {
+              source: 'acme/catalog',
+              commit: 'def5678',
+            },
+          },
+          compatibility: {
+            strategy: 'full',
+          },
+          summary: {
+            breaking: true,
+            resourcesAdded: 0,
+            resourcesRemoved: 0,
+            resourcesChanged: 1,
+            edgesAdded: 0,
+            edgesRemoved: 0,
+            schemaChanges: 1,
+            schemaBreaking: 1,
+            schemaUnknown: 0,
+          },
+          resources: {
+            added: [],
+            removed: [],
+            changed: [
+              {
+                type: 'event',
+                id: 'order-created',
+                version: {
+                  a: '1.0.0',
+                  b: '2.0.0',
+                },
+                fields: ['version'],
+              },
+            ],
+          },
+          edges: {
+            added: [],
+            removed: [],
+          },
+          schemaChanges: [
+            {
+              message: {
+                type: 'event',
+                id: 'order-created',
+                version: {
+                  a: '1.0.0',
+                  b: '2.0.0',
+                },
+              },
+              change: 'modified',
+              before: {
+                path: 'schema.json',
+                hash: orderCreatedSchema.hash,
+              },
+              after: {
+                path: 'schema.json',
+                hash: orderCreatedSchemaWithoutCustomerId.hash,
+              },
+              strategy: 'full',
+              breaking: true,
+              direction: 'forward',
+              ops: [
+                {
+                  op: 'remove',
+                  path: '/properties/customerId',
+                  kind: 'property.removed',
+                  reason: 'property removed',
+                  breaking: false,
+                },
+                {
+                  op: 'replace',
+                  path: '/properties/customerId',
+                  kind: 'required.removed',
+                  reason: 'property is no longer required',
+                  breaking: true,
+                },
+              ],
+            },
+          ],
+          impact: [
+            {
+              message: {
+                type: 'event',
+                id: 'order-created',
+                version: '1.0.0',
+              },
+              reason: 'schema_breaking_change',
+              direction: 'forward',
+              producers: [
+                {
+                  type: 'service',
+                  id: 'orders-service',
+                  version: '3.1.0',
+                  owners: ['team-orders'],
+                },
+              ],
+              consumers: [
+                {
+                  type: 'service',
+                  id: 'payment-service',
+                  version: '2.0.0',
+                  owners: ['team-payments'],
+                },
+                {
+                  type: 'service',
+                  id: 'shipping-service',
+                  version: '1.2.0',
+                  owners: ['team-fulfilment'],
+                },
+              ],
+            },
+          ],
+        });
+      });
+
+      it('is NOT listed when an older, non-latest version is patched, because latest never pointed at it', () => {
+        // Given OrderCreated exists at 1.0.0 and 2.0.0, latest subscribers are on 2.0.0, and 1.0.0 is patched
+        const orderCreatedV2 = event('order-created', '2.0.0', {
+          owners: ['team-orders'],
+          schemas: [orderCreatedSchemaWithOptionalTotal],
+        });
+        const a = index({
+          commit: 'abc1234',
+          resources: [ordersService, paymentOnLatest, shippingNoVersion, orderCreated, orderCreatedV2],
+        });
+        const b = index({
+          commit: 'def5678',
+          resources: [
+            ordersService,
+            paymentOnLatest,
+            shippingNoVersion,
+            event('order-created', '1.0.0', { owners: ['team-orders'], schemas: [orderCreatedSchemaWithoutCustomerId] }),
+            orderCreatedV2,
+          ],
+        });
+
+        const result = diff(a, b);
+
+        expect(result).toEqual({
+          schemaVersion: 1,
+          refs: {
+            a: {
+              source: 'acme/catalog',
+              commit: 'abc1234',
+            },
+            b: {
+              source: 'acme/catalog',
+              commit: 'def5678',
+            },
+          },
+          compatibility: {
+            strategy: 'full',
+          },
+          summary: {
+            breaking: true,
+            resourcesAdded: 0,
+            resourcesRemoved: 0,
+            resourcesChanged: 0,
+            edgesAdded: 0,
+            edgesRemoved: 0,
+            schemaChanges: 1,
+            schemaBreaking: 1,
+            schemaUnknown: 0,
+          },
+          resources: {
+            added: [],
+            removed: [],
+            changed: [],
+          },
+          edges: {
+            added: [],
+            removed: [],
+          },
+          schemaChanges: [
+            {
+              message: {
+                type: 'event',
+                id: 'order-created',
+                version: {
+                  a: '1.0.0',
+                  b: '1.0.0',
+                },
+              },
+              change: 'modified',
+              before: {
+                path: 'schema.json',
+                hash: orderCreatedSchema.hash,
+              },
+              after: {
+                path: 'schema.json',
+                hash: orderCreatedSchemaWithoutCustomerId.hash,
+              },
+              strategy: 'full',
+              breaking: true,
+              direction: 'forward',
+              ops: [
+                {
+                  op: 'remove',
+                  path: '/properties/customerId',
+                  kind: 'property.removed',
+                  reason: 'property removed',
+                  breaking: false,
+                },
+                {
+                  op: 'replace',
+                  path: '/properties/customerId',
+                  kind: 'required.removed',
+                  reason: 'property is no longer required',
+                  breaking: true,
+                },
+              ],
+            },
+          ],
+          impact: [
+            {
+              message: {
+                type: 'event',
+                id: 'order-created',
+                version: '1.0.0',
+              },
+              reason: 'schema_breaking_change',
+              direction: 'forward',
+              producers: [
+                {
+                  type: 'service',
+                  id: 'orders-service',
+                  version: '3.1.0',
+                  owners: ['team-orders'],
+                },
+              ],
+              consumers: [],
+            },
+          ],
+        });
+      });
+    });
+
+    describe('when the producer or consumer is not a service', () => {
+      it('lists domains and agents that send or receive the message, with their own type', () => {
+        // Given a domain publishes OrderCreated at the domain level, and an AI agent consumes it
+        const shoppingDomain = domain('shopping', '1.0.0', {
+          owners: ['team-shopping'],
+          sends: [sends('order-created', '1.0.0')],
+        });
+        const fraudAgent = resource('agent', 'fraud-agent', '0.3.0', {
+          owners: ['team-risk'],
+          receives: [receives('order-created', '1.0.0')],
+        });
+        const a = index({ commit: 'abc1234', resources: [shoppingDomain, fraudAgent, paymentService, orderCreated] });
+        const b = index({
+          commit: 'def5678',
+          resources: [
+            shoppingDomain,
+            fraudAgent,
+            paymentService,
+            event('order-created', '1.0.0', { owners: ['team-orders'], schemas: [orderCreatedSchemaWithoutCustomerId] }),
+          ],
+        });
+
+        // When they are compared
+        const result = diff(a, b);
+
+        // Then every party appears, typed as what it is
+        expect(result).toEqual({
+          schemaVersion: 1,
+          refs: {
+            a: { source: 'acme/catalog', commit: 'abc1234' },
+            b: { source: 'acme/catalog', commit: 'def5678' },
+          },
+          compatibility: { strategy: 'full' },
+          summary: {
+            breaking: true,
+            resourcesAdded: 0,
+            resourcesRemoved: 0,
+            resourcesChanged: 0,
+            edgesAdded: 0,
+            edgesRemoved: 0,
+            schemaChanges: 1,
+            schemaBreaking: 1,
+            schemaUnknown: 0,
+          },
+          resources: { added: [], removed: [], changed: [] },
+          edges: { added: [], removed: [] },
+          schemaChanges: [
+            {
+              message: { type: 'event', id: 'order-created', version: { a: '1.0.0', b: '1.0.0' } },
+              change: 'modified',
+              before: { path: 'schema.json', hash: orderCreatedSchema.hash },
+              after: { path: 'schema.json', hash: orderCreatedSchemaWithoutCustomerId.hash },
+              strategy: 'full',
+              breaking: true,
+              direction: 'forward',
+              ops: [
+                {
+                  op: 'remove',
+                  path: '/properties/customerId',
+                  kind: 'property.removed',
+                  reason: 'property removed',
+                  breaking: false,
+                },
+                {
+                  op: 'replace',
+                  path: '/properties/customerId',
+                  kind: 'required.removed',
+                  reason: 'property is no longer required',
+                  breaking: true,
+                },
+              ],
+            },
+          ],
+          impact: [
+            {
+              message: { type: 'event', id: 'order-created', version: '1.0.0' },
+              reason: 'schema_breaking_change',
+              direction: 'forward',
+              producers: [{ type: 'domain', id: 'shopping', version: '1.0.0', owners: ['team-shopping'] }],
+              consumers: [
+                { type: 'agent', id: 'fraud-agent', version: '0.3.0', owners: ['team-risk'] },
+                { type: 'service', id: 'payment-service', version: '2.0.0', owners: ['team-payments'] },
+              ],
+            },
+          ],
+        });
+      });
+
+      it('lists a domain as a removed consumer when it stops receiving a message', () => {
+        const shoppingListening = domain('shopping', '1.0.0', {
+          owners: ['team-shopping'],
+          receives: [receives('order-created', '1.0.0')],
+        });
+        const shoppingNotListening = domain('shopping', '1.0.0', { owners: ['team-shopping'] });
+        const a = index({ commit: 'abc1234', resources: [...catalog, shoppingListening] });
+        const b = index({ commit: 'def5678', resources: [...catalog, shoppingNotListening] });
+
+        const result = diff(a, b);
+
+        expect(result).toEqual({
+          schemaVersion: 1,
+          refs: {
+            a: { source: 'acme/catalog', commit: 'abc1234' },
+            b: { source: 'acme/catalog', commit: 'def5678' },
+          },
+          compatibility: { strategy: 'full' },
+          summary: {
+            breaking: false,
+            resourcesAdded: 0,
+            resourcesRemoved: 0,
+            resourcesChanged: 0,
+            edgesAdded: 0,
+            edgesRemoved: 1,
+            schemaChanges: 0,
+            schemaBreaking: 0,
+            schemaUnknown: 0,
+          },
+          resources: { added: [], removed: [], changed: [] },
+          edges: {
+            added: [],
+            removed: [
+              {
+                direction: 'receives',
+                from: { type: 'domain', id: 'shopping', version: '1.0.0' },
+                to: { type: 'event', id: 'order-created', version: '1.0.0' },
+              },
+            ],
+          },
+          schemaChanges: [],
+          impact: [
+            {
+              message: { type: 'event', id: 'order-created' },
+              reason: 'consumer_removed',
+              producers: [],
+              consumers: [{ type: 'domain', id: 'shopping', version: '1.0.0', owners: ['team-shopping'] }],
+            },
+          ],
+        });
+      });
+    });
+
+    describe('when a consumer subscribes with a semver range', () => {
+      it('is listed when the version the range resolves to is the one that changed', () => {
+        // Given Payments accepts any 1.x, which today resolves to 1.0.0, and 1.0.0 is bumped to 2.0.0
+        const paymentOnRange = service('payment-service', '2.0.0', {
+          owners: ['team-payments'],
+          receives: [receives('order-created', '^1.0.0')],
+        });
+        const a = index({ commit: 'abc1234', resources: [ordersService, paymentOnRange, orderCreated] });
+        const b = index({
+          commit: 'def5678',
+          resources: [
+            ordersService,
+            paymentOnRange,
+            orderCreated,
+            event('order-created', '2.0.0', { owners: ['team-orders'], schemas: [orderCreatedSchemaWithoutCustomerId] }),
+          ],
+        });
+
+        const result = diff(a, b);
+
+        // Then Payments is listed: the catalog cannot know whether the producer keeps publishing 1.x, so it errs on inclusion
+        expect(result).toEqual({
+          schemaVersion: 1,
+          refs: {
+            a: {
+              source: 'acme/catalog',
+              commit: 'abc1234',
+            },
+            b: {
+              source: 'acme/catalog',
+              commit: 'def5678',
+            },
+          },
+          compatibility: {
+            strategy: 'full',
+          },
+          summary: {
+            breaking: true,
+            resourcesAdded: 0,
+            resourcesRemoved: 0,
+            resourcesChanged: 1,
+            edgesAdded: 0,
+            edgesRemoved: 0,
+            schemaChanges: 1,
+            schemaBreaking: 1,
+            schemaUnknown: 0,
+          },
+          resources: {
+            added: [],
+            removed: [],
+            changed: [
+              {
+                type: 'event',
+                id: 'order-created',
+                version: {
+                  a: '1.0.0',
+                  b: '2.0.0',
+                },
+                fields: ['version'],
+              },
+            ],
+          },
+          edges: {
+            added: [],
+            removed: [],
+          },
+          schemaChanges: [
+            {
+              message: {
+                type: 'event',
+                id: 'order-created',
+                version: {
+                  a: '1.0.0',
+                  b: '2.0.0',
+                },
+              },
+              change: 'modified',
+              before: {
+                path: 'schema.json',
+                hash: orderCreatedSchema.hash,
+              },
+              after: {
+                path: 'schema.json',
+                hash: orderCreatedSchemaWithoutCustomerId.hash,
+              },
+              strategy: 'full',
+              breaking: true,
+              direction: 'forward',
+              ops: [
+                {
+                  op: 'remove',
+                  path: '/properties/customerId',
+                  kind: 'property.removed',
+                  reason: 'property removed',
+                  breaking: false,
+                },
+                {
+                  op: 'replace',
+                  path: '/properties/customerId',
+                  kind: 'required.removed',
+                  reason: 'property is no longer required',
+                  breaking: true,
+                },
+              ],
+            },
+          ],
+          impact: [
+            {
+              message: {
+                type: 'event',
+                id: 'order-created',
+                version: '1.0.0',
+              },
+              reason: 'schema_breaking_change',
+              direction: 'forward',
+              producers: [
+                {
+                  type: 'service',
+                  id: 'orders-service',
+                  version: '3.1.0',
+                  owners: ['team-orders'],
+                },
+              ],
+              consumers: [
+                {
+                  type: 'service',
+                  id: 'payment-service',
+                  version: '2.0.0',
+                  owners: ['team-payments'],
+                },
+              ],
+            },
+          ],
+        });
+      });
+    });
+
+    describe('when a consumer is pinned to an older version of the message', () => {
+      it('is not listed, because a change to the newer version does not reach it', () => {
+        // Given OrderCreated exists at 0.6.0 and 1.0.0, Payments still consumes 0.6.0, and 1.0.0 changes
+        const legacyOrderCreated = event('order-created', '0.6.0', { owners: ['team-orders'], schemas: [orderCreatedSchema] });
+        const legacyPaymentService = service('payment-service', '1.0.0', {
+          owners: ['team-payments'],
+          receives: [receives('order-created', '0.6.0')],
+        });
+        const a = index({
+          commit: 'abc1234',
+          resources: [ordersService, legacyPaymentService, legacyOrderCreated, orderCreated],
+        });
+        const b = index({
+          commit: 'def5678',
+          resources: [
+            ordersService,
+            legacyPaymentService,
+            legacyOrderCreated,
+            event('order-created', '1.0.0', { owners: ['team-orders'], schemas: [orderCreatedSchemaWithoutCustomerId] }),
+          ],
+        });
+
+        // When they are compared
+        const result = diff(a, b);
+
+        // Then only the producer on 1.0.0 is listed
+        expect(result).toEqual({
+          schemaVersion: 1,
+          refs: {
+            a: { source: 'acme/catalog', commit: 'abc1234' },
+            b: { source: 'acme/catalog', commit: 'def5678' },
+          },
+          compatibility: { strategy: 'full' },
+          summary: {
+            breaking: true,
+            resourcesAdded: 0,
+            resourcesRemoved: 0,
+            resourcesChanged: 0,
+            edgesAdded: 0,
+            edgesRemoved: 0,
+            schemaChanges: 1,
+            schemaBreaking: 1,
+            schemaUnknown: 0,
+          },
+          resources: { added: [], removed: [], changed: [] },
+          edges: { added: [], removed: [] },
+          schemaChanges: [
+            {
+              message: { type: 'event', id: 'order-created', version: { a: '1.0.0', b: '1.0.0' } },
+              change: 'modified',
+              before: { path: 'schema.json', hash: orderCreatedSchema.hash },
+              after: { path: 'schema.json', hash: orderCreatedSchemaWithoutCustomerId.hash },
+              strategy: 'full',
+              breaking: true,
+              direction: 'forward',
+              ops: [
+                {
+                  op: 'remove',
+                  path: '/properties/customerId',
+                  kind: 'property.removed',
+                  reason: 'property removed',
+                  breaking: false,
+                },
+                {
+                  op: 'replace',
+                  path: '/properties/customerId',
+                  kind: 'required.removed',
+                  reason: 'property is no longer required',
+                  breaking: true,
+                },
+              ],
+            },
+          ],
+          impact: [
+            {
+              message: { type: 'event', id: 'order-created', version: '1.0.0' },
+              reason: 'schema_breaking_change',
+              direction: 'forward',
+              producers: [{ type: 'service', id: 'orders-service', version: '3.1.0', owners: ['team-orders'] }],
+              consumers: [],
+            },
+          ],
+        });
+      });
+    });
+
+    describe('when a message that services still use is removed', () => {
+      it('is breaking, and impact names everyone who still produced or consumed it', () => {
+        // Given OrderCreated is deleted while Orders still sends it and Payments still receives it
+        const a = index({ commit: 'abc1234', resources: catalog });
+        const b = index({ commit: 'def5678', resources: [ordersService, paymentService] });
+
+        // When they are compared
+        const result = diff(a, b);
+
+        // Then the removal, the orphaned edges and the impact are all in the document
+        expect(result).toEqual({
+          schemaVersion: 1,
+          refs: {
+            a: { source: 'acme/catalog', commit: 'abc1234' },
+            b: { source: 'acme/catalog', commit: 'def5678' },
+          },
+          compatibility: { strategy: 'full' },
+          summary: {
+            breaking: true,
+            resourcesAdded: 0,
+            resourcesRemoved: 1,
+            resourcesChanged: 0,
+            edgesAdded: 0,
+            edgesRemoved: 2,
+            schemaChanges: 0,
+            schemaBreaking: 0,
+            schemaUnknown: 0,
+          },
+          resources: { added: [], removed: [{ type: 'event', id: 'order-created', version: '1.0.0' }], changed: [] },
+          edges: {
+            added: [],
+            removed: [
+              {
+                direction: 'receives',
+                from: { type: 'service', id: 'payment-service', version: '2.0.0' },
+                to: { type: 'event', id: 'order-created', version: '1.0.0' },
+              },
+              {
+                direction: 'sends',
+                from: { type: 'service', id: 'orders-service', version: '3.1.0' },
+                to: { type: 'event', id: 'order-created', version: '1.0.0' },
+              },
+            ],
+          },
+          schemaChanges: [],
+          impact: [
+            {
+              message: { type: 'event', id: 'order-created', version: '1.0.0' },
+              reason: 'message_removed',
+              producers: [{ type: 'service', id: 'orders-service', version: '3.1.0', owners: ['team-orders'] }],
+              consumers: [{ type: 'service', id: 'payment-service', version: '2.0.0', owners: ['team-payments'] }],
+            },
+          ],
+        });
+      });
+
+      it('is a plain removal with no impact when nobody used it any more', () => {
+        // Given an orphaned event with no producers or consumers is deleted
+        const orphan = event('legacy-ping', '1.0.0', { owners: ['team-orders'] });
+        const a = index({ commit: 'abc1234', resources: [...catalog, orphan] });
+        const b = index({ commit: 'def5678', resources: catalog });
+
+        const result = diff(a, b);
+
+        expect(result).toEqual({
+          schemaVersion: 1,
+          refs: {
+            a: {
+              source: 'acme/catalog',
+              commit: 'abc1234',
+            },
+            b: {
+              source: 'acme/catalog',
+              commit: 'def5678',
+            },
+          },
+          compatibility: {
+            strategy: 'full',
+          },
+          summary: {
+            breaking: false,
+            resourcesAdded: 0,
+            resourcesRemoved: 1,
+            resourcesChanged: 0,
+            edgesAdded: 0,
+            edgesRemoved: 0,
+            schemaChanges: 0,
+            schemaBreaking: 0,
+            schemaUnknown: 0,
+          },
+          resources: {
+            added: [],
+            removed: [
+              {
+                type: 'event',
+                id: 'legacy-ping',
+                version: '1.0.0',
+              },
+            ],
+            changed: [],
+          },
+          edges: {
+            added: [],
+            removed: [],
+          },
+          schemaChanges: [],
+          impact: [],
+        });
+      });
+
+      it('an old version that a consumer is still pinned to is reported when it is deleted', () => {
+        // Given OrderCreated 0.6.0 and 1.0.0 both exist, a legacy consumer is pinned to 0.6.0, and 0.6.0 is deleted
+        const legacyOrderCreated = event('order-created', '0.6.0', { owners: ['team-orders'], schemas: [orderCreatedSchema] });
+        const legacyPaymentService = service('payment-service', '1.0.0', {
+          owners: ['team-payments'],
+          receives: [receives('order-created', '0.6.0')],
+        });
+        const a = index({
+          commit: 'abc1234',
+          resources: [ordersService, legacyPaymentService, legacyOrderCreated, orderCreated],
+        });
+        const b = index({ commit: 'def5678', resources: [ordersService, legacyPaymentService, orderCreated] });
+
+        const result = diff(a, b);
+
+        expect(result).toEqual({
+          schemaVersion: 1,
+          refs: {
+            a: {
+              source: 'acme/catalog',
+              commit: 'abc1234',
+            },
+            b: {
+              source: 'acme/catalog',
+              commit: 'def5678',
+            },
+          },
+          compatibility: {
+            strategy: 'full',
+          },
+          summary: {
+            breaking: true,
+            resourcesAdded: 0,
+            resourcesRemoved: 1,
+            resourcesChanged: 0,
+            edgesAdded: 0,
+            edgesRemoved: 1,
+            schemaChanges: 0,
+            schemaBreaking: 0,
+            schemaUnknown: 0,
+          },
+          resources: {
+            added: [],
+            removed: [
+              {
+                type: 'event',
+                id: 'order-created',
+                version: '0.6.0',
+              },
+            ],
+            changed: [],
+          },
+          edges: {
+            added: [],
+            removed: [
+              {
+                direction: 'receives',
+                from: {
+                  type: 'service',
+                  id: 'payment-service',
+                  version: '1.0.0',
+                },
+                to: {
+                  type: 'event',
+                  id: 'order-created',
+                  version: '0.6.0',
+                },
+              },
+            ],
+          },
+          schemaChanges: [],
+          impact: [
+            {
+              message: {
+                type: 'event',
+                id: 'order-created',
+                version: '0.6.0',
+              },
+              reason: 'message_removed',
+              producers: [],
+              consumers: [
+                {
+                  type: 'service',
+                  id: 'payment-service',
+                  version: '1.0.0',
+                  owners: ['team-payments'],
+                },
+              ],
+            },
+          ],
+        });
+      });
+    });
+
+    describe('when a service stops receiving a message that still exists', () => {
+      it("is listed as a removed consumer, and is not breaking, because dropping a subscription is the consumer's own choice", () => {
+        // Given Payments no longer receives OrderCreated
+        const paymentNoLongerListening = service('payment-service', '2.0.0', { owners: ['team-payments'] });
+        const a = index({ commit: 'abc1234', resources: catalog });
+        const b = index({ commit: 'def5678', resources: [ordersService, paymentNoLongerListening, orderCreated] });
+
+        // When they are compared
+        const result = diff(a, b);
+
+        // Then the edge is gone and impact says who left
+        expect(result).toEqual({
+          schemaVersion: 1,
+          refs: {
+            a: { source: 'acme/catalog', commit: 'abc1234' },
+            b: { source: 'acme/catalog', commit: 'def5678' },
+          },
+          compatibility: { strategy: 'full' },
+          summary: {
+            breaking: false,
+            resourcesAdded: 0,
+            resourcesRemoved: 0,
+            resourcesChanged: 0,
+            edgesAdded: 0,
+            edgesRemoved: 1,
+            schemaChanges: 0,
+            schemaBreaking: 0,
+            schemaUnknown: 0,
+          },
+          resources: { added: [], removed: [], changed: [] },
+          edges: {
+            added: [],
+            removed: [
+              {
+                direction: 'receives',
+                from: { type: 'service', id: 'payment-service', version: '2.0.0' },
+                to: { type: 'event', id: 'order-created', version: '1.0.0' },
+              },
+            ],
+          },
+          schemaChanges: [],
+          impact: [
+            {
+              message: { type: 'event', id: 'order-created' },
+              reason: 'consumer_removed',
+              producers: [],
+              consumers: [{ type: 'service', id: 'payment-service', version: '2.0.0', owners: ['team-payments'] }],
+            },
+          ],
+        });
+      });
+    });
+
+    describe('when a service stops sending a message that still exists', () => {
+      it('is listed as a removed producer', () => {
+        const ordersNoLongerSending = service('orders-service', '3.1.0', { owners: ['team-orders'] });
+        const a = index({ commit: 'abc1234', resources: catalog });
+        const b = index({ commit: 'def5678', resources: [ordersNoLongerSending, paymentService, orderCreated] });
+
+        const result = diff(a, b);
+
+        expect(result).toEqual({
+          schemaVersion: 1,
+          refs: {
+            a: {
+              source: 'acme/catalog',
+              commit: 'abc1234',
+            },
+            b: {
+              source: 'acme/catalog',
+              commit: 'def5678',
+            },
+          },
+          compatibility: {
+            strategy: 'full',
+          },
+          summary: {
+            breaking: false,
+            resourcesAdded: 0,
+            resourcesRemoved: 0,
+            resourcesChanged: 0,
+            edgesAdded: 0,
+            edgesRemoved: 1,
+            schemaChanges: 0,
+            schemaBreaking: 0,
+            schemaUnknown: 0,
+          },
+          resources: {
+            added: [],
+            removed: [],
+            changed: [],
+          },
+          edges: {
+            added: [],
+            removed: [
+              {
+                direction: 'sends',
+                from: {
+                  type: 'service',
+                  id: 'orders-service',
+                  version: '3.1.0',
+                },
+                to: {
+                  type: 'event',
+                  id: 'order-created',
+                  version: '1.0.0',
+                },
+              },
+            ],
+          },
+          schemaChanges: [],
+          impact: [
+            {
+              message: {
+                type: 'event',
+                id: 'order-created',
+              },
+              reason: 'producer_removed',
+              producers: [
+                {
+                  type: 'service',
+                  id: 'orders-service',
+                  version: '3.1.0',
+                  owners: ['team-orders'],
+                },
+              ],
+              consumers: [],
+            },
+          ],
+        });
+      });
+    });
+
+    describe('when a whole consuming service is deleted', () => {
+      it('reports the service removed, its edge removed, and it as a removed consumer', () => {
+        const a = index({ commit: 'abc1234', resources: catalog });
+        const b = index({ commit: 'def5678', resources: [ordersService, orderCreated] });
+
+        const result = diff(a, b);
+
+        expect(result).toEqual({
+          schemaVersion: 1,
+          refs: {
+            a: {
+              source: 'acme/catalog',
+              commit: 'abc1234',
+            },
+            b: {
+              source: 'acme/catalog',
+              commit: 'def5678',
+            },
+          },
+          compatibility: {
+            strategy: 'full',
+          },
+          summary: {
+            breaking: false,
+            resourcesAdded: 0,
+            resourcesRemoved: 1,
+            resourcesChanged: 0,
+            edgesAdded: 0,
+            edgesRemoved: 1,
+            schemaChanges: 0,
+            schemaBreaking: 0,
+            schemaUnknown: 0,
+          },
+          resources: {
+            added: [],
+            removed: [
+              {
+                type: 'service',
+                id: 'payment-service',
+                version: '2.0.0',
+              },
+            ],
+            changed: [],
+          },
+          edges: {
+            added: [],
+            removed: [
+              {
+                direction: 'receives',
+                from: {
+                  type: 'service',
+                  id: 'payment-service',
+                  version: '2.0.0',
+                },
+                to: {
+                  type: 'event',
+                  id: 'order-created',
+                  version: '1.0.0',
+                },
+              },
+            ],
+          },
+          schemaChanges: [],
+          impact: [
+            {
+              message: {
+                type: 'event',
+                id: 'order-created',
+              },
+              reason: 'consumer_removed',
+              producers: [],
+              consumers: [
+                {
+                  type: 'service',
+                  id: 'payment-service',
+                  version: '2.0.0',
+                  owners: ['team-payments'],
+                },
+              ],
+            },
+          ],
+        });
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Resources: what was added, removed or changed. Identity is type + id.
+  // ---------------------------------------------------------------------------
+
+  describe('resources', () => {
+    it('a resource present only in the candidate is reported as added', () => {
+      // Given a new service appears, sending a new command
+      const a = index({ commit: 'abc1234', resources: catalog });
+      const b = index({
+        commit: 'def5678',
+        resources: [
+          ...catalog,
+          service('inventory-service', '1.0.0', { owners: ['team-warehouse'], sends: [sends('stock-reserved', '1.0.0')] }),
+          event('stock-reserved', '1.0.0', { owners: ['team-warehouse'] }),
+        ],
+      });
+
+      const result = diff(a, b);
+
+      expect(result).toEqual({
+        schemaVersion: 1,
+        refs: {
+          a: { source: 'acme/catalog', commit: 'abc1234' },
+          b: { source: 'acme/catalog', commit: 'def5678' },
+        },
+        compatibility: { strategy: 'full' },
+        summary: {
+          breaking: false,
+          resourcesAdded: 2,
+          resourcesRemoved: 0,
+          resourcesChanged: 0,
+          edgesAdded: 1,
+          edgesRemoved: 0,
+          schemaChanges: 0,
+          schemaBreaking: 0,
+          schemaUnknown: 0,
+        },
+        resources: {
+          added: [
+            { type: 'event', id: 'stock-reserved', version: '1.0.0' },
+            { type: 'service', id: 'inventory-service', version: '1.0.0' },
+          ],
+          removed: [],
+          changed: [],
+        },
+        edges: {
+          added: [
+            {
+              direction: 'sends',
+              from: { type: 'service', id: 'inventory-service', version: '1.0.0' },
+              to: { type: 'event', id: 'stock-reserved', version: '1.0.0' },
+            },
+          ],
+          removed: [],
+        },
+        schemaChanges: [],
+        impact: [],
+      });
+    });
+
+    it('a resource present only in the baseline is reported as removed', () => {
+      const a = index({ commit: 'abc1234', resources: [...catalog, domain('shopping', '1.0.0')] });
+      const b = index({ commit: 'def5678', resources: catalog });
+
+      const result = diff(a, b);
+
+      expect(result).toEqual({
+        schemaVersion: 1,
+        refs: {
+          a: {
+            source: 'acme/catalog',
+            commit: 'abc1234',
+          },
+          b: {
+            source: 'acme/catalog',
+            commit: 'def5678',
+          },
+        },
+        compatibility: {
+          strategy: 'full',
+        },
+        summary: {
+          breaking: false,
+          resourcesAdded: 0,
+          resourcesRemoved: 1,
+          resourcesChanged: 0,
+          edgesAdded: 0,
+          edgesRemoved: 0,
+          schemaChanges: 0,
+          schemaBreaking: 0,
+          schemaUnknown: 0,
+        },
+        resources: {
+          added: [],
+          removed: [
+            {
+              type: 'domain',
+              id: 'shopping',
+              version: '1.0.0',
+            },
+          ],
+          changed: [],
+        },
+        edges: {
+          added: [],
+          removed: [],
+        },
+        schemaChanges: [],
+        impact: [],
+      });
+    });
+
+    it('a resource whose version changed is reported as changed, not as removed plus added', () => {
+      // Given Orders bumps from 3.1.0 to 4.0.0 with the same edges
+      const ordersV4 = service('orders-service', '4.0.0', { owners: ['team-orders'], sends: [sends('order-created', '1.0.0')] });
+      const a = index({ commit: 'abc1234', resources: catalog });
+      const b = index({ commit: 'def5678', resources: [ordersV4, paymentService, orderCreated] });
+
+      const result = diff(a, b);
+
+      expect(result).toEqual({
+        schemaVersion: 1,
+        refs: {
+          a: {
+            source: 'acme/catalog',
+            commit: 'abc1234',
+          },
+          b: {
+            source: 'acme/catalog',
+            commit: 'def5678',
+          },
+        },
+        compatibility: {
+          strategy: 'full',
+        },
+        summary: {
+          breaking: false,
+          resourcesAdded: 0,
+          resourcesRemoved: 0,
+          resourcesChanged: 1,
+          edgesAdded: 0,
+          edgesRemoved: 0,
+          schemaChanges: 0,
+          schemaBreaking: 0,
+          schemaUnknown: 0,
+        },
+        resources: {
+          added: [],
+          removed: [],
+          changed: [
+            {
+              type: 'service',
+              id: 'orders-service',
+              version: {
+                a: '3.1.0',
+                b: '4.0.0',
+              },
+              fields: ['version'],
+            },
+          ],
+        },
+        edges: {
+          added: [],
+          removed: [],
+        },
+        schemaChanges: [],
+        impact: [],
+      });
+    });
+
+    it('a resource is identified by its type and id, so an event and a service with the same id are different resources', () => {
+      // Given a service called "orders" is added while an event called "orders" already exists
+      const a = index({ commit: 'abc1234', resources: [event('orders', '1.0.0')] });
+      const b = index({ commit: 'def5678', resources: [event('orders', '1.0.0'), service('orders', '1.0.0')] });
+
+      const result = diff(a, b);
+
+      expect(result).toEqual({
+        schemaVersion: 1,
+        refs: {
+          a: {
+            source: 'acme/catalog',
+            commit: 'abc1234',
+          },
+          b: {
+            source: 'acme/catalog',
+            commit: 'def5678',
+          },
+        },
+        compatibility: {
+          strategy: 'full',
+        },
+        summary: {
+          breaking: false,
+          resourcesAdded: 1,
+          resourcesRemoved: 0,
+          resourcesChanged: 0,
+          edgesAdded: 0,
+          edgesRemoved: 0,
+          schemaChanges: 0,
+          schemaBreaking: 0,
+          schemaUnknown: 0,
+        },
+        resources: {
+          added: [
+            {
+              type: 'service',
+              id: 'orders',
+              version: '1.0.0',
+            },
+          ],
+          removed: [],
+          changed: [],
+        },
+        edges: {
+          added: [],
+          removed: [],
+        },
+        schemaChanges: [],
+        impact: [],
+      });
+    });
+
+    it('a resource whose owners changed is reported as changed, with the field named', () => {
+      const reassigned = service('payment-service', '2.0.0', {
+        owners: ['team-checkout'],
+        receives: [receives('order-created', '1.0.0')],
+      });
+      const a = index({ commit: 'abc1234', resources: catalog });
+      const b = index({ commit: 'def5678', resources: [ordersService, reassigned, orderCreated] });
+
+      const result = diff(a, b);
+
+      expect(result).toEqual({
+        schemaVersion: 1,
+        refs: {
+          a: {
+            source: 'acme/catalog',
+            commit: 'abc1234',
+          },
+          b: {
+            source: 'acme/catalog',
+            commit: 'def5678',
+          },
+        },
+        compatibility: {
+          strategy: 'full',
+        },
+        summary: {
+          breaking: false,
+          resourcesAdded: 0,
+          resourcesRemoved: 0,
+          resourcesChanged: 1,
+          edgesAdded: 0,
+          edgesRemoved: 0,
+          schemaChanges: 0,
+          schemaBreaking: 0,
+          schemaUnknown: 0,
+        },
+        resources: {
+          added: [],
+          removed: [],
+          changed: [
+            {
+              type: 'service',
+              id: 'payment-service',
+              version: {
+                a: '2.0.0',
+                b: '2.0.0',
+              },
+              fields: ['owners'],
+            },
+          ],
+        },
+        edges: {
+          added: [],
+          removed: [],
+        },
+        schemaChanges: [],
+        impact: [],
+      });
+    });
+
+    it('a resource that became deprecated is reported as changed, with the field named', () => {
+      const deprecated = event('order-created', '1.0.0', {
+        owners: ['team-orders'],
+        schemas: [orderCreatedSchema],
+        deprecated: { date: '2026-12-31', message: 'Use OrderPlaced' },
+      });
+      const a = index({ commit: 'abc1234', resources: catalog });
+      const b = index({ commit: 'def5678', resources: [ordersService, paymentService, deprecated] });
+
+      const result = diff(a, b);
+
+      expect(result).toEqual({
+        schemaVersion: 1,
+        refs: {
+          a: {
+            source: 'acme/catalog',
+            commit: 'abc1234',
+          },
+          b: {
+            source: 'acme/catalog',
+            commit: 'def5678',
+          },
+        },
+        compatibility: {
+          strategy: 'full',
+        },
+        summary: {
+          breaking: false,
+          resourcesAdded: 0,
+          resourcesRemoved: 0,
+          resourcesChanged: 1,
+          edgesAdded: 0,
+          edgesRemoved: 0,
+          schemaChanges: 0,
+          schemaBreaking: 0,
+          schemaUnknown: 0,
+        },
+        resources: {
+          added: [],
+          removed: [],
+          changed: [
+            {
+              type: 'event',
+              id: 'order-created',
+              version: {
+                a: '1.0.0',
+                b: '1.0.0',
+              },
+              fields: ['deprecated'],
+            },
+          ],
+        },
+        edges: {
+          added: [],
+          removed: [],
+        },
+        schemaChanges: [],
+        impact: [],
+      });
+    });
+
+    it('a version bump that also changes owners names both fields', () => {
+      const ordersV4 = service('orders-service', '4.0.0', {
+        owners: ['team-orders', 'team-platform'],
+        sends: [sends('order-created', '1.0.0')],
+      });
+      const a = index({ commit: 'abc1234', resources: catalog });
+      const b = index({ commit: 'def5678', resources: [ordersV4, paymentService, orderCreated] });
+
+      const result = diff(a, b);
+
+      expect(result).toEqual({
+        schemaVersion: 1,
+        refs: {
+          a: {
+            source: 'acme/catalog',
+            commit: 'abc1234',
+          },
+          b: {
+            source: 'acme/catalog',
+            commit: 'def5678',
+          },
+        },
+        compatibility: {
+          strategy: 'full',
+        },
+        summary: {
+          breaking: false,
+          resourcesAdded: 0,
+          resourcesRemoved: 0,
+          resourcesChanged: 1,
+          edgesAdded: 0,
+          edgesRemoved: 0,
+          schemaChanges: 0,
+          schemaBreaking: 0,
+          schemaUnknown: 0,
+        },
+        resources: {
+          added: [],
+          removed: [],
+          changed: [
+            {
+              type: 'service',
+              id: 'orders-service',
+              version: {
+                a: '3.1.0',
+                b: '4.0.0',
+              },
+              fields: ['version', 'owners'],
+            },
+          ],
+        },
+        edges: {
+          added: [],
+          removed: [],
+        },
+        schemaChanges: [],
+        impact: [],
+      });
+    });
+
+    it('a markdown-only edit is not a resource change', () => {
+      // Given only the mdx content hash differs
+      const a = index({ commit: 'abc1234', resources: catalog });
+      const b = index({
+        commit: 'def5678',
+        resources: catalog.map((r) => (r.id === 'order-created' ? { ...r, contentHash: 'sha256:' + 'f'.repeat(64) } : r)),
+      });
+
+      const result = diff(a, b);
+
+      expect(result).toEqual({
+        schemaVersion: 1,
+        refs: {
+          a: {
+            source: 'acme/catalog',
+            commit: 'abc1234',
+          },
+          b: {
+            source: 'acme/catalog',
+            commit: 'def5678',
+          },
+        },
+        compatibility: {
+          strategy: 'full',
+        },
+        summary: {
+          breaking: false,
+          resourcesAdded: 0,
+          resourcesRemoved: 0,
+          resourcesChanged: 0,
+          edgesAdded: 0,
+          edgesRemoved: 0,
+          schemaChanges: 0,
+          schemaBreaking: 0,
+          schemaUnknown: 0,
+        },
+        resources: {
+          added: [],
+          removed: [],
+          changed: [],
+        },
+        edges: {
+          added: [],
+          removed: [],
+        },
+        schemaChanges: [],
+        impact: [],
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Edges: relationships that appeared or disappeared. Identity ignores versions.
+  // ---------------------------------------------------------------------------
+
+  describe('edges', () => {
+    it('a service that starts sending a message adds a sends edge', () => {
+      // Given Payments starts publishing PaymentTaken
+      const paymentTaken = event('payment-taken', '1.0.0', { owners: ['team-payments'] });
+      const paymentNowSending = service('payment-service', '2.0.0', {
+        owners: ['team-payments'],
+        receives: [receives('order-created', '1.0.0')],
+        sends: [sends('payment-taken', '1.0.0')],
+      });
+      const a = index({ commit: 'abc1234', resources: [...catalog, paymentTaken] });
+      const b = index({ commit: 'def5678', resources: [ordersService, paymentNowSending, orderCreated, paymentTaken] });
+
+      const result = diff(a, b);
+
+      expect(result).toEqual({
+        schemaVersion: 1,
+        refs: {
+          a: {
+            source: 'acme/catalog',
+            commit: 'abc1234',
+          },
+          b: {
+            source: 'acme/catalog',
+            commit: 'def5678',
+          },
+        },
+        compatibility: {
+          strategy: 'full',
+        },
+        summary: {
+          breaking: false,
+          resourcesAdded: 0,
+          resourcesRemoved: 0,
+          resourcesChanged: 0,
+          edgesAdded: 1,
+          edgesRemoved: 0,
+          schemaChanges: 0,
+          schemaBreaking: 0,
+          schemaUnknown: 0,
+        },
+        resources: {
+          added: [],
+          removed: [],
+          changed: [],
+        },
+        edges: {
+          added: [
+            {
+              direction: 'sends',
+              from: {
+                type: 'service',
+                id: 'payment-service',
+                version: '2.0.0',
+              },
+              to: {
+                type: 'event',
+                id: 'payment-taken',
+                version: '1.0.0',
+              },
+            },
+          ],
+          removed: [],
+        },
+        schemaChanges: [],
+        impact: [],
+      });
+    });
+
+    it('a service that stops receiving a message removes a receives edge', () => {
+      const paymentNoLongerListening = service('payment-service', '2.0.0', { owners: ['team-payments'] });
+      const a = index({ commit: 'abc1234', resources: catalog });
+      const b = index({ commit: 'def5678', resources: [ordersService, paymentNoLongerListening, orderCreated] });
+
+      const result = diff(a, b);
+
+      expect(result).toEqual({
+        schemaVersion: 1,
+        refs: {
+          a: {
+            source: 'acme/catalog',
+            commit: 'abc1234',
+          },
+          b: {
+            source: 'acme/catalog',
+            commit: 'def5678',
+          },
+        },
+        compatibility: {
+          strategy: 'full',
+        },
+        summary: {
+          breaking: false,
+          resourcesAdded: 0,
+          resourcesRemoved: 0,
+          resourcesChanged: 0,
+          edgesAdded: 0,
+          edgesRemoved: 1,
+          schemaChanges: 0,
+          schemaBreaking: 0,
+          schemaUnknown: 0,
+        },
+        resources: {
+          added: [],
+          removed: [],
+          changed: [],
+        },
+        edges: {
+          added: [],
+          removed: [
+            {
+              direction: 'receives',
+              from: {
+                type: 'service',
+                id: 'payment-service',
+                version: '2.0.0',
+              },
+              to: {
+                type: 'event',
+                id: 'order-created',
+                version: '1.0.0',
+              },
+            },
+          ],
+        },
+        schemaChanges: [],
+        impact: [
+          {
+            message: {
+              type: 'event',
+              id: 'order-created',
+            },
+            reason: 'consumer_removed',
+            producers: [],
+            consumers: [
+              {
+                type: 'service',
+                id: 'payment-service',
+                version: '2.0.0',
+                owners: ['team-payments'],
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    it('a pointer to latest is resolved before comparing, so bumping a message version does not churn edges', () => {
+      // Given Payments follows latest, and OrderCreated is bumped to 2.0.0 with the same schema
+      const paymentOnLatest = service('payment-service', '2.0.0', {
+        owners: ['team-payments'],
+        receives: [receives('order-created', 'latest')],
+      });
+      const a = index({ commit: 'abc1234', resources: [ordersService, paymentOnLatest, orderCreated] });
+      const b = index({
+        commit: 'def5678',
+        resources: [
+          ordersService,
+          paymentOnLatest,
+          orderCreated,
+          event('order-created', '2.0.0', { owners: ['team-orders'], schemas: [orderCreatedSchema] }),
+        ],
+      });
+
+      const result = diff(a, b);
+
+      // Then the only thing reported is the version change itself
+      expect(result).toEqual({
+        schemaVersion: 1,
+        refs: {
+          a: {
+            source: 'acme/catalog',
+            commit: 'abc1234',
+          },
+          b: {
+            source: 'acme/catalog',
+            commit: 'def5678',
+          },
+        },
+        compatibility: {
+          strategy: 'full',
+        },
+        summary: {
+          breaking: false,
+          resourcesAdded: 0,
+          resourcesRemoved: 0,
+          resourcesChanged: 1,
+          edgesAdded: 0,
+          edgesRemoved: 0,
+          schemaChanges: 0,
+          schemaBreaking: 0,
+          schemaUnknown: 0,
+        },
+        resources: {
+          added: [],
+          removed: [],
+          changed: [
+            {
+              type: 'event',
+              id: 'order-created',
+              version: {
+                a: '1.0.0',
+                b: '2.0.0',
+              },
+              fields: ['version'],
+            },
+          ],
+        },
+        edges: {
+          added: [],
+          removed: [],
+        },
+        schemaChanges: [],
+        impact: [],
+      });
+    });
+
+    it('every direction the SDK resolves is compared, not only sends and receives', () => {
+      // Given Orders starts writing to a database and a domain starts containing it
+      const ordersDb = resource('container', 'orders-db', '1.0.0', { owners: ['team-orders'] });
+      const ordersWriting = service('orders-service', '3.1.0', {
+        owners: ['team-orders'],
+        sends: [sends('order-created', '1.0.0')],
+        writesTo: [{ id: 'orders-db' }],
+      });
+      const shopping = domain('shopping', '1.0.0', { services: [{ id: 'orders-service', version: '3.1.0' }] });
+      const a = index({ commit: 'abc1234', resources: [...catalog, ordersDb] });
+      const b = index({ commit: 'def5678', resources: [ordersWriting, paymentService, orderCreated, ordersDb, shopping] });
+
+      const result = diff(a, b);
+
+      expect(result).toEqual({
+        schemaVersion: 1,
+        refs: {
+          a: {
+            source: 'acme/catalog',
+            commit: 'abc1234',
+          },
+          b: {
+            source: 'acme/catalog',
+            commit: 'def5678',
+          },
+        },
+        compatibility: {
+          strategy: 'full',
+        },
+        summary: {
+          breaking: false,
+          resourcesAdded: 1,
+          resourcesRemoved: 0,
+          resourcesChanged: 0,
+          edgesAdded: 2,
+          edgesRemoved: 0,
+          schemaChanges: 0,
+          schemaBreaking: 0,
+          schemaUnknown: 0,
+        },
+        resources: {
+          added: [
+            {
+              type: 'domain',
+              id: 'shopping',
+              version: '1.0.0',
+            },
+          ],
+          removed: [],
+          changed: [],
+        },
+        edges: {
+          added: [
+            {
+              direction: 'contains',
+              from: {
+                type: 'domain',
+                id: 'shopping',
+                version: '1.0.0',
+              },
+              to: {
+                type: 'service',
+                id: 'orders-service',
+                version: '3.1.0',
+              },
+              via: 'services',
+            },
+            {
+              direction: 'writesTo',
+              from: {
+                type: 'service',
+                id: 'orders-service',
+                version: '3.1.0',
+              },
+              to: {
+                type: 'container',
+                id: 'orders-db',
+                version: '1.0.0',
+              },
+            },
+          ],
+          removed: [],
+        },
+        schemaChanges: [],
+        impact: [],
+      });
+    });
+
+    it('an edge to something that is not in the catalog is still reported, without a type', () => {
+      // Given Payments starts receiving an event nobody has documented
+      const paymentListeningToUnknown = service('payment-service', '2.0.0', {
+        owners: ['team-payments'],
+        receives: [receives('order-created', '1.0.0'), receives('fraud-flagged', '1.0.0')],
+      });
+      const a = index({ commit: 'abc1234', resources: catalog });
+      const b = index({ commit: 'def5678', resources: [ordersService, paymentListeningToUnknown, orderCreated] });
+
+      const result = diff(a, b);
+
+      expect(result).toEqual({
+        schemaVersion: 1,
+        refs: {
+          a: {
+            source: 'acme/catalog',
+            commit: 'abc1234',
+          },
+          b: {
+            source: 'acme/catalog',
+            commit: 'def5678',
+          },
+        },
+        compatibility: {
+          strategy: 'full',
+        },
+        summary: {
+          breaking: false,
+          resourcesAdded: 0,
+          resourcesRemoved: 0,
+          resourcesChanged: 0,
+          edgesAdded: 1,
+          edgesRemoved: 0,
+          schemaChanges: 0,
+          schemaBreaking: 0,
+          schemaUnknown: 0,
+        },
+        resources: {
+          added: [],
+          removed: [],
+          changed: [],
+        },
+        edges: {
+          added: [
+            {
+              direction: 'receives',
+              from: {
+                type: 'service',
+                id: 'payment-service',
+                version: '2.0.0',
+              },
+              to: {
+                id: 'fraud-flagged',
+              },
+            },
+          ],
+          removed: [],
+        },
+        schemaChanges: [],
+        impact: [],
+      });
+    });
+  });
+});

--- a/packages/diff/src/test/fixtures/builders.ts
+++ b/packages/diff/src/test/fixtures/builders.ts
@@ -1,0 +1,51 @@
+import { createHash } from 'node:crypto';
+import type { Index, IndexResource, IndexSchema, ReceivesPointer, SendsPointer } from '@eventcatalog/sdk';
+
+/**
+ * Small builders so tests can describe an SDK `Index` in a few lines instead of
+ * hand-writing full documents. Shapes mirror what `buildIndex()` emits.
+ */
+
+type ResourceExtra = Partial<Omit<IndexResource, 'type' | 'id' | 'version' | 'name' | 'contentPath'>>;
+
+export const resource = (type: IndexResource['type'], id: string, version: string, extra: ResourceExtra = {}): IndexResource => ({
+  type,
+  id,
+  version,
+  name: id,
+  contentPath: `${type}s/${id}/index.mdx`,
+  ...extra,
+});
+
+export const service = (id: string, version = '1.0.0', extra: ResourceExtra = {}) => resource('service', id, version, extra);
+export const domain = (id: string, version = '1.0.0', extra: ResourceExtra = {}) => resource('domain', id, version, extra);
+export const event = (id: string, version = '1.0.0', extra: ResourceExtra = {}) => resource('event', id, version, extra);
+export const command = (id: string, version = '1.0.0', extra: ResourceExtra = {}) => resource('command', id, version, extra);
+export const query = (id: string, version = '1.0.0', extra: ResourceExtra = {}) => resource('query', id, version, extra);
+
+/**
+ * A schema entry with content embedded, as `buildIndex({ includeSchemaContent: true })`
+ * would produce. The hash is the real sha256 of the content, so two builders with
+ * the same content get the same hash and different content gets a different one.
+ */
+export const schema = (content: unknown, extra: Partial<IndexSchema> = {}): IndexSchema => {
+  const text = typeof content === 'string' ? content : JSON.stringify(content);
+  return {
+    path: 'schema.json',
+    format: 'json-schema',
+    default: true,
+    hash: `sha256:${createHash('sha256').update(text).digest('hex')}`,
+    content: text,
+    ...extra,
+  };
+};
+
+export const sends = (id: string, version = '1.0.0'): SendsPointer => ({ id, version });
+export const receives = (id: string, version = '1.0.0'): ReceivesPointer => ({ id, version });
+
+export const index = (options: { source?: string; commit?: string; resources?: IndexResource[] } = {}): Index => ({
+  indexVersion: 1,
+  source: options.source ?? 'acme/catalog',
+  commit: options.commit ?? 'abc1234',
+  resources: options.resources ?? [],
+});

--- a/packages/diff/src/test/fixtures/scenarios.ts
+++ b/packages/diff/src/test/fixtures/scenarios.ts
@@ -1,0 +1,48 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { Index } from '@eventcatalog/sdk';
+import { parseIndex } from '@eventcatalog/sdk';
+import type { ArchitectureDiff, CompatibilityStrategy } from '../../types';
+
+/**
+ * Scenario fixtures live in `src/test/fixtures/scenarios/<name>/` and contain:
+ *
+ *   a.json         baseline SDK Index (as returned by `buildIndex()`)
+ *   b.json         candidate SDK Index
+ *   expected.json  the ArchitectureDiff `diff(a, b)` must produce
+ *   options.json   optional DiffOptions (e.g. `{ "strategy": "full" }`)
+ *
+ * `scenarios.test.ts` loads every folder and asserts the diff matches exactly,
+ * so adding a scenario is just adding a folder. Indexes are validated with the
+ * SDK's `parseIndex` so a fixture can never drift from what `buildIndex` emits.
+ */
+
+export type Scenario = {
+  name: string;
+  a: Index;
+  b: Index;
+  expected: ArchitectureDiff;
+  options?: { strategy?: CompatibilityStrategy };
+};
+
+const SCENARIOS_DIR = path.join(__dirname, 'scenarios');
+
+const readJson = <T>(file: string): T => JSON.parse(fs.readFileSync(file, 'utf-8')) as T;
+
+export const loadScenarios = (): Scenario[] =>
+  fs
+    .readdirSync(SCENARIOS_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort()
+    .map((name) => {
+      const dir = path.join(SCENARIOS_DIR, name);
+      const optionsFile = path.join(dir, 'options.json');
+      return {
+        name,
+        a: parseIndex(readJson(path.join(dir, 'a.json'))),
+        b: parseIndex(readJson(path.join(dir, 'b.json'))),
+        expected: readJson<ArchitectureDiff>(path.join(dir, 'expected.json')),
+        options: fs.existsSync(optionsFile) ? readJson<Scenario['options']>(optionsFile) : undefined,
+      };
+    });

--- a/packages/diff/src/test/fixtures/scenarios/breaking-required-property-removed/a.json
+++ b/packages/diff/src/test/fixtures/scenarios/breaking-required-property-removed/a.json
@@ -1,0 +1,54 @@
+{
+  "indexVersion": 1,
+  "source": "acme/catalog",
+  "commit": "abc1234",
+  "resources": [
+    {
+      "type": "event",
+      "id": "order-created",
+      "version": "1.0.0",
+      "name": "Order Created",
+      "contentPath": "events/order-created/index.mdx",
+      "contentHash": "sha256:7a4ebbd6cdbb418b6cadaaeb771e8c2b948e5756333d659a6eb29df44a24bfae",
+      "owners": ["team-orders"],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:e8eb015db559f7afbfa9c5f44583254c2c634975e450a42a15fed62973c90c2b",
+          "content": "{\n  \"type\": \"object\",\n  \"required\": [\n    \"orderId\",\n    \"customerId\"\n  ],\n  \"properties\": {\n    \"orderId\": {\n      \"type\": \"string\"\n    },\n    \"customerId\": {\n      \"type\": \"string\"\n    }\n  }\n}"
+        }
+      ]
+    },
+    {
+      "type": "service",
+      "id": "orders-service",
+      "version": "3.1.0",
+      "name": "Orders Service",
+      "contentPath": "services/orders-service/index.mdx",
+      "contentHash": "sha256:ae99e36b006e8c01215ed0b8379c4a7eaccffad03344de13f50876c224b07cda",
+      "owners": ["team-orders"],
+      "sends": [
+        {
+          "id": "order-created",
+          "version": "1.0.0"
+        }
+      ]
+    },
+    {
+      "type": "service",
+      "id": "payment-service",
+      "version": "2.0.0",
+      "name": "Payment Service",
+      "contentPath": "services/payment-service/index.mdx",
+      "contentHash": "sha256:8ed758ac399464871bd5bf73cfeeda466e531267a1869a4e00096cec57822bc0",
+      "owners": ["team-payments"],
+      "receives": [
+        {
+          "id": "order-created",
+          "version": "1.0.0"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/diff/src/test/fixtures/scenarios/breaking-required-property-removed/b.json
+++ b/packages/diff/src/test/fixtures/scenarios/breaking-required-property-removed/b.json
@@ -1,0 +1,54 @@
+{
+  "indexVersion": 1,
+  "source": "acme/catalog",
+  "commit": "def5678",
+  "resources": [
+    {
+      "type": "event",
+      "id": "order-created",
+      "version": "1.0.0",
+      "name": "Order Created",
+      "contentPath": "events/order-created/index.mdx",
+      "contentHash": "sha256:7a4ebbd6cdbb418b6cadaaeb771e8c2b948e5756333d659a6eb29df44a24bfae",
+      "owners": ["team-orders"],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:d7903c9db989ea3edc6c9bb87092d8c5a71c507d1075970512feff280748715a",
+          "content": "{\n  \"type\": \"object\",\n  \"required\": [\n    \"orderId\"\n  ],\n  \"properties\": {\n    \"orderId\": {\n      \"type\": \"string\"\n    }\n  }\n}"
+        }
+      ]
+    },
+    {
+      "type": "service",
+      "id": "orders-service",
+      "version": "3.1.0",
+      "name": "Orders Service",
+      "contentPath": "services/orders-service/index.mdx",
+      "contentHash": "sha256:ae99e36b006e8c01215ed0b8379c4a7eaccffad03344de13f50876c224b07cda",
+      "owners": ["team-orders"],
+      "sends": [
+        {
+          "id": "order-created",
+          "version": "1.0.0"
+        }
+      ]
+    },
+    {
+      "type": "service",
+      "id": "payment-service",
+      "version": "2.0.0",
+      "name": "Payment Service",
+      "contentPath": "services/payment-service/index.mdx",
+      "contentHash": "sha256:8ed758ac399464871bd5bf73cfeeda466e531267a1869a4e00096cec57822bc0",
+      "owners": ["team-payments"],
+      "receives": [
+        {
+          "id": "order-created",
+          "version": "1.0.0"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/diff/src/test/fixtures/scenarios/breaking-required-property-removed/expected.json
+++ b/packages/diff/src/test/fixtures/scenarios/breaking-required-property-removed/expected.json
@@ -1,0 +1,103 @@
+{
+  "schemaVersion": 1,
+  "refs": {
+    "a": {
+      "source": "acme/catalog",
+      "commit": "abc1234"
+    },
+    "b": {
+      "source": "acme/catalog",
+      "commit": "def5678"
+    }
+  },
+  "compatibility": {
+    "strategy": "full"
+  },
+  "summary": {
+    "breaking": true,
+    "resourcesAdded": 0,
+    "resourcesRemoved": 0,
+    "resourcesChanged": 0,
+    "edgesAdded": 0,
+    "edgesRemoved": 0,
+    "schemaChanges": 1,
+    "schemaBreaking": 1,
+    "schemaUnknown": 0
+  },
+  "resources": {
+    "added": [],
+    "removed": [],
+    "changed": []
+  },
+  "edges": {
+    "added": [],
+    "removed": []
+  },
+  "schemaChanges": [
+    {
+      "message": {
+        "type": "event",
+        "id": "order-created",
+        "version": {
+          "a": "1.0.0",
+          "b": "1.0.0"
+        }
+      },
+      "change": "modified",
+      "before": {
+        "path": "schema.json",
+        "hash": "sha256:e8eb015db559f7afbfa9c5f44583254c2c634975e450a42a15fed62973c90c2b"
+      },
+      "after": {
+        "path": "schema.json",
+        "hash": "sha256:d7903c9db989ea3edc6c9bb87092d8c5a71c507d1075970512feff280748715a"
+      },
+      "strategy": "full",
+      "breaking": true,
+      "direction": "forward",
+      "ops": [
+        {
+          "op": "remove",
+          "path": "/properties/customerId",
+          "kind": "property.removed",
+          "reason": "property removed",
+          "breaking": false
+        },
+        {
+          "op": "replace",
+          "path": "/properties/customerId",
+          "kind": "required.removed",
+          "reason": "property is no longer required",
+          "breaking": true
+        }
+      ]
+    }
+  ],
+  "impact": [
+    {
+      "message": {
+        "type": "event",
+        "id": "order-created",
+        "version": "1.0.0"
+      },
+      "reason": "schema_breaking_change",
+      "direction": "forward",
+      "producers": [
+        {
+          "type": "service",
+          "id": "orders-service",
+          "version": "3.1.0",
+          "owners": ["team-orders"]
+        }
+      ],
+      "consumers": [
+        {
+          "type": "service",
+          "id": "payment-service",
+          "version": "2.0.0",
+          "owners": ["team-payments"]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/diff/src/test/fixtures/scenarios/no-changes/a.json
+++ b/packages/diff/src/test/fixtures/scenarios/no-changes/a.json
@@ -1,0 +1,54 @@
+{
+  "indexVersion": 1,
+  "source": "acme/catalog",
+  "commit": "abc1234",
+  "resources": [
+    {
+      "type": "event",
+      "id": "order-created",
+      "version": "1.0.0",
+      "name": "Order Created",
+      "contentPath": "events/order-created/index.mdx",
+      "contentHash": "sha256:7a4ebbd6cdbb418b6cadaaeb771e8c2b948e5756333d659a6eb29df44a24bfae",
+      "owners": ["team-orders"],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:afdafd245ee63d65039f2e9022135266d3e78bb4d55d9c31b2b31bb7053d09a5",
+          "content": "{\n  \"type\": \"object\",\n  \"required\": [\n    \"customerId\"\n  ],\n  \"properties\": {\n    \"customerId\": {\n      \"type\": \"string\"\n    }\n  }\n}"
+        }
+      ]
+    },
+    {
+      "type": "service",
+      "id": "orders-service",
+      "version": "3.1.0",
+      "name": "Orders Service",
+      "contentPath": "services/orders-service/index.mdx",
+      "contentHash": "sha256:ae99e36b006e8c01215ed0b8379c4a7eaccffad03344de13f50876c224b07cda",
+      "owners": ["team-orders"],
+      "sends": [
+        {
+          "id": "order-created",
+          "version": "1.0.0"
+        }
+      ]
+    },
+    {
+      "type": "service",
+      "id": "payment-service",
+      "version": "2.0.0",
+      "name": "Payment Service",
+      "contentPath": "services/payment-service/index.mdx",
+      "contentHash": "sha256:8ed758ac399464871bd5bf73cfeeda466e531267a1869a4e00096cec57822bc0",
+      "owners": ["team-payments"],
+      "receives": [
+        {
+          "id": "order-created",
+          "version": "1.0.0"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/diff/src/test/fixtures/scenarios/no-changes/b.json
+++ b/packages/diff/src/test/fixtures/scenarios/no-changes/b.json
@@ -1,0 +1,54 @@
+{
+  "indexVersion": 1,
+  "source": "acme/catalog",
+  "commit": "def5678",
+  "resources": [
+    {
+      "type": "event",
+      "id": "order-created",
+      "version": "1.0.0",
+      "name": "Order Created",
+      "contentPath": "events/order-created/index.mdx",
+      "contentHash": "sha256:7a4ebbd6cdbb418b6cadaaeb771e8c2b948e5756333d659a6eb29df44a24bfae",
+      "owners": ["team-orders"],
+      "schemas": [
+        {
+          "path": "schema.json",
+          "default": true,
+          "hash": "sha256:afdafd245ee63d65039f2e9022135266d3e78bb4d55d9c31b2b31bb7053d09a5",
+          "content": "{\n  \"type\": \"object\",\n  \"required\": [\n    \"customerId\"\n  ],\n  \"properties\": {\n    \"customerId\": {\n      \"type\": \"string\"\n    }\n  }\n}"
+        }
+      ]
+    },
+    {
+      "type": "service",
+      "id": "orders-service",
+      "version": "3.1.0",
+      "name": "Orders Service",
+      "contentPath": "services/orders-service/index.mdx",
+      "contentHash": "sha256:ae99e36b006e8c01215ed0b8379c4a7eaccffad03344de13f50876c224b07cda",
+      "owners": ["team-orders"],
+      "sends": [
+        {
+          "id": "order-created",
+          "version": "1.0.0"
+        }
+      ]
+    },
+    {
+      "type": "service",
+      "id": "payment-service",
+      "version": "2.0.0",
+      "name": "Payment Service",
+      "contentPath": "services/payment-service/index.mdx",
+      "contentHash": "sha256:8ed758ac399464871bd5bf73cfeeda466e531267a1869a4e00096cec57822bc0",
+      "owners": ["team-payments"],
+      "receives": [
+        {
+          "id": "order-created",
+          "version": "1.0.0"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/diff/src/test/fixtures/scenarios/no-changes/expected.json
+++ b/packages/diff/src/test/fixtures/scenarios/no-changes/expected.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "refs": {
+    "a": {
+      "source": "acme/catalog",
+      "commit": "abc1234"
+    },
+    "b": {
+      "source": "acme/catalog",
+      "commit": "def5678"
+    }
+  },
+  "compatibility": {
+    "strategy": "full"
+  },
+  "summary": {
+    "breaking": false,
+    "resourcesAdded": 0,
+    "resourcesRemoved": 0,
+    "resourcesChanged": 0,
+    "edgesAdded": 0,
+    "edgesRemoved": 0,
+    "schemaChanges": 0,
+    "schemaBreaking": 0,
+    "schemaUnknown": 0
+  },
+  "resources": {
+    "added": [],
+    "removed": [],
+    "changed": []
+  },
+  "edges": {
+    "added": [],
+    "removed": []
+  },
+  "schemaChanges": [],
+  "impact": []
+}

--- a/packages/diff/src/test/json-schema/json-schema.test.ts
+++ b/packages/diff/src/test/json-schema/json-schema.test.ts
@@ -1,0 +1,2757 @@
+import { describe, expect, it } from 'vitest';
+import { checkJsonSchemaCompatibility } from '../../json-schema';
+
+/**
+ * JSON Schema compatibility scenarios.
+ *
+ * One file, organised by strategy, every schema written out in full. This is the
+ * place to reproduce a user-reported scenario: find the strategy they run, copy the
+ * closest test, paste their before and after schema, state the verdict you expect.
+ *
+ *   backward  a consumer on the NEW schema reads OLD messages   (consumers upgrade first)
+ *   forward   a consumer on the OLD schema reads NEW messages   (producers upgrade first)
+ *   full      both directions must hold
+ *   none      nothing is ever breaking, changes are still reported
+ *
+ * The one question behind every verdict: does the reader's schema accept everything
+ * the writer's schema could have produced?
+ *   - a change that makes the schema accept MORE is safe backward, breaking forward
+ *   - a change that makes the schema accept LESS is breaking backward, safe forward
+ *
+ * Schemas use the open content model (unknown properties are accepted), which is
+ * the JSON Schema default.
+ */
+
+describe('JSON Schema compatibility', () => {
+  // ===========================================================================
+  // backward: a consumer on the NEW schema must be able to read OLD messages
+  // ===========================================================================
+  describe('backward: a consumer on the new schema reads old messages', () => {
+    describe('properties', () => {
+      it('adding an optional property is not breaking, because old messages simply do not have it', () => {
+        const before = {
+          type: 'object',
+          properties: { orderId: { type: 'string' } },
+          required: ['orderId'],
+        };
+        const after = {
+          type: 'object',
+          properties: { orderId: { type: 'string' }, customerId: { type: 'string' } },
+          required: ['orderId'],
+        };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(false);
+        expect(result.ops).toEqual([
+          { op: 'add', path: '/properties/customerId', kind: 'property.added', reason: 'property added', breaking: false },
+        ]);
+      });
+
+      it('adding a required property is breaking, because old messages do not have it and the new consumer insists on it', () => {
+        const before = {
+          type: 'object',
+          properties: { orderId: { type: 'string' } },
+          required: ['orderId'],
+        };
+        const after = {
+          type: 'object',
+          properties: { orderId: { type: 'string' }, customerId: { type: 'string' } },
+          required: ['orderId', 'customerId'],
+        };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.direction).toBe('backward');
+        expect(result.ops).toEqual([
+          { op: 'add', path: '/properties/customerId', kind: 'property.added', reason: 'property added', breaking: false },
+          {
+            op: 'replace',
+            path: '/properties/customerId',
+            kind: 'required.added',
+            reason: 'property became required',
+            breaking: true,
+          },
+        ]);
+      });
+
+      it('adding a required property WITH a default is not breaking, because the new consumer fills the gap with the default', () => {
+        const before = {
+          type: 'object',
+          properties: { orderId: { type: 'string' } },
+          required: ['orderId'],
+        };
+        const after = {
+          type: 'object',
+          properties: { orderId: { type: 'string' }, currency: { type: 'string', default: 'GBP' } },
+          required: ['orderId', 'currency'],
+        };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(false);
+        expect(result.ops).toEqual([
+          { op: 'add', path: '/properties/currency', kind: 'property.added', reason: 'property added', breaking: false },
+          {
+            op: 'replace',
+            path: '/properties/currency',
+            kind: 'required.added-with-default',
+            reason: 'property became required but has a default',
+            breaking: false,
+          },
+        ]);
+      });
+
+      it('removing an optional property is not breaking, because old messages may carry it and the open model ignores it', () => {
+        const before = {
+          type: 'object',
+          properties: { orderId: { type: 'string' }, note: { type: 'string' } },
+          required: ['orderId'],
+        };
+        const after = {
+          type: 'object',
+          properties: { orderId: { type: 'string' } },
+          required: ['orderId'],
+        };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(false);
+        expect(result.ops).toEqual([
+          { op: 'remove', path: '/properties/note', kind: 'property.removed', reason: 'property removed', breaking: false },
+        ]);
+      });
+
+      it('removing a required property is not breaking, because old messages carry it and the new consumer no longer cares', () => {
+        const before = {
+          type: 'object',
+          properties: { orderId: { type: 'string' }, customerId: { type: 'string' } },
+          required: ['orderId', 'customerId'],
+        };
+        const after = {
+          type: 'object',
+          properties: { orderId: { type: 'string' } },
+          required: ['orderId'],
+        };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(false);
+      });
+
+      it('making an optional property required is breaking, because old messages may omit it', () => {
+        const before = {
+          type: 'object',
+          properties: { orderId: { type: 'string' }, customerId: { type: 'string' } },
+          required: ['orderId'],
+        };
+        const after = {
+          type: 'object',
+          properties: { orderId: { type: 'string' }, customerId: { type: 'string' } },
+          required: ['orderId', 'customerId'],
+        };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          {
+            op: 'replace',
+            path: '/properties/customerId',
+            kind: 'required.added',
+            reason: 'property became required',
+            breaking: true,
+          },
+        ]);
+      });
+
+      it('making a required property optional is not breaking, because old messages always carry it', () => {
+        const before = {
+          type: 'object',
+          properties: { orderId: { type: 'string' }, customerId: { type: 'string' } },
+          required: ['orderId', 'customerId'],
+        };
+        const after = {
+          type: 'object',
+          properties: { orderId: { type: 'string' }, customerId: { type: 'string' } },
+          required: ['orderId'],
+        };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(false);
+      });
+
+      it('renaming a required property is breaking, because old messages use the old name and the new consumer requires the new one', () => {
+        const before = {
+          type: 'object',
+          properties: { orderId: { type: 'string' }, customerId: { type: 'string' } },
+          required: ['orderId', 'customerId'],
+        };
+        const after = {
+          type: 'object',
+          properties: { orderId: { type: 'string' }, customer_id: { type: 'string' } },
+          required: ['orderId', 'customer_id'],
+        };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          { op: 'remove', path: '/properties/customerId', kind: 'property.removed', reason: 'property removed', breaking: false },
+          { op: 'add', path: '/properties/customer_id', kind: 'property.added', reason: 'property added', breaking: false },
+          {
+            op: 'replace',
+            path: '/properties/customer_id',
+            kind: 'required.added',
+            reason: 'property became required',
+            breaking: true,
+          },
+          {
+            op: 'replace',
+            path: '/properties/customerId',
+            kind: 'required.removed',
+            reason: 'property is no longer required',
+            breaking: false,
+          },
+        ]);
+      });
+
+      it('making a property required inside a nested object is breaking, and the path says exactly where', () => {
+        const before = {
+          type: 'object',
+          properties: {
+            customer: {
+              type: 'object',
+              properties: { id: { type: 'string' }, email: { type: 'string' } },
+              required: ['id'],
+            },
+          },
+          required: ['customer'],
+        };
+        const after = {
+          type: 'object',
+          properties: {
+            customer: {
+              type: 'object',
+              properties: { id: { type: 'string' }, email: { type: 'string' } },
+              required: ['id', 'email'],
+            },
+          },
+          required: ['customer'],
+        };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          {
+            op: 'replace',
+            path: '/properties/customer/properties/email',
+            kind: 'required.added',
+            reason: 'property became required',
+            breaking: true,
+          },
+        ]);
+      });
+    });
+
+    describe('types', () => {
+      it('widening integer to number is not breaking, because every old integer is a valid number', () => {
+        const before = { type: 'object', properties: { quantity: { type: 'integer' } } };
+        const after = { type: 'object', properties: { quantity: { type: 'number' } } };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(false);
+        expect(result.ops).toEqual([
+          {
+            op: 'replace',
+            path: '/properties/quantity/type',
+            kind: 'type.widened',
+            reason: 'type widened from integer to number',
+            breaking: false,
+          },
+        ]);
+      });
+
+      it('narrowing number to integer is breaking, because old messages may carry 2.5', () => {
+        const before = { type: 'object', properties: { quantity: { type: 'number' } } };
+        const after = { type: 'object', properties: { quantity: { type: 'integer' } } };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          {
+            op: 'replace',
+            path: '/properties/quantity/type',
+            kind: 'type.narrowed',
+            reason: 'type narrowed from number to integer',
+            breaking: true,
+          },
+        ]);
+      });
+
+      it('changing string to number is breaking, because old messages carry strings the new consumer rejects', () => {
+        const before = { type: 'object', properties: { orderId: { type: 'string' } } };
+        const after = { type: 'object', properties: { orderId: { type: 'number' } } };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          {
+            op: 'replace',
+            path: '/properties/orderId/type',
+            kind: 'type.changed',
+            reason: 'type changed from string to number',
+            breaking: true,
+          },
+        ]);
+      });
+
+      it('making a property nullable is not breaking, because old messages always carry a string', () => {
+        const before = { type: 'object', properties: { note: { type: 'string' } } };
+        const after = { type: 'object', properties: { note: { type: ['string', 'null'] } } };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(false);
+        expect(result.ops).toEqual([
+          {
+            op: 'replace',
+            path: '/properties/note/type',
+            kind: 'type.widened',
+            reason: 'type widened from string to ["string","null"]',
+            breaking: false,
+          },
+        ]);
+      });
+
+      it('removing null from a nullable property is breaking, because old messages may carry null', () => {
+        const before = { type: 'object', properties: { note: { type: ['string', 'null'] } } };
+        const after = { type: 'object', properties: { note: { type: 'string' } } };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          {
+            op: 'replace',
+            path: '/properties/note/type',
+            kind: 'type.narrowed',
+            reason: 'type narrowed from ["string","null"] to string',
+            breaking: true,
+          },
+        ]);
+      });
+
+      it('removing the type entirely is not breaking, because the property now accepts anything', () => {
+        const before = { type: 'object', properties: { payload: { type: 'string' } } };
+        const after = { type: 'object', properties: { payload: {} } };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(false);
+        expect(result.ops).toEqual([
+          {
+            op: 'replace',
+            path: '/properties/payload/type',
+            kind: 'type.widened',
+            reason: 'type widened from string to any',
+            breaking: false,
+          },
+        ]);
+      });
+
+      it('adding a type where there was none is breaking, because old messages could have carried anything', () => {
+        const before = { type: 'object', properties: { payload: {} } };
+        const after = { type: 'object', properties: { payload: { type: 'string' } } };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          {
+            op: 'replace',
+            path: '/properties/payload/type',
+            kind: 'type.narrowed',
+            reason: 'type narrowed from any to string',
+            breaking: true,
+          },
+        ]);
+      });
+
+      it('changing the root from object to array is breaking', () => {
+        const before = { type: 'object', properties: { orderId: { type: 'string' } } };
+        const after = { type: 'array', items: { type: 'string' } };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          { op: 'replace', path: '/type', kind: 'type.changed', reason: 'type changed from object to array', breaking: true },
+          { op: 'remove', path: '/properties/orderId', kind: 'property.removed', reason: 'property removed', breaking: false },
+          { op: 'replace', path: '/items', kind: 'schema.restricted', reason: 'schema now accepts fewer values', breaking: true },
+        ]);
+      });
+    });
+
+    describe('enums', () => {
+      it('adding an enum value is not breaking, because old messages only ever used the old values', () => {
+        const before = { type: 'object', properties: { status: { type: 'string', enum: ['pending', 'paid'] } } };
+        const after = { type: 'object', properties: { status: { type: 'string', enum: ['pending', 'paid', 'refunded'] } } };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(false);
+        expect(result.ops).toEqual([
+          {
+            op: 'add',
+            path: '/properties/status/enum',
+            kind: 'enum.value.added',
+            reason: 'enum value refunded added',
+            breaking: false,
+          },
+        ]);
+      });
+
+      it('removing an enum value is breaking, because old messages may carry it', () => {
+        const before = { type: 'object', properties: { status: { type: 'string', enum: ['pending', 'paid', 'refunded'] } } };
+        const after = { type: 'object', properties: { status: { type: 'string', enum: ['pending', 'paid'] } } };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          {
+            op: 'remove',
+            path: '/properties/status/enum',
+            kind: 'enum.value.removed',
+            reason: 'enum value refunded removed',
+            breaking: true,
+          },
+        ]);
+      });
+
+      it('restricting a free string to an enum is breaking, because old messages may carry any string', () => {
+        const before = { type: 'object', properties: { status: { type: 'string' } } };
+        const after = { type: 'object', properties: { status: { type: 'string', enum: ['pending', 'paid'] } } };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          {
+            op: 'add',
+            path: '/properties/status/enum',
+            kind: 'enum.added',
+            reason: 'values restricted to ["pending","paid"]',
+            breaking: true,
+          },
+        ]);
+      });
+
+      it('lifting an enum restriction is not breaking, because every old value is still accepted', () => {
+        const before = { type: 'object', properties: { status: { type: 'string', enum: ['pending', 'paid'] } } };
+        const after = { type: 'object', properties: { status: { type: 'string' } } };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(false);
+        expect(result.ops).toEqual([
+          {
+            op: 'remove',
+            path: '/properties/status/enum',
+            kind: 'enum.removed',
+            reason: 'enum restriction removed',
+            breaking: false,
+          },
+        ]);
+      });
+
+      it('changing a const is breaking, because old messages carry the old value', () => {
+        const before = { type: 'object', properties: { eventType: { const: 'OrderCreated' } } };
+        const after = { type: 'object', properties: { eventType: { const: 'OrderPlaced' } } };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          {
+            op: 'add',
+            path: '/properties/eventType/enum',
+            kind: 'enum.value.added',
+            reason: 'enum value OrderPlaced added',
+            breaking: false,
+          },
+          {
+            op: 'remove',
+            path: '/properties/eventType/enum',
+            kind: 'enum.value.removed',
+            reason: 'enum value OrderCreated removed',
+            breaking: true,
+          },
+        ]);
+      });
+
+      it('reordering enum values is not a change at all', () => {
+        const before = { type: 'object', properties: { status: { enum: ['pending', 'paid'] } } };
+        const after = { type: 'object', properties: { status: { enum: ['paid', 'pending'] } } };
+
+        expect(checkJsonSchemaCompatibility(before, after, 'backward')).toEqual({ breaking: false, direction: null, ops: [] });
+      });
+    });
+
+    describe('constraints', () => {
+      it('raising minLength is breaking, because old messages may carry shorter strings', () => {
+        const before = { type: 'object', properties: { sku: { type: 'string', minLength: 1 } } };
+        const after = { type: 'object', properties: { sku: { type: 'string', minLength: 3 } } };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          {
+            op: 'replace',
+            path: '/properties/sku/minLength',
+            kind: 'constraint.tightened',
+            reason: 'minLength tightened from 1 to 3',
+            breaking: true,
+          },
+        ]);
+      });
+
+      it('lowering minLength is not breaking, because every old string still qualifies', () => {
+        const before = { type: 'object', properties: { sku: { type: 'string', minLength: 3 } } };
+        const after = { type: 'object', properties: { sku: { type: 'string', minLength: 1 } } };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(false);
+        expect(result.ops).toEqual([
+          {
+            op: 'replace',
+            path: '/properties/sku/minLength',
+            kind: 'constraint.loosened',
+            reason: 'minLength loosened from 3 to 1',
+            breaking: false,
+          },
+        ]);
+      });
+
+      it('adding a minLength where there was none is breaking', () => {
+        const before = { type: 'object', properties: { sku: { type: 'string' } } };
+        const after = { type: 'object', properties: { sku: { type: 'string', minLength: 3 } } };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          {
+            op: 'add',
+            path: '/properties/sku/minLength',
+            kind: 'constraint.tightened',
+            reason: 'minLength added (3)',
+            breaking: true,
+          },
+        ]);
+      });
+
+      it('lowering maxLength is breaking, because old messages may carry longer strings', () => {
+        const before = { type: 'object', properties: { note: { type: 'string', maxLength: 100 } } };
+        const after = { type: 'object', properties: { note: { type: 'string', maxLength: 50 } } };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          {
+            op: 'replace',
+            path: '/properties/note/maxLength',
+            kind: 'constraint.tightened',
+            reason: 'maxLength tightened from 100 to 50',
+            breaking: true,
+          },
+        ]);
+      });
+
+      it('raising maximum is not breaking, because every old number still fits', () => {
+        const before = { type: 'object', properties: { quantity: { type: 'integer', maximum: 100 } } };
+        const after = { type: 'object', properties: { quantity: { type: 'integer', maximum: 200 } } };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(false);
+        expect(result.ops).toEqual([
+          {
+            op: 'replace',
+            path: '/properties/quantity/maximum',
+            kind: 'constraint.loosened',
+            reason: 'maximum loosened from 100 to 200',
+            breaking: false,
+          },
+        ]);
+      });
+
+      it('adding a pattern is breaking, because old messages were never checked against it', () => {
+        const before = { type: 'object', properties: { sku: { type: 'string' } } };
+        const after = { type: 'object', properties: { sku: { type: 'string', pattern: '^[A-Z]{3}-[0-9]+$' } } };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          {
+            op: 'add',
+            path: '/properties/sku/pattern',
+            kind: 'constraint.tightened',
+            reason: 'pattern added (^[A-Z]{3}-[0-9]+$)',
+            breaking: true,
+          },
+        ]);
+      });
+
+      it('removing a pattern is not breaking', () => {
+        const before = { type: 'object', properties: { sku: { type: 'string', pattern: '^[A-Z]{3}-[0-9]+$' } } };
+        const after = { type: 'object', properties: { sku: { type: 'string' } } };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(false);
+        expect(result.ops).toEqual([
+          {
+            op: 'remove',
+            path: '/properties/sku/pattern',
+            kind: 'constraint.loosened',
+            reason: 'pattern removed',
+            breaking: false,
+          },
+        ]);
+      });
+
+      it('changing a pattern is breaking, because we cannot tell whether the new one accepts every old value', () => {
+        const before = { type: 'object', properties: { sku: { type: 'string', pattern: '^[A-Z]+$' } } };
+        const after = { type: 'object', properties: { sku: { type: 'string', pattern: '^[A-Z0-9]+$' } } };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          {
+            op: 'replace',
+            path: '/properties/sku/pattern',
+            kind: 'constraint.changed',
+            reason: 'pattern changed from ^[A-Z]+$ to ^[A-Z0-9]+$',
+            breaking: true,
+          },
+        ]);
+      });
+
+      it('adding a format is breaking, because old messages were never checked against it', () => {
+        const before = { type: 'object', properties: { email: { type: 'string' } } };
+        const after = { type: 'object', properties: { email: { type: 'string', format: 'email' } } };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          {
+            op: 'add',
+            path: '/properties/email/format',
+            kind: 'constraint.tightened',
+            reason: 'format added (email)',
+            breaking: true,
+          },
+        ]);
+      });
+
+      it('requiring unique array items is breaking, because old messages may contain duplicates', () => {
+        const before = { type: 'object', properties: { tags: { type: 'array', items: { type: 'string' } } } };
+        const after = { type: 'object', properties: { tags: { type: 'array', items: { type: 'string' }, uniqueItems: true } } };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          {
+            op: 'replace',
+            path: '/properties/tags/uniqueItems',
+            kind: 'constraint.tightened',
+            reason: 'uniqueItems tightened from false to true',
+            breaking: true,
+          },
+        ]);
+      });
+
+      it('adding minItems is breaking, because old messages may carry empty arrays', () => {
+        const before = { type: 'object', properties: { lines: { type: 'array', items: { type: 'object' } } } };
+        const after = { type: 'object', properties: { lines: { type: 'array', items: { type: 'object' }, minItems: 1 } } };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          {
+            op: 'add',
+            path: '/properties/lines/minItems',
+            kind: 'constraint.tightened',
+            reason: 'minItems added (1)',
+            breaking: true,
+          },
+        ]);
+      });
+
+      it('changing multipleOf is breaking, because we cannot tell whether every old value is still a multiple', () => {
+        const before = { type: 'object', properties: { amount: { type: 'number', multipleOf: 0.01 } } };
+        const after = { type: 'object', properties: { amount: { type: 'number', multipleOf: 0.05 } } };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          {
+            op: 'replace',
+            path: '/properties/amount/multipleOf',
+            kind: 'constraint.changed',
+            reason: 'multipleOf changed from 0.01 to 0.05',
+            breaking: true,
+          },
+        ]);
+      });
+    });
+
+    describe('closed objects (additionalProperties: false)', () => {
+      it('adding an optional property to a closed object is not breaking, because old messages never had it', () => {
+        const before = { type: 'object', properties: { orderId: { type: 'string' } }, additionalProperties: false };
+        const after = {
+          type: 'object',
+          properties: { orderId: { type: 'string' }, customerId: { type: 'string' } },
+          additionalProperties: false,
+        };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(false);
+        expect(result.ops).toEqual([
+          {
+            op: 'add',
+            path: '/properties/customerId',
+            kind: 'property.added-to-closed-object',
+            reason: 'property added to a closed object (old readers reject unknown properties)',
+            breaking: false,
+          },
+        ]);
+      });
+
+      it('removing a property from a closed object is breaking, because old messages still carry it and the new closed reader rejects it', () => {
+        const before = {
+          type: 'object',
+          properties: { orderId: { type: 'string' }, note: { type: 'string' } },
+          additionalProperties: false,
+        };
+        const after = { type: 'object', properties: { orderId: { type: 'string' } }, additionalProperties: false };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          {
+            op: 'remove',
+            path: '/properties/note',
+            kind: 'property.removed-from-closed-object',
+            reason: 'property removed from a closed object (new readers reject old messages that still carry it)',
+            breaking: true,
+          },
+        ]);
+      });
+
+      it('removing a property while also opening the object is not breaking, because the new reader now accepts the stray field', () => {
+        const before = {
+          type: 'object',
+          properties: { orderId: { type: 'string' }, note: { type: 'string' } },
+          additionalProperties: false,
+        };
+        const after = { type: 'object', properties: { orderId: { type: 'string' } } };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(false);
+        expect(result.ops).toEqual([
+          { op: 'remove', path: '/properties/note', kind: 'property.removed', reason: 'property removed', breaking: false },
+          {
+            op: 'replace',
+            path: '/additionalProperties',
+            kind: 'additionalProperties.opened',
+            reason: 'additional properties are now allowed',
+            breaking: false,
+          },
+        ]);
+      });
+    });
+
+    describe('additional properties (content model)', () => {
+      it('closing an open object with additionalProperties false is breaking, because old messages may carry extra fields', () => {
+        const before = { type: 'object', properties: { orderId: { type: 'string' } } };
+        const after = { type: 'object', properties: { orderId: { type: 'string' } }, additionalProperties: false };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          {
+            op: 'replace',
+            path: '/additionalProperties',
+            kind: 'additionalProperties.closed',
+            reason: 'additional properties are no longer allowed',
+            breaking: true,
+          },
+        ]);
+      });
+
+      it('opening a closed object is not breaking, because old messages never had extra fields', () => {
+        const before = { type: 'object', properties: { orderId: { type: 'string' } }, additionalProperties: false };
+        const after = { type: 'object', properties: { orderId: { type: 'string' } } };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(false);
+        expect(result.ops).toEqual([
+          {
+            op: 'replace',
+            path: '/additionalProperties',
+            kind: 'additionalProperties.opened',
+            reason: 'additional properties are now allowed',
+            breaking: false,
+          },
+        ]);
+      });
+
+      it('constraining the type of additional properties is breaking, because old extra fields could have been anything', () => {
+        const before = { type: 'object', properties: { orderId: { type: 'string' } } };
+        const after = { type: 'object', properties: { orderId: { type: 'string' } }, additionalProperties: { type: 'string' } };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          {
+            op: 'replace',
+            path: '/additionalProperties',
+            kind: 'schema.restricted',
+            reason: 'schema now accepts fewer values',
+            breaking: true,
+          },
+        ]);
+      });
+    });
+
+    describe('arrays', () => {
+      it('narrowing the item type is breaking, and the path points inside items', () => {
+        const before = { type: 'object', properties: { amounts: { type: 'array', items: { type: 'number' } } } };
+        const after = { type: 'object', properties: { amounts: { type: 'array', items: { type: 'integer' } } } };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          {
+            op: 'replace',
+            path: '/properties/amounts/items/type',
+            kind: 'type.narrowed',
+            reason: 'type narrowed from number to integer',
+            breaking: true,
+          },
+        ]);
+      });
+
+      it('widening the item type is not breaking', () => {
+        const before = { type: 'object', properties: { amounts: { type: 'array', items: { type: 'integer' } } } };
+        const after = { type: 'object', properties: { amounts: { type: 'array', items: { type: 'number' } } } };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(false);
+      });
+
+      it('making an item property required is breaking, and the path walks through items', () => {
+        const before = {
+          type: 'object',
+          properties: {
+            lines: {
+              type: 'array',
+              items: { type: 'object', properties: { sku: { type: 'string' }, qty: { type: 'integer' } } },
+            },
+          },
+        };
+        const after = {
+          type: 'object',
+          properties: {
+            lines: {
+              type: 'array',
+              items: { type: 'object', properties: { sku: { type: 'string' }, qty: { type: 'integer' } }, required: ['sku'] },
+            },
+          },
+        };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          {
+            op: 'replace',
+            path: '/properties/lines/items/properties/sku',
+            kind: 'required.added',
+            reason: 'property became required',
+            breaking: true,
+          },
+        ]);
+      });
+
+      it('constraining a new tuple position (draft-07 items array) is breaking, because old tuples had anything there', () => {
+        const before = { type: 'object', properties: { point: { type: 'array', items: [{ type: 'number' }] } } };
+        const after = {
+          type: 'object',
+          properties: { point: { type: 'array', items: [{ type: 'number' }, { type: 'number' }] } },
+        };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          {
+            op: 'add',
+            path: '/properties/point/items/1',
+            kind: 'tuple.item.added',
+            reason: 'tuple position is now constrained',
+            breaking: true,
+          },
+        ]);
+      });
+
+      it('constraining a new tuple position (2020-12 prefixItems) is breaking', () => {
+        const before = { type: 'object', properties: { point: { type: 'array', prefixItems: [{ type: 'number' }] } } };
+        const after = {
+          type: 'object',
+          properties: { point: { type: 'array', prefixItems: [{ type: 'number' }, { type: 'number' }] } },
+        };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          {
+            op: 'add',
+            path: '/properties/point/prefixItems/1',
+            kind: 'tuple.item.added',
+            reason: 'tuple position is now constrained',
+            breaking: true,
+          },
+        ]);
+      });
+
+      it('dropping a tuple position is not breaking', () => {
+        const before = {
+          type: 'object',
+          properties: { point: { type: 'array', items: [{ type: 'number' }, { type: 'number' }] } },
+        };
+        const after = { type: 'object', properties: { point: { type: 'array', items: [{ type: 'number' }] } } };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(false);
+        expect(result.ops).toEqual([
+          {
+            op: 'remove',
+            path: '/properties/point/items/1',
+            kind: 'tuple.item.removed',
+            reason: 'tuple position is no longer constrained',
+            breaking: false,
+          },
+        ]);
+      });
+    });
+
+    describe('composition (oneOf, anyOf, allOf)', () => {
+      it('adding a oneOf branch is not breaking, because every old message matched one of the old branches', () => {
+        const before = { oneOf: [{ type: 'string' }, { type: 'number' }] };
+        const after = { oneOf: [{ type: 'string' }, { type: 'number' }, { type: 'boolean' }] };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(false);
+        expect(result.ops).toEqual([
+          { op: 'add', path: '/oneOf/2', kind: 'union.branch.added', reason: 'oneOf branch added', breaking: false },
+        ]);
+      });
+
+      it('removing a oneOf branch is breaking, because old messages may have matched it', () => {
+        const before = { oneOf: [{ type: 'string' }, { type: 'number' }] };
+        const after = { oneOf: [{ type: 'string' }] };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          { op: 'remove', path: '/oneOf/1', kind: 'union.branch.removed', reason: 'oneOf branch removed', breaking: true },
+        ]);
+      });
+
+      it('narrowing a type inside a oneOf branch is breaking, and the path points into that branch', () => {
+        const before = {
+          type: 'object',
+          properties: { payment: { oneOf: [{ type: 'object', properties: { amount: { type: 'number' } } }, { type: 'null' }] } },
+        };
+        const after = {
+          type: 'object',
+          properties: { payment: { oneOf: [{ type: 'object', properties: { amount: { type: 'integer' } } }, { type: 'null' }] } },
+        };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          {
+            op: 'replace',
+            path: '/properties/payment/oneOf/0/properties/amount/type',
+            kind: 'type.narrowed',
+            reason: 'type narrowed from number to integer',
+            breaking: true,
+          },
+        ]);
+      });
+
+      it('removing an anyOf branch is breaking', () => {
+        const before = { type: 'object', properties: { id: { anyOf: [{ type: 'string' }, { type: 'integer' }] } } };
+        const after = { type: 'object', properties: { id: { anyOf: [{ type: 'string' }] } } };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          {
+            op: 'remove',
+            path: '/properties/id/anyOf/1',
+            kind: 'union.branch.removed',
+            reason: 'anyOf branch removed',
+            breaking: true,
+          },
+        ]);
+      });
+
+      it('wrapping a plain type in a oneOf is breaking, because the value must now match a branch', () => {
+        const before = { type: 'object', properties: { id: { type: 'string' } } };
+        const after = { type: 'object', properties: { id: { type: 'string', oneOf: [{ minLength: 1 }, { const: 'unknown' }] } } };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          {
+            op: 'add',
+            path: '/properties/id/oneOf',
+            kind: 'constraint.tightened',
+            reason: 'oneOf added ([{"minLength":1},{"const":"unknown"}])',
+            breaking: true,
+          },
+        ]);
+      });
+
+      it('reordering oneOf branches is not a change', () => {
+        const card = {
+          type: 'object',
+          required: ['method', 'last4'],
+          properties: { method: { const: 'card' }, last4: { type: 'string' } },
+        };
+        const paypal = {
+          type: 'object',
+          required: ['method', 'payerId'],
+          properties: { method: { const: 'paypal' }, payerId: { type: 'string' } },
+        };
+        const before = { type: 'object', properties: { payment: { oneOf: [card, paypal] } } };
+        const after = { type: 'object', properties: { payment: { oneOf: [paypal, card] } } };
+
+        expect(checkJsonSchemaCompatibility(before, after, 'backward')).toEqual({ breaking: false, direction: null, ops: [] });
+      });
+
+      it('editing one branch while reordering the others still reports the edit precisely, at its new position', () => {
+        const card = {
+          type: 'object',
+          required: ['method', 'last4'],
+          properties: { method: { const: 'card' }, last4: { type: 'string' } },
+        };
+        const paypal = {
+          type: 'object',
+          required: ['method', 'payerId'],
+          properties: { method: { const: 'paypal' }, payerId: { type: 'string' } },
+        };
+        const paypalWithEmail = {
+          type: 'object',
+          required: ['method', 'payerId', 'email'],
+          properties: { method: { const: 'paypal' }, payerId: { type: 'string' }, email: { type: 'string' } },
+        };
+        const before = { type: 'object', properties: { payment: { oneOf: [card, paypal] } } };
+        const after = { type: 'object', properties: { payment: { oneOf: [paypalWithEmail, card] } } };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          {
+            op: 'add',
+            path: '/properties/payment/oneOf/0/properties/email',
+            kind: 'property.added',
+            reason: 'property added',
+            breaking: false,
+          },
+          {
+            op: 'replace',
+            path: '/properties/payment/oneOf/0/properties/email',
+            kind: 'required.added',
+            reason: 'property became required',
+            breaking: true,
+          },
+        ]);
+      });
+
+      it('adding an allOf branch is breaking, because it adds a constraint old messages never met', () => {
+        const before = { allOf: [{ type: 'object', properties: { id: { type: 'string' } } }] };
+        const after = { allOf: [{ type: 'object', properties: { id: { type: 'string' } } }, { required: ['id'] }] };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          { op: 'add', path: '/allOf/1', kind: 'allOf.branch.added', reason: 'allOf branch added', breaking: true },
+        ]);
+      });
+
+      it('removing an allOf branch is not breaking', () => {
+        const before = { allOf: [{ type: 'object', properties: { id: { type: 'string' } } }, { required: ['id'] }] };
+        const after = { allOf: [{ type: 'object', properties: { id: { type: 'string' } } }] };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(false);
+        expect(result.ops).toEqual([
+          { op: 'remove', path: '/allOf/1', kind: 'allOf.branch.removed', reason: 'allOf branch removed', breaking: false },
+        ]);
+      });
+    });
+
+    describe('$ref (local definitions)', () => {
+      it('a change inside a shared definition is reported once, at the definition, not once per property that uses it', () => {
+        const before = {
+          type: 'object',
+          properties: {
+            billingAddress: { $ref: '#/definitions/Address' },
+            shippingAddress: { $ref: '#/definitions/Address' },
+          },
+          definitions: {
+            Address: { type: 'object', properties: { street: { type: 'string' } }, required: ['street'] },
+          },
+        };
+        const after = {
+          type: 'object',
+          properties: {
+            billingAddress: { $ref: '#/definitions/Address' },
+            shippingAddress: { $ref: '#/definitions/Address' },
+          },
+          definitions: {
+            Address: {
+              type: 'object',
+              properties: { street: { type: 'string' }, postcode: { type: 'string' } },
+              required: ['street', 'postcode'],
+            },
+          },
+        };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          {
+            op: 'add',
+            path: '/definitions/Address/properties/postcode',
+            kind: 'property.added',
+            reason: 'property added',
+            breaking: false,
+          },
+          {
+            op: 'replace',
+            path: '/definitions/Address/properties/postcode',
+            kind: 'required.added',
+            reason: 'property became required',
+            breaking: true,
+          },
+        ]);
+      });
+
+      it('a recursive definition is compared once and terminates', () => {
+        const before = {
+          type: 'object',
+          properties: { root: { $ref: '#/$defs/Node' } },
+          $defs: {
+            Node: {
+              type: 'object',
+              properties: { value: { type: 'string' }, children: { type: 'array', items: { $ref: '#/$defs/Node' } } },
+            },
+          },
+        };
+        const after = {
+          type: 'object',
+          properties: { root: { $ref: '#/$defs/Node' } },
+          $defs: {
+            Node: {
+              type: 'object',
+              properties: { value: { type: 'number' }, children: { type: 'array', items: { $ref: '#/$defs/Node' } } },
+            },
+          },
+        };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          {
+            op: 'replace',
+            path: '/$defs/Node/properties/value/type',
+            kind: 'type.changed',
+            reason: 'type changed from string to number',
+            breaking: true,
+          },
+        ]);
+      });
+
+      it('extracting an inline object into a definition with identical content is not a change', () => {
+        const before = {
+          type: 'object',
+          properties: { address: { type: 'object', properties: { street: { type: 'string' } }, required: ['street'] } },
+        };
+        const after = {
+          type: 'object',
+          properties: { address: { $ref: '#/definitions/Address' } },
+          definitions: { Address: { type: 'object', properties: { street: { type: 'string' } }, required: ['street'] } },
+        };
+
+        expect(checkJsonSchemaCompatibility(before, after, 'backward')).toEqual({ breaking: false, direction: null, ops: [] });
+      });
+
+      it('a ref that points at another ref is followed to the end', () => {
+        const before = {
+          type: 'object',
+          properties: { address: { $ref: '#/definitions/Address' } },
+          definitions: {
+            Address: { $ref: '#/definitions/PostalAddress' },
+            PostalAddress: { type: 'object', properties: { street: { type: 'string' } } },
+          },
+        };
+        const after = {
+          type: 'object',
+          properties: { address: { $ref: '#/definitions/Address' } },
+          definitions: {
+            Address: { $ref: '#/definitions/PostalAddress' },
+            PostalAddress: { type: 'object', properties: { street: { type: 'string' } }, required: ['street'] },
+          },
+        };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          {
+            op: 'replace',
+            path: '/definitions/Address/properties/street',
+            kind: 'required.added',
+            reason: 'property became required',
+            breaking: true,
+          },
+        ]);
+      });
+
+      it('changing an external $ref is reported as breaking, because we cannot see what it points at', () => {
+        const before = { type: 'object', properties: { address: { $ref: './common.json#/Address' } } };
+        const after = { type: 'object', properties: { address: { $ref: './common-v2.json#/Address' } } };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          {
+            op: 'replace',
+            path: '/properties/address/$ref',
+            kind: 'keyword.changed',
+            reason: '$ref changed, compatibility cannot be determined',
+            breaking: true,
+          },
+        ]);
+      });
+
+      it('an unchanged external $ref is not a change', () => {
+        const before = { type: 'object', properties: { address: { $ref: './common.json#/Address' } } };
+        const after = { type: 'object', properties: { address: { $ref: './common.json#/Address' } } };
+
+        expect(checkJsonSchemaCompatibility(before, after, 'backward')).toEqual({ breaking: false, direction: null, ops: [] });
+      });
+
+      it('renaming a definition with identical content is not a change', () => {
+        const before = {
+          type: 'object',
+          properties: { address: { $ref: '#/definitions/Addr' } },
+          definitions: { Addr: { type: 'object', properties: { street: { type: 'string' } } } },
+        };
+        const after = {
+          type: 'object',
+          properties: { address: { $ref: '#/definitions/Address' } },
+          definitions: { Address: { type: 'object', properties: { street: { type: 'string' } } } },
+        };
+
+        expect(checkJsonSchemaCompatibility(before, after, 'backward')).toEqual({ breaking: false, direction: null, ops: [] });
+      });
+    });
+
+    describe('boolean schemas', () => {
+      it('replacing an accept-anything property (true) with a real schema is breaking', () => {
+        const before = { type: 'object', properties: { metadata: true } };
+        const after = { type: 'object', properties: { metadata: { type: 'object' } } };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          {
+            op: 'replace',
+            path: '/properties/metadata',
+            kind: 'schema.restricted',
+            reason: 'schema now accepts fewer values',
+            breaking: true,
+          },
+        ]);
+      });
+
+      it('replacing a real schema with accept-anything (true) is not breaking', () => {
+        const before = { type: 'object', properties: { metadata: { type: 'object' } } };
+        const after = { type: 'object', properties: { metadata: true } };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(false);
+        expect(result.ops).toEqual([
+          {
+            op: 'replace',
+            path: '/properties/metadata',
+            kind: 'schema.relaxed',
+            reason: 'schema now accepts more values',
+            breaking: false,
+          },
+        ]);
+      });
+    });
+
+    describe('keywords we cannot reason about', () => {
+      it('changing patternProperties is reported as breaking, because we refuse to call it safe without understanding it', () => {
+        const before = { type: 'object', properties: { orderId: { type: 'string' } } };
+        const after = {
+          type: 'object',
+          properties: { orderId: { type: 'string' } },
+          patternProperties: { '^x-': { type: 'string' } },
+        };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          {
+            op: 'add',
+            path: '/patternProperties',
+            kind: 'keyword.changed',
+            reason: 'patternProperties changed, compatibility cannot be determined',
+            breaking: true,
+          },
+        ]);
+      });
+
+      it('adding an if/then is reported as breaking for the same reason', () => {
+        const before = { type: 'object', properties: { country: { type: 'string' }, postcode: { type: 'string' } } };
+        const after = {
+          type: 'object',
+          properties: { country: { type: 'string' }, postcode: { type: 'string' } },
+          if: { properties: { country: { const: 'UK' } } },
+          then: { required: ['postcode'] },
+        };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops.map((op) => op.kind)).toEqual(['keyword.changed', 'keyword.changed']);
+        expect(result.ops.map((op) => op.path)).toEqual(['/if', '/then']);
+      });
+    });
+
+    describe('changes that are never breaking', () => {
+      it('marking a property deprecated is reported so a UI can show it, but is not breaking', () => {
+        const before = { type: 'object', properties: { legacyId: { type: 'string' } } };
+        const after = { type: 'object', properties: { legacyId: { type: 'string', deprecated: true } } };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'backward');
+
+        expect(result.breaking).toBe(false);
+        expect(result.ops).toEqual([
+          {
+            op: 'replace',
+            path: '/properties/legacyId',
+            kind: 'schema.deprecated',
+            reason: 'marked as deprecated',
+            breaking: false,
+          },
+        ]);
+      });
+
+      it('changing only title, description, examples or $comment produces no ops at all', () => {
+        const before = {
+          title: 'Order Created',
+          description: 'Raised when an order is placed',
+          type: 'object',
+          properties: { orderId: { type: 'string', description: 'The order id', examples: ['ord_1'] } },
+          required: ['orderId'],
+        };
+        const after = {
+          title: 'OrderCreated',
+          description: 'Raised when a customer places an order',
+          $comment: 'owned by team-orders',
+          type: 'object',
+          properties: { orderId: { type: 'string', description: 'Unique order identifier', examples: ['ord_123'] } },
+          required: ['orderId'],
+        };
+
+        expect(checkJsonSchemaCompatibility(before, after, 'backward')).toEqual({ breaking: false, direction: null, ops: [] });
+      });
+
+      it('reordering properties and required entries is not a change', () => {
+        const before = {
+          type: 'object',
+          properties: { orderId: { type: 'string' }, customerId: { type: 'string' } },
+          required: ['orderId', 'customerId'],
+        };
+        const after = {
+          type: 'object',
+          properties: { customerId: { type: 'string' }, orderId: { type: 'string' } },
+          required: ['customerId', 'orderId'],
+        };
+
+        expect(checkJsonSchemaCompatibility(before, after, 'backward')).toEqual({ breaking: false, direction: null, ops: [] });
+      });
+    });
+  });
+
+  // ===========================================================================
+  // forward: a consumer on the OLD schema must be able to read NEW messages
+  // Every verdict here is the mirror of the backward one above.
+  // ===========================================================================
+  describe('forward: a consumer on the old schema reads new messages', () => {
+    describe('properties', () => {
+      it('adding an optional property is not breaking, because the old consumer ignores properties it does not know', () => {
+        const before = {
+          type: 'object',
+          properties: { orderId: { type: 'string' } },
+          required: ['orderId'],
+        };
+        const after = {
+          type: 'object',
+          properties: { orderId: { type: 'string' }, customerId: { type: 'string' } },
+          required: ['orderId'],
+        };
+
+        expect(checkJsonSchemaCompatibility(before, after, 'forward').breaking).toBe(false);
+      });
+
+      it('adding a required property is not breaking, because the old consumer still ignores it', () => {
+        const before = {
+          type: 'object',
+          properties: { orderId: { type: 'string' } },
+          required: ['orderId'],
+        };
+        const after = {
+          type: 'object',
+          properties: { orderId: { type: 'string' }, customerId: { type: 'string' } },
+          required: ['orderId', 'customerId'],
+        };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'forward');
+
+        expect(result.breaking).toBe(false);
+        expect(result.ops).toEqual([
+          { op: 'add', path: '/properties/customerId', kind: 'property.added', reason: 'property added', breaking: false },
+          {
+            op: 'replace',
+            path: '/properties/customerId',
+            kind: 'required.added',
+            reason: 'property became required',
+            breaking: false,
+          },
+        ]);
+      });
+
+      it('removing an optional property is not breaking, because the old consumer never relied on it being there', () => {
+        const before = {
+          type: 'object',
+          properties: { orderId: { type: 'string' }, note: { type: 'string' } },
+          required: ['orderId'],
+        };
+        const after = {
+          type: 'object',
+          properties: { orderId: { type: 'string' } },
+          required: ['orderId'],
+        };
+
+        expect(checkJsonSchemaCompatibility(before, after, 'forward').breaking).toBe(false);
+      });
+
+      it('removing a required property is breaking, because new messages no longer carry a field the old consumer insists on', () => {
+        const before = {
+          type: 'object',
+          properties: { orderId: { type: 'string' }, customerId: { type: 'string' } },
+          required: ['orderId', 'customerId'],
+        };
+        const after = {
+          type: 'object',
+          properties: { orderId: { type: 'string' } },
+          required: ['orderId'],
+        };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'forward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.direction).toBe('forward');
+        expect(result.ops).toEqual([
+          { op: 'remove', path: '/properties/customerId', kind: 'property.removed', reason: 'property removed', breaking: false },
+          {
+            op: 'replace',
+            path: '/properties/customerId',
+            kind: 'required.removed',
+            reason: 'property is no longer required',
+            breaking: true,
+          },
+        ]);
+      });
+
+      it('making an optional property required is not breaking, because new messages always carry it', () => {
+        const before = {
+          type: 'object',
+          properties: { orderId: { type: 'string' }, customerId: { type: 'string' } },
+          required: ['orderId'],
+        };
+        const after = {
+          type: 'object',
+          properties: { orderId: { type: 'string' }, customerId: { type: 'string' } },
+          required: ['orderId', 'customerId'],
+        };
+
+        expect(checkJsonSchemaCompatibility(before, after, 'forward').breaking).toBe(false);
+      });
+
+      it('making a required property optional is breaking, because new messages may omit a field the old consumer insists on', () => {
+        const before = {
+          type: 'object',
+          properties: { orderId: { type: 'string' }, customerId: { type: 'string' } },
+          required: ['orderId', 'customerId'],
+        };
+        const after = {
+          type: 'object',
+          properties: { orderId: { type: 'string' }, customerId: { type: 'string' } },
+          required: ['orderId'],
+        };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'forward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          {
+            op: 'replace',
+            path: '/properties/customerId',
+            kind: 'required.removed',
+            reason: 'property is no longer required',
+            breaking: true,
+          },
+        ]);
+      });
+
+      it('renaming a required property is breaking, because new messages no longer carry the old name', () => {
+        const before = {
+          type: 'object',
+          properties: { orderId: { type: 'string' }, customerId: { type: 'string' } },
+          required: ['orderId', 'customerId'],
+        };
+        const after = {
+          type: 'object',
+          properties: { orderId: { type: 'string' }, customer_id: { type: 'string' } },
+          required: ['orderId', 'customer_id'],
+        };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'forward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops.filter((op) => op.breaking)).toEqual([
+          {
+            op: 'replace',
+            path: '/properties/customerId',
+            kind: 'required.removed',
+            reason: 'property is no longer required',
+            breaking: true,
+          },
+        ]);
+      });
+
+      it('removing a required property from a nested object is breaking', () => {
+        const before = {
+          type: 'object',
+          properties: {
+            customer: {
+              type: 'object',
+              properties: { id: { type: 'string' }, email: { type: 'string' } },
+              required: ['id', 'email'],
+            },
+          },
+          required: ['customer'],
+        };
+        const after = {
+          type: 'object',
+          properties: {
+            customer: {
+              type: 'object',
+              properties: { id: { type: 'string' } },
+              required: ['id'],
+            },
+          },
+          required: ['customer'],
+        };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'forward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops.filter((op) => op.breaking)).toEqual([
+          {
+            op: 'replace',
+            path: '/properties/customer/properties/email',
+            kind: 'required.removed',
+            reason: 'property is no longer required',
+            breaking: true,
+          },
+        ]);
+      });
+    });
+
+    describe('types', () => {
+      it('widening integer to number is breaking, because new messages may carry 2.5 and the old consumer expects integers', () => {
+        const before = { type: 'object', properties: { quantity: { type: 'integer' } } };
+        const after = { type: 'object', properties: { quantity: { type: 'number' } } };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'forward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          {
+            op: 'replace',
+            path: '/properties/quantity/type',
+            kind: 'type.widened',
+            reason: 'type widened from integer to number',
+            breaking: true,
+          },
+        ]);
+      });
+
+      it('narrowing number to integer is not breaking, because every new integer is a valid number', () => {
+        const before = { type: 'object', properties: { quantity: { type: 'number' } } };
+        const after = { type: 'object', properties: { quantity: { type: 'integer' } } };
+
+        expect(checkJsonSchemaCompatibility(before, after, 'forward').breaking).toBe(false);
+      });
+
+      it('changing string to number is breaking', () => {
+        const before = { type: 'object', properties: { orderId: { type: 'string' } } };
+        const after = { type: 'object', properties: { orderId: { type: 'number' } } };
+
+        expect(checkJsonSchemaCompatibility(before, after, 'forward').breaking).toBe(true);
+      });
+
+      it('making a property nullable is breaking, because new messages may carry null and the old consumer expects a string', () => {
+        const before = { type: 'object', properties: { note: { type: 'string' } } };
+        const after = { type: 'object', properties: { note: { type: ['string', 'null'] } } };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'forward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          {
+            op: 'replace',
+            path: '/properties/note/type',
+            kind: 'type.widened',
+            reason: 'type widened from string to ["string","null"]',
+            breaking: true,
+          },
+        ]);
+      });
+
+      it('removing null from a nullable property is not breaking', () => {
+        const before = { type: 'object', properties: { note: { type: ['string', 'null'] } } };
+        const after = { type: 'object', properties: { note: { type: 'string' } } };
+
+        expect(checkJsonSchemaCompatibility(before, after, 'forward').breaking).toBe(false);
+      });
+
+      it('removing the type entirely is breaking, because new messages may carry anything', () => {
+        const before = { type: 'object', properties: { payload: { type: 'string' } } };
+        const after = { type: 'object', properties: { payload: {} } };
+
+        expect(checkJsonSchemaCompatibility(before, after, 'forward').breaking).toBe(true);
+      });
+    });
+
+    describe('enums', () => {
+      it('adding an enum value is breaking, because new messages may carry a value the old consumer has never seen', () => {
+        const before = { type: 'object', properties: { status: { type: 'string', enum: ['pending', 'paid'] } } };
+        const after = { type: 'object', properties: { status: { type: 'string', enum: ['pending', 'paid', 'refunded'] } } };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'forward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          {
+            op: 'add',
+            path: '/properties/status/enum',
+            kind: 'enum.value.added',
+            reason: 'enum value refunded added',
+            breaking: true,
+          },
+        ]);
+      });
+
+      it('removing an enum value is not breaking, because new messages only use values the old consumer knows', () => {
+        const before = { type: 'object', properties: { status: { type: 'string', enum: ['pending', 'paid', 'refunded'] } } };
+        const after = { type: 'object', properties: { status: { type: 'string', enum: ['pending', 'paid'] } } };
+
+        expect(checkJsonSchemaCompatibility(before, after, 'forward').breaking).toBe(false);
+      });
+
+      it('restricting a free string to an enum is not breaking', () => {
+        const before = { type: 'object', properties: { status: { type: 'string' } } };
+        const after = { type: 'object', properties: { status: { type: 'string', enum: ['pending', 'paid'] } } };
+
+        expect(checkJsonSchemaCompatibility(before, after, 'forward').breaking).toBe(false);
+      });
+
+      it('lifting an enum restriction is breaking, because new messages may carry any string', () => {
+        const before = { type: 'object', properties: { status: { type: 'string', enum: ['pending', 'paid'] } } };
+        const after = { type: 'object', properties: { status: { type: 'string' } } };
+
+        expect(checkJsonSchemaCompatibility(before, after, 'forward').breaking).toBe(true);
+      });
+    });
+
+    describe('constraints', () => {
+      it('raising minLength is not breaking, because every new string still satisfies the old bound', () => {
+        const before = { type: 'object', properties: { sku: { type: 'string', minLength: 1 } } };
+        const after = { type: 'object', properties: { sku: { type: 'string', minLength: 3 } } };
+
+        expect(checkJsonSchemaCompatibility(before, after, 'forward').breaking).toBe(false);
+      });
+
+      it('lowering minLength is breaking, because new messages may carry strings the old consumer rejects', () => {
+        const before = { type: 'object', properties: { sku: { type: 'string', minLength: 3 } } };
+        const after = { type: 'object', properties: { sku: { type: 'string', minLength: 1 } } };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'forward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          {
+            op: 'replace',
+            path: '/properties/sku/minLength',
+            kind: 'constraint.loosened',
+            reason: 'minLength loosened from 3 to 1',
+            breaking: true,
+          },
+        ]);
+      });
+
+      it('raising maximum is breaking, because new messages may carry numbers above the old bound', () => {
+        const before = { type: 'object', properties: { quantity: { type: 'integer', maximum: 100 } } };
+        const after = { type: 'object', properties: { quantity: { type: 'integer', maximum: 200 } } };
+
+        expect(checkJsonSchemaCompatibility(before, after, 'forward').breaking).toBe(true);
+      });
+
+      it('removing a pattern is breaking, because new messages are no longer held to it', () => {
+        const before = { type: 'object', properties: { sku: { type: 'string', pattern: '^[A-Z]{3}-[0-9]+$' } } };
+        const after = { type: 'object', properties: { sku: { type: 'string' } } };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'forward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          {
+            op: 'remove',
+            path: '/properties/sku/pattern',
+            kind: 'constraint.loosened',
+            reason: 'pattern removed',
+            breaking: true,
+          },
+        ]);
+      });
+
+      it('adding a pattern is not breaking', () => {
+        const before = { type: 'object', properties: { sku: { type: 'string' } } };
+        const after = { type: 'object', properties: { sku: { type: 'string', pattern: '^[A-Z]{3}-[0-9]+$' } } };
+
+        expect(checkJsonSchemaCompatibility(before, after, 'forward').breaking).toBe(false);
+      });
+
+      it('changing a pattern is breaking, because we cannot tell whether the old one accepts every new value', () => {
+        const before = { type: 'object', properties: { sku: { type: 'string', pattern: '^[A-Z]+$' } } };
+        const after = { type: 'object', properties: { sku: { type: 'string', pattern: '^[A-Z0-9]+$' } } };
+
+        expect(checkJsonSchemaCompatibility(before, after, 'forward').breaking).toBe(true);
+      });
+
+      it('dropping uniqueItems is breaking, because new messages may contain duplicates', () => {
+        const before = { type: 'object', properties: { tags: { type: 'array', items: { type: 'string' }, uniqueItems: true } } };
+        const after = { type: 'object', properties: { tags: { type: 'array', items: { type: 'string' } } } };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'forward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          {
+            op: 'replace',
+            path: '/properties/tags/uniqueItems',
+            kind: 'constraint.loosened',
+            reason: 'uniqueItems loosened from true to false',
+            breaking: true,
+          },
+        ]);
+      });
+    });
+
+    describe('closed objects (additionalProperties: false)', () => {
+      it('adding an optional property to a closed object IS breaking, because the old closed reader rejects the unknown field', () => {
+        const before = { type: 'object', properties: { orderId: { type: 'string' } }, additionalProperties: false };
+        const after = {
+          type: 'object',
+          properties: { orderId: { type: 'string' }, customerId: { type: 'string' } },
+          additionalProperties: false,
+        };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'forward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          {
+            op: 'add',
+            path: '/properties/customerId',
+            kind: 'property.added-to-closed-object',
+            reason: 'property added to a closed object (old readers reject unknown properties)',
+            breaking: true,
+          },
+        ]);
+      });
+
+      it('removing an optional property from a closed object is not breaking, because new messages simply lack it', () => {
+        const before = {
+          type: 'object',
+          properties: { orderId: { type: 'string' }, note: { type: 'string' } },
+          additionalProperties: false,
+        };
+        const after = { type: 'object', properties: { orderId: { type: 'string' } }, additionalProperties: false };
+
+        expect(checkJsonSchemaCompatibility(before, after, 'forward').breaking).toBe(false);
+      });
+    });
+
+    describe('additional properties (content model)', () => {
+      it('closing an open object is not breaking, because new messages carry fewer surprises', () => {
+        const before = { type: 'object', properties: { orderId: { type: 'string' } } };
+        const after = { type: 'object', properties: { orderId: { type: 'string' } }, additionalProperties: false };
+
+        expect(checkJsonSchemaCompatibility(before, after, 'forward').breaking).toBe(false);
+      });
+
+      it('opening a closed object is breaking, because new messages may carry fields the old consumer rejects', () => {
+        const before = { type: 'object', properties: { orderId: { type: 'string' } }, additionalProperties: false };
+        const after = { type: 'object', properties: { orderId: { type: 'string' } } };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'forward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          {
+            op: 'replace',
+            path: '/additionalProperties',
+            kind: 'additionalProperties.opened',
+            reason: 'additional properties are now allowed',
+            breaking: true,
+          },
+        ]);
+      });
+    });
+
+    describe('arrays', () => {
+      it('widening the item type is breaking', () => {
+        const before = { type: 'object', properties: { amounts: { type: 'array', items: { type: 'integer' } } } };
+        const after = { type: 'object', properties: { amounts: { type: 'array', items: { type: 'number' } } } };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'forward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          {
+            op: 'replace',
+            path: '/properties/amounts/items/type',
+            kind: 'type.widened',
+            reason: 'type widened from integer to number',
+            breaking: true,
+          },
+        ]);
+      });
+
+      it('narrowing the item type is not breaking', () => {
+        const before = { type: 'object', properties: { amounts: { type: 'array', items: { type: 'number' } } } };
+        const after = { type: 'object', properties: { amounts: { type: 'array', items: { type: 'integer' } } } };
+
+        expect(checkJsonSchemaCompatibility(before, after, 'forward').breaking).toBe(false);
+      });
+
+      it('dropping a tuple position is breaking, because new messages may carry anything there', () => {
+        const before = {
+          type: 'object',
+          properties: { point: { type: 'array', items: [{ type: 'number' }, { type: 'number' }] } },
+        };
+        const after = { type: 'object', properties: { point: { type: 'array', items: [{ type: 'number' }] } } };
+
+        expect(checkJsonSchemaCompatibility(before, after, 'forward').breaking).toBe(true);
+      });
+    });
+
+    describe('composition (oneOf, anyOf, allOf)', () => {
+      it('adding a oneOf branch is breaking, because new messages may match a shape the old consumer has never seen', () => {
+        const before = { oneOf: [{ type: 'string' }, { type: 'number' }] };
+        const after = { oneOf: [{ type: 'string' }, { type: 'number' }, { type: 'boolean' }] };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'forward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          { op: 'add', path: '/oneOf/2', kind: 'union.branch.added', reason: 'oneOf branch added', breaking: true },
+        ]);
+      });
+
+      it('removing a oneOf branch is not breaking', () => {
+        const before = { oneOf: [{ type: 'string' }, { type: 'number' }] };
+        const after = { oneOf: [{ type: 'string' }] };
+
+        expect(checkJsonSchemaCompatibility(before, after, 'forward').breaking).toBe(false);
+      });
+
+      it('adding an allOf branch is not breaking, because new messages satisfy more constraints, not fewer', () => {
+        const before = { allOf: [{ type: 'object', properties: { id: { type: 'string' } } }] };
+        const after = { allOf: [{ type: 'object', properties: { id: { type: 'string' } } }, { required: ['id'] }] };
+
+        expect(checkJsonSchemaCompatibility(before, after, 'forward').breaking).toBe(false);
+      });
+
+      it('removing an allOf branch is breaking', () => {
+        const before = { allOf: [{ type: 'object', properties: { id: { type: 'string' } } }, { required: ['id'] }] };
+        const after = { allOf: [{ type: 'object', properties: { id: { type: 'string' } } }] };
+
+        expect(checkJsonSchemaCompatibility(before, after, 'forward').breaking).toBe(true);
+      });
+    });
+
+    describe('boolean schemas', () => {
+      it('replacing a real schema with accept-anything (true) is breaking, because new messages may carry anything', () => {
+        const before = { type: 'object', properties: { metadata: { type: 'object' } } };
+        const after = { type: 'object', properties: { metadata: true } };
+
+        expect(checkJsonSchemaCompatibility(before, after, 'forward').breaking).toBe(true);
+      });
+
+      it('replacing accept-anything (true) with a real schema is not breaking', () => {
+        const before = { type: 'object', properties: { metadata: true } };
+        const after = { type: 'object', properties: { metadata: { type: 'object' } } };
+
+        expect(checkJsonSchemaCompatibility(before, after, 'forward').breaking).toBe(false);
+      });
+    });
+
+    describe('keywords we cannot reason about', () => {
+      it('changing patternProperties is reported as breaking here too', () => {
+        const before = { type: 'object', patternProperties: { '^x-': { type: 'string' } } };
+        const after = { type: 'object' };
+
+        const result = checkJsonSchemaCompatibility(before, after, 'forward');
+
+        expect(result.breaking).toBe(true);
+        expect(result.ops).toEqual([
+          {
+            op: 'remove',
+            path: '/patternProperties',
+            kind: 'keyword.changed',
+            reason: 'patternProperties changed, compatibility cannot be determined',
+            breaking: true,
+          },
+        ]);
+      });
+    });
+  });
+
+  // ===========================================================================
+  // full: both directions must hold
+  // ===========================================================================
+  describe('full: both directions must hold', () => {
+    it('adding an optional property is not breaking, because neither direction cares', () => {
+      const before = { type: 'object', properties: { orderId: { type: 'string' } }, required: ['orderId'] };
+      const after = {
+        type: 'object',
+        properties: { orderId: { type: 'string' }, customerId: { type: 'string' } },
+        required: ['orderId'],
+      };
+
+      expect(checkJsonSchemaCompatibility(before, after, 'full')).toEqual({
+        breaking: false,
+        direction: null,
+        ops: [{ op: 'add', path: '/properties/customerId', kind: 'property.added', reason: 'property added', breaking: false }],
+      });
+    });
+
+    it('adding a required property with a default is not breaking, because neither direction cares', () => {
+      const before = { type: 'object', properties: { orderId: { type: 'string' } }, required: ['orderId'] };
+      const after = {
+        type: 'object',
+        properties: { orderId: { type: 'string' }, currency: { type: 'string', default: 'GBP' } },
+        required: ['orderId', 'currency'],
+      };
+
+      expect(checkJsonSchemaCompatibility(before, after, 'full').breaking).toBe(false);
+    });
+
+    it('adding a required property is breaking in the backward direction only', () => {
+      const before = { type: 'object', properties: { orderId: { type: 'string' } }, required: ['orderId'] };
+      const after = {
+        type: 'object',
+        properties: { orderId: { type: 'string' }, customerId: { type: 'string' } },
+        required: ['orderId', 'customerId'],
+      };
+
+      const result = checkJsonSchemaCompatibility(before, after, 'full');
+
+      expect(result.breaking).toBe(true);
+      expect(result.direction).toBe('backward');
+    });
+
+    it('removing a required property is breaking in the forward direction only', () => {
+      const before = {
+        type: 'object',
+        properties: { orderId: { type: 'string' }, customerId: { type: 'string' } },
+        required: ['orderId', 'customerId'],
+      };
+      const after = { type: 'object', properties: { orderId: { type: 'string' } }, required: ['orderId'] };
+
+      const result = checkJsonSchemaCompatibility(before, after, 'full');
+
+      expect(result.breaking).toBe(true);
+      expect(result.direction).toBe('forward');
+    });
+
+    it('widening a type is breaking in the forward direction only', () => {
+      const before = { type: 'object', properties: { quantity: { type: 'integer' } } };
+      const after = { type: 'object', properties: { quantity: { type: 'number' } } };
+
+      const result = checkJsonSchemaCompatibility(before, after, 'full');
+
+      expect(result.breaking).toBe(true);
+      expect(result.direction).toBe('forward');
+    });
+
+    it('changing a type outright breaks both directions', () => {
+      const before = { type: 'object', properties: { orderId: { type: 'string' } } };
+      const after = { type: 'object', properties: { orderId: { type: 'number' } } };
+
+      const result = checkJsonSchemaCompatibility(before, after, 'full');
+
+      expect(result.breaking).toBe(true);
+      expect(result.direction).toBe('both');
+    });
+
+    it('changing a const breaks both directions: the old value is gone (backward) and a new value appears (forward)', () => {
+      const before = { type: 'object', properties: { eventType: { const: 'OrderCreated' } } };
+      const after = { type: 'object', properties: { eventType: { const: 'OrderPlaced' } } };
+
+      const result = checkJsonSchemaCompatibility(before, after, 'full');
+
+      expect(result.breaking).toBe(true);
+      expect(result.direction).toBe('both');
+      expect(result.ops).toEqual([
+        {
+          op: 'add',
+          path: '/properties/eventType/enum',
+          kind: 'enum.value.added',
+          reason: 'enum value OrderPlaced added',
+          breaking: true,
+        },
+        {
+          op: 'remove',
+          path: '/properties/eventType/enum',
+          kind: 'enum.value.removed',
+          reason: 'enum value OrderCreated removed',
+          breaking: true,
+        },
+      ]);
+    });
+
+    it('renaming a required property breaks both directions', () => {
+      const before = {
+        type: 'object',
+        properties: { orderId: { type: 'string' }, customerId: { type: 'string' } },
+        required: ['orderId', 'customerId'],
+      };
+      const after = {
+        type: 'object',
+        properties: { orderId: { type: 'string' }, customer_id: { type: 'string' } },
+        required: ['orderId', 'customer_id'],
+      };
+
+      const result = checkJsonSchemaCompatibility(before, after, 'full');
+
+      expect(result.breaking).toBe(true);
+      expect(result.direction).toBe('both');
+    });
+
+    it('changing a pattern breaks both directions, because neither side can be trusted to accept the other', () => {
+      const before = { type: 'object', properties: { sku: { type: 'string', pattern: '^[A-Z]+$' } } };
+      const after = { type: 'object', properties: { sku: { type: 'string', pattern: '^[A-Z0-9]+$' } } };
+
+      const result = checkJsonSchemaCompatibility(before, after, 'full');
+
+      expect(result.breaking).toBe(true);
+      expect(result.direction).toBe('both');
+    });
+
+    it('a keyword we cannot reason about breaks both directions', () => {
+      const before = { type: 'object' };
+      const after = { type: 'object', propertyNames: { pattern: '^[a-z]+$' } };
+
+      const result = checkJsonSchemaCompatibility(before, after, 'full');
+
+      expect(result.breaking).toBe(true);
+      expect(result.direction).toBe('both');
+    });
+
+    it('a realistic event evolution: optional field added, description updated, enum value added, is breaking forward only', () => {
+      const before = {
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        title: 'OrderCreated',
+        type: 'object',
+        properties: {
+          orderId: { type: 'string' },
+          status: { type: 'string', enum: ['pending', 'paid'] },
+          lines: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: { sku: { type: 'string' }, qty: { type: 'integer' } },
+              required: ['sku', 'qty'],
+            },
+          },
+        },
+        required: ['orderId', 'status', 'lines'],
+      };
+      const after = {
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        title: 'OrderCreated',
+        description: 'Raised when a customer completes checkout',
+        type: 'object',
+        properties: {
+          orderId: { type: 'string' },
+          status: { type: 'string', enum: ['pending', 'paid', 'refunded'] },
+          lines: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: { sku: { type: 'string' }, qty: { type: 'integer' }, unitPrice: { type: 'number' } },
+              required: ['sku', 'qty'],
+            },
+          },
+          placedAt: { type: 'string', format: 'date-time' },
+        },
+        required: ['orderId', 'status', 'lines'],
+      };
+
+      const result = checkJsonSchemaCompatibility(before, after, 'full');
+
+      expect(result.breaking).toBe(true);
+      expect(result.direction).toBe('forward');
+      expect(result.ops).toEqual([
+        {
+          op: 'add',
+          path: '/properties/status/enum',
+          kind: 'enum.value.added',
+          reason: 'enum value refunded added',
+          breaking: true,
+        },
+        {
+          op: 'add',
+          path: '/properties/lines/items/properties/unitPrice',
+          kind: 'property.added',
+          reason: 'property added',
+          breaking: false,
+        },
+        { op: 'add', path: '/properties/placedAt', kind: 'property.added', reason: 'property added', breaking: false },
+      ]);
+    });
+  });
+
+  // ===========================================================================
+  // none: nothing is breaking, but every change is still reported
+  // ===========================================================================
+  describe('none: compatibility is not checked', () => {
+    it('is not breaking even when a type changes outright, but the change is still reported', () => {
+      const before = { type: 'object', properties: { orderId: { type: 'string' } }, required: ['orderId'] };
+      const after = { type: 'object', properties: { orderId: { type: 'number' } }, required: ['orderId'] };
+
+      expect(checkJsonSchemaCompatibility(before, after, 'none')).toEqual({
+        breaking: false,
+        direction: null,
+        ops: [
+          {
+            op: 'replace',
+            path: '/properties/orderId/type',
+            kind: 'type.changed',
+            reason: 'type changed from string to number',
+            breaking: false,
+          },
+        ],
+      });
+    });
+  });
+
+  // ===========================================================================
+  // complex and deeply nested schemas
+  // Real event schemas are big. These check that a single change buried several
+  // levels down is found, reported once, with a path that leads straight to it,
+  // and that everything around it is left alone.
+  // ===========================================================================
+  describe('complex and deeply nested schemas', () => {
+    /**
+     * A realistic OrderCreated: customer with addresses and geo, order lines with
+     * product variants, a payment union, shipment tracking events, free metadata.
+     * Typed loosely so tests can mutate any node to describe a change.
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    type LooseSchema = { [keyword: string]: any };
+    const orderCreated = (): LooseSchema => ({
+      $schema: 'https://json-schema.org/draft/2020-12/schema',
+      $id: 'https://acme.example/schemas/order-created.json',
+      title: 'OrderCreated',
+      type: 'object',
+      additionalProperties: false,
+      required: ['orderId', 'customer', 'lines', 'payment', 'placedAt'],
+      properties: {
+        orderId: { type: 'string', pattern: '^ord_[a-z0-9]+$' },
+        placedAt: { type: 'string', format: 'date-time' },
+        currency: { type: 'string', enum: ['GBP', 'EUR', 'USD'], default: 'GBP' },
+        customer: {
+          type: 'object',
+          required: ['id', 'email'],
+          properties: {
+            id: { type: 'string' },
+            email: { type: 'string', format: 'email' },
+            name: {
+              type: 'object',
+              properties: { first: { type: 'string' }, last: { type: 'string' } },
+              required: ['first', 'last'],
+            },
+            addresses: {
+              type: 'array',
+              minItems: 1,
+              items: { $ref: '#/$defs/Address' },
+            },
+          },
+        },
+        lines: {
+          type: 'array',
+          minItems: 1,
+          items: {
+            type: 'object',
+            required: ['sku', 'quantity', 'product'],
+            properties: {
+              sku: { type: 'string' },
+              quantity: { type: 'integer', minimum: 1 },
+              unitPrice: { $ref: '#/$defs/Money' },
+              product: {
+                type: 'object',
+                required: ['id', 'variant'],
+                properties: {
+                  id: { type: 'string' },
+                  variant: {
+                    oneOf: [
+                      {
+                        type: 'object',
+                        required: ['kind', 'size'],
+                        properties: { kind: { const: 'apparel' }, size: { enum: ['S', 'M', 'L'] }, colour: { type: 'string' } },
+                      },
+                      {
+                        type: 'object',
+                        required: ['kind', 'weightGrams'],
+                        properties: { kind: { const: 'grocery' }, weightGrams: { type: 'integer', minimum: 1 } },
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          },
+        },
+        payment: {
+          oneOf: [
+            {
+              type: 'object',
+              required: ['method', 'last4'],
+              properties: { method: { const: 'card' }, last4: { type: 'string', pattern: '^[0-9]{4}$' } },
+            },
+            {
+              type: 'object',
+              required: ['method', 'payerId'],
+              properties: { method: { const: 'paypal' }, payerId: { type: 'string' } },
+            },
+          ],
+        },
+        shipments: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              carrier: { type: 'string' },
+              events: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  required: ['status', 'at'],
+                  properties: {
+                    status: { enum: ['dispatched', 'in_transit', 'delivered'] },
+                    at: { type: 'string', format: 'date-time' },
+                    location: { $ref: '#/$defs/GeoPoint' },
+                  },
+                },
+              },
+            },
+          },
+        },
+        metadata: { type: 'object', additionalProperties: { type: 'string' } },
+      },
+      $defs: {
+        Money: {
+          type: 'object',
+          required: ['amount', 'currency'],
+          properties: { amount: { type: 'number', multipleOf: 0.01 }, currency: { type: 'string', enum: ['GBP', 'EUR', 'USD'] } },
+        },
+        GeoPoint: {
+          type: 'object',
+          required: ['lat', 'lng'],
+          properties: {
+            lat: { type: 'number', minimum: -90, maximum: 90 },
+            lng: { type: 'number', minimum: -180, maximum: 180 },
+          },
+        },
+        Address: {
+          type: 'object',
+          required: ['line1', 'postcode', 'country'],
+          properties: {
+            line1: { type: 'string' },
+            line2: { type: 'string' },
+            postcode: { type: 'string' },
+            country: { type: 'string', minLength: 2, maxLength: 2 },
+            geo: { $ref: '#/$defs/GeoPoint' },
+          },
+        },
+      },
+    });
+
+    it('an identical complex schema reports nothing', () => {
+      expect(checkJsonSchemaCompatibility(orderCreated(), orderCreated(), 'full')).toEqual({
+        breaking: false,
+        direction: null,
+        ops: [],
+      });
+    });
+
+    it('a single change six levels deep is found, reported once, and nothing else is touched', () => {
+      // Given the apparel variant size enum, inside lines > items > product > variant > oneOf[0], gains XL
+      const before = orderCreated();
+      const after = orderCreated();
+      after.properties.lines.items.properties.product.properties.variant.oneOf[0]!.properties.size = {
+        enum: ['S', 'M', 'L', 'XL'],
+      };
+
+      const result = checkJsonSchemaCompatibility(before, after, 'full');
+
+      expect(result.breaking).toBe(true);
+      expect(result.direction).toBe('forward');
+      expect(result.ops).toEqual([
+        {
+          op: 'add',
+          path: '/properties/lines/items/properties/product/properties/variant/oneOf/0/properties/size/enum',
+          kind: 'enum.value.added',
+          reason: 'enum value XL added',
+          breaking: true,
+        },
+      ]);
+    });
+
+    it('a change in a definition reached through two levels of $ref is reported once, at the inner definition', () => {
+      // Given GeoPoint is used directly by shipment events and indirectly via Address > geo, and its bounds loosen
+      const before = orderCreated();
+      const after = orderCreated();
+      after.$defs.GeoPoint.properties.lat = { type: 'number' };
+
+      const result = checkJsonSchemaCompatibility(before, after, 'full');
+
+      expect(result.breaking).toBe(true);
+      expect(result.direction).toBe('forward');
+      expect(result.ops).toEqual([
+        {
+          op: 'remove',
+          path: '/$defs/GeoPoint/properties/lat/minimum',
+          kind: 'constraint.loosened',
+          reason: 'minimum removed',
+          breaking: true,
+        },
+        {
+          op: 'remove',
+          path: '/$defs/GeoPoint/properties/lat/maximum',
+          kind: 'constraint.loosened',
+          reason: 'maximum removed',
+          breaking: true,
+        },
+      ]);
+    });
+
+    it('a required property added to a definition used inside an array inside a nested object is found', () => {
+      // Given Address (used by customer > addresses > items) gains a required city
+      const before = orderCreated();
+      const after = orderCreated();
+      after.$defs.Address.properties = { ...after.$defs.Address.properties, city: { type: 'string' } };
+      after.$defs.Address.required = ['line1', 'postcode', 'country', 'city'];
+
+      const result = checkJsonSchemaCompatibility(before, after, 'full');
+
+      expect(result.breaking).toBe(true);
+      expect(result.direction).toBe('backward');
+      expect(result.ops).toEqual([
+        { op: 'add', path: '/$defs/Address/properties/city', kind: 'property.added', reason: 'property added', breaking: false },
+        {
+          op: 'replace',
+          path: '/$defs/Address/properties/city',
+          kind: 'required.added',
+          reason: 'property became required',
+          breaking: true,
+        },
+      ]);
+    });
+
+    it('a new payment method (oneOf branch) plus a tightened card pattern are both found at their own depth', () => {
+      const before = orderCreated();
+      const after = orderCreated();
+      after.properties.payment.oneOf = [
+        {
+          type: 'object',
+          required: ['method', 'last4'],
+          properties: { method: { const: 'card' }, last4: { type: 'string', pattern: '^[0-9]{4}$' } },
+        },
+        {
+          type: 'object',
+          required: ['method', 'payerId'],
+          properties: { method: { const: 'paypal' }, payerId: { type: 'string' } },
+        },
+        {
+          type: 'object',
+          required: ['method', 'walletId'],
+          properties: { method: { const: 'apple_pay' }, walletId: { type: 'string' } },
+        },
+      ];
+
+      const result = checkJsonSchemaCompatibility(before, after, 'full');
+
+      expect(result.breaking).toBe(true);
+      expect(result.direction).toBe('forward');
+      expect(result.ops).toEqual([
+        {
+          op: 'add',
+          path: '/properties/payment/oneOf/2',
+          kind: 'union.branch.added',
+          reason: 'oneOf branch added',
+          breaking: true,
+        },
+      ]);
+    });
+
+    it('several changes at different depths are all reported, and the directions combine to both', () => {
+      const before = orderCreated();
+      const after = orderCreated();
+      // 1. root: currency becomes required (has a default, so safe)
+      after.required = ['orderId', 'customer', 'lines', 'payment', 'placedAt', 'currency'];
+      // 2. customer.name.last is no longer required (breaks forward)
+      after.properties.customer.properties.name.required = ['first'];
+      // 3. lines.items.quantity minimum raised (breaks backward)
+      after.properties.lines.items.properties.quantity = { type: 'integer', minimum: 2 };
+      // 4. shipments.items.events.items.status loses a value (breaks backward)
+      after.properties.shipments.items.properties.events.items.properties.status = { enum: ['dispatched', 'delivered'] };
+      // 5. metadata values can now be anything (breaks forward)
+      after.properties.metadata = { type: 'object', additionalProperties: true };
+      // 6. Money.amount loses multipleOf (breaks forward)
+      after.$defs.Money.properties.amount = { type: 'number' };
+
+      const result = checkJsonSchemaCompatibility(before, after, 'full');
+
+      expect(result.breaking).toBe(true);
+      expect(result.direction).toBe('both');
+      expect(result.ops).toEqual([
+        {
+          op: 'replace',
+          path: '/properties/customer/properties/name/properties/last',
+          kind: 'required.removed',
+          reason: 'property is no longer required',
+          breaking: true,
+        },
+        {
+          op: 'replace',
+          path: '/properties/lines/items/properties/quantity/minimum',
+          kind: 'constraint.tightened',
+          reason: 'minimum tightened from 1 to 2',
+          breaking: true,
+        },
+        {
+          op: 'remove',
+          path: '/$defs/Money/properties/amount/multipleOf',
+          kind: 'constraint.loosened',
+          reason: 'multipleOf removed',
+          breaking: true,
+        },
+        {
+          op: 'remove',
+          path: '/properties/shipments/items/properties/events/items/properties/status/enum',
+          kind: 'enum.value.removed',
+          reason: 'enum value in_transit removed',
+          breaking: true,
+        },
+        {
+          op: 'replace',
+          path: '/properties/metadata/additionalProperties',
+          kind: 'schema.relaxed',
+          reason: 'schema now accepts more values',
+          breaking: true,
+        },
+        {
+          op: 'replace',
+          path: '/properties/currency',
+          kind: 'required.added-with-default',
+          reason: 'property became required but has a default',
+          breaking: false,
+        },
+      ]);
+    });
+
+    it('an array of arrays: changing the inner item type is found at items/items', () => {
+      const before = {
+        type: 'object',
+        properties: { matrix: { type: 'array', items: { type: 'array', items: { type: 'integer' } } } },
+      };
+      const after = {
+        type: 'object',
+        properties: { matrix: { type: 'array', items: { type: 'array', items: { type: 'number' } } } },
+      };
+
+      const result = checkJsonSchemaCompatibility(before, after, 'full');
+
+      expect(result.breaking).toBe(true);
+      expect(result.direction).toBe('forward');
+      expect(result.ops).toEqual([
+        {
+          op: 'replace',
+          path: '/properties/matrix/items/items/type',
+          kind: 'type.widened',
+          reason: 'type widened from integer to number',
+          breaking: true,
+        },
+      ]);
+    });
+
+    it('a definition that references a definition that references itself terminates and reports the one real change', () => {
+      const tree = (leafType: string) => ({
+        type: 'object',
+        properties: { root: { $ref: '#/$defs/Category' } },
+        $defs: {
+          Category: {
+            type: 'object',
+            required: ['name'],
+            properties: {
+              name: { type: 'string' },
+              products: { type: 'array', items: { $ref: '#/$defs/Product' } },
+              children: { type: 'array', items: { $ref: '#/$defs/Category' } },
+            },
+          },
+          Product: {
+            type: 'object',
+            properties: { sku: { type: leafType }, category: { $ref: '#/$defs/Category' } },
+          },
+        },
+      });
+
+      const result = checkJsonSchemaCompatibility(tree('string'), tree('integer'), 'full');
+
+      expect(result.breaking).toBe(true);
+      expect(result.direction).toBe('both');
+      expect(result.ops).toEqual([
+        {
+          op: 'replace',
+          path: '/$defs/Product/properties/sku/type',
+          kind: 'type.changed',
+          reason: 'type changed from string to integer',
+          breaking: true,
+        },
+      ]);
+    });
+
+    it('moving a nested inline object into a definition, unchanged, is not a change even when it is deep', () => {
+      const before = orderCreated();
+      const after = orderCreated();
+      const name = after.properties.customer.properties.name;
+      after.properties.customer.properties.name = { $ref: '#/$defs/PersonName' };
+      after.$defs.PersonName = name;
+
+      expect(checkJsonSchemaCompatibility(before, after, 'full')).toEqual({ breaking: false, direction: null, ops: [] });
+    });
+
+    it('a wholesale rewrite of a deep subtree reports every difference under that subtree', () => {
+      // Given shipment events are restructured: status becomes a typed string, location is inlined, a required carrier code is added
+      const before = orderCreated();
+      const after = orderCreated();
+      after.properties.shipments.items = {
+        type: 'object',
+        required: ['carrierCode'],
+        properties: {
+          carrierCode: { type: 'string', minLength: 2 },
+          events: {
+            type: 'array',
+            items: {
+              type: 'object',
+              required: ['status', 'at'],
+              properties: {
+                status: { type: 'string' },
+                at: { type: 'string', format: 'date-time' },
+                location: {
+                  type: 'object',
+                  required: ['lat', 'lng'],
+                  properties: { lat: { type: 'number' }, lng: { type: 'number' } },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const result = checkJsonSchemaCompatibility(before, after, 'full');
+
+      expect(result.breaking).toBe(true);
+      expect(result.direction).toBe('both');
+      expect(result.ops).toEqual([
+        {
+          op: 'remove',
+          path: '/properties/shipments/items/properties/carrier',
+          kind: 'property.removed',
+          reason: 'property removed',
+          breaking: false,
+        },
+        {
+          op: 'replace',
+          path: '/properties/shipments/items/properties/events/items/properties/status/type',
+          kind: 'type.narrowed',
+          reason: 'type narrowed from any to string',
+          breaking: true,
+        },
+        {
+          op: 'remove',
+          path: '/properties/shipments/items/properties/events/items/properties/status/enum',
+          kind: 'enum.removed',
+          reason: 'enum restriction removed',
+          breaking: true,
+        },
+        {
+          op: 'remove',
+          path: '/properties/shipments/items/properties/events/items/properties/location/properties/lat/minimum',
+          kind: 'constraint.loosened',
+          reason: 'minimum removed',
+          breaking: true,
+        },
+        {
+          op: 'remove',
+          path: '/properties/shipments/items/properties/events/items/properties/location/properties/lat/maximum',
+          kind: 'constraint.loosened',
+          reason: 'maximum removed',
+          breaking: true,
+        },
+        {
+          op: 'remove',
+          path: '/properties/shipments/items/properties/events/items/properties/location/properties/lng/minimum',
+          kind: 'constraint.loosened',
+          reason: 'minimum removed',
+          breaking: true,
+        },
+        {
+          op: 'remove',
+          path: '/properties/shipments/items/properties/events/items/properties/location/properties/lng/maximum',
+          kind: 'constraint.loosened',
+          reason: 'maximum removed',
+          breaking: true,
+        },
+        {
+          op: 'add',
+          path: '/properties/shipments/items/properties/carrierCode',
+          kind: 'property.added',
+          reason: 'property added',
+          breaking: false,
+        },
+        {
+          op: 'replace',
+          path: '/properties/shipments/items/properties/carrierCode',
+          kind: 'required.added',
+          reason: 'property became required',
+          breaking: true,
+        },
+      ]);
+    });
+  });
+
+  // ===========================================================================
+  // sanity
+  // ===========================================================================
+  describe('identical schemas', () => {
+    it('reports nothing under any strategy', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          orderId: { type: 'string', minLength: 1 },
+          status: { enum: ['pending', 'paid'] },
+          lines: { type: 'array', items: { $ref: '#/definitions/Line' } },
+        },
+        required: ['orderId'],
+        additionalProperties: false,
+        definitions: { Line: { type: 'object', properties: { sku: { type: 'string' } } } },
+      };
+
+      for (const strategy of ['backward', 'forward', 'full', 'none'] as const) {
+        expect(checkJsonSchemaCompatibility(schema, schema, strategy)).toEqual({ breaking: false, direction: null, ops: [] });
+      }
+    });
+  });
+});

--- a/packages/diff/src/test/scenarios.test.ts
+++ b/packages/diff/src/test/scenarios.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { diff } from '../index';
+import { loadScenarios } from './fixtures/scenarios';
+
+/**
+ * End-to-end scenarios built from real `buildIndex()` output.
+ *
+ * Each folder under `fixtures/scenarios/` is a story: a baseline catalog (a.json),
+ * a candidate catalog (b.json) and the exact ArchitectureDiff we expect (expected.json).
+ * Where `diff.test.ts` states each rule in isolation, these check that the rules
+ * compose correctly on catalogs shaped exactly like the ones users have.
+ */
+
+const scenarios = loadScenarios();
+
+describe('scenarios', () => {
+  it('has at least one scenario so the runner never silently passes on an empty folder', () => {
+    expect(scenarios.length).toBeGreaterThan(0);
+  });
+
+  describe.each(scenarios)('given the catalogs in "$name"', ({ a, b, options, expected }) => {
+    it('produces exactly the expected ArchitectureDiff when a is compared against b', () => {
+      expect(diff(a, b, options)).toEqual(expected);
+    });
+  });
+});

--- a/packages/diff/src/types.ts
+++ b/packages/diff/src/types.ts
@@ -1,0 +1,190 @@
+/**
+ * ArchitectureDiff
+ *
+ * The single versioned document produced by `diff(a, b)`. Consumers (CI actions,
+ * policy engines, notifiers, UIs) build on top of this and never re-walk the graph.
+ *
+ * Input is the SDK `Index` returned by `buildIndex()`. Vocabulary follows the SDK:
+ * resources have a `type`, edges have a `direction`.
+ */
+
+import type { EdgeDirection, IndexResourceType } from '@eventcatalog/sdk';
+
+export const ARCHITECTURE_DIFF_SCHEMA_VERSION = 1 as const;
+
+export type CompatibilityStrategy = 'backward' | 'forward' | 'full' | 'none';
+
+/** Which side a breaking change hurts. `both` only occurs under the `full` strategy. */
+export type BreakingDirection = 'backward' | 'forward' | 'both';
+
+/** Resource types that carry schemas and travel along sends/receives edges. */
+export type MessageType = Extract<IndexResourceType, 'event' | 'command' | 'query'>;
+
+/** Where an index came from: the SDK index `source` and `commit`. */
+export type DiffRef = {
+  source: string;
+  commit: string;
+};
+
+/** A value that differs between the baseline (a) and the candidate (b). */
+export type Change<T> = {
+  a: T;
+  b: T;
+};
+
+export type DiffSummary = {
+  breaking: boolean;
+  resourcesAdded: number;
+  resourcesRemoved: number;
+  resourcesChanged: number;
+  edgesAdded: number;
+  edgesRemoved: number;
+  schemaChanges: number;
+  schemaBreaking: number;
+  /** Schema changes with no verdict (`breaking: null`). Policy should decide whether these warn or fail. */
+  schemaUnknown: number;
+};
+
+export type ResourceRef = {
+  type: IndexResourceType;
+  id: string;
+  version?: string;
+};
+
+export type ResourceAdded = ResourceRef;
+
+export type ResourceRemoved = ResourceRef;
+
+/** The fields of a resource the diff compares. Markdown content and schema files are covered elsewhere. */
+export type ResourceField = 'version' | 'name' | 'owners' | 'deprecated';
+
+export type ResourceChanged = {
+  type: IndexResourceType;
+  id: string;
+  /** Latest version on each side. Equal when only metadata changed. */
+  version: Change<string | undefined>;
+  /** Which fields differ between the latest version on each side. */
+  fields: ResourceField[];
+};
+
+/** One end of an edge. `type` is absent when the target could not be resolved in the index. */
+export type EdgeEnd = {
+  type?: IndexResourceType;
+  id: string;
+  version?: string;
+};
+
+/**
+ * An edge between two resources, as resolved by the SDK. Identity ignores versions,
+ * so bumping a message does not churn every edge that points at it.
+ */
+export type DiffEdge = {
+  direction: EdgeDirection;
+  from: EdgeEnd;
+  to: EdgeEnd;
+  /** The field the pointer came from when it is not the direction itself, e.g. `steps`. */
+  via?: string;
+};
+
+export type SchemaPointer = {
+  path: string;
+  hash?: string;
+  /** Raw schema text. Only present when `diff()` is called with `includeSchemaContent: true`. */
+  content?: string;
+};
+
+export type SchemaOp = {
+  op: 'add' | 'remove' | 'replace';
+  /** JSON pointer into the schema document, e.g. `/properties/customerId`. */
+  path: string;
+  /** Stable machine-readable change kind, e.g. `required.added`, for consumers that key on it. */
+  kind: string;
+  /** Human-readable explanation. */
+  reason: string;
+  /** Whether this op alone breaks the chosen strategy. */
+  breaking: boolean;
+};
+
+export type SchemaChange = {
+  message: {
+    type: MessageType;
+    id: string;
+    version: Change<string | undefined>;
+  };
+  /** `modified` when the same schema file changed; `added` / `removed` when a schema file appeared or disappeared. */
+  change: 'modified' | 'added' | 'removed';
+  /** Absent when the schema was added. */
+  before?: SchemaPointer;
+  /** Absent when the schema was removed. */
+  after?: SchemaPointer;
+  /**
+   * `null` when no verdict was possible: the schema was added or removed, the index was
+   * built without schema content, the content is not valid JSON, or the format is not
+   * one we can compare yet. Counted in `summary.schemaUnknown` so it is never silent.
+   */
+  breaking: boolean | null;
+  strategy: CompatibilityStrategy;
+  /** Which side the change breaks. `null` when not breaking or when no verdict was possible. */
+  direction: BreakingDirection | null;
+  ops: SchemaOp[];
+};
+
+export type ImpactReason =
+  | 'schema_breaking_change'
+  | 'schema_changed'
+  | 'message_removed'
+  | 'producer_removed'
+  | 'consumer_removed';
+
+export type ImpactedResource = {
+  type: IndexResourceType;
+  id: string;
+  version?: string;
+  owners?: string[];
+};
+
+/**
+ * Who a change hurts, derived from the baseline graph so consumers of the diff
+ * never have to walk edges themselves.
+ *
+ * - `forward` breaking: the consumers listed are on the old schema and will fail
+ *   to read new messages.
+ * - `backward` breaking: the consumers listed will fail to read old messages once
+ *   they move to the new schema (e.g. when replaying history).
+ * - `both`: both of the above.
+ */
+export type Impact = {
+  message: {
+    type: MessageType;
+    id: string;
+    version?: string;
+  };
+  reason: ImpactReason;
+  /** Which direction broke. Only present for schema-related reasons. */
+  direction?: BreakingDirection;
+  producers: ImpactedResource[];
+  consumers: ImpactedResource[];
+};
+
+export type ArchitectureDiff = {
+  schemaVersion: typeof ARCHITECTURE_DIFF_SCHEMA_VERSION;
+  refs: {
+    a: DiffRef;
+    b: DiffRef;
+  };
+  compatibility: {
+    strategy: CompatibilityStrategy;
+  };
+  summary: DiffSummary;
+  resources: {
+    added: ResourceAdded[];
+    removed: ResourceRemoved[];
+    changed: ResourceChanged[];
+  };
+  edges: {
+    added: DiffEdge[];
+    removed: DiffEdge[];
+  };
+  schemaChanges: SchemaChange[];
+  impact: Impact[];
+};

--- a/packages/diff/src/utils/entities.ts
+++ b/packages/diff/src/utils/entities.ts
@@ -1,0 +1,23 @@
+import type { ResolvedEntity, ResolvedGraph } from '@eventcatalog/sdk';
+
+/**
+ * Constant-time entity lookup by id and version, built once per graph so impact
+ * and edge reporting stay linear on catalogs with thousands of resources.
+ */
+export type EntityIndex = {
+  find: (id: string, version: string | null) => ResolvedEntity | undefined;
+};
+
+export const indexEntities = (graph: ResolvedGraph): EntityIndex => {
+  const byIdAndVersion = new Map<string, ResolvedEntity>();
+  const firstById = new Map<string, ResolvedEntity>();
+
+  for (const entity of graph.entities) {
+    byIdAndVersion.set(`${entity.id}@${entity.version ?? ''}`, entity);
+    if (!firstById.has(entity.id)) firstById.set(entity.id, entity);
+  }
+
+  return {
+    find: (id, version) => (version === null ? firstById.get(id) : byIdAndVersion.get(`${id}@${version}`)),
+  };
+};

--- a/packages/diff/src/utils/versions.ts
+++ b/packages/diff/src/utils/versions.ts
@@ -1,0 +1,23 @@
+import { coerce, compare, valid } from 'semver';
+
+/** Accepts strict semver and number-like versions such as `1`, `v1`, `1.2`. */
+const toComparable = (version: string) => valid(version) ?? coerce(version)?.version ?? undefined;
+
+/**
+ * Orders two version strings. Semver-like versions are compared numerically,
+ * anything else falls back to a plain string compare so the result is still stable.
+ */
+export const compareVersions = (left: string | undefined, right: string | undefined): number => {
+  const a = left ? toComparable(left) : undefined;
+  const b = right ? toComparable(right) : undefined;
+
+  if (a && b) return compare(a, b);
+  return (left ?? '').localeCompare(right ?? '');
+};
+
+/** Picks the item with the highest version. */
+export const latest = <T extends { version?: string }>(items: T[]): T | undefined =>
+  items.reduce<T | undefined>(
+    (best, item) => (best && compareVersions(best.version, item.version) >= 0 ? best : item),
+    undefined
+  );

--- a/packages/diff/tsconfig.json
+++ b/packages/diff/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "moduleResolution": "bundler",
+    "noUncheckedIndexedAccess": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/diff/tsup.config.ts
+++ b/packages/diff/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+  shims: true,
+});

--- a/packages/diff/vitest.config.ts
+++ b/packages/diff/vitest.config.ts
@@ -1,0 +1,9 @@
+/// <reference types="vitest" />
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+    testTimeout: 15_000,
+  },
+});

--- a/packages/sdk/src/build-index.ts
+++ b/packages/sdk/src/build-index.ts
@@ -47,6 +47,11 @@ type BuildIndexOptions = {
   commit: string;
   hashContent?: boolean;
   includeFederated?: boolean;
+  /**
+   * When true, the raw text of every message schema file is embedded in the index
+   * alongside its hash. Off by default so federation payloads stay small.
+   */
+  includeSchemaContent?: boolean;
 };
 
 type IndexableResource = {
@@ -229,7 +234,12 @@ const normalizeAssets = async (directory: string, hashContent: boolean, ignoreRu
   return assets.length === 0 ? undefined : assets;
 };
 
-const normalizeSchemas = async (resource: IndexableResource, resourcePath: string, hashContent: boolean) => {
+const normalizeSchemas = async (
+  resource: IndexableResource,
+  resourcePath: string,
+  hashContent: boolean,
+  includeSchemaContent: boolean
+) => {
   const schemas = resource.schemas ?? (resource.schemaPath ? [{ path: resource.schemaPath, default: true }] : undefined);
 
   if (schemas === undefined) return undefined;
@@ -237,17 +247,14 @@ const normalizeSchemas = async (resource: IndexableResource, resourcePath: strin
   return Promise.all(
     schemas.map(async ({ file, ...schema }) => {
       const schemaPath = file ?? schema.path;
+      const readSchema = schemaPath && (hashContent || includeSchemaContent);
+      const bytes = readSchema ? await fs.readFile(path.join(path.dirname(resourcePath), schemaPath)) : undefined;
 
       return {
         ...schema,
         ...(schemaPath === undefined ? {} : { path: schemaPath }),
-        ...(hashContent && schemaPath
-          ? {
-              hash: `sha256:${createHash('sha256')
-                .update(await fs.readFile(path.join(path.dirname(resourcePath), schemaPath)))
-                .digest('hex')}`,
-            }
-          : {}),
+        ...(bytes && hashContent ? { hash: `sha256:${createHash('sha256').update(bytes).digest('hex')}` } : {}),
+        ...(bytes && includeSchemaContent ? { content: bytes.toString('utf8') } : {}),
       };
     })
   );
@@ -324,12 +331,13 @@ const toIndexResource = async (
   type: IndexResourceType,
   resource: IndexableResource,
   hashContent: boolean,
+  includeSchemaContent: boolean,
   sourcePath: string,
   resourceDirectories: Set<string>,
   ignoreRules?: ignore.Ignore
 ): Promise<IndexResource> => {
   const { id, version, name } = resource;
-  const schemas = await normalizeSchemas(resource, sourcePath, hashContent);
+  const schemas = await normalizeSchemas(resource, sourcePath, hashContent, includeSchemaContent);
   const specifications = await normalizeSpecifications(resource, sourcePath, hashContent);
   const representedPaths = new Set(
     [
@@ -404,7 +412,13 @@ const toIndexResource = async (
 
 export const buildIndex =
   (directory: string) =>
-  async ({ source, commit, hashContent = true, includeFederated = true }: BuildIndexOptions): Promise<Index> => {
+  async ({
+    source,
+    commit,
+    hashContent = true,
+    includeFederated = true,
+    includeSchemaContent = false,
+  }: BuildIndexOptions): Promise<Index> => {
     const ignoreRules = await loadIgnoreRules(directory);
     const [
       domains,
@@ -495,7 +509,16 @@ export const buildIndex =
     );
     const resources = await Promise.all(
       locatedResources.map(({ type, resource, sourcePath }) =>
-        toIndexResource(directory, type, resource, hashContent, sourcePath, resourceDirectories, ignoreRules)
+        toIndexResource(
+          directory,
+          type,
+          resource,
+          hashContent,
+          includeSchemaContent,
+          sourcePath,
+          resourceDirectories,
+          ignoreRules
+        )
       )
     );
     const assets = await normalizeAssets(directory, hashContent, ignoreRules);

--- a/packages/sdk/src/index-types.ts
+++ b/packages/sdk/src/index-types.ts
@@ -37,6 +37,8 @@ export type IndexResourceType =
 
 export type IndexSchema = Omit<SchemaPointer, 'file'> & {
   hash?: string;
+  /** Raw schema file text. Only present when the index was built with `includeSchemaContent`. */
+  content?: string;
 };
 
 export type IndexSpecification = Specification & {

--- a/packages/sdk/src/parse-index.ts
+++ b/packages/sdk/src/parse-index.ts
@@ -105,6 +105,7 @@ const IndexSchemaPointerSchema = z
     environments: z.array(z.string()).optional(),
     default: z.boolean().optional(),
     hash: contentHash.optional(),
+    content: z.string().optional(),
   })
   .strict();
 

--- a/packages/sdk/src/test/build-index.test.ts
+++ b/packages/sdk/src/test/build-index.test.ts
@@ -14,6 +14,7 @@ const rawHashFile = (contentPath: string) =>
     .digest('hex');
 
 const hashFile = (contentPath: string) => `sha256:${rawHashFile(contentPath)}`;
+const readFile = (contentPath: string) => fs.readFileSync(path.join(CATALOG_PATH, contentPath), 'utf8');
 
 beforeEach(() => {
   fs.rmSync(CATALOG_PATH, { recursive: true, force: true });
@@ -1614,6 +1615,86 @@ describe('buildIndex', () => {
           },
         ],
       });
+    });
+
+    it('embeds raw schema content when `includeSchemaContent` is true', async () => {
+      const avro = '{"type":"record","name":"PaymentCaptured","fields":[]}';
+      const json = '{"type":"object","properties":{}}';
+      await sdk.writeEvent({
+        id: 'payment-captured',
+        name: 'Payment Captured',
+        version: '2.0.0',
+        markdown: '# Payment Captured',
+        schemas: [
+          { id: 'avro', file: 'schema.avsc', format: 'avro', default: true },
+          { id: 'json', path: 'schema.json', format: 'json-schema' },
+        ],
+      });
+      await sdk.addFileToEvent('payment-captured', { fileName: 'schema.avsc', content: avro });
+      await sdk.addFileToEvent('payment-captured', { fileName: 'schema.json', content: json });
+
+      const index = await sdk.buildIndex({ source: 'acme/payments', commit: '4a1b7e2', includeSchemaContent: true });
+
+      expect(index.resources[0].schemas).toEqual([
+        {
+          id: 'avro',
+          path: 'schema.avsc',
+          format: 'avro',
+          default: true,
+          hash: hashFile('events/payment-captured/schema.avsc'),
+          content: readFile('events/payment-captured/schema.avsc'),
+        },
+        {
+          id: 'json',
+          path: 'schema.json',
+          format: 'json-schema',
+          hash: hashFile('events/payment-captured/schema.json'),
+          content: readFile('events/payment-captured/schema.json'),
+        },
+      ]);
+    });
+
+    it('embeds schema content without hashes when `includeSchemaContent` is true and `hashContent` is false', async () => {
+      const avro = '{"type":"record","name":"PaymentCaptured","fields":[]}';
+      await sdk.writeEvent({
+        id: 'payment-captured',
+        name: 'Payment Captured',
+        version: '2.0.0',
+        markdown: '# Payment Captured',
+        schemaPath: 'schema.avsc',
+      });
+      await sdk.addSchemaToEvent('payment-captured', { fileName: 'schema.avsc', schema: avro });
+
+      const index = await sdk.buildIndex({
+        source: 'acme/payments',
+        commit: '4a1b7e2',
+        hashContent: false,
+        includeSchemaContent: true,
+      });
+
+      expect(index.resources[0]).not.toHaveProperty('contentHash');
+      expect(index.resources[0].schemas).toEqual([
+        { path: 'schema.avsc', default: true, content: readFile('events/payment-captured/schema.avsc') },
+      ]);
+      expect(JSON.parse(index.resources[0].schemas![0].content!)).toEqual(JSON.parse(avro));
+    });
+
+    it('does not embed schema content by default', async () => {
+      await sdk.writeEvent({
+        id: 'payment-captured',
+        name: 'Payment Captured',
+        version: '2.0.0',
+        markdown: '# Payment Captured',
+        schemaPath: 'schema.avsc',
+      });
+      await sdk.addSchemaToEvent('payment-captured', {
+        fileName: 'schema.avsc',
+        schema: '{"type":"record","name":"PaymentCaptured","fields":[]}',
+      });
+
+      const index = await sdk.buildIndex({ source: 'acme/payments', commit: '4a1b7e2' });
+
+      expect(index.resources[0].schemas?.[0]).not.toHaveProperty('content');
     });
 
     it('does not hash schemas when `hashContent` is false', async () => {

--- a/packages/sdk/src/test/parse-index.test.ts
+++ b/packages/sdk/src/test/parse-index.test.ts
@@ -57,6 +57,31 @@ describe('parseIndex', () => {
     expect(parseIndex(index)).toEqual(index);
   });
 
+  it('parses embedded schema content', () => {
+    const index = {
+      ...validIndex,
+      resources: [
+        {
+          type: 'event',
+          id: 'payment-requested',
+          version: '2.0.0',
+          name: 'Payment Requested',
+          contentPath: 'events/payment-requested/index.mdx',
+          schemas: [
+            {
+              path: 'schema.json',
+              format: 'json-schema',
+              hash: 'sha256:3e63897b7cc3a92411599289d00d686f1b1fc8e336927efa46101c8943410c70',
+              content: '{"type":"object","properties":{}}',
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(parseIndex(index)).toEqual(index);
+  });
+
   it('rejects an unsupported index version', () => {
     expect(() => parseIndex({ ...validIndex, indexVersion: 2 })).toThrow(
       new InvalidIndexError([{ path: ['indexVersion'], message: 'Invalid input: expected 1' }])

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -538,6 +538,37 @@ importers:
         specifier: 3.0.0
         version: 3.0.0
 
+  packages/diff:
+    dependencies:
+      '@eventcatalog/sdk':
+        specifier: workspace:*
+        version: link:../sdk
+      semver:
+        specifier: ^7.7.2
+        version: 7.7.3
+    devDependencies:
+      '@types/node':
+        specifier: ^20.14.10
+        version: 20.19.19
+      '@types/semver':
+        specifier: ^7.5.8
+        version: 7.7.1
+      prettier:
+        specifier: ^3.3.3
+        version: 3.6.2
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.1.3
+      tsup:
+        specifier: ^8.1.0
+        version: 8.5.0(jiti@2.7.0)(postcss@8.5.15)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: ^5.5.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.19)(jiti@2.7.0)(jsdom@27.0.0(postcss@8.5.15))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+
   packages/linter:
     dependencies:
       '@eventcatalog/sdk':
@@ -8272,46 +8303,6 @@ packages:
       yaml:
         optional: true
 
-  vite@7.3.1:
-    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
-      jiti: '>=1.21.0'
-      less: ^4.0.0
-      lightningcss: ^1.21.0
-      sass: ^1.70.0
-      sass-embedded: ^1.70.0
-      stylus: '>=0.54.8'
-      sugarss: ^5.0.0
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      jiti:
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
-
   vite@7.3.2:
     resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -9478,7 +9469,7 @@ snapshots:
       package-manager-detector: 0.2.11
       picocolors: 1.1.1
       resolve-from: 5.0.0
-      semver: 7.7.4
+      semver: 7.7.3
       spawndamnit: 3.0.1
       term-size: 2.2.1
     transitivePeerDependencies:
@@ -12179,21 +12170,21 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@20.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@20.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@20.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 7.3.2(@types/node@20.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 7.3.2(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@vitest/mocker@4.0.18(vite@7.3.2(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
@@ -14071,7 +14062,7 @@ snapshots:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
       minimatch: 9.0.5
-      minipass: 7.1.2
+      minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
@@ -15920,7 +15911,7 @@ snapshots:
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   path-scurry@2.0.0:
     dependencies:
@@ -17258,7 +17249,7 @@ snapshots:
       source-map: 0.8.0-beta.0
       sucrase: 3.35.0
       tinyexec: 0.3.2
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       tree-kill: 1.2.2
     optionalDependencies:
       postcss: 8.5.15
@@ -17286,7 +17277,7 @@ snapshots:
       source-map: 0.8.0-beta.0
       sucrase: 3.35.0
       tinyexec: 0.3.2
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       tree-kill: 1.2.2
     optionalDependencies:
       postcss: 8.5.6
@@ -17647,40 +17638,6 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.9.0
 
-  vite@7.3.1(@types/node@20.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0):
-    dependencies:
-      esbuild: 0.27.3
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-      postcss: 8.5.6
-      rollup: 4.52.4
-      tinyglobby: 0.2.17
-    optionalDependencies:
-      '@types/node': 20.19.19
-      fsevents: 2.3.3
-      jiti: 2.7.0
-      lightningcss: 1.32.0
-      terser: 5.46.0
-      tsx: 4.21.0
-      yaml: 2.9.0
-
-  vite@7.3.1(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0):
-    dependencies:
-      esbuild: 0.27.3
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-      postcss: 8.5.6
-      rollup: 4.52.4
-      tinyglobby: 0.2.17
-    optionalDependencies:
-      '@types/node': 25.0.3
-      fsevents: 2.3.3
-      jiti: 2.7.0
-      lightningcss: 1.32.0
-      terser: 5.46.0
-      tsx: 4.21.0
-      yaml: 2.9.0
-
   vite@7.3.2(@types/node@20.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.3
@@ -17756,7 +17713,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@20.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@20.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -17771,10 +17728,10 @@ snapshots:
       std-env: 3.10.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@20.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 7.3.2(@types/node@20.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
       vite-node: 3.2.4(@types/node@20.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
@@ -17799,7 +17756,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -17814,10 +17771,10 @@ snapshots:
       std-env: 3.10.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 7.3.2(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
       vite-node: 3.2.4(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:


### PR DESCRIPTION

## What This PR Does

Adds a new package, `@eventcatalog/diff`, that compares two catalog indexes and returns a single versioned `ArchitectureDiff` document. It answers three questions about a change to a catalog: what was added, removed or changed, whether any message schema change is breaking, and which producers and consumers are hurt. It is a pure library with no knowledge of git, CI or policy, so it can sit underneath a future `governance` CLI command, a PR comment, or a UI.

It also adds an `includeSchemaContent` option to `buildIndex` in `@eventcatalog/sdk`, so an index can carry raw schema text for the diff to compare. It is off by default and does not affect federation.

## Changes Overview

### Key Changes

- **New package `packages/diff`** with tsup, vitest and prettier set up like the other standalone packages.
- **Input is the SDK `Index`** returned by `buildIndex()`. The diff resolves each side with the SDK resolver, so pointers such as `version: latest` become concrete edges. No new index format was introduced.
- **Resources** added, removed and changed. Identity is type plus id. A version bump is one changed entry with both versions, not a removal plus an addition. Name, owners and deprecated changes are reported with the field named.
- **Edges** added and removed across every direction the SDK resolves. Identity ignores versions so a bump does not churn edges. An edge whose target disappears is reported as removed.
- **JSON Schema compatibility** under `backward`, `forward`, `full` (default) and `none`, following Confluent Schema Registry semantics. Covers properties and required (with `default`), types, enums and const, min/max constraints, pattern, format, multipleOf, uniqueItems, open and closed content models, arrays and tuples, oneOf/anyOf/allOf, local `$ref` with cycle handling, and boolean schemas. Keywords it cannot reason about are reported as breaking rather than silently passed.
- **Impact** naming producers and consumers with owners for each breaking schema change, removed message, removed consumer or removed producer. Services, domains and agents all appear with their own type.
- **Unknown verdicts are never silent.** Unsupported formats, missing content, and added or removed schema files are counted in `summary.schemaUnknown`.
- **Docs**: a README covering the document shape and every rule, and `COMPATIBILITY.md`, a plain-language guide to backward and forward compatibility for people new to the topic.
- **SDK**: `buildIndex({ includeSchemaContent: true })` embeds schema text next to its hash. The `IndexSchema` type and `parseIndex` Zod schema accept the new `content` field.

## How It Works

`diff(a, b, options)` resolves both indexes, then runs four steps: `diffResources` over the raw resources, `diffEdges` over the two resolved graphs, `diffSchemas` over paired message versions and schema files, and `impactOf` over the baseline graph using the results of the other three.

Schema comparison pairs every message version present on both sides, plus the latest-to-latest bump. Schema files within a message are paired by id, then path, then the default flag, then by elimination when one file remains on each side. Only files whose hash changed are parsed. The JSON Schema walker (`json-schema/compare.ts`) emits semantic changes with a JSON pointer path, and a single rules table (`json-schema/rules.ts`) decides whether each change breaks backward or forward. Every rule derives from one principle: a change that makes the schema accept more is safe backward and breaking forward, and the reverse.

The default strategy is `full` rather than Confluent's `backward`, because the diff runs on a pull request where a producer changes a message that other services already consume. A backward-only default would pass changes that break every consumer in the graph.

## Breaking Changes

None. The new package is additive and the SDK option defaults to off.

## Additional Notes

- Tests: 184 in the diff package, including 132 explicit JSON Schema scenarios organised by strategy with every schema inline, 49 end-to-end scenarios asserting the whole diff document, and two fixture scenarios generated from real `buildIndex` output. SDK suite passes with 4 new tests.
- Known limits, documented in the README: Avro, Protobuf, OpenAPI and AsyncAPI schemas get a null verdict; impact is direct only, no channels or data products; `format` is treated as a constraint even on 2020-12 schemas.
- Follow-up: the CLI `governance` command that builds two indexes and applies policy on top of this document; Avro compatibility; deprecating the old `breaking-changes` package.
- No editor repository change is needed.

https://claude.ai/code/session_0143a661oqpHMk7tbgLwsWwW