### PR TITLE
chore(diff): align package with the manual 0.1.0 publish

### DIFF
--- a/.changeset/diff-package-scaffold.md
+++ b/.changeset/diff-package-scaffold.md
@@ -1,11 +1,5 @@
 ---
-'@eventcatalog/diff': minor
 '@eventcatalog/sdk': minor
 ---
 
-feat(diff): new `@eventcatalog/diff` package that compares two catalog indexes and returns an `ArchitectureDiff`
-
-- Compares two SDK `Index` documents (from `buildIndex`) and reports resources added / removed / changed, edges added / removed across every direction the SDK resolves, schema changes with a compatibility verdict, and impact naming the producers and consumers hurt by each breaking change, with owners.
-- JSON Schema compatibility under `backward`, `forward`, `full` (default) and `none` strategies, following Confluent Schema Registry semantics: properties and required (with `default`), types, enums and const, min/max constraints, pattern, format, multipleOf, uniqueItems, open and closed content models, arrays and tuples, oneOf / anyOf / allOf, local `$ref`, boolean schemas. Keywords it cannot reason about are reported as breaking rather than silently passed.
-- Unknown verdicts (unsupported formats, missing content, added or removed schema files) are counted in `summary.schemaUnknown` so they are never silent.
-- `buildIndex` in `@eventcatalog/sdk` gains an `includeSchemaContent` option that embeds raw schema text alongside its hash. Off by default.
+feat(sdk): `buildIndex` gains an `includeSchemaContent` option that embeds raw schema text alongside its hash, off by default. Used by the new `@eventcatalog/diff` package (published separately at 0.1.0) to compute schema compatibility verdicts.

--- a/packages/diff/package.json
+++ b/packages/diff/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eventcatalog/diff",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Compare two EventCatalog indexes and produce a versioned ArchitectureDiff document",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -13,7 +13,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "COMPATIBILITY.md"
   ],
   "publishConfig": {
     "access": "public"
@@ -44,7 +45,7 @@
   "author": "EventCatalog",
   "license": "MIT",
   "dependencies": {
-    "@eventcatalog/sdk": "workspace:*",
+    "@eventcatalog/sdk": "workspace:^",
     "semver": "^7.7.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -541,7 +541,7 @@ importers:
   packages/diff:
     dependencies:
       '@eventcatalog/sdk':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../sdk
       semver:
         specifier: ^7.7.2


### PR DESCRIPTION
## What This PR Does

`@eventcatalog/diff` 0.1.0 was published to npm by hand because the release workflow's token cannot create a new scoped package. This lines main up with what was published so the changeset bot does not try to release it again.

## Changes Overview

- `packages/diff/package.json`: version `0.1.0`, `COMPATIBILITY.md` added to `files`, SDK dependency changed from `workspace:*` to `workspace:^` so the published range is `^2.28.1` and picks up the SDK release carrying `includeSchemaContent`.
- `.changeset/diff-package-scaffold.md`: drops the `@eventcatalog/diff` bump, keeping the SDK minor bump.

## Breaking Changes

None.

https://claude.ai/code/session_0143a661oqpHMk7tbgLwsWwW