### PR TITLE
fix(core): restore command and query links in DomainGrid

### DIFF
--- a/.changeset/fix-domaingrid-command-links.md
+++ b/.changeset/fix-domaingrid-command-links.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/core': patch
+---
+
+Fix DomainGrid command and query links in domain/system architecture views. SSR (and system pages) now hydrate service sends/receives so links use `/docs/commands|queries|events/...` and the resource name, instead of defaulting missing collections to events.

--- a/packages/core/eventcatalog/src/components/Grids/DomainGrid.tsx
+++ b/packages/core/eventcatalog/src/components/Grids/DomainGrid.tsx
@@ -17,6 +17,7 @@ import {
 import { buildUrl } from '@utils/url-builder';
 import { BoxIcon, Group as GroupIcon } from 'lucide-react';
 import { getSpecUrl, getSpecIcon, getSpecLabel, getServiceSpecifications } from './specification-utils';
+import { getMessageLinkProps } from './message-link';
 
 // ============================================
 // Types
@@ -64,12 +65,8 @@ export const EntityBadge = memo(({ entity }: { entity: any }) => {
 });
 
 const MessageLink = memo(({ message }: { message: any }) => {
-  const data = message?.data || message;
-  const collection = message?.collection || 'events';
-  const { Icon, color } = getMessageIcon(collection);
-  const id = data?.id || message?.id;
-  const name = data?.name || data?.id || id;
-  const version = data?.version || message?.data?.version || 'latest';
+  const { collection, name, version, href } = getMessageLinkProps(message);
+  const { Icon, color } = getMessageIcon(collection || '');
 
   const iconStyles: Record<string, string> = {
     orange: 'text-orange-500',
@@ -78,14 +75,25 @@ const MessageLink = memo(({ message }: { message: any }) => {
     gray: 'text-gray-500',
   };
 
-  return (
-    <a
-      href={buildUrl(`/docs/${collection}/${id}/${version}`)}
-      className="flex items-center gap-2 py-1.5 text-sm text-[rgb(var(--ec-page-text-muted))] hover:text-[rgb(var(--ec-page-text))] transition-colors group"
-    >
+  const content = (
+    <>
       <Icon className={`h-4 w-4 flex-shrink-0 ${iconStyles[color]}`} />
-      <span className="group-hover:underline">{name}</span>
+      <span className={href ? 'group-hover:underline' : undefined}>{name}</span>
       <span className="text-xs text-[rgb(var(--ec-icon-color))]">v{version}</span>
+    </>
+  );
+
+  const className =
+    'flex items-center gap-2 py-1.5 text-sm text-[rgb(var(--ec-page-text-muted))] hover:text-[rgb(var(--ec-page-text))] transition-colors group';
+
+  // Missing collection means an unhydrated pointer — do not guess `/docs/events/...`.
+  if (!href) {
+    return <span className={className}>{content}</span>;
+  }
+
+  return (
+    <a href={buildUrl(href)} className={className}>
+      {content}
     </a>
   );
 });

--- a/packages/core/eventcatalog/src/components/Grids/message-link.spec.ts
+++ b/packages/core/eventcatalog/src/components/Grids/message-link.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { getMessageLinkProps } from './message-link';
+
+describe('getMessageLinkProps', () => {
+  it('builds a command docs url and prefers the resource name over the id', () => {
+    expect(
+      getMessageLinkProps({
+        collection: 'commands',
+        data: { id: 'order-create', name: 'Create Order', version: '0.0.1' },
+      })
+    ).toEqual({
+      collection: 'commands',
+      id: 'order-create',
+      name: 'Create Order',
+      version: '0.0.1',
+      href: '/docs/commands/order-create/0.0.1',
+    });
+  });
+
+  it('builds a query docs url from a hydrated collection entry', () => {
+    expect(
+      getMessageLinkProps({
+        collection: 'queries',
+        data: { id: 'get-stock-level', name: 'Get Stock Level', version: '1.0.0' },
+      })
+    ).toEqual({
+      collection: 'queries',
+      id: 'get-stock-level',
+      name: 'Get Stock Level',
+      version: '1.0.0',
+      href: '/docs/queries/get-stock-level/1.0.0',
+    });
+  });
+
+  it('does not default a missing collection to events', () => {
+    expect(getMessageLinkProps({ id: 'order-create', version: '0.0.1' })).toEqual({
+      collection: undefined,
+      id: 'order-create',
+      name: 'order-create',
+      version: '0.0.1',
+      href: undefined,
+    });
+  });
+
+  it('ignores unknown collection values instead of linking to events', () => {
+    expect(
+      getMessageLinkProps({
+        collection: 'services',
+        data: { id: 'order-service', name: 'Order Service', version: '1.0.0' },
+      })
+    ).toEqual({
+      collection: undefined,
+      id: 'order-service',
+      name: 'Order Service',
+      version: '1.0.0',
+      href: undefined,
+    });
+  });
+});

--- a/packages/core/eventcatalog/src/components/Grids/message-link.ts
+++ b/packages/core/eventcatalog/src/components/Grids/message-link.ts
@@ -1,0 +1,38 @@
+import type { CollectionMessageTypes } from '@types';
+
+export const MESSAGE_COLLECTIONS: readonly CollectionMessageTypes[] = ['events', 'commands', 'queries'];
+
+export function isMessageCollection(value: unknown): value is CollectionMessageTypes {
+  return value === 'events' || value === 'commands' || value === 'queries';
+}
+
+export interface MessageLinkProps {
+  collection?: CollectionMessageTypes;
+  id?: string;
+  name?: string;
+  version: string;
+  href?: string;
+}
+
+/**
+ * Resolve a DomainGrid/SystemGrid receives/sends item into a docs link.
+ *
+ * Hydrated collection entries carry `collection` + `data.name`. Bare `{id, version}`
+ * pointers do not — never guess `events` for those, or commands/queries get the wrong URL.
+ */
+export function getMessageLinkProps(message: any): MessageLinkProps {
+  const data = message?.data ?? message;
+  const collectionCandidate = message?.collection ?? data?.collection;
+  const collection = isMessageCollection(collectionCandidate) ? collectionCandidate : undefined;
+  const id = data?.id ?? message?.id;
+  const name = data?.name || message?.name || id;
+  const version = data?.version ?? message?.version ?? 'latest';
+
+  return {
+    collection,
+    id,
+    name,
+    version,
+    href: collection && id ? `/docs/${collection}/${id}/${version}` : undefined,
+  };
+}

--- a/packages/core/eventcatalog/src/pages/architecture/[type]/[id]/[version]/_index.data.spec.ts
+++ b/packages/core/eventcatalog/src/pages/architecture/[type]/[id]/[version]/_index.data.spec.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { loadArchitectureItems, Page } from './_index.data';
+
+const collectionMocks = vi.hoisted(() => ({
+  getDomains: vi.fn(),
+  getServices: vi.fn(),
+  getSystems: vi.fn(),
+}));
+
+vi.mock('@utils/feature', () => ({
+  isSSR: () => false,
+}));
+
+vi.mock('@utils/collections/domains', () => ({ getDomains: collectionMocks.getDomains }));
+vi.mock('@utils/collections/systems', () => ({ getSystems: collectionMocks.getSystems }));
+vi.mock('@utils/page-loaders/page-data-loader', () => ({
+  pageDataLoader: {
+    services: (...args: unknown[]) => collectionMocks.getServices(...args),
+    domains: (...args: unknown[]) => collectionMocks.getDomains(...args),
+    systems: (...args: unknown[]) => collectionMocks.getSystems(...args),
+  },
+}));
+
+const domain = {
+  collection: 'domains',
+  data: { id: 'ordering', name: 'Ordering', version: '1.0.0' },
+};
+
+const service = {
+  collection: 'services',
+  data: { id: 'order-service', name: 'Order Service', version: '1.0.0' },
+};
+
+const system = {
+  collection: 'systems',
+  data: { id: 'order-management-system', name: 'Order Management', version: '1.0.0' },
+};
+
+describe('architecture page data', () => {
+  beforeEach(() => {
+    collectionMocks.getDomains.mockReset().mockResolvedValue([domain]);
+    collectionMocks.getServices.mockReset().mockResolvedValue([service]);
+    collectionMocks.getSystems.mockReset().mockResolvedValue([system]);
+  });
+
+  it('hydrates domain and system services for static architecture paths', async () => {
+    const paths = await Page.getStaticPaths();
+
+    expect(collectionMocks.getDomains).toHaveBeenCalledWith({ enrichServices: true });
+    expect(collectionMocks.getSystems).toHaveBeenCalledWith({ enrichServices: true });
+    expect(paths).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          params: { type: 'domains', id: 'ordering', version: '1.0.0' },
+        }),
+        expect.objectContaining({
+          params: { type: 'systems', id: 'order-management-system', version: '1.0.0' },
+        }),
+        expect.objectContaining({
+          params: { type: 'services', id: 'order-service', version: '1.0.0' },
+        }),
+      ])
+    );
+  });
+
+  it('hydrates domain services when architecture pages are fetched in SSR', async () => {
+    await Page.getData({
+      props: {},
+      params: { type: 'domains', id: 'ordering', version: '1.0.0' },
+    } as any);
+
+    expect(collectionMocks.getDomains).toHaveBeenCalledWith({ enrichServices: true });
+  });
+
+  it('hydrates system services when architecture pages are fetched in SSR', async () => {
+    await Page.getData({
+      props: {},
+      params: { type: 'systems', id: 'order-management-system', version: '1.0.0' },
+    } as any);
+
+    expect(collectionMocks.getSystems).toHaveBeenCalledWith({ enrichServices: true });
+  });
+
+  it('loads domains with enrichServices so DomainGrid command links keep their collection', async () => {
+    await loadArchitectureItems('domains');
+    expect(collectionMocks.getDomains).toHaveBeenCalledWith({ enrichServices: true });
+  });
+});

