### PR TITLE
Validate internal links after static builds and fix resource reference links

### DIFF
--- a/.changeset/quiet-links-validate.md
+++ b/.changeset/quiet-links-validate.md
@@ -1,0 +1,12 @@
+---
+"@eventcatalog/core": patch
+"@eventcatalog/create-eventcatalog": patch
+"@eventcatalog/linter": patch
+---
+
+Add build-time link validation for static catalogs and fix broken resource reference links
+
+- New `linkValidation` config option checks internal links and anchors in generated HTML after static builds (warns by default, can be set to `error` or `ignore`, supports `ignore` globs)
+- `<ResourceRef>` now links teams, users, and custom pages without a version segment, resolves owners to the correct users or teams page, and resolves messages to the collection they actually live in
+- Catalog discovery, schema loading, design discovery, and the linter scanner now exclude `node_modules` so dependency example catalogs are never loaded as catalog resources
+- Default template containers now declare owners

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,4 +61,6 @@ Use `<type>(<scope>): <imperative summary>` when possible. For PRs:
 
 ## Important
 
+Do not create or update project documentation unless the user explicitly asks. Do not add documentation as an automatic follow-up to code changes; the user will tell you when documentation is needed.
+
 Never start the catalog, the catalog is already running.

--- a/packages/core/eventcatalog/astro.config.mjs
+++ b/packages/core/eventcatalog/astro.config.mjs
@@ -17,6 +17,7 @@ import rehypeAutolinkHeadings from 'rehype-autolink-headings';
 import { eventCatalogLikeC4 } from './src/plugins/likec4';
 import { loadAstroCompressIntegration } from './src/plugins/astro-compress';
 import { astroTrailingSlashEndpointFix } from './src/plugins/astro-trailing-slash-endpoint-fix';
+import { linkValidation } from './src/plugins/link-validation';
 
 import rehypeExpressiveCode from 'rehype-expressive-code';
 
