### PR TITLE
perf(core): use tight-tree dagre ranker for large node graphs

### DIFF
--- a/.changeset/tight-tree-large-graphs.md
+++ b/.changeset/tight-tree-large-graphs.md
@@ -1,0 +1,6 @@
+---
+'@eventcatalog/core': patch
+'@eventcatalog/visualiser': patch
+---
+
+Use dagre's tight-tree ranker for large node graphs so domain and architecture maps layout in hundreds of milliseconds instead of several seconds.

--- a/packages/core/eventcatalog/src/utils/__tests__/node-graphs/large-catalog.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/node-graphs/large-catalog.ts
@@ -1,0 +1,136 @@
+/**
+ * Builds a large synthetic catalog for node-graph performance benchmarks.
+ *
+ * Commerce domain owns `domainServiceCount` services. The remaining services
+ * sit outside the domain so producer/consumer scans still walk the full catalog.
+ * Each service sends and receives a sliding window of events, creating a dense
+ * producer/consumer mesh similar to a busy event-driven architecture.
+ */
+export interface LargeCatalogOptions {
+  catalogServiceCount?: number;
+  domainServiceCount?: number;
+  eventCount?: number;
+  messagesPerDirection?: number;
+}
+
+export interface LargeCatalog {
+  domains: any[];
+  services: any[];
+  events: any[];
+  commands: any[];
+  queries: any[];
+  agents: any[];
+  channels: any[];
+  containers: any[];
+  'data-products': any[];
+}
+
+const DEFAULTS = {
+  catalogServiceCount: 200,
+  domainServiceCount: 80,
+  eventCount: 400,
+  messagesPerDirection: 10,
+};
+
+export const createLargeCatalog = (options: LargeCatalogOptions = {}): LargeCatalog => {
+  const catalogServiceCount = options.catalogServiceCount ?? DEFAULTS.catalogServiceCount;
+  const domainServiceCount = options.domainServiceCount ?? DEFAULTS.domainServiceCount;
+  const eventCount = options.eventCount ?? DEFAULTS.eventCount;
+  const messagesPerDirection = options.messagesPerDirection ?? DEFAULTS.messagesPerDirection;
+
+  const events = Array.from({ length: eventCount }, (_, i) => {
+    const id = `Event${i}`;
+    return {
+      id: `events/${id}/index.mdx`,
+      slug: `events/${id}`,
+      collection: 'events',
+      data: {
+        id,
+        name: id,
+        version: '1.0.0',
+      },
+    };
+  });
+
+  const services = Array.from({ length: catalogServiceCount }, (_, i) => {
+    const id = `Service${i}`;
+    const sends = Array.from({ length: messagesPerDirection }, (_, j) => ({
+      id: `Event${(i + j) % eventCount}`,
+      version: '1.0.0',
+    }));
+    const receives = Array.from({ length: messagesPerDirection }, (_, j) => ({
+      id: `Event${(i + 50 + j) % eventCount}`,
+      version: '1.0.0',
+    }));
+
+    return {
+      id: `services/${id}/index.mdx`,
+      slug: `services/${id}`,
+      collection: 'services',
+      data: {
+        id,
+        name: id,
+        version: '1.0.0',
+        sends,
+        receives,
+      },
+    };
+  });
+
+  const domains = [
+    {
+      id: 'domains/Commerce/index.mdx',
+      slug: 'domains/Commerce',
+      collection: 'domains',
+      filePath: 'domains/Commerce/index.mdx',
+      data: {
+        id: 'Commerce',
+        name: 'Commerce',
+        version: '1.0.0',
+        services: services.slice(0, domainServiceCount).map((service) => ({
+          id: service.data.id,
+          version: service.data.version,
+        })),
+      },
+    },
+  ];
+
+  return {
+    domains,
+    services,
+    events,
+    commands: [],
+    queries: [],
+    agents: [],
+    channels: [],
+    containers: [],
+    'data-products': [],
+  };
+};
+
+export const installLargeCatalogMock = (catalog: LargeCatalog, getCollection: (key: string) => Promise<any[]>) => {
+  return ((key: string) => {
+    switch (key) {
+      case 'domains':
+        return Promise.resolve(catalog.domains);
+      case 'services':
+        return Promise.resolve(catalog.services);
+      case 'events':
+        return Promise.resolve(catalog.events);
+      case 'commands':
+        return Promise.resolve(catalog.commands);
+      case 'queries':
+        return Promise.resolve(catalog.queries);
+      case 'agents':
+        return Promise.resolve(catalog.agents);
+      case 'channels':
+        return Promise.resolve(catalog.channels);
+      case 'containers':
+        return Promise.resolve(catalog.containers);
+      case 'data-products':
+        return Promise.resolve(catalog['data-products']);
+      default:
+        return Promise.resolve([]);
+    }
+  }) as typeof getCollection;
+};

--- a/packages/core/eventcatalog/src/utils/__tests__/node-graphs/large-graph.bench.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/node-graphs/large-graph.bench.spec.ts
@@ -1,4 +1,11 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+/**
+ * Optional wall-clock repro. Skipped in the default unit suite so CI does not
+ * depend on host speed. Run with:
+ *
+ *   EVENTCATALOG_GRAPH_BENCH=1 pnpm --filter @eventcatalog/core exec vitest run \
+ *     eventcatalog/src/utils/__tests__/node-graphs/large-graph.bench.spec.ts
+ */
+import { describe, it, vi, beforeEach } from 'vitest';
 import { getCollection } from 'astro:content';
 import { getNodesAndEdges as getDomainNodesAndEdges } from '@utils/node-graphs/domains-node-graph';
 import { getNodesAndEdges as getServiceNodesAndEdges } from '@utils/node-graphs/services-node-graph';
@@ -12,6 +19,7 @@ vi.mock('astro:content', async (importOriginal) => {
 });
 
 const catalog = createLargeCatalog();
+const RUN_BENCH = process.env.EVENTCATALOG_GRAPH_BENCH === '1';
 
 const median = (values: number[]) => {
   const sorted = [...values].sort((a, b) => a - b);
@@ -32,38 +40,22 @@ const time = async (label: string, fn: () => Promise<void> | void, runs = 3) => 
   return result;
 };
 
-describe('large node-graph benchmark', () => {
+describe.skipIf(!RUN_BENCH)('large node-graph benchmark', () => {
   beforeEach(() => {
     vi.mocked(getCollection).mockImplementation(installLargeCatalogMock(catalog, getCollection) as any);
   });
 
-  it('builds a large domain graph quickly and keeps a stable node/edge count', async () => {
-    const first = await getDomainNodesAndEdges({
-      id: 'Commerce',
-      version: '1.0.0',
-      mode: 'simple',
-      layout: true,
-    } as any);
-
-    expect(first.nodes).toHaveLength(278);
-    expect(first.edges).toHaveLength(2145);
-
-    const domainWithoutLayout = await time('domain getNodesAndEdges layout:false', async () => {
+  it('prints domain and service graph timings for a large catalog', async () => {
+    await time('domain getNodesAndEdges layout:false', async () => {
       await getDomainNodesAndEdges({ id: 'Commerce', version: '1.0.0', mode: 'simple', layout: false } as any);
     });
 
-    const domainWithLayout = await time('domain getNodesAndEdges layout:true', async () => {
+    await time('domain getNodesAndEdges layout:true', async () => {
       await getDomainNodesAndEdges({ id: 'Commerce', version: '1.0.0', mode: 'simple', layout: true } as any);
     });
 
-    const serviceWithLayout = await time('service getNodesAndEdges layout:true', async () => {
+    await time('service getNodesAndEdges layout:true', async () => {
       await getServiceNodesAndEdges({ id: 'Service0', version: '1.0.0', mode: 'simple', layout: true });
     });
-
-    expect(domainWithoutLayout.median).toBeGreaterThan(0);
-    expect(serviceWithLayout.median).toBeGreaterThan(0);
-    // Before this change, layout:true on this catalog was ~7s (network-simplex).
-    // tight-tree should keep the full domain graph well under 2.5s.
-    expect(domainWithLayout.median).toBeLessThan(2500);
   }, 60_000);
 });

--- a/packages/core/eventcatalog/src/utils/__tests__/node-graphs/large-graph.bench.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/node-graphs/large-graph.bench.spec.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getCollection } from 'astro:content';
+import { getNodesAndEdges as getDomainNodesAndEdges } from '@utils/node-graphs/domains-node-graph';
+import { getNodesAndEdges as getServiceNodesAndEdges } from '@utils/node-graphs/services-node-graph';
+import { createLargeCatalog, installLargeCatalogMock } from './large-catalog';
+
+vi.mock('astro:content', async (importOriginal) => {
+  return {
+    ...(await importOriginal<typeof import('astro:content')>()),
+    getCollection: vi.fn(),
+  };
+});
+
+const catalog = createLargeCatalog();
+
+const median = (values: number[]) => {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+};
+
+const time = async (label: string, fn: () => Promise<void> | void, runs = 3) => {
+  const samples: number[] = [];
+  for (let i = 0; i < runs; i++) {
+    const start = performance.now();
+    await fn();
+    samples.push(performance.now() - start);
+  }
+  const result = { label, samples, median: median(samples) };
+  // eslint-disable-next-line no-console
+  console.log(`[bench] ${label}: ${samples.map((s) => s.toFixed(1)).join(', ')} ms (median ${result.median.toFixed(1)} ms)`);
+  return result;
+};
+
+describe('large node-graph benchmark', () => {
+  beforeEach(() => {
+    vi.mocked(getCollection).mockImplementation(installLargeCatalogMock(catalog, getCollection) as any);
+  });
+
+  it('builds a large domain graph quickly and keeps a stable node/edge count', async () => {
+    const first = await getDomainNodesAndEdges({
+      id: 'Commerce',
+      version: '1.0.0',
+      mode: 'simple',
+      layout: true,
+    } as any);
+
+    expect(first.nodes).toHaveLength(278);
+    expect(first.edges).toHaveLength(2145);
+
+    const domainWithoutLayout = await time('domain getNodesAndEdges layout:false', async () => {
+      await getDomainNodesAndEdges({ id: 'Commerce', version: '1.0.0', mode: 'simple', layout: false } as any);
+    });
+
+    const domainWithLayout = await time('domain getNodesAndEdges layout:true', async () => {
+      await getDomainNodesAndEdges({ id: 'Commerce', version: '1.0.0', mode: 'simple', layout: true } as any);
+    });
+
+    const serviceWithLayout = await time('service getNodesAndEdges layout:true', async () => {
+      await getServiceNodesAndEdges({ id: 'Service0', version: '1.0.0', mode: 'simple', layout: true });
+    });
+
+    expect(domainWithoutLayout.median).toBeGreaterThan(0);
+    expect(serviceWithLayout.median).toBeGreaterThan(0);
+    // Before this change, layout:true on this catalog was ~7s (network-simplex).
+    // tight-tree should keep the full domain graph well under 2.5s.
+    expect(domainWithLayout.median).toBeLessThan(2500);
+  }, 60_000);
+});

--- a/packages/core/eventcatalog/src/utils/__tests__/node-graphs/large-graph.generation.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/node-graphs/large-graph.generation.spec.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getCollection } from 'astro:content';
+import { getNodesAndEdges as getDomainNodesAndEdges } from '@utils/node-graphs/domains-node-graph';
+import { LARGE_GRAPH_RANKER, selectDagreRanker } from '@utils/node-graphs/utils/utils';
+import { createLargeCatalog, installLargeCatalogMock } from './large-catalog';
+
+vi.mock('astro:content', async (importOriginal) => {
+  return {
+    ...(await importOriginal<typeof import('astro:content')>()),
+    getCollection: vi.fn(),
+  };
+});
+
+const catalog = createLargeCatalog();
+
+describe('large domain graph generation', () => {
+  beforeEach(() => {
+    vi.mocked(getCollection).mockImplementation(installLargeCatalogMock(catalog, getCollection) as any);
+  });
+
+  it('builds a stable Commerce graph that crosses the large-graph ranker threshold', async () => {
+    const { nodes, edges } = await getDomainNodesAndEdges({
+      id: 'Commerce',
+      version: '1.0.0',
+      mode: 'simple',
+      layout: false,
+    } as any);
+
+    expect(nodes).toHaveLength(278);
+    expect(edges).toHaveLength(2145);
+    expect(selectDagreRanker(nodes.length, edges.length)).toBe(LARGE_GRAPH_RANKER);
+  });
+});

--- a/packages/core/eventcatalog/src/utils/__tests__/node-graphs/layout-dagre-graph.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/node-graphs/layout-dagre-graph.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import dagre from 'dagre';
+import {
+  LARGE_GRAPH_EDGE_THRESHOLD,
+  LARGE_GRAPH_NODE_THRESHOLD,
+  LARGE_GRAPH_RANKER,
+  createDagreGraph,
+  layoutDagreGraph,
+  selectDagreRanker,
+} from '@utils/node-graphs/utils/utils';
+
+const addCompleteGraph = (flow: dagre.graphlib.Graph, nodeCount: number, extraEdges = 0) => {
+  for (let i = 0; i < nodeCount; i++) {
+    flow.setNode(`n${i}`, { width: 150, height: 120 });
+  }
+  for (let i = 0; i < nodeCount - 1; i++) {
+    flow.setEdge(`n${i}`, `n${i + 1}`);
+  }
+  for (let i = 0; i < extraEdges; i++) {
+    flow.setEdge(`n${i % nodeCount}`, `n${(i + 3) % nodeCount}`);
+  }
+};
+
+describe('layoutDagreGraph', () => {
+  it('keeps the default network-simplex ranker for small graphs', () => {
+    expect(selectDagreRanker(10, 12)).toBeUndefined();
+    expect(selectDagreRanker(LARGE_GRAPH_NODE_THRESHOLD - 1, LARGE_GRAPH_EDGE_THRESHOLD - 1)).toBeUndefined();
+  });
+
+  it('selects tight-tree once a graph crosses the node or edge threshold', () => {
+    expect(selectDagreRanker(LARGE_GRAPH_NODE_THRESHOLD, 10)).toBe(LARGE_GRAPH_RANKER);
+    expect(selectDagreRanker(10, LARGE_GRAPH_EDGE_THRESHOLD)).toBe(LARGE_GRAPH_RANKER);
+  });
+
+  it('respects an explicit ranker', () => {
+    expect(selectDagreRanker(500, 2000, 'network-simplex')).toBe('network-simplex');
+    expect(selectDagreRanker(5, 4, 'longest-path')).toBe('longest-path');
+  });
+
+  it('positions every node on a small graph without changing the ranker', () => {
+    const flow = createDagreGraph({ ranksep: 300, nodesep: 50 });
+    addCompleteGraph(flow, 6);
+    layoutDagreGraph(flow);
+
+    expect(flow.graph().ranker).toBeUndefined();
+    for (let i = 0; i < 6; i++) {
+      const node = flow.node(`n${i}`);
+      expect(typeof node.x).toBe('number');
+      expect(typeof node.y).toBe('number');
+    }
+  });
+
+  it('applies tight-tree to a large graph and still positions every node', () => {
+    const flow = createDagreGraph({ ranksep: 300, nodesep: 50 });
+    addCompleteGraph(flow, LARGE_GRAPH_NODE_THRESHOLD, LARGE_GRAPH_EDGE_THRESHOLD);
+    layoutDagreGraph(flow);
+
+    expect(flow.graph().ranker).toBe(LARGE_GRAPH_RANKER);
+    for (let i = 0; i < LARGE_GRAPH_NODE_THRESHOLD; i++) {
+      const node = flow.node(`n${i}`);
+      expect(typeof node.x).toBe('number');
+      expect(typeof node.y).toBe('number');
+    }
+  });
+});

--- a/packages/core/eventcatalog/src/utils/node-graphs/channel-node-graph.ts
+++ b/packages/core/eventcatalog/src/utils/node-graphs/channel-node-graph.ts
@@ -1,5 +1,4 @@
 import { getCollection, type CollectionEntry } from 'astro:content';
-import dagre from 'dagre';
 import {
   buildContextMenuForAgent,
   buildContextMenuForMessage,
@@ -17,6 +16,7 @@ import {
   getOperationFields,
   DEFAULT_NODE_WIDTH,
   DEFAULT_NODE_HEIGHT,
+  layoutDagreGraph,
 } from './utils/utils';
 import { createVersionedMap, findInMap } from '@utils/collections/util';
 import { getChannelChain, getChannels } from '@utils/collections/channels';
@@ -457,7 +457,7 @@ export const getNodesAndEdges = async ({ id, version, defaultFlow, mode = 'simpl
   });
 
   if (layout) {
-    dagre.layout(flow);
+    layoutDagreGraph(flow);
   }
 
   return {

--- a/packages/core/eventcatalog/src/utils/node-graphs/container-node-graph.ts
+++ b/packages/core/eventcatalog/src/utils/node-graphs/container-node-graph.ts
@@ -1,5 +1,4 @@
 import type { CollectionEntry } from 'astro:content';
-import dagre from 'dagre';
 import {
   calculatedNodes,
   createDagreGraph,
@@ -10,6 +9,7 @@ import {
   buildContextMenuForResource,
   DEFAULT_NODE_WIDTH,
   DEFAULT_NODE_HEIGHT,
+  layoutDagreGraph,
 } from './utils/utils';
 import { MarkerType } from '@xyflow/react';
 import { findMatchingNodes } from '@utils/collections/util';
@@ -299,7 +299,7 @@ export const getNodesAndEdges = async ({
 
   // Render the diagram in memory getting hte X and Y
   if (layout) {
-    dagre.layout(flow);
+    layoutDagreGraph(flow);
   }
 
   return {

--- a/packages/core/eventcatalog/src/utils/node-graphs/data-products-node-graph.ts
+++ b/packages/core/eventcatalog/src/utils/node-graphs/data-products-node-graph.ts
@@ -1,5 +1,4 @@
 import { getCollection, type CollectionEntry } from 'astro:content';
-import dagre from 'dagre';
 import {
   createDagreGraph,
   generateIdForNode,
@@ -10,6 +9,7 @@ import {
   buildContextMenuForResource,
   DEFAULT_NODE_WIDTH,
   DEFAULT_NODE_HEIGHT,
+  layoutDagreGraph,
 } from '@utils/node-graphs/utils/utils';
 
 import { findInMap, createVersionedMap, mergeMaps, collectionToResourceMap } from '@utils/collections/util';
@@ -220,7 +220,7 @@ export const getNodesAndEdges = async ({ id, defaultFlow, version, mode = 'simpl
 
   if (layout) {
     // Render the diagram in memory getting the X and Y
-    dagre.layout(flow);
+    layoutDagreGraph(flow);
   }
 
   // Find any duplicated edges, and merge them into one edge

--- a/packages/core/eventcatalog/src/utils/node-graphs/domains-canvas.ts
+++ b/packages/core/eventcatalog/src/utils/node-graphs/domains-canvas.ts
@@ -1,11 +1,11 @@
 import { getCollection, type CollectionEntry } from 'astro:content';
-import dagre from 'dagre';
 import {
   generateIdForNode,
   createDagreGraph,
   calculatedNodes,
   createEdge,
   getOperationFields,
+  layoutDagreGraph,
 } from '@utils/node-graphs/utils/utils';
 import { findInMap, createVersionedMap } from '@utils/collections/util';
 import type { Node, Edge } from '@xyflow/react';
@@ -247,7 +247,7 @@ export const getDomainsCanvasData = async (): Promise<DomainCanvasData> => {
   });
 
   // Calculate layout using dagre
-  dagre.layout(dagreGraph);
+  layoutDagreGraph(dagreGraph);
 
   // Apply calculated positions to nodes
   const layoutedDomainNodes = calculatedNodes(dagreGraph, domainNodes);

--- a/packages/core/eventcatalog/src/utils/node-graphs/domains-node-graph.ts
+++ b/packages/core/eventcatalog/src/utils/node-graphs/domains-node-graph.ts
@@ -1,5 +1,4 @@
 import { getCollection } from 'astro:content';
-import dagre from 'dagre';
 import {
   createDagreGraph,
   calculatedNodes,
@@ -7,6 +6,7 @@ import {
   getEdgeLabelForServiceAsTarget,
   generatedIdForEdge,
   createEdge,
+  layoutDagreGraph,
 } from '@utils/node-graphs/utils/utils';
 import { getNodesAndEdges as getServicesNodeAndEdges } from './services-node-graph';
 import { getNodesAndEdges as getAgentsNodeAndEdges } from './agents-node-graph';
@@ -176,7 +176,7 @@ export const getNodesAndEdges = async ({
   }
 
   if (layout) {
-    dagre.layout(flow);
+    layoutDagreGraph(flow);
   }
 
   return {

--- a/packages/core/eventcatalog/src/utils/node-graphs/flows-node-graph.ts
+++ b/packages/core/eventcatalog/src/utils/node-graphs/flows-node-graph.ts
@@ -1,5 +1,4 @@
 import { getCollection, type CollectionEntry } from 'astro:content';
-import dagre from 'dagre';
 import {
   createDagreGraph,
   calculatedNodes,
@@ -7,6 +6,7 @@ import {
   DEFAULT_NODE_HEIGHT,
   buildContextMenuForResource,
   buildContextMenuForService,
+  layoutDagreGraph,
 } from '@utils/node-graphs/utils/utils';
 import { MarkerType } from '@xyflow/react';
 import type { Node as NodeType } from '@xyflow/react';
@@ -321,7 +321,7 @@ export const getNodesAndEdges = async ({ id, defaultFlow, version, mode = 'simpl
     graph.setEdge(edge.source, edge.target);
   });
 
-  dagre.layout(graph);
+  layoutDagreGraph(graph);
 
   return {
     nodes: calculatedNodes(graph, nodes),

--- a/packages/core/eventcatalog/src/utils/node-graphs/message-node-graph.ts
+++ b/packages/core/eventcatalog/src/utils/node-graphs/message-node-graph.ts
@@ -1,7 +1,6 @@
 // import { getColor } from '@utils/colors';
 import { getEvents } from '@utils/collections/events';
 import { getCollection, type CollectionEntry } from 'astro:content';
-import dagre from 'dagre';
 import {
   calculatedNodes,
   createDagreGraph,
@@ -12,6 +11,7 @@ import {
   getEdgeLabelForMessageAsSource,
   getEdgeLabelForServiceAsTarget,
   versionMatches,
+  layoutDagreGraph,
 } from './utils/utils';
 import { MarkerType, type Node, type Edge } from '@xyflow/react';
 import {
@@ -691,7 +691,7 @@ const getNodesAndEdges = async ({
   });
 
   // Render the diagram in memory getting hte X and Y
-  dagre.layout(flow);
+  layoutDagreGraph(flow);
 
   return {
     nodes: calculatedNodes(flow, nodes),

--- a/packages/core/eventcatalog/src/utils/node-graphs/services-node-graph.ts
+++ b/packages/core/eventcatalog/src/utils/node-graphs/services-node-graph.ts
@@ -1,5 +1,4 @@
 import { getCollection, type CollectionEntry } from 'astro:content';
-import dagre from 'dagre';
 import {
   createDagreGraph,
   generateIdForNode,
@@ -14,6 +13,7 @@ import {
   DEFAULT_NODE_HEIGHT,
   partitionMessagesByGroup,
   getOperationFields,
+  layoutDagreGraph,
 } from '@utils/node-graphs/utils/utils';
 
 const sanitizeGroupId = (name: string) => name.replace(/[^a-zA-Z0-9]/g, '-').toLowerCase();
@@ -636,7 +636,7 @@ export const getNodesAndEdges = async ({
 
   if (layout) {
     // Render the diagram in memory getting the X and Y
-    dagre.layout(flow);
+    layoutDagreGraph(flow);
   }
 
   // Find any duplicated edges, and merge them into one edge

--- a/packages/core/eventcatalog/src/utils/node-graphs/system-context-node-graph.ts
+++ b/packages/core/eventcatalog/src/utils/node-graphs/system-context-node-graph.ts
@@ -1,6 +1,5 @@
 import { getCollection } from 'astro:content';
 import type { CollectionEntry } from 'astro:content';
-import dagre from 'dagre';
 import {
   createDagreGraph,
   calculatedNodes,
@@ -8,6 +7,7 @@ import {
   generateIdForNode,
   buildContextMenuForSystem,
   DEFAULT_NODE_HEIGHT,
+  layoutDagreGraph,
 } from '@utils/node-graphs/utils/utils';
 import { MarkerType } from '@xyflow/react';
 import { createVersionedMap, findInMap } from '@utils/collections/util';
@@ -302,7 +302,7 @@ const buildContextGraphFromSeeds = ({
   edges.forEach((edge) => flow.setEdge(edge.source, edge.target));
 
   if (layout) {
-    dagre.layout(flow);
+    layoutDagreGraph(flow);
   }
 
   return {

--- a/packages/core/eventcatalog/src/utils/node-graphs/systems-node-graph.ts
+++ b/packages/core/eventcatalog/src/utils/node-graphs/systems-node-graph.ts
@@ -1,6 +1,11 @@
 import { getCollection } from 'astro:content';
-import dagre from 'dagre';
-import { createDagreGraph, calculatedNodes, DEFAULT_NODE_WIDTH, DEFAULT_NODE_HEIGHT } from '@utils/node-graphs/utils/utils';
+import {
+  createDagreGraph,
+  calculatedNodes,
+  DEFAULT_NODE_WIDTH,
+  DEFAULT_NODE_HEIGHT,
+  layoutDagreGraph,
+} from '@utils/node-graphs/utils/utils';
 import { getNodesAndEdges as getServicesNodeAndEdges } from './services-node-graph';
 import { getNodesAndEdges as getContainerNodeAndEdges } from './container-node-graph';
 import merge from 'lodash.merge';
@@ -121,7 +126,7 @@ export const getNodesAndEdges = async ({
   }
 
   if (layout) {
-    dagre.layout(flow);
+    layoutDagreGraph(flow);
   }
 
   let laidOutNodes = calculatedNodes(flow, Array.from(nodes.values()));

--- a/packages/core/eventcatalog/src/utils/node-graphs/utils/utils.ts
+++ b/packages/core/eventcatalog/src/utils/node-graphs/utils/utils.ts
@@ -109,6 +109,34 @@ export const createDagreGraph = ({ ranksep = 180, nodesep = 50, ...rest }: any) 
   return graph;
 };
 
+/**
+ * network-simplex produces the nicest layered layout but is O(V·E) and hangs on
+ * large architecture maps. tight-tree keeps the same LR layering with far less
+ * work. Callers can still force a ranker via createDagreGraph({ ranker }).
+ */
+export const LARGE_GRAPH_NODE_THRESHOLD = 80;
+export const LARGE_GRAPH_EDGE_THRESHOLD = 200;
+export const LARGE_GRAPH_RANKER = 'tight-tree';
+
+export const selectDagreRanker = (nodeCount: number, edgeCount: number, explicitRanker?: string) => {
+  if (explicitRanker) return explicitRanker;
+  if (nodeCount >= LARGE_GRAPH_NODE_THRESHOLD || edgeCount >= LARGE_GRAPH_EDGE_THRESHOLD) {
+    return LARGE_GRAPH_RANKER;
+  }
+  return undefined;
+};
+
+export const layoutDagreGraph = (flow: dagre.graphlib.Graph) => {
+  const label = (flow.graph() || {}) as { ranker?: string };
+  const nodeCount = flow.nodeCount();
+  const edgeCount = flow.edgeCount();
+  const ranker = selectDagreRanker(nodeCount, edgeCount, label.ranker);
+  if (ranker && label.ranker !== ranker) {
+    flow.setGraph({ ...label, ranker });
+  }
+  dagre.layout(flow);
+};
+
 export const createEdge = (edgeOptions: Edge) => {
   return {
     label: 'subscribed by',
@@ -430,8 +458,8 @@ export const getNodesAndEdgesFromDagre = ({
     flow.setEdge(edge.source, edge.target);
   });
 
-  // Render the diagram in memory getting hte X and Y
-  dagre.layout(flow);
+  // Render the diagram in memory getting the X and Y
+  layoutDagreGraph(flow);
 
   return {
     nodes: calculatedNodes(flow, nodes),

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Minor Changes
 
 - b0b0b11: feat(diff): new `@eventcatalog/diff` package that compares two catalog indexes and returns an `ArchitectureDiff`
-
   - Compares two SDK `Index` documents (from `buildIndex`) and reports resources added / removed / changed, edges added / removed across every direction the SDK resolves, schema changes with a compatibility verdict, and impact naming the producers and consumers hurt by each breaking change, with owners.
   - JSON Schema compatibility under `backward`, `forward`, `full` (default) and `none` strategies, following Confluent Schema Registry semantics: properties and required (with `default`), types, enums and const, min/max constraints, pattern, format, multipleOf, uniqueItems, open and closed content models, arrays and tuples, oneOf / anyOf / allOf, local `$ref`, boolean schemas. Keywords it cannot reason about are reported as breaking rather than silently passed.
   - Unknown verdicts (unsupported formats, missing content, added or removed schema files) are counted in `summary.schemaUnknown` so they are never silent.
@@ -171,7 +170,6 @@
 - 8f724a7: feat: add `externalSystem` flag to services for modelling third-party integrations
 
   Services can now set `externalSystem: true` in their frontmatter to be rendered as external systems. This changes their presentation without changing their capabilities — they still send and receive messages, have owners, and support specifications like any other service.
-
   - Visualiser: external services render purple with a Globe icon and an "External System" badge
   - Sidebar (root): a dedicated "External Systems" section lists externals; the regular "Services" section excludes them
   - Sidebar (domain): externals appear under a new "External Integrations" group, separate from "Services In Domain"

--- a/packages/visualiser/src/components/NodeGraph.tsx
+++ b/packages/visualiser/src/components/NodeGraph.tsx
@@ -117,6 +117,7 @@ import {
 } from "../utils/message-group-expansion";
 import { AllNotesModal, getNotesFromNode } from "./NotesToolbarButton";
 import { setBuildUrlFn } from "../utils/url-builder";
+import { layoutDagreGraph } from "../utils/utils/utils";
 import { PortalContainerProvider } from "../context/PortalContainerContext";
 import type { DslGraph } from "../types";
 import dagre from "dagre";
@@ -757,7 +758,7 @@ const NodeGraphBuilder = ({
         }
       });
 
-      dagre.layout(g);
+      layoutDagreGraph(g);
 
       // Apply dagre positions to top-level nodes
       const positioned = nextNodes.map((node) => {
@@ -888,7 +889,7 @@ const NodeGraphBuilder = ({
           g.setEdge(e.source, e.target);
         }
       });
-      dagre.layout(g);
+      layoutDagreGraph(g);
 
       let minX = Infinity;
       let minY = Infinity;

--- a/packages/visualiser/src/utils/utils/layout-dagre-graph.test.ts
+++ b/packages/visualiser/src/utils/utils/layout-dagre-graph.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  LARGE_GRAPH_EDGE_THRESHOLD,
+  LARGE_GRAPH_NODE_THRESHOLD,
+  LARGE_GRAPH_RANKER,
+  createDagreGraph,
+  layoutDagreGraph,
+  selectDagreRanker,
+} from "./utils";
+
+describe("layoutDagreGraph", () => {
+  it("keeps the default ranker for small graphs", () => {
+    expect(selectDagreRanker(10, 12)).toBeUndefined();
+  });
+
+  it("selects tight-tree for large graphs", () => {
+    expect(selectDagreRanker(LARGE_GRAPH_NODE_THRESHOLD, 1)).toBe(
+      LARGE_GRAPH_RANKER,
+    );
+    expect(selectDagreRanker(1, LARGE_GRAPH_EDGE_THRESHOLD)).toBe(
+      LARGE_GRAPH_RANKER,
+    );
+  });
+
+  it("respects an explicit ranker", () => {
+    expect(selectDagreRanker(500, 2000, "network-simplex")).toBe(
+      "network-simplex",
+    );
+  });
+
+  it("applies tight-tree and positions nodes on a large graph", () => {
+    const flow = createDagreGraph({ ranksep: 300, nodesep: 50 });
+    for (let i = 0; i < LARGE_GRAPH_NODE_THRESHOLD; i++) {
+      flow.setNode(`n${i}`, { width: 150, height: 120 });
+    }
+    for (let i = 0; i < LARGE_GRAPH_EDGE_THRESHOLD; i++) {
+      flow.setEdge(
+        `n${i % LARGE_GRAPH_NODE_THRESHOLD}`,
+        `n${(i + 1) % LARGE_GRAPH_NODE_THRESHOLD}`,
+      );
+    }
+
+    layoutDagreGraph(flow);
+
+    expect(flow.graph().ranker).toBe(LARGE_GRAPH_RANKER);
+    expect(typeof flow.node("n0").x).toBe("number");
+    expect(typeof flow.node("n0").y).toBe("number");
+  });
+});

--- a/packages/visualiser/src/utils/utils/utils.ts
+++ b/packages/visualiser/src/utils/utils/utils.ts
@@ -99,6 +99,41 @@ export const createDagreGraph = ({
   return graph;
 };
 
+/**
+ * network-simplex produces the nicest layered layout but is O(V·E) and hangs on
+ * large architecture maps. tight-tree keeps the same LR layering with far less
+ * work. Callers can still force a ranker via createDagreGraph({ ranker }).
+ */
+export const LARGE_GRAPH_NODE_THRESHOLD = 80;
+export const LARGE_GRAPH_EDGE_THRESHOLD = 200;
+export const LARGE_GRAPH_RANKER = "tight-tree";
+
+export const selectDagreRanker = (
+  nodeCount: number,
+  edgeCount: number,
+  explicitRanker?: string,
+) => {
+  if (explicitRanker) return explicitRanker;
+  if (
+    nodeCount >= LARGE_GRAPH_NODE_THRESHOLD ||
+    edgeCount >= LARGE_GRAPH_EDGE_THRESHOLD
+  ) {
+    return LARGE_GRAPH_RANKER;
+  }
+  return undefined;
+};
+
+export const layoutDagreGraph = (flow: dagre.graphlib.Graph) => {
+  const label = (flow.graph() || {}) as { ranker?: string };
+  const nodeCount = flow.nodeCount();
+  const edgeCount = flow.edgeCount();
+  const ranker = selectDagreRanker(nodeCount, edgeCount, label.ranker);
+  if (ranker && label.ranker !== ranker) {
+    flow.setGraph({ ...label, ranker });
+  }
+  dagre.layout(flow);
+};
+
 export const createEdge = (edgeOptions: Edge): Edge => {
   return {
     label: "subscribed by",
@@ -152,8 +187,8 @@ export const getNodesAndEdgesFromDagre = ({
     flow.setEdge(edge.source, edge.target);
   });
 
-  // Render the diagram in memory getting hte X and Y
-  dagre.layout(flow);
+  // Render the diagram in memory getting the X and Y
+  layoutDagreGraph(flow);
 
   return {
     nodes: calculatedNodes(flow, nodes),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Motivation

Large domain and architecture maps spend almost all of `getNodesAndEdges` in dagre's default `network-simplex` ranker. On a synthetic Commerce domain (80 services in a 200-service catalog, 400 events, 10 sends/receives per service) that is **278 nodes / 2145 edges**, a single layout pass took ~6.6–7.1 seconds. Node/edge generation itself is only ~140ms.

This PR keeps `network-simplex` for small service/message graphs (unchanged look) and switches large graphs to dagre's `tight-tree` ranker. Same left-to-right layered layout, dramatically less CPU. The same policy is used for client-side relayout (group expand, channel hide) in `@eventcatalog/visualiser`.

Builds on #2639 (child graphs already skip layout; this speeds up the remaining parent/client layout pass). Does not touch schema explorer.

## Before / after

Synthetic catalog: 200 services, 80 in `Commerce`, 400 events, 10 sends + 10 receives each. Measured with `performance.now()` (median of 3) via:

```bash
EVENTCATALOG_GRAPH_BENCH=1 pnpm --filter @eventcatalog/core exec vitest run \
  eventcatalog/src/utils/__tests__/node-graphs/large-graph.bench.spec.ts
```

Isolated ranker comparison on the same 278-node / 2145-edge graph:

| Ranker | Layout time |
|---|---|
| `network-simplex` (before) | **6605 ms** |
| `tight-tree` (after) | **615 ms** |
| `longest-path` (not used) | 517 ms |

Full `domains-node-graph.getNodesAndEdges`:

| Path | Before | After | Change |
|---|---|---|---|
| Domain graph `layout: false` (node/edge gen) | 142 ms | 138 ms | unchanged |
| Domain graph `layout: true` | **7055 ms** | **691 ms** | **90% faster (10.2×)** |
| Single service graph `layout: true` | 28 ms | 30 ms | unchanged (still `network-simplex`) |

The default unit suite does **not** assert wall-clock time. It checks that this catalog still produces 278 nodes / 2145 edges and that those counts select `tight-tree`.

## How it works

`layoutDagreGraph()` inspects the dagre graph size. If nodes ≥ 80 or edges ≥ 200 and no ranker was set explicitly, it sets `ranker: 'tight-tree'` before `dagre.layout()`. Small graphs keep dagre's default.

## Repro

1. Synthetic catalog factory: `packages/core/eventcatalog/src/utils/__tests__/node-graphs/large-catalog.ts`
2. Deterministic checks (CI): `large-graph.generation.spec.ts` and `layout-dagre-graph.spec.ts`
3. Timed bench (optional): the `EVENTCATALOG_GRAPH_BENCH=1` command above

## Runner-up (not shipped)

Producer/consumer resolution still uses linear `getProducersOfMessage` / `getConsumersOfMessage` scans. A reverse index (already used by `getEvents`) drops that work from **38 ms → 3.4 ms** on this catalog, but that is ~0.5% of the original 7s layout cost. Worth a follow-up after layout is no longer the bottleneck.

## Additional Notes

No editor (`eventcatalog/eventcatalog-editor`) change is needed — these utilities are internal to `@eventcatalog/core` and `@eventcatalog/visualiser`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-378e5bbd-a6ee-4b14-ab1e-ae36a8ca52c4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-378e5bbd-a6ee-4b14-ab1e-ae36a8ca52c4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

