### PR TITLE
Disable RSS by default in the default create-eventcatalog template

### DIFF
--- a/.changeset/quiet-rss-default.md
+++ b/.changeset/quiet-rss-default.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/create-eventcatalog': patch
+---
+
+Disable RSS by default in catalogs created using the default template.

--- a/packages/create-eventcatalog/CHANGELOG.md
+++ b/packages/create-eventcatalog/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Patch Changes
 
 - 55c993d: Add build-time link validation for static catalogs and fix broken resource reference links
-
   - New `linkValidation` config option checks internal links and anchors in generated HTML after static builds (warns by default, can be set to `error` or `ignore`, supports `ignore` globs)
   - `<ResourceRef>` now links teams, users, and custom pages without a version segment, resolves owners to the correct users or teams page, and resolves messages to the collection they actually live in
   - Catalog discovery, schema loading, design discovery, and the linter scanner now exclude `node_modules` so dependency example catalogs are never loaded as catalog resources

--- a/packages/create-eventcatalog/templates/default/eventcatalog.config.js
+++ b/packages/create-eventcatalog/templates/default/eventcatalog.config.js
@@ -30,7 +30,7 @@ export default {
     iconPacks: ['logos'],
   },
   rss: {
-    enabled: true,
+    enabled: false,
     limit: 15,
   },
   visualiser: {

--- a/packages/linter/CHANGELOG.md
+++ b/packages/linter/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Patch Changes
 
 - 55c993d: Add build-time link validation for static catalogs and fix broken resource reference links
-
   - New `linkValidation` config option checks internal links and anchors in generated HTML after static builds (warns by default, can be set to `error` or `ignore`, supports `ignore` globs)
   - `<ResourceRef>` now links teams, users, and custom pages without a version segment, resolves owners to the correct users or teams page, and resolves messages to the collection they actually live in
   - Catalog discovery, schema loading, design discovery, and the linter scanner now exclude `node_modules` so dependency example catalogs are never loaded as catalog resources


### PR DESCRIPTION

## What This PR Does

New catalogs scaffolded with `@eventcatalog/create-eventcatalog` using the default template currently ship with RSS feeds enabled. This PR flips that default to disabled, so RSS is an opt-in feature for new projects rather than something users have to turn off.

## Changes Overview

### Key Changes
- Set `rss.enabled` to `false` in `packages/create-eventcatalog/templates/default/eventcatalog.config.js` (the `limit: 15` value is kept so enabling it is a one-line change)
- Add a patch changeset for `@eventcatalog/create-eventcatalog`
- Prettier removed a stray blank line in two generated changelogs (`packages/create-eventcatalog/CHANGELOG.md`, `packages/linter/CHANGELOG.md`)

## How It Works

The default template's `eventcatalog.config.js` is copied verbatim into newly scaffolded projects. Changing the `rss.enabled` value there means every new catalog created from the default template starts with RSS off. Users who want RSS feeds can set `enabled: true` in their config.

## Breaking Changes

None. This only affects the config file written into newly created catalogs. Existing catalogs and other templates are untouched.

## Additional Notes

- No change is needed in the `eventcatalog-editor` repository; this is a scaffolding template default only.
- Reviewers may want to confirm whether the other templates (asyncapi, openapi, etc.) should get the same default in a follow-up.

false

https://claude.ai/code/session_0182Y7fKoPDab3vjoNZCdzwP