@@ -111,6 +112,7 @@ export default defineConfig({
     effectiveOutput !== 'server' && compress && (await loadAstroCompressIntegration(projectDirectory)),
     ecstudioWatcher(),
     eventCatalogIntegration(),
+    linkValidation(config.linkValidation),
   ].filter(Boolean),
   vite: {
     plugins: [

--- a/packages/core/eventcatalog/src/components/MDX/ResourceRef/ResourceRef.astro
+++ b/packages/core/eventcatalog/src/components/MDX/ResourceRef/ResourceRef.astro
@@ -16,6 +16,12 @@ import { getCollection } from 'astro:content';
 import { getServiceSpecifications, getSpecUrl, getSpecLabel } from '@components/Grids/specification-utils';
 import { getResourceReferenceStyle } from '@utils/resource-reference-colors';
 import { isIconPath, resolveIconUrl } from '@utils/icon';
+import {
+  getResourceReferenceUrl,
+  isVersionedReference,
+  resolveMessageReference,
+  resolveOwnerReference,
+} from '@utils/resource-reference-links';
 
 interface Props {
   type:
@@ -157,18 +163,16 @@ try {
     }
 
     const resourcesCollection = (await getCollection(collection as any)) as { data: { id: string; version: string } }[];
-    const resources = getItemsFromCollectionByIdAndSemverOrLatest(resourcesCollection, resourceId, version);
+    const resources = isVersionedReference(collection)
+      ? getItemsFromCollectionByIdAndSemverOrLatest(resourcesCollection, resourceId, version)
+      : resourcesCollection.filter((item) => item.data.id === resourceId);
 
     if (resources.length === 0) {
       throw new Error(`Resource not found: ${resourceId}`);
     }
 
     resource = resources[0];
-    // Diagrams use /diagrams/ path, other resources use /docs/{collection}/
-    href =
-      type === 'diagram'
-        ? buildUrl(`/diagrams/${resourceId}/${resource.data.version}`)
-        : buildUrl(`/docs/${collection}/${resourceId}/${resource.data.version}`);
+    href = getResourceReferenceUrl(collection, resourceId, resource.data.version);
   }
 } catch (error) {
   hasError = true;
@@ -180,7 +184,7 @@ const maxSummaryLength = 120;
 const summary = resource?.data?.summary || '';
 const truncatedSummary = summary.length > maxSummaryLength ? summary.slice(0, maxSummaryLength) + '...' : summary;
 
-const isVersionedResource = type !== 'doc';
+const isVersionedResource = type !== 'doc' && isVersionedReference(collection);
 
 // Only these types have visualizers
 const hasVisualizer = ['agent', 'domain', 'service', 'event', 'query', 'command', 'container', 'system'].includes(type);
@@ -191,7 +195,7 @@ const isDeprecated = deprecation?.isMarkedAsDeprecated || false;
 const resourceIconUrl = isIconPath(resource?.data?.styles?.icon) ? resolveIconUrl(resource.data.styles.icon) : null;
 
 // Get owners (first 2)
-const owners = resource?.data?.owners?.slice(0, 2) || [];
+const owners = await Promise.all((resource?.data?.owners?.slice(0, 2) || []).map(resolveOwnerReference));
 
 // Check if message type has a schema
 const isMessageType = ['event', 'command', 'query'].includes(type);
@@ -207,39 +211,16 @@ const receives = resource?.data?.receives || [];
 const isService = type === 'service' || type === 'agent';
 const supportsSpecifications = type === 'service';
 
-// Helper to resolve message version and collection - use specified version or fetch from collection
-const resolveMessage = async (msg: any): Promise<{ version: string | null; collection: string | null }> => {
-  // If version is specified and not "latest", use it (assume event as default collection)
-  if (msg.version && msg.version !== 'latest') {
-    return { version: msg.version, collection: 'events' };
-  }
-
-  // Try to find the message in events, commands, or queries collections
-  const collections = ['events', 'commands', 'queries'];
-  for (const col of collections) {
-    try {
-      const items = (await getCollection(col as any)) as { data: { id: string; version: string } }[];
-      const found = getItemsFromCollectionByIdAndSemverOrLatest(items, msg.id);
-      if (found.length > 0 && found[0].data.version && found[0].data.version !== 'latest') {
-        return { version: found[0].data.version, collection: col };
-      }
-    } catch (e) {
-      // Collection might not exist or item not found, continue
-    }
-  }
-  return { version: null, collection: null };
-};
-
 // Resolve versions and collections for messages to show
 const sendsWithVersions = await Promise.all(
   sends.slice(0, maxMessages).map(async (msg: any) => {
-    const resolved = await resolveMessage(msg);
+    const resolved = await resolveMessageReference(msg);
     return { ...msg, resolvedVersion: resolved.version, resolvedCollection: resolved.collection };
   })
 );
 const receivesWithVersions = await Promise.all(
   receives.slice(0, maxMessages).map(async (msg: any) => {
-    const resolved = await resolveMessage(msg);
+    const resolved = await resolveMessageReference(msg);
     return { ...msg, resolvedVersion: resolved.version, resolvedCollection: resolved.collection };
   })
 );
@@ -422,15 +403,16 @@ const tooltipId = `ref-tooltip-${Math.random().toString(36).slice(2, 9)}`;
                     <span class="text-[rgb(var(--ec-page-text-muted))]">Owner</span>
                     <span class="font-mono text-[rgb(var(--ec-page-text))]">
                       {owners.map((o: any, idx: number) => {
-                        const ownerId = typeof o === 'string' ? o : o.id;
+                        const ownerId = o.id;
                         return (
                           <>
-                            <a
-                              href={buildUrl(`/docs/users/${ownerId}`)}
-                              class="hover:underline hover:text-[rgb(var(--ec-accent))]"
-                            >
-                              {ownerId}
-                            </a>
+                            {o.href ? (
+                              <a href={o.href} class="hover:underline hover:text-[rgb(var(--ec-accent))]">
+                                {ownerId}
+                              </a>
+                            ) : (
+                              <span>{ownerId}</span>
+                            )}
                             {idx < owners.length - 1 && ', '}
                           </>
                         );

--- a/packages/core/eventcatalog/src/content.config.ts
+++ b/packages/core/eventcatalog/src/content.config.ts
@@ -1107,7 +1107,7 @@ const teams = defineCollection({
 
 const designs = defineCollection({
   loader: async () => {
-    const data = await globPackage('**/**/*.ecstudio', { cwd: projectDirBase, ignore: ['dist/**'] });
+    const data = await globPackage('**/**/*.ecstudio', { cwd: projectDirBase, ignore: ['dist/**', '**/node_modules/**'] });
     // File all the files in the designs folder
     // Limit 3 designs community edition?
     const files = data.reduce<{ id: string; name: string }[]>((acc, filePath) => {

--- a/packages/core/eventcatalog/src/plugins/__tests__/link-validation.spec.ts
+++ b/packages/core/eventcatalog/src/plugins/__tests__/link-validation.spec.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { linkValidation } from '../link-validation';
+import type { LinkValidationOptions } from '../../utils/link-validation';
+
+let outDir: string;
+beforeEach(async () => {
+  outDir = await fs.mkdtemp(path.join(os.tmpdir(), 'eventcatalog-link-integration-'));
+  await fs.writeFile(path.join(outDir, 'index.html'), '<a href="/missing">Missing</a><a href="#absent">Anchor</a>');
+});
+afterEach(async () => {
+  await fs.rm(outDir, { recursive: true, force: true });
+});
+
+const runIntegration = async (options?: LinkValidationOptions | false, server = false) => {
+  const integration = linkValidation(options);
+  const logger = { info: vi.fn(), warn: vi.fn() };
+  await integration.hooks['astro:config:done']!({
+    config: { base: '/', build: { format: 'directory' } },
+    buildOutput: server ? 'server' : 'static',
+  } as any);
+  const run = () => integration.hooks['astro:build:done']!({ dir: pathToFileURL(`${outDir}/`), logger } as any);
+  return { run, logger };
+};
+
+describe('link validation integration', () => {
+  it('warns by default without failing the build', async () => {
+    const { run, logger } = await runIntegration();
+    await expect(run()).resolves.toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledOnce();
+    expect(logger.warn.mock.calls[0][0]).toContain('Broken link: /missing');
+    expect(logger.warn.mock.calls[0][0]).toContain('Broken anchor: /#absent');
+    expect(logger.info.mock.calls[0][0]).toMatch(/^Checked links in 1 HTML page\(s\) in /);
+  });
+
+  it('fails the build for error-level links while reporting warning-level anchors separately', async () => {
+    const { run, logger } = await runIntegration({ onBrokenLinks: 'error' });
+    await expect(run()).rejects.toThrow(
+      'Link validation failed.\nFound 1 broken link/anchor destination(s) in 1 page reference(s).\n\nBroken link: /missing\n  From: /'
+    );
+    expect(logger.warn.mock.calls[0][0]).toContain('Broken anchor: /#absent');
+    expect(logger.warn.mock.calls[0][0]).not.toContain('/missing');
+  });
+
+  it('can fail only on broken anchors', async () => {
+    const { run, logger } = await runIntegration({ onBrokenLinks: 'ignore', onBrokenAnchors: 'error' });
+    await expect(run()).rejects.toThrow('Broken anchor: /#absent');
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it.each([false, { onBrokenLinks: 'ignore', onBrokenAnchors: 'ignore' }] as const)(
+    'does no work when disabled with %j',
+    async (options) => {
+      const { run, logger } = await runIntegration(options);
+      await run();
+      expect(logger.warn).not.toHaveBeenCalled();
+      expect(logger.info).not.toHaveBeenCalled();
+    }
+  );
+
+  it('explicitly skips server output instead of reporting dynamic routes as missing files', async () => {
+    const { run, logger } = await runIntegration({ onBrokenLinks: 'error' }, true);
+    await expect(run()).resolves.toBeUndefined();
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith('Link validation skipped: only static catalog builds are supported.');
+  });
+});

--- a/packages/core/eventcatalog/src/plugins/link-validation.ts
+++ b/packages/core/eventcatalog/src/plugins/link-validation.ts
@@ -1,0 +1,42 @@
+import type { AstroConfig, AstroIntegration } from 'astro';
+import { fileURLToPath } from 'node:url';
+import { formatBrokenLinks, validateBuiltLinks, type LinkValidationOptions } from '../utils/link-validation';
+
+export const linkValidation = (options: LinkValidationOptions | false = {}): AstroIntegration => {
+  let config: AstroConfig;
+  let serverOutput = false;
+  return {
+    name: 'eventcatalog:link-validation',
+    hooks: {
+      'astro:config:done': ({ config: resolvedConfig, buildOutput }) => {
+        config = resolvedConfig;
+        serverOutput = buildOutput === 'server';
+      },
+      'astro:build:done': async ({ dir, logger }) => {
+        if (options === false || (options.onBrokenLinks === 'ignore' && options.onBrokenAnchors === 'ignore')) return;
+        if (serverOutput) {
+          logger.info('Link validation skipped: only static catalog builds are supported.');
+          return;
+        }
+        const start = performance.now();
+        const { pages, diagnostics } = await validateBuiltLinks({
+          ...options,
+          outDir: fileURLToPath(dir),
+          base: config.base,
+          site: config.site,
+          format: config.build.format,
+          trailingSlash: config.trailingSlash,
+        });
+        const errors = diagnostics.filter((diagnostic) =>
+          diagnostic.kind === 'link' ? options.onBrokenLinks === 'error' : options.onBrokenAnchors === 'error'
+        );
+        const warnings = diagnostics.filter((diagnostic) =>
+          diagnostic.kind === 'link' ? options.onBrokenLinks !== 'error' : options.onBrokenAnchors !== 'error'
+        );
+        if (warnings.length > 0) logger.warn(formatBrokenLinks(warnings));
+        if (errors.length > 0) throw new Error(`Link validation failed.\n${formatBrokenLinks(errors)}`);
+        logger.info(`Checked links in ${pages} HTML page(s) in ${((performance.now() - start) / 1000).toFixed(2)}s.`);
+      },
+    },
+  };
+};

--- a/packages/core/eventcatalog/src/utils/__tests__/link-validation.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/link-validation.spec.ts
@@ -1,0 +1,196 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { formatBrokenLinks, validateBuiltLinks } from '../link-validation';
+
+let outDir: string;
+const write = async (file: string, content: string) => {
+  await fs.mkdir(path.dirname(path.join(outDir, file)), { recursive: true });
+  await fs.writeFile(path.join(outDir, file), content);
+};
+
+beforeEach(async () => {
+  outDir = await fs.mkdtemp(path.join(os.tmpdir(), 'eventcatalog-links-'));
+});
+afterEach(async () => {
+  await fs.rm(outDir, { recursive: true, force: true });
+});
+
+describe('validateBuiltLinks', () => {
+  it('checks actual generated pages and downloads with relative URLs, base paths, queries and trailing slashes', async () => {
+    await write(
+      'docs/start/index.html',
+      `<a href="../next/">Next</a><a href="/catalog/docs/next?tab=1&amp;view=2">Next</a>
+       <a href="/catalog/docs/next/index.html">HTML</a><a href="../../schema.json">Schema</a>
+       <a href="/catalog">Home</a><a href="https://catalog.example/catalog/docs/next/">Absolute</a>`
+    );
+    await write('index.html', 'Home');
+    await write('docs/next/index.html', 'Next');
+    await write('schema.json', '{}');
+    expect(await validateBuiltLinks({ outDir, base: '/catalog/', site: 'https://catalog.example' })).toEqual({
+      pages: 3,
+      diagnostics: [],
+    });
+  });
+
+  it('reports missing targets once per source page and suggests existing resource collections', async () => {
+    await write(
+      'index.html',
+      `<a href="/docs/events/create-order/1.0.0">One</a><a href="/docs/events/create-order/1.0.0?view=2">Two</a>
+       <a href="/docs/users/platform">Owner</a>`
+    );
+    await write('docs/commands/create-order/1.0.0/index.html', 'Command');
+    await write('docs/teams/platform/index.html', 'Team');
+    expect((await validateBuiltLinks({ outDir })).diagnostics).toEqual([
+      {
+        kind: 'link',
+        source: '/',
+        destination: '/docs/events/create-order/1.0.0',
+        suggestion: '/docs/commands/create-order/1.0.0',
+      },
+      { kind: 'link', source: '/', destination: '/docs/users/platform', suggestion: '/docs/teams/platform' },
+    ]);
+  });
+
+  it('checks HTML ids and legacy named anchors, including encoded fragments and HTML entities', async () => {
+    await write(
+      'index.html',
+      `<a href='/guide/#caf%C3%A9'>Unicode</a><a href='/guide/#a&amp;b'>Entity</a>
+       <a href=/guide/#legacy>Legacy</a><a href='/guide/#missing'>Missing</a>
+       <a href='/guide/#top'>Top</a><a href='/guide/#'>Empty</a>
+       <a href='/guide/#:~:text=word'>Text fragment</a><a href='/guide/#legacy:~:text=word'>Named text fragment</a>`
+    );
+    await write('guide/index.html', '<h2 id="café">Title</h2><p id="a&amp;b"></p><a name="legacy"></a>');
+    expect((await validateBuiltLinks({ outDir })).diagnostics).toEqual([
+      { kind: 'anchor', source: '/', destination: '/guide/#missing' },
+    ]);
+  });
+
+  it('does not invent links or anchor targets from scripts, comments, or inert templates', async () => {
+    await write(
+      'index.html',
+      `<script>const html = '<a href="/script-link">';</script><!-- <a href="/comment-link"> -->
+       <template><a href="/template-link" id="inert">Template</a></template>
+       <a href="#inert">Missing target</a><a title="a > b" href="/real-missing">Real link</a>`
+    );
+    expect((await validateBuiltLinks({ outDir })).diagnostics).toEqual([
+      { kind: 'anchor', source: '/', destination: '/#inert' },
+      { kind: 'link', source: '/', destination: '/real-missing' },
+    ]);
+  });
+
+  it('resolves links using the first HTML base element', async () => {
+    await write('index.html', '<base href="/nested/"><base href="/wrong/"><a href="page/#title">Page</a>');
+    await write('nested/page/index.html', '<h1 id="title">Page</h1>');
+    expect((await validateBuiltLinks({ outDir })).diagnostics).toEqual([]);
+  });
+
+  it('ignores external URLs, non-HTTP schemes, and paths outside the catalog base without fetching them', async () => {
+    await write(
+      'index.html',
+      `<a href="https://elsewhere.example/missing">External</a><a href="//elsewhere.example/">Protocol relative</a>
+       <a href="mailto:person@example.com">Mail</a><a href="tel:123">Call</a><a href="javascript:void(0)">Action</a>
+       <a href="/other-app">Outside base</a><a href="https://catalog.example/other-app">Outside base absolute</a>`
+    );
+    expect((await validateBuiltLinks({ outDir, base: '/catalog', site: 'https://catalog.example' })).diagnostics).toEqual([]);
+  });
+
+  it('matches ignore globs against destination paths relative to the catalog base', async () => {
+    await write('index.html', '<a href="/catalog/api/runtime?x=1#part">API</a><a href="/catalog/missing">Missing</a>');
+    expect((await validateBuiltLinks({ outDir, base: '/catalog', ignore: ['/api/**'] })).diagnostics).toEqual([
+      { kind: 'link', source: '/catalog/', destination: '/catalog/missing' },
+    ]);
+  });
+
+  it('validates sidebar hrefs that are only rendered by client-side navigation', async () => {
+    await write('index.html', 'Home');
+    await write('guide/index.html', '<h1 id="heading">Guide</h1>');
+    await write(
+      'api/sidebar-data.json',
+      JSON.stringify({
+        nodes: {
+          root: { pages: [{ href: '/catalog/guide/#heading' }, { href: '/catalog/missing' }] },
+          duplicate: { href: '/catalog/missing' },
+          relative: { href: 'guide/#missing' },
+          description: '<a href="/not-navigation">',
+        },
+      })
+    );
+    expect((await validateBuiltLinks({ outDir, base: '/catalog' })).diagnostics).toEqual([
+      { kind: 'anchor', source: '/catalog/api/sidebar-data.json', destination: '/catalog/guide/#missing' },
+      { kind: 'link', source: '/catalog/api/sidebar-data.json', destination: '/catalog/missing' },
+    ]);
+  });
+
+  it('can disable links and anchors independently without treating missing pages as missing anchors', async () => {
+    await write('index.html', '<a href="/absent#heading">Absent</a><a href="#heading">Anchor</a>');
+    expect((await validateBuiltLinks({ outDir, onBrokenLinks: 'ignore' })).diagnostics).toEqual([
+      { kind: 'anchor', source: '/', destination: '/#heading' },
+    ]);
+    expect((await validateBuiltLinks({ outDir, onBrokenAnchors: 'ignore' })).diagnostics).toEqual([
+      { kind: 'link', source: '/', destination: '/absent#heading' },
+    ]);
+    expect(await validateBuiltLinks({ outDir: '/does-not-exist', onBrokenLinks: 'ignore', onBrokenAnchors: 'ignore' })).toEqual({
+      pages: 0,
+      diagnostics: [],
+    });
+  });
+
+  it.each(['file', 'preserve'] as const)('supports %s output and encoded filenames', async (format) => {
+    await write('index.html', '<a href="/hello%20world">File</a><a href="/hello%20world.html#ok">File anchor</a>');
+    await write('hello world.html', '<h1 id="ok">Hello</h1><a href="/">Home</a>');
+    expect((await validateBuiltLinks({ outDir, format })).diagnostics).toEqual([]);
+  });
+
+  it('does not check PDF or SVG fragment identifiers as HTML anchors', async () => {
+    await write('index.html', '<a href="/document.pdf#page=2">PDF</a><a href="/image.svg#icon">SVG</a>');
+    await write('document.pdf', 'test document');
+    await write('image.svg', '<svg></svg>');
+    expect((await validateBuiltLinks({ outDir })).diagnostics).toEqual([]);
+  });
+
+  it('resolves relative links from the canonical URL when trailing slashes are disabled', async () => {
+    await write('guide/index.html', '<a href="next">Next</a>');
+    await write('next/index.html', 'Next');
+    expect((await validateBuiltLinks({ outDir, trailingSlash: 'never' })).diagnostics).toEqual([]);
+  });
+
+  it('normalizes Unicode base paths and keeps malformed fragment escapes separate from missing links', async () => {
+    await write('index.html', '<a href="/caf%C3%A9/#bad%ZZ">Fragment</a>');
+    expect((await validateBuiltLinks({ outDir, base: '/café', onBrokenAnchors: 'ignore' })).diagnostics).toEqual([]);
+    expect((await validateBuiltLinks({ outDir, base: '/café', onBrokenLinks: 'ignore' })).diagnostics).toEqual([
+      { kind: 'anchor', source: '/caf%C3%A9/', destination: '/caf%C3%A9/#bad%ZZ' },
+    ]);
+  });
+
+  it('reports malformed internal URLs and missing encoded paths without crashing', async () => {
+    await write('index.html', '<a href="/bad%ZZ">Bad encoding</a><a href="/missing%20page">Missing</a>');
+    expect((await validateBuiltLinks({ outDir })).diagnostics).toEqual([
+      { kind: 'link', source: '/', destination: '/bad%ZZ' },
+      { kind: 'link', source: '/', destination: '/missing%20page' },
+    ]);
+  });
+
+  it('produces deterministic, grouped diagnostics rather than repeating every broken link in the build log', () => {
+    expect(
+      formatBrokenLinks([
+        { kind: 'link', source: '/one/', destination: '/missing', suggestion: '/found' },
+        { kind: 'link', source: '/two/', destination: '/missing', suggestion: '/found' },
+      ])
+    ).toBe(
+      'Found 1 broken link/anchor destination(s) in 2 page reference(s).\n\nBroken link: /missing\n  From: /one/\n  From: /two/\n  Possible destination: /found'
+    );
+  });
+
+  it('reports every broken destination even when there are more than thirty', () => {
+    const diagnostics = Array.from({ length: 40 }, (_, i) => ({
+      kind: 'link' as const,
+      source: '/',
+      destination: `/missing-${i}`,
+    }));
+    const output = formatBrokenLinks(diagnostics);
+    expect(output).toContain('Found 40 broken link/anchor destination(s) in 40 page reference(s).');
+    expect(output).toContain('Broken link: /missing-39\n  From: /');
+  });
+});

--- a/packages/core/eventcatalog/src/utils/__tests__/resource-reference-links.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/resource-reference-links.spec.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getCollection } from 'astro:content';
+import {
+  getResourceReferenceUrl,
+  isVersionedReference,
+  resolveMessageReference,
+  resolveOwnerReference,
+} from '../resource-reference-links';
+
+vi.mock('astro:content', () => ({ getCollection: vi.fn() }));
+
+describe('resource reference links', () => {
+  beforeEach(() => {
+    vi.mocked(getCollection).mockReset();
+    vi.mocked(getCollection).mockResolvedValue([]);
+  });
+
+  it.each(['events', 'commands', 'queries'])('resolves explicit versions in %s to the correct collection', async (collection) => {
+    vi.mocked(getCollection).mockImplementation(
+      async (name) => (name === collection ? [{ data: { id: 'message', version: '1.0.0' } }] : []) as any
+    );
+    expect(await resolveMessageReference({ id: 'message', version: '1.0.0' })).toEqual({ collection, version: '1.0.0' });
+  });
+
+  it.each([undefined, 'latest', '^1.0.0'])('resolves %s to an actual message version', async (version) => {
+    vi.mocked(getCollection).mockImplementation(
+      async (name) =>
+        (name === 'commands' ? ['1.0.0', '1.2.0'].map((version) => ({ data: { id: 'message', version } })) : []) as any
+    );
+    expect(await resolveMessageReference({ id: 'message', version })).toEqual({ collection: 'commands', version: '1.2.0' });
+  });
+
+  it('does not invent a destination for a missing message or version', async () => {
+    vi.mocked(getCollection).mockResolvedValue([{ data: { id: 'message', version: '1.0.0' } }] as any);
+    expect(await resolveMessageReference({ id: 'missing' })).toEqual({ collection: null, version: null });
+    expect(await resolveMessageReference({ id: 'message', version: '2.0.0' })).toEqual({ collection: null, version: null });
+  });
+
+  it.each(['users', 'teams'])('links %s without a version suffix', async (collection) => {
+    vi.mocked(getCollection).mockImplementation(async (name) => (name === collection ? [{ data: { id: 'owner' } }] : []) as any);
+    expect(isVersionedReference(collection)).toBe(false);
+    expect(getResourceReferenceUrl(collection, 'owner')).toBe(`/docs/${collection}/owner`);
+    expect(await resolveOwnerReference('owner')).toEqual({ id: 'owner', href: `/docs/${collection}/owner` });
+    expect(await resolveOwnerReference({ id: 'owner' })).toEqual({ id: 'owner', href: `/docs/${collection}/owner` });
+  });
+
+  it('leaves unknown owners unlinked', async () => {
+    expect(await resolveOwnerReference('missing')).toEqual({ id: 'missing', href: null });
+  });
+
+  it('preserves diagram and versioned resource routes', () => {
+    expect(getResourceReferenceUrl('diagrams', 'architecture', '1.0.0')).toBe('/diagrams/architecture/1.0.0');
+    expect(getResourceReferenceUrl('services', 'orders', '2.0.0')).toBe('/docs/services/orders/2.0.0');
+  });
+});

--- a/packages/core/eventcatalog/src/utils/__tests__/schemas/schema-loader.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/schemas/schema-loader.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
@@ -8,6 +8,31 @@ import { getMessageSchemasFromFrontmatter, loadMessageSchemas } from '@utils/col
 const originalScale = process.env.EVENTCATALOG_SCALE;
 
 describe('schema-loader', () => {
+  it('excludes dependency schemas while retaining nested and federated message schemas', async () => {
+    const catalogDir = await mkdtemp(path.join(tmpdir(), 'eventcatalog-schema-discovery-'));
+    const messages = [
+      ['domains/Orders/services/Shipping/events/Shipped', 'Shipped'],
+      ['federated/orders/events/Confirmed', 'Confirmed'],
+      ['node_modules/core/events/Fixture', 'Fixture'],
+      ['federated/orders/node_modules/sdk/events/NestedFixture', 'NestedFixture'],
+    ];
+    try {
+      for (const [relativeDir, id] of messages) {
+        const directory = path.join(catalogDir, relativeDir);
+        await mkdir(directory, { recursive: true });
+        await writeFile(path.join(directory, 'schema.json'), '{"type":"object"}');
+        await writeFile(
+          path.join(directory, 'index.mdx'),
+          `---\nid: ${id}\nname: ${id}\nversion: 1.0.0\nschemaPath: schema.json\n---\n`
+        );
+      }
+      const schemas = await loadMessageSchemas({ base: catalogDir, pattern: ['**/events/*/index.{md,mdx}'] });
+      expect(schemas.map((schema) => schema.message.id).sort()).toEqual(['Confirmed', 'Shipped']);
+    } finally {
+      await rm(catalogDir, { recursive: true, force: true });
+    }
+  });
+
   beforeEach(() => {
     delete process.env.EVENTCATALOG_SCALE;
   });

--- a/packages/core/eventcatalog/src/utils/collections/glob-loader.spec.ts
+++ b/packages/core/eventcatalog/src/utils/collections/glob-loader.spec.ts
@@ -1,6 +1,73 @@
 import picomatch from 'picomatch';
-import { describe, expect, it } from 'vitest';
-import { withFederatedContent } from './glob-loader';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, mkdir, writeFile, symlink, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { globWithSafeWatcher, withFederatedContent, withIgnoredBuildArtifacts } from './glob-loader';
+
+describe('catalog discovery', () => {
+  const directories: string[] = [];
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await Promise.all(directories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })));
+  });
+
+  it.each([undefined, 'false', 'true'])('excludes dependency catalogs when IGNORE_BUILD_ARTIFACTS is %s', async (flag) => {
+    vi.stubEnv('IGNORE_BUILD_ARTIFACTS', flag);
+    const root = await mkdtemp(path.join(tmpdir(), 'catalog-discovery-'));
+    directories.push(root);
+    const catalog = path.join(root, 'catalog');
+    const resources = [
+      'events/OrderConfirmed/index.md',
+      'domains/Orders/services/Inventory/events/Adjusted/versioned/1.0.0/index.mdx',
+      'federated/orders/events/OrderConfirmed/index.mdx',
+    ];
+    const dependencies = [
+      'node_modules/core/src/__tests__/events/OrderConfirmed/index.md',
+      'node_modules/core/node_modules/sdk/events/OrderConfirmed/index.mdx',
+      'federated/orders/node_modules/sdk/events/OrderConfirmed/index.md',
+    ];
+    for (const entry of [...resources, ...dependencies]) {
+      const file = path.join(catalog, entry);
+      await mkdir(path.dirname(file), { recursive: true });
+      await writeFile(file, entry);
+    }
+    // Workspace dependencies are often symlinked outside the catalog.
+    const linkedPackage = path.join(root, 'linked-package');
+    await mkdir(path.join(linkedPackage, 'events/OrderConfirmed'), { recursive: true });
+    await writeFile(path.join(linkedPackage, 'events/OrderConfirmed/index.md'), 'dependency');
+    await symlink(linkedPackage, path.join(catalog, 'node_modules/linked'));
+
+    const loaded = new Map();
+    const logger = { warn: vi.fn(), error: vi.fn() };
+    const base = pathToFileURL(`${catalog}/`);
+    const loader = globWithSafeWatcher({
+      pattern: withIgnoredBuildArtifacts('**/events/**/index.(md|mdx)'),
+      base,
+      generateId: ({ entry }) => entry,
+    });
+    await loader.load({
+      config: { root: base, srcDir: new URL('src/', base) },
+      collection: 'events',
+      logger,
+      store: {
+        keys: () => loaded.keys(),
+        get: (id: string) => loaded.get(id),
+        set: (entry: { id: string }) => loaded.set(entry.id, entry),
+        delete: (id: string) => loaded.delete(id),
+      },
+      parseData: async ({ data }: { data: unknown }) => data,
+      generateDigest: (contents: string) => contents,
+      entryTypes: new Map(['.md', '.mdx'].map((ext) => [ext, { getEntryInfo: () => ({ data: {}, body: '' }) }])),
+    } as unknown as Parameters<typeof loader.load>[0]);
+
+    expect([...loaded.keys()].sort()).toEqual(resources.sort());
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+});
 
 describe('withFederatedContent', () => {
   it('loads root catalog content from every federated source directory', () => {

--- a/packages/core/eventcatalog/src/utils/collections/glob-loader.ts
+++ b/packages/core/eventcatalog/src/utils/collections/glob-loader.ts
@@ -6,11 +6,13 @@ import { fileURLToPath } from 'url';
 export type GlobOptions = Parameters<typeof glob>[0];
 
 export const withIgnoredBuildArtifacts = (patterns: string | string[]) => {
+  // Dependencies can contain entire example catalogs, including duplicate resource IDs.
+  // Exclude them in every mode, including astro check and the development watcher.
+  const ignoredArtifacts = ['!**/node_modules/**'];
   if (process.env.IGNORE_BUILD_ARTIFACTS === 'true') {
-    const ignoredArtifacts = ['!dist/**', '!**/dist/**'];
-    return Array.isArray(patterns) ? [...patterns, ...ignoredArtifacts] : [patterns, ...ignoredArtifacts];
+    ignoredArtifacts.push('!dist/**', '!**/dist/**');
   }
-  return patterns;
+  return [...(Array.isArray(patterns) ? patterns : [patterns]), ...ignoredArtifacts];
 };
 
 const toPatterns = (patterns: string | string[]) => (Array.isArray(patterns) ? patterns : [patterns]);

--- a/packages/core/eventcatalog/src/utils/collections/schema-loader.ts
+++ b/packages/core/eventcatalog/src/utils/collections/schema-loader.ts
@@ -450,7 +450,7 @@ const loadMessageSchemaResources = async ({ pattern, base }: SchemaLoaderOptions
     cwd: base,
     absolute: true,
     nodir: true,
-    ignore: ['dist/**', '**/dist/**'],
+    ignore: ['dist/**', '**/dist/**', '**/node_modules/**'],
   });
 
   const schemas = await Promise.all(

--- a/packages/core/eventcatalog/src/utils/link-validation.ts
+++ b/packages/core/eventcatalog/src/utils/link-validation.ts
@@ -1,0 +1,224 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { parse, type DefaultTreeAdapterMap } from 'parse5';
+import picomatch from 'picomatch';
+
+export type LinkValidationSeverity = 'warn' | 'error' | 'ignore';
+
+export interface LinkValidationOptions {
+  onBrokenLinks?: LinkValidationSeverity;
+  onBrokenAnchors?: LinkValidationSeverity;
+  ignore?: string[];
+}
+
+export interface BrokenLink {
+  kind: 'link' | 'anchor';
+  source: string;
+  destination: string;
+  suggestion?: string;
+}
+
+interface PageLinks {
+  source: string;
+  baseHref?: string;
+  anchors: Set<string>;
+  links: Set<string>;
+}
+
+interface ValidateLinksOptions extends LinkValidationOptions {
+  outDir: string;
+  base?: string;
+  site?: string;
+  format?: 'directory' | 'file' | 'preserve';
+  trailingSlash?: 'always' | 'never' | 'ignore';
+}
+
+const decodeUrlPart = (value: string): string => {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    // A literal malformed percent escape can still be an HTML id or filename.
+    return value;
+  }
+};
+
+// Parse HTML rather than searching markup with a regex: attributes can contain
+// entities, quoted > characters, or single/unquoted values. Scripts and inert
+// template contents must not be mistaken for rendered links or anchor targets.
+const readPage = (html: string, source: string): PageLinks => {
+  const page: PageLinks = { source, anchors: new Set(), links: new Set() };
+  const nodes: DefaultTreeAdapterMap['node'][] = [parse(html)];
+  while (nodes.length > 0) {
+    const node = nodes.pop()!;
+    if ('tagName' in node) {
+      const attrs = new Map(node.attrs.map((attr) => [attr.name, attr.value]));
+      const id = attrs.get('id');
+      if (id) page.anchors.add(id);
+      if (node.tagName === 'a' && attrs.get('name')) page.anchors.add(attrs.get('name')!);
+      const href = attrs.get('href');
+      if (href !== undefined) {
+        if (node.tagName === 'base' && page.baseHref === undefined) page.baseHref = href;
+        if (node.tagName === 'a' || node.tagName === 'area') page.links.add(href);
+      }
+    }
+    // Reverse the stack so the first <base href> wins in document order.
+    if ('childNodes' in node) {
+      for (let i = node.childNodes.length - 1; i >= 0; i--) nodes.push(node.childNodes[i]);
+    }
+  }
+  return page;
+};
+
+const listFiles = async (root: string, relative = '', files = new Set<string>()): Promise<Set<string>> => {
+  for (const entry of await fs.readdir(path.join(root, relative), { withFileTypes: true })) {
+    const file = path.posix.join(relative, entry.name);
+    if (entry.isDirectory()) await listFiles(root, file, files);
+    else if (entry.isFile()) files.add(file);
+  }
+  return files;
+};
+
+const readNavigationLinks = (value: unknown, links: Set<string>) => {
+  if (!value || typeof value !== 'object') return;
+  for (const [key, child] of Object.entries(value)) {
+    if (key === 'href' && typeof child === 'string') links.add(child);
+    else if (child && typeof child === 'object') readNavigationLinks(child, links);
+  }
+};
+
+export const validateBuiltLinks = async ({
+  outDir,
+  base = '/',
+  site,
+  format = 'directory',
+  trailingSlash = 'ignore',
+  onBrokenLinks = 'warn',
+  onBrokenAnchors = 'warn',
+  ignore = [],
+}: ValidateLinksOptions): Promise<{ pages: number; diagnostics: BrokenLink[] }> => {
+  if (onBrokenLinks === 'ignore' && onBrokenAnchors === 'ignore') return { pages: 0, diagnostics: [] };
+
+  const origin = site ? new URL(site).origin : 'https://eventcatalog.invalid';
+  const prefix = new URL(`/${base.replace(/^\/+|\/+$/g, '')}`, origin).pathname.replace(/\/$/, '');
+  const withBase = (route: string) => `${prefix}${route}`;
+  const files = await listFiles(outDir);
+  const pages = new Map<string, PageLinks>();
+  const ignored = ignore.map((pattern) => picomatch(pattern, { dot: true }));
+
+  for (const file of [...files].sort()) {
+    if (!file.endsWith('.html')) continue;
+    let route = `/${file}`;
+    if (file === 'index.html') route = '/';
+    else if (file.endsWith('/index.html')) route = route.slice(0, -'index.html'.length);
+    else if (format !== 'directory') route = route.slice(0, -'.html'.length);
+    if (route !== '/' && trailingSlash === 'never') route = route.replace(/\/$/, '');
+    else if (format === 'file' && trailingSlash === 'always' && !route.endsWith('/')) route += '/';
+    // Encode path segments, not slashes, to handle spaces, # and Unicode in filenames.
+    const source = withBase(route.split('/').map(encodeURIComponent).join('/'));
+    pages.set(file, readPage(await fs.readFile(path.join(outDir, file), 'utf8'), source));
+  }
+
+  const sources = [...pages.values()];
+  // This is also used by client-only navigation, so its links aren't necessarily
+  // present as <a> elements in any generated HTML page.
+  if (files.has('api/sidebar-data.json')) {
+    const links = new Set<string>();
+    readNavigationLinks(JSON.parse(await fs.readFile(path.join(outDir, 'api/sidebar-data.json'), 'utf8')), links);
+    sources.push({
+      source: withBase('/api/sidebar-data.json'),
+      baseHref: withBase('/'),
+      anchors: new Set(),
+      links,
+    });
+  }
+
+  const findFile = (pathname: string): string | undefined => {
+    const relative = pathname.replace(/^\/+/, '');
+    if (files.has(relative)) return relative;
+    const index = path.posix.join(relative, 'index.html');
+    if (files.has(index)) return index;
+    const html = `${relative.replace(/\/$/, '')}.html`;
+    if (format !== 'directory' && files.has(html)) return html;
+    return undefined;
+  };
+
+  const diagnostics: BrokenLink[] = [];
+  for (const page of sources) {
+    const sourceUrl = new URL(page.source, origin);
+    let documentBase = sourceUrl;
+    try {
+      if (page.baseHref !== undefined) documentBase = new URL(page.baseHref, sourceUrl);
+    } catch {
+      // Browsers ignore an invalid base URL and use the document URL instead.
+    }
+    const seen = new Set<string>();
+    for (const href of page.links) {
+      let target: URL;
+      try {
+        target = new URL(href, documentBase);
+      } catch {
+        if (onBrokenLinks !== 'ignore') diagnostics.push({ kind: 'link', source: page.source, destination: href });
+        continue;
+      }
+      if (!['http:', 'https:'].includes(target.protocol) || target.origin !== origin) continue;
+      if (prefix && target.pathname !== prefix && !target.pathname.startsWith(`${prefix}/`)) continue;
+      const pathname = target.pathname.slice(prefix.length) || '/';
+      // Ignore patterns use paths relative to the catalog base, never filesystem paths.
+      if (ignored.some((matches) => matches(pathname))) continue;
+      const destination = target.pathname + target.hash;
+      if (seen.has(destination)) continue;
+      seen.add(destination);
+
+      const decodedPath = decodeUrlPart(pathname);
+      const anchor = decodeUrlPart(target.hash.slice(1).split(':~:')[0]);
+      const file = findFile(decodedPath);
+      if (!file) {
+        if (onBrokenLinks === 'ignore') continue;
+        // Give a precise suggestion for the common resource-type mixups, but
+        // only if the suggested destination actually exists in this build.
+        const alternatives = /^\/docs\/(users|teams)\//.test(decodedPath)
+          ? ['users', 'teams']
+          : /^\/docs\/(events|commands|queries)\//.test(decodedPath)
+            ? ['events', 'commands', 'queries']
+            : [];
+        const suggestion = alternatives
+          .map((collection) => decodedPath.replace(/^\/docs\/[^/]+\//, `/docs/${collection}/`))
+          .find((route) => findFile(route));
+        diagnostics.push({
+          kind: 'link',
+          source: page.source,
+          destination,
+          ...(suggestion ? { suggestion: withBase(suggestion) } : {}),
+        });
+      } else if (onBrokenAnchors !== 'ignore' && anchor && anchor.toLowerCase() !== 'top') {
+        const targetPage = pages.get(file);
+        // Fragments in PDFs/SVGs and other non-HTML assets have different semantics.
+        if (targetPage && !targetPage.anchors.has(anchor)) {
+          diagnostics.push({ kind: 'anchor', source: page.source, destination });
+        }
+      }
+    }
+  }
+  return {
+    pages: pages.size,
+    diagnostics: diagnostics.sort((a, b) => a.destination.localeCompare(b.destination) || a.source.localeCompare(b.source)),
+  };
+};
+
+export const formatBrokenLinks = (diagnostics: BrokenLink[]): string => {
+  const groups = new Map<string, { diagnostic: BrokenLink; sources: Set<string> }>();
+  for (const diagnostic of diagnostics) {
+    const key = `${diagnostic.kind}:${diagnostic.destination}`;
+    const group = groups.get(key) ?? { diagnostic, sources: new Set<string>() };
+    group.sources.add(diagnostic.source);
+    groups.set(key, group);
+  }
+  const lines = [`Found ${groups.size} broken link/anchor destination(s) in ${diagnostics.length} page reference(s).`];
+  for (const { diagnostic, sources } of groups.values()) {
+    lines.push(`\nBroken ${diagnostic.kind}: ${diagnostic.destination}`);
+    for (const source of [...sources].slice(0, 5)) lines.push(`  From: ${source}`);
+    if (sources.size > 5) lines.push(`  ...and ${sources.size - 5} more source(s)`);
+    if (diagnostic.suggestion) lines.push(`  Possible destination: ${diagnostic.suggestion}`);
+  }
+  return lines.join('\n');
+};

--- a/packages/core/eventcatalog/src/utils/resource-reference-links.ts
+++ b/packages/core/eventcatalog/src/utils/resource-reference-links.ts
@@ -1,0 +1,29 @@
+import { getCollection } from 'astro:content';
+import { getItemsFromCollectionByIdAndSemverOrLatest, sortVersioned } from './collections/util';
+import { buildUrl } from './url-builder';
+
+export const isVersionedReference = (collection: string) => !['users', 'teams', 'customPages'].includes(collection);
+
+export const getResourceReferenceUrl = (collection: string, id: string, version?: string) => {
+  if (!isVersionedReference(collection)) return buildUrl(`/docs/${collection}/${id}`);
+  return buildUrl(`${collection === 'diagrams' ? '/diagrams' : `/docs/${collection}`}/${id}/${version}`);
+};
+
+export const resolveMessageReference = async (message: { id: string; version?: string }) => {
+  for (const collection of ['events', 'commands', 'queries'] as const) {
+    const items = await getCollection(collection);
+    const matches = getItemsFromCollectionByIdAndSemverOrLatest(items, message.id, message.version);
+    const [resource] = sortVersioned(matches, (item) => item.data.version);
+    if (resource) return { version: resource.data.version, collection };
+  }
+  return { version: null, collection: null };
+};
+
+export const resolveOwnerReference = async (owner: string | { id: string }) => {
+  const id = typeof owner === 'string' ? owner : owner.id;
+  for (const collection of ['users', 'teams'] as const) {
+    const items = await getCollection(collection);
+    if (items.some((item) => item.data.id === id)) return { id, href: getResourceReferenceUrl(collection, id) };
+  }
+  return { id, href: null };
+};

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -122,6 +122,7 @@
     "nanostores": "^1.1.0",
     "pagefind": "^1.5.2",
     "pako": "^2.1.0",
+    "parse5": "^7.3.0",
     "picocolors": "^1.1.1",
     "picomatch": "^4.0.4",
     "react": "^18.3.1",

--- a/packages/core/src/eventcatalog.config.ts
+++ b/packages/core/src/eventcatalog.config.ts
@@ -280,6 +280,17 @@ export interface Config {
   host?: string | boolean;
   trailingSlash?: boolean;
   output?: 'server' | 'static';
+  /** Validate internal links and anchors after static builds. Set false to disable. */
+  linkValidation?:
+    | false
+    | {
+        /** @default 'warn' */
+        onBrokenLinks?: 'warn' | 'error' | 'ignore';
+        /** @default 'warn' */
+        onBrokenAnchors?: 'warn' | 'error' | 'ignore';
+        /** Glob patterns for destination URL paths, relative to the catalog base (e.g. /api/**). */
+        ignore?: string[];
+      };
   server?: {
     allowedHosts?: string[] | true;
   };

--- a/packages/create-eventcatalog/templates/default/domains/Catalog/systems/product-catalog-system/containers/product-database/index.mdx
+++ b/packages/create-eventcatalog/templates/default/domains/Catalog/systems/product-catalog-system/containers/product-database/index.mdx
@@ -2,6 +2,8 @@
 id: product-database
 name: Product Database
 version: 1.0.0
+owners:
+  - product-platform
 summary: PostgreSQL database that is the system of record for all product data.
 container_type: database
 technology: postgres@16

--- a/packages/create-eventcatalog/templates/default/domains/Catalog/systems/search-system/containers/search-index/index.mdx
+++ b/packages/create-eventcatalog/templates/default/domains/Catalog/systems/search-system/containers/search-index/index.mdx
@@ -2,6 +2,8 @@
 id: search-index
 name: Search Index
 version: 1.0.0
+owners:
+  - search-platform
 summary: The denormalised, search-optimised index of products that powers product search.
 container_type: searchIndex
 technology: opensearch@2

--- a/packages/create-eventcatalog/templates/default/domains/Customer/systems/customer-management-system/containers/customer-database/index.mdx
+++ b/packages/create-eventcatalog/templates/default/domains/Customer/systems/customer-management-system/containers/customer-database/index.mdx
@@ -2,6 +2,8 @@
 id: customer-database
 name: Customer Database
 version: 1.0.0
+owners:
+  - customer-platform
 summary: PostgreSQL database that is the system of record for all customer profile data.
 container_type: database
 technology: postgres@16

--- a/packages/create-eventcatalog/templates/default/domains/Customer/systems/identity-provider/containers/user-directory/index.mdx
+++ b/packages/create-eventcatalog/templates/default/domains/Customer/systems/identity-provider/containers/user-directory/index.mdx
@@ -2,6 +2,8 @@
 id: user-directory
 name: User Directory
 version: 1.0.0
+owners:
+  - customer-platform
 summary: The directory of customer credentials and identities — the source of truth for authentication.
 container_type: database
 technology: postgres@16

--- a/packages/create-eventcatalog/templates/default/domains/Fulfilment/systems/inventory-system/containers/inventory-database/index.mdx
+++ b/packages/create-eventcatalog/templates/default/domains/Fulfilment/systems/inventory-system/containers/inventory-database/index.mdx
@@ -2,6 +2,8 @@
 id: inventory-database
 name: Inventory Database
 version: 1.0.0
+owners:
+  - fulfilment-platform
 summary: PostgreSQL database that is the system of record for stock levels and reservations.
 container_type: database
 technology: postgres@16

--- a/packages/create-eventcatalog/templates/default/domains/Fulfilment/systems/warehouse-system/containers/warehouse-database/index.mdx
+++ b/packages/create-eventcatalog/templates/default/domains/Fulfilment/systems/warehouse-system/containers/warehouse-database/index.mdx
@@ -2,6 +2,8 @@
 id: warehouse-database
 name: Warehouse Database
 version: 1.0.0
+owners:
+  - fulfilment-platform
 summary: PostgreSQL database that stores picking jobs and their status.
 container_type: database
 technology: postgres@16

--- a/packages/create-eventcatalog/templates/default/domains/Ordering/systems/order-management-system/containers/order-database/index.mdx
+++ b/packages/create-eventcatalog/templates/default/domains/Ordering/systems/order-management-system/containers/order-database/index.mdx
@@ -2,6 +2,8 @@
 id: order-database
 name: Order Database
 version: 1.0.0
+owners:
+  - ordering-platform
 summary: PostgreSQL database that is the system of record for orders and their items.
 container_type: database
 technology: postgres@16

--- a/packages/create-eventcatalog/templates/default/domains/Payments/systems/payment-processing-system/containers/payment-database/index.mdx
+++ b/packages/create-eventcatalog/templates/default/domains/Payments/systems/payment-processing-system/containers/payment-database/index.mdx
@@ -2,6 +2,8 @@
 id: payment-database
 name: Payment Database
 version: 1.0.0
+owners:
+  - payments-platform
 summary: PostgreSQL database that is the system of record for payments and refunds.
 container_type: database
 technology: postgres@16

--- a/packages/create-eventcatalog/templates/default/domains/Reviews/containers/rating-cache/index.mdx
+++ b/packages/create-eventcatalog/templates/default/domains/Reviews/containers/rating-cache/index.mdx
@@ -2,6 +2,8 @@
 id: rating-cache
 name: Rating Cache
 version: 1.0.0
+owners:
+  - reviews-platform
 summary: Redis cache that serves each product's aggregate star rating with low latency.
 container_type: cache
 technology: redis@7

--- a/packages/create-eventcatalog/templates/default/domains/Reviews/containers/review-database/index.mdx
+++ b/packages/create-eventcatalog/templates/default/domains/Reviews/containers/review-database/index.mdx
@@ -2,6 +2,8 @@
 id: review-database
 name: Review Database
 version: 1.0.0
+owners:
+  - reviews-platform
 summary: PostgreSQL database that is the system of record for reviews and their moderation state.
 container_type: database
 technology: postgres@16

--- a/packages/create-eventcatalog/templates/default/domains/Shopping/systems/cart-system/containers/cart-database/index.mdx
+++ b/packages/create-eventcatalog/templates/default/domains/Shopping/systems/cart-system/containers/cart-database/index.mdx
@@ -2,6 +2,8 @@
 id: cart-database
 name: Cart Database
 version: 1.0.0
+owners:
+  - shopping-platform
 summary: PostgreSQL database that is the system of record for shopping carts and their items.
 container_type: database
 technology: postgres@16

--- a/packages/create-eventcatalog/templates/default/domains/Shopping/systems/promotion-system/containers/promotion-database/index.mdx
+++ b/packages/create-eventcatalog/templates/default/domains/Shopping/systems/promotion-system/containers/promotion-database/index.mdx
@@ -2,6 +2,8 @@
 id: promotion-database
 name: Promotion Database
 version: 1.0.0
+owners:
+  - shopping-platform
 summary: PostgreSQL store of promotion and discount rules.
 container_type: database
 technology: postgres@16

--- a/packages/linter/src/scanner/index.ts
+++ b/packages/linter/src/scanner/index.ts
@@ -132,6 +132,8 @@ export const scanCatalogFiles = async (rootDir: string): Promise<CatalogFile[]> 
       absolute: true,
       onlyFiles: true,
       followSymbolicLinks: false,
+      // Builds copy resource files into dist/generated; these are not catalog inputs.
+      ignore: ['**/dist/**', '**/node_modules/**'],
     });
 
     for (const filePath of foundFiles) {

--- a/packages/linter/tests/scanner.test.ts
+++ b/packages/linter/tests/scanner.test.ts
@@ -5,6 +5,30 @@ import path from 'path';
 import { extractResourceInfo, scanCatalogFiles } from '../src/scanner';
 
 describe('extractResourceInfo', () => {
+  it('excludes generated resources and dependency fixtures while preserving nested and federated content', async () => {
+    const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), 'eventcatalog-linter-artifacts-'));
+    const sources = ['domains/orders/services/orders-api/index.mdx', 'federated/payments/events/paid/index.mdx'];
+    const artifacts = [
+      'dist/generated/domains/orders/services/orders-api/index.mdx',
+      'dist/generated/events/paid/index.mdx',
+      'federated/payments/dist/events/paid/index.mdx',
+      'node_modules/example/events/paid/index.mdx',
+      'node_modules/example/entities/order/index.mdx',
+      'federated/payments/node_modules/example/containers/database/index.mdx',
+    ];
+    try {
+      for (const file of [...sources, ...artifacts]) {
+        const filePath = path.join(rootDir, file);
+        await fs.mkdir(path.dirname(filePath), { recursive: true });
+        await fs.writeFile(filePath, '---\nid: test\nname: Test\nversion: 1.0.0\n---\n');
+      }
+      const files = await scanCatalogFiles(rootDir);
+      expect(files.map((file) => file.relativePath).sort()).toEqual(sources.sort());
+    } finally {
+      await fs.rm(rootDir, { recursive: true, force: true });
+    }
+  });
+
   it('should extract simple resource id', () => {
     const result = extractResourceInfo('services/user-service/index.mdx', 'service');
     expect(result).toEqual({ id: 'user-service' });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -307,6 +307,9 @@ importers:
       pako:
         specifier: ^2.1.0
         version: 2.1.0
+      parse5:
+        specifier: ^7.3.0
+        version: 7.3.0
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1


### PR DESCRIPTION

## What This PR Does

Adds a build-time link validator to EventCatalog so broken internal links and anchors in a static catalog build are surfaced at build time rather than discovered by users. It also fixes several ways `<ResourceRef>` produced broken links (teams, users, custom pages, owners, and messages in the wrong collection), and stops catalog discovery from loading example catalogs that live inside `node_modules`.

## Changes Overview

### Key Changes
- New `linkValidation` option in `eventcatalog.config.js`, with `onBrokenLinks`, `onBrokenAnchors` (`warn` | `error` | `ignore`, default `warn`) and `ignore` glob patterns. Set to `false` to disable.
- New Astro integration `eventcatalog:link-validation` that runs on `astro:build:done` for static builds only and reports grouped diagnostics with source pages and, where possible, a suggested destination.
- New `@utils/resource-reference-links` helpers used by `<ResourceRef>`:
  - Teams, users and custom pages link without a version segment.
  - Owners resolve to `/docs/users/...` or `/docs/teams/...` depending on where the owner actually exists, and render as plain text if not found.
  - Messages resolve to the collection they exist in (events, commands or queries) instead of assuming events when a version is specified.
- `node_modules` is now always excluded from catalog globbing (content collections, schema loader, `.ecstudio` design discovery, and the linter scanner), so dependency example catalogs can no longer introduce duplicate resource IDs.
- Default template containers now declare `owners`.
- `parse5` added as a dependency of `@eventcatalog/core` for HTML parsing.
- Changeset covering `@eventcatalog/core`, `@eventcatalog/create-eventcatalog` and `@eventcatalog/linter`.

## How It Works

After a static build the integration walks the output directory, parses every HTML file with `parse5`, and collects `id` / `<a name>` anchors and `<a>` / `<area>` hrefs (respecting `<base href>`). It also reads `api/sidebar-data.json` because the sidebar navigates client-side and its links are not guaranteed to appear in any HTML page.

Each href is resolved against the page URL and the configured `site` and `base`. Only same-origin links under the base path are checked. Destinations are mapped back to output files according to Astro's `build.format` and `trailingSlash` settings, and anchors are checked against the target page's collected ids. Broken links to `/docs/users|teams/...` and `/docs/events|commands|queries/...` get a suggested alternative when that alternative exists in the build. Diagnostics are grouped per destination and either logged as warnings or thrown as an error depending on configuration. Server builds skip validation with an info log.

The `withIgnoredBuildArtifacts` helper now always appends `!**/node_modules/**`, and continues to add `dist` exclusions only when `IGNORE_BUILD_ARTIFACTS=true`.

## Breaking Changes

None. Link validation defaults to `warn` and does not fail builds unless configured to.

## Additional Notes

- Tests added for the validator (relative URLs, base paths, trailing slash modes, anchors, ignore patterns), the integration (severity handling, server skip), resource reference resolution, and `node_modules` exclusion in the glob loader, schema loader and linter scanner.
- `AGENTS.md` gains an instruction to not auto-generate documentation.
- No change is needed in the `eventcatalog-editor` repository; the `linkValidation` config type is optional and additive.

https://claude.ai/code/session_016AnJrqfRof5LYMFqkoQu3E