--- a/packages/core/eventcatalog/src/pages/architecture/[type]/[id]/[version]/_index.data.ts
+++ b/packages/core/eventcatalog/src/pages/architecture/[type]/[id]/[version]/_index.data.ts
@@ -3,10 +3,26 @@ import { HybridPage } from '@utils/page-loaders/hybrid-page';
 import type { PageTypes } from '@types';
 import { pageDataLoader } from '@utils/page-loaders/page-data-loader';
 import { getDomains } from '@utils/collections/domains';
-import { getServices } from '@utils/collections/services';
 import { getSystems } from '@utils/collections/systems';
 
 const architecturePageTypes: PageTypes[] = ['services', 'domains', 'systems'];
+
+/**
+ * Architecture grids render service sends/receives as docs links, so domains and
+ * systems must hydrate those messages (collection + name). `pageDataLoader`
+ * uses the cheaper unenriched path used by docs/sidebar.
+ */
+export const loadArchitectureItems = (type: PageTypes) => {
+  if (type === 'domains') {
+    return getDomains({ enrichServices: true });
+  }
+
+  if (type === 'systems') {
+    return getSystems({ enrichServices: true });
+  }
+
+  return pageDataLoader[type as PageTypes]();
+};
 
 /**
  * Documentation page class for all collection types with versioning
@@ -17,11 +33,7 @@ export class Page extends HybridPage {
       return [];
     }
 
-    const domains = await getDomains({ enrichServices: true });
-    const services = await getServices();
-    const systems = await getSystems();
-
-    const pageData = [services, domains, systems];
+    const pageData = await Promise.all(architecturePageTypes.map((type) => loadArchitectureItems(type)));
 
     return pageData.flatMap((items, index) =>
       items.map((item) => ({
@@ -47,8 +59,7 @@ export class Page extends HybridPage {
       return null;
     }
 
-    // Get all items of the specified type
-    const items = await pageDataLoader[type as PageTypes]();
+    const items = await loadArchitectureItems(type as PageTypes);
 
     // Find the specific item by id and version
     const item = items.find((i) => i.data.id === id && i.data.version === version);

--- a/packages/core/eventcatalog/src/utils/__tests__/domains/domains.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/domains/domains.spec.ts
@@ -99,6 +99,38 @@ describe('Domains', () => {
       expect(checkout.data.services.map((service: any) => service.data.id)).toEqual(['OrderService', 'PaymentService']);
       expect(checkout.data.agents.map((agent: any) => agent.data.id)).toEqual(['FraudReviewAgent']);
     });
+
+    it('leaves service receives and sends as id/version pointers when services are not enriched', async () => {
+      const domains = await getDomains();
+      const checkout = domains.find((domain) => domain.data.id === 'Checkout');
+      const orderService = (checkout?.data.services as any[])?.find(
+        (service) => service.data.id === 'OrderService' && service.data.version === '1.0.0'
+      );
+
+      expect(orderService.data.receives).toEqual([{ id: 'PlaceOrder', version: '>1.5.0' }]);
+      expect(orderService.data.sends).toEqual([{ id: 'OrderPlaced', version: '0.0.1' }]);
+    });
+
+    it('hydrates service receives and sends with collection and name when enrichServices is true', async () => {
+      const domains = await getDomains({ enrichServices: true });
+      const checkout = domains.find((domain) => domain.data.id === 'Checkout');
+      const orderService = (checkout?.data.services as any[])?.find(
+        (service) => service.data.id === 'OrderService' && service.data.version === '1.0.0'
+      );
+
+      expect(orderService.data.receives).toEqual([
+        expect.objectContaining({
+          collection: 'commands',
+          data: expect.objectContaining({ id: 'PlaceOrder', name: 'Place Order', version: '1.7.7' }),
+        }),
+      ]);
+      expect(orderService.data.sends).toEqual([
+        expect.objectContaining({
+          collection: 'events',
+          data: expect.objectContaining({ id: 'OrderPlaced', version: '0.0.1' }),
+        }),
+      ]);
+    });
   });
 
   describe('ubiquitous-language', () => {

--- a/packages/core/eventcatalog/src/utils/__tests__/domains/mocks.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/domains/mocks.ts
@@ -168,6 +168,7 @@ export const mockCommands = [
     collection: 'commands',
     data: {
       id: 'PlaceOrder',
+      name: 'Place Order',
       version: '1.0.0',
     },
   },
@@ -177,6 +178,7 @@ export const mockCommands = [
     collection: 'commands',
     data: {
       id: 'PlaceOrder',
+      name: 'Place Order',
       version: '1.5.0',
     },
   },
@@ -186,6 +188,7 @@ export const mockCommands = [
     collection: 'commands',
     data: {
       id: 'PlaceOrder',
+      name: 'Place Order',
       version: '1.7.7',
     },
   },

--- a/packages/core/eventcatalog/src/utils/__tests__/systems/systems.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/systems/systems.spec.ts
@@ -1,0 +1,58 @@
+import type { CollectionKey } from 'astro:content';
+import { describe, expect, it, vi } from 'vitest';
+import { mockCommands, mockContainers, mockEvents, mockQueries, mockServices, mockSystems } from './mocks';
+import { getSystems } from '@utils/collections/systems';
+
+vi.mock('astro:content', async (importOriginal) => {
+  return {
+    ...(await importOriginal<typeof import('astro:content')>()),
+    getCollection: (key: CollectionKey) => {
+      switch (key) {
+        case 'systems':
+          return Promise.resolve(mockSystems);
+        case 'services':
+          return Promise.resolve(mockServices);
+        case 'events':
+          return Promise.resolve(mockEvents);
+        case 'commands':
+          return Promise.resolve(mockCommands);
+        case 'queries':
+          return Promise.resolve(mockQueries);
+        case 'containers':
+          return Promise.resolve(mockContainers);
+        default:
+          return Promise.resolve([]);
+      }
+    },
+  };
+});
+
+describe('getSystems', () => {
+  it('leaves service sends and receives as id/version pointers when services are not enriched', async () => {
+    const systems = await getSystems();
+    const core = systems.find((system) => system.data.id === 'CoreMonolith');
+    const orderService = (core?.data.services as any[])?.find((service) => service.data.id === 'OrderService');
+
+    expect(orderService.data.sends).toEqual([{ id: 'OrderPlaced', version: '1.0.0' }]);
+  });
+
+  it('hydrates service sends with collection entries when enrichServices is true', async () => {
+    const systems = await getSystems({ enrichServices: true });
+    const core = systems.find((system) => system.data.id === 'CoreMonolith');
+    const orderService = (core?.data.services as any[])?.find((service) => service.data.id === 'OrderService');
+    const paymentService = (core?.data.services as any[])?.find((service) => service.data.id === 'PaymentService');
+
+    expect(orderService.data.sends).toEqual([
+      expect.objectContaining({
+        collection: 'events',
+        data: expect.objectContaining({ id: 'OrderPlaced', version: '1.0.0' }),
+      }),
+    ]);
+    expect(paymentService.data.receives).toEqual([
+      expect.objectContaining({
+        collection: 'events',
+        data: expect.objectContaining({ id: 'OrderPlaced', version: '1.0.0' }),
+      }),
+    ]);
+  });
+});

--- a/packages/core/eventcatalog/src/utils/collections/domains.ts
+++ b/packages/core/eventcatalog/src/utils/collections/domains.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import type { CollectionMessageTypes } from '@types';
 import type { Agent, Service } from './types';
 import { createVersionedMap, findInMap, processSpecifications } from '@utils/collections/util';
+import { hydrateAgents, hydrateServices } from '@utils/collections/hydrate-services';
 
 const CACHE_ENABLED = process.env.DISABLE_EVENTCATALOG_CACHE !== 'true';
 
@@ -18,86 +19,6 @@ interface Props {
 
 // Simple in-memory cache variable
 let memoryCache: Record<string, Domain[]> = {};
-
-// Helper to hydrate services
-const hydrateServices = (
-  servicesList: any[],
-  serviceMap: Map<string, any[]>,
-  messageMap: Map<string, any[]>,
-  containerMap: Map<string, any[]>
-) => {
-  return servicesList
-    .map((service: { id: string; version: string | undefined }) => findInMap(serviceMap, service.id, service.version))
-    .filter((s) => !!s)
-    .map((service) => {
-      // Hydrate service messages and containers
-      const sends = (service.data.sends || [])
-        .map((msg: any) => findInMap(messageMap, msg.id, msg.version))
-        .filter((m: any) => !!m);
-
-      const receives = (service.data.receives || [])
-        .map((msg: any) => findInMap(messageMap, msg.id, msg.version))
-        .filter((m: any) => !!m);
-
-      const readsFrom = (service.data.readsFrom || [])
-        .map((c: any) => findInMap(containerMap, c.id, c.version))
-        .filter((c: any) => !!c);
-
-      const writesTo = (service.data.writesTo || [])
-        .map((c: any) => findInMap(containerMap, c.id, c.version))
-        .filter((c: any) => !!c);
-
-      return {
-        ...service,
-        data: {
-          ...service.data,
-          sends: sends as any,
-          receives: receives as any,
-          readsFrom: readsFrom as any,
-          writesTo: writesTo as any,
-        },
-      };
-    });
-};
-
-const hydrateAgents = (
-  agentsList: any[],
-  agentMap: Map<string, any[]>,
-  messageMap: Map<string, any[]>,
-  containerMap: Map<string, any[]>
-) => {
-  return agentsList
-    .map((agent: { id: string; version: string | undefined }) => findInMap(agentMap, agent.id, agent.version))
-    .filter((a) => !!a)
-    .map((agent) => {
-      const sends = (agent.data.sends || [])
-        .map((msg: any) => findInMap(messageMap, msg.id, msg.version))
-        .filter((m: any) => !!m);
-
-      const receives = (agent.data.receives || [])
-        .map((msg: any) => findInMap(messageMap, msg.id, msg.version))
-        .filter((m: any) => !!m);
-
-      const readsFrom = (agent.data.readsFrom || [])
-        .map((c: any) => findInMap(containerMap, c.id, c.version))
-        .filter((c: any) => !!c);
-
-      const writesTo = (agent.data.writesTo || [])
-        .map((c: any) => findInMap(containerMap, c.id, c.version))
-        .filter((c: any) => !!c);
-
-      return {
-        ...agent,
-        data: {
-          ...agent.data,
-          sends: sends as any,
-          receives: receives as any,
-          readsFrom: readsFrom as any,
-          writesTo: writesTo as any,
-        },
-      };
-    });
-};
 
 // --- MAIN FUNCTION ---
 

--- a/packages/core/eventcatalog/src/utils/collections/hydrate-services.ts
+++ b/packages/core/eventcatalog/src/utils/collections/hydrate-services.ts
@@ -1,0 +1,51 @@
+import { findInMap } from '@utils/collections/util';
+
+/**
+ * Resolve service/agent pointers to collection entries and hydrate their
+ * sends/receives/readsFrom/writesTo relationships.
+ */
+export const hydrateServices = (
+  servicesList: any[],
+  serviceMap: Map<string, any[]>,
+  messageMap: Map<string, any[]>,
+  containerMap: Map<string, any[]>
+) => {
+  return servicesList
+    .map((service: { id: string; version: string | undefined }) => findInMap(serviceMap, service.id, service.version))
+    .filter((s) => !!s)
+    .map((service) => {
+      const sends = (service.data.sends || [])
+        .map((msg: any) => findInMap(messageMap, msg.id, msg.version))
+        .filter((m: any) => !!m);
+
+      const receives = (service.data.receives || [])
+        .map((msg: any) => findInMap(messageMap, msg.id, msg.version))
+        .filter((m: any) => !!m);
+
+      const readsFrom = (service.data.readsFrom || [])
+        .map((c: any) => findInMap(containerMap, c.id, c.version))
+        .filter((c: any) => !!c);
+
+      const writesTo = (service.data.writesTo || [])
+        .map((c: any) => findInMap(containerMap, c.id, c.version))
+        .filter((c: any) => !!c);
+
+      return {
+        ...service,
+        data: {
+          ...service.data,
+          sends: sends as any,
+          receives: receives as any,
+          readsFrom: readsFrom as any,
+          writesTo: writesTo as any,
+        },
+      };
+    });
+};
+
+export const hydrateAgents = (
+  agentsList: any[],
+  agentMap: Map<string, any[]>,
+  messageMap: Map<string, any[]>,
+  containerMap: Map<string, any[]>
+) => hydrateServices(agentsList, agentMap, messageMap, containerMap);

--- a/packages/core/eventcatalog/src/utils/collections/systems.ts
+++ b/packages/core/eventcatalog/src/utils/collections/systems.ts
@@ -1,5 +1,6 @@
 import { getCollection } from 'astro:content';
 import type { CollectionEntry } from 'astro:content';
+import { hydrateServices } from '@utils/collections/hydrate-services';
 import { createVersionedMap, findInMap } from './util';
 
 const CACHE_ENABLED = process.env.DISABLE_EVENTCATALOG_CACHE !== 'true';
@@ -7,24 +8,28 @@ export type System = CollectionEntry<'systems'>;
 
 interface Props {
   getAllVersions?: boolean;
+  enrichServices?: boolean;
 }
 
 // cache for build time
 let memoryCache: Record<string, System[]> = {};
 
-export const getSystems = async ({ getAllVersions = true }: Props = {}): Promise<System[]> => {
-  const cacheKey = getAllVersions ? 'allVersions' : 'currentVersions';
+export const getSystems = async ({ getAllVersions = true, enrichServices = false }: Props = {}): Promise<System[]> => {
+  const cacheKey = `${getAllVersions ? 'allVersions' : 'currentVersions'}-${enrichServices ? 'enriched' : 'simple'}`;
 
   if (memoryCache[cacheKey] && memoryCache[cacheKey].length > 0 && CACHE_ENABLED) {
     return memoryCache[cacheKey];
   }
 
-  const [allSystems, allServices, allFlows, allEntities, allContainers] = await Promise.all([
+  const [allSystems, allServices, allFlows, allEntities, allContainers, allEvents, allCommands, allQueries] = await Promise.all([
     getCollection('systems'),
     getCollection('services'),
     getCollection('flows'),
     getCollection('entities'),
     getCollection('containers'),
+    enrichServices ? getCollection('events') : Promise.resolve([]),
+    enrichServices ? getCollection('commands') : Promise.resolve([]),
+    enrichServices ? getCollection('queries') : Promise.resolve([]),
   ]);
 
   // Build optimized map of id -> versions (sorted latest first)
@@ -33,6 +38,7 @@ export const getSystems = async ({ getAllVersions = true }: Props = {}): Promise
   const flowMap = createVersionedMap(allFlows);
   const entityMap = createVersionedMap(allEntities);
   const containerMap = createVersionedMap(allContainers);
+  const messageMap = createVersionedMap([...allEvents, ...allCommands, ...allQueries]);
 
   // Filter systems
   const targetSystems = allSystems.filter((system) => {
@@ -47,10 +53,14 @@ export const getSystems = async ({ getAllVersions = true }: Props = {}): Promise
     const latestVersion = systemVersions[0]?.data.version || system.data.version;
     const versions = systemVersions.map((s) => s.data.version);
 
-    // Resolve service pointers to their full collection entries
-    const services = (system.data.services || [])
-      .map((service: { id: string; version?: string }) => findInMap(serviceMap, service.id, service.version))
-      .filter((s): s is NonNullable<typeof s> => !!s);
+    // Resolve service pointers to their full collection entries.
+    // Architecture grids need sends/receives hydrated so command/query links
+    // keep the correct collection instead of falling back to events.
+    const services = enrichServices
+      ? hydrateServices(system.data.services || [], serviceMap, messageMap, containerMap)
+      : (system.data.services || [])
+          .map((service: { id: string; version?: string }) => findInMap(serviceMap, service.id, service.version))
+          .filter((s): s is NonNullable<typeof s> => !!s);
 
     // Resolve flow pointers to their full collection entries
     const flows = (system.data.flows || [])


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Motivation

Regression reported on closed issue https://github.com/event-catalog/eventcatalog/issues/2073 ([comment](https://github.com/event-catalog/eventcatalog/issues/2073#issuecomment-5584077576)): in `@eventcatalog/core@4.10.10`, clicking a **command** in a service’s Receives/Sends on the Domain architecture grid still navigates to `/docs/events/<id>/<version>` and shows the resource **id** instead of its **name**.

Root cause was two-fold:

1. **SSR architecture pages** loaded domains via `pageDataLoader.domains` → `getDomains()` **without** `enrichServices: true`. Static paths already passed that flag. Unenriched `sends`/`receives` stay as `{id, version}` pointers with no `collection` or `name`.
2. **`MessageLink`** used `message?.collection || 'events'` and fell back to the id for the label. System architecture had the same gap because `getSystems()` never hydrated service messages, and `SystemGrid` reuses `ServiceCard`.

## Changes

- Architecture static + SSR loaders now hydrate domain and system services (`enrichServices: true`).
- `getSystems` accepts `enrichServices` and shares the same hydrate helper as domains.
- `MessageLink` prefers the resource **name**, uses the **id** only as the route key, and does **not** default a missing/unknown collection to `events`.
- Tests for message link props, domain/system hydration, and the architecture loader.
- Patch changeset for `@eventcatalog/core`.

No editor-repo follow-up: this is catalog DomainGrid/SystemGrid data loading only.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-60b7c933-f344-4a0c-8e43-8698e2955f34?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-60b7c933-f344-4a0c-8e43-8698e2955f34&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

