### PR TITLE
fix(core): show assistant by default with model setup guidance

### DIFF
--- a/.changeset/bright-cats-ask.md
+++ b/.changeset/bright-cats-ask.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/core': patch
+---
+
+Show the Assistant by default with bring-your-own-model setup guidance and an option to hide it. Refresh the Ask and search UI, add the keyboard shortcut, and prevent focus from entering the closed assistant sidebar.

--- a/examples/default/eventcatalog.config.js
+++ b/examples/default/eventcatalog.config.js
@@ -6,23 +6,24 @@ const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 /** @type {import('../../bin/eventcatalog.config').Config} */
 export default {
   cId: "8027010c-f3d6-417a-8234-e2f46087fc56",
-  title: "Acme Inc",
-  tagline: "Discover, Explore and Document your Event Driven Architectures.",
-  organizationName: "Acme Inc",
-  homepageLink: "https://eventcatalog.dev",
-  editUrl: "https://github.com/event-catalog/eventcatalog/edit/main",
+  title: 'Acme Inc',
+  tagline: 'Discover, Explore and Document your Event Driven Architectures.',
+  organizationName: 'Acme Inc',
+  homepageLink: 'https://eventcatalog.dev',
+  editUrl: 'https://github.com/event-catalog/eventcatalog/edit/main',
   port: 3000,
   outDir: "dist",
+
   logo: {
     src: "/logo.png",
-    text: "Acme Inc",
+    text: 'Acme Inc',
   },
 
   base: "/",
   trailingSlash: false,
 
   // Theme: 'default', 'ocean', 'sapphire', 'sunset', 'forest', or custom (defined in eventcatalog.styles.css)
-  theme: "sunset",
+  theme: 'forest',
 
   mermaid: {
     enableSupportForElkLayout: true,
@@ -111,4 +112,8 @@ export default {
   llmsTxt: {
     enabled: true,
   },
+
+  chat: {
+    enabled: true
+  }
 };

--- a/packages/core/eventcatalog/src/components/ChatPanel/ChatPanel.tsx
+++ b/packages/core/eventcatalog/src/components/ChatPanel/ChatPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useCallback, useState, useMemo, memo } from 'react';
-import { X, Square, Trash2, BookOpen, Copy, Check, Maximize2, Minimize2, Wrench, ChevronDown, MessageSquare } from 'lucide-react';
+import { X, Square, Trash2, Sparkles, Copy, Check, Maximize2, Minimize2, Wrench, ChevronDown, MessageSquare } from 'lucide-react';
 import { useChat } from '@ai-sdk/react';
 import { DefaultChatTransport } from 'ai';
 import ReactMarkdown from 'react-markdown';
@@ -9,6 +9,7 @@ import { oneDark } from 'react-syntax-highlighter/dist/cjs/styles/prism';
 import * as Dialog from '@radix-ui/react-dialog';
 import * as Popover from '@radix-ui/react-popover';
 import { buildUrl } from '@utils/url-builder';
+import OfflineReply, { offlineReplyText } from './OfflineReply';
 
 interface ToolMetadata {
   name: string;
@@ -18,6 +19,44 @@ interface ToolMetadata {
 
 // CSS keyframes - defined once outside component to avoid re-injection
 const CHAT_PANEL_STYLES = `
+  @keyframes ec-chat-breathe {
+    0%, 100% { transform: scale(1); opacity: .7; }
+    50% { transform: scale(1.06); opacity: 1; }
+  }
+  @keyframes ec-chat-dot {
+    0%, 80%, 100% { transform: translateY(0); opacity: .35; }
+    40% { transform: translateY(-3px); opacity: 1; }
+  }
+  .ec-chat-surface { font-weight: 400; }
+  .ec-chat-avatar { background: rgb(var(--ec-accent) / .06); animation: ec-chat-breathe 5s ease-in-out infinite; }
+  .ec-chat-suggestion { width: fit-content; max-width: 100%; transition: background 180ms, transform 180ms; }
+  .ec-chat-suggestion:hover { transform: translateX(3px); }
+  .ec-chat-message { animation: fadeInUp 280ms ease-out both; }
+  .ec-chat-offline > * { animation: fadeInUp 350ms ease-out both; }
+  .ec-chat-offline > :nth-child(2) { animation-delay: 100ms; }
+  .ec-chat-offline > :nth-child(3) { animation-delay: 220ms; }
+  .ec-chat-offline > :nth-child(4) { animation-delay: 340ms; }
+  .ec-chat-dot { width: 4px; height: 4px; border-radius: 50%; background: rgb(var(--ec-accent)); animation: ec-chat-dot 1.2s infinite; }
+  .ec-chat-dot:nth-child(2) { animation-delay: 150ms; }
+  .ec-chat-dot:nth-child(3) { animation-delay: 300ms; }
+  .ec-chat-composer {
+    border-radius: 20px;
+    border-color: rgb(var(--ec-accent) / .22);
+    background: rgb(var(--ec-page-bg));
+    box-shadow: 0 0 0 3px rgb(var(--ec-accent) / .04), 0 8px 28px rgb(var(--ec-accent) / .04);
+    transition: border-color 200ms, box-shadow 200ms;
+  }
+  .ec-chat-composer:focus-within { border-color: rgb(var(--ec-accent) / .5); box-shadow: 0 0 0 3px rgb(var(--ec-accent) / .09); }
+  .ec-chat-composer textarea { display: block; resize: none; min-height: 104px; padding: 14px 16px 46px; border-radius: 20px; }
+  .ec-chat-composer-actions { top: auto; bottom: 10px; transform: none; }
+  @media (prefers-reduced-motion: reduce) {
+    .ec-chat-surface, .ec-chat-surface *, #eventcatalog-header, #eventcatalog-application {
+      animation: none !important;
+      transition: none !important;
+      scroll-behavior: auto !important;
+    }
+  }
+
   @keyframes fadeIn {
     from { opacity: 0; }
     to { opacity: 1; }
@@ -335,26 +374,27 @@ const getSuggestedQuestions = (pathname: string): SuggestedQuestion[] => {
 };
 
 interface ChatPanelProps {
+  configured?: boolean;
   isOpen: boolean;
   onClose: () => void;
 }
 
 const PANEL_WIDTH = 400;
 
-// Staggered fade-in animation styles (delays account for 800ms panel slide)
+// Staggered fade-in animation styles (delays account for 420ms panel slide)
 const fadeInStyles = {
   header: {
     animation: 'fadeIn 0.5s ease-out 0.3s both',
   },
   welcome: {
-    animation: 'fadeIn 0.6s ease-out 0.4s both',
+    animation: 'fadeInUp 0.45s ease-out 0.12s both',
   },
   // Label and questions will be staggered individually in the component
   questionsLabel: {
     animation: 'fadeIn 0.5s ease-out 0.7s both',
   },
   getQuestionStyle: (index: number) => ({
-    animation: `fadeIn 0.5s ease-out ${0.85 + index * 0.12}s both`,
+    animation: `fadeIn 0.5s ease-out ${0.22 + index * 0.07}s both`,
   }),
   inputFocus: {
     animation: 'focusIn 0.6s ease-out 1.4s both',
@@ -436,12 +476,14 @@ const getCompletedTools = (message: { parts?: Array<any> }): string[] => {
 };
 
 // Skeleton loading component - memoized since it never changes
-const SkeletonLoader = memo(() => (
-  <div className="animate-pulse space-y-3">
-    <div className="h-4 bg-[rgb(var(--ec-content-hover))] rounded w-[90%]" />
-    <div className="h-4 bg-[rgb(var(--ec-content-hover))] rounded w-[75%]" />
-    <div className="h-4 bg-[rgb(var(--ec-content-hover))] rounded w-[85%]" />
-    <div className="h-4 bg-[rgb(var(--ec-content-hover))] rounded w-[60%]" />
+const SkeletonLoader = memo(({ label = 'Thinking it through…' }: { label?: string }) => (
+  <div role="status" className="ec-chat-message flex items-center gap-3 py-3 text-xs text-[rgb(var(--ec-page-text-muted))]">
+    <span className="flex items-center gap-1" aria-hidden="true">
+      <span className="ec-chat-dot" />
+      <span className="ec-chat-dot" />
+      <span className="ec-chat-dot" />
+    </span>
+    {label}
   </div>
 ));
 SkeletonLoader.displayName = 'SkeletonLoader';
@@ -517,13 +559,22 @@ const modalMarkdownComponents = {
   ),
 };
 
-const ChatPanel = ({ isOpen, onClose }: ChatPanelProps) => {
-  const inputRef = useRef<HTMLInputElement>(null);
-  const modalInputRef = useRef<HTMLInputElement>(null);
+const ChatPanel = ({ isOpen, onClose, configured = false }: ChatPanelProps) => {
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+  const modalInputRef = useRef<HTMLTextAreaElement>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const modalMessagesEndRef = useRef<HTMLDivElement>(null);
   const messagesContainerRef = useRef<HTMLDivElement>(null);
   const [inputValue, setInputValue] = useState('');
+  const [isSetupThinking, setIsSetupThinking] = useState(false);
+  const setupReplyTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (setupReplyTimer.current !== null) clearTimeout(setupReplyTimer.current);
+    },
+    []
+  );
   const [isWaitingForResponse, setIsWaitingForResponse] = useState(false);
   const [pathname, setPathname] = useState('');
   const [isFullscreen, setIsFullscreen] = useState(false);
@@ -543,7 +594,7 @@ const ChatPanel = ({ isOpen, onClose }: ChatPanelProps) => {
 
   // Fetch available tools when panel opens
   useEffect(() => {
-    if (isOpen && tools.length === 0) {
+    if (configured && isOpen && tools.length === 0) {
       fetch(chatApiUrl)
         .then((res) => res.json())
         .then((data) => {
@@ -555,7 +606,7 @@ const ChatPanel = ({ isOpen, onClose }: ChatPanelProps) => {
           // Silently fail - tools info is optional
         });
     }
-  }, [isOpen, tools.length]);
+  }, [configured, isOpen, tools.length, chatApiUrl]);
 
   // Get current URL (pathname + search) on mount and when panel opens
   useEffect(() => {
@@ -624,7 +675,9 @@ const ChatPanel = ({ isOpen, onClose }: ChatPanelProps) => {
 
   const isStreaming = status === 'streaming' && assistantHasContent;
   const isThinking =
-    isWaitingForResponse || (messages.length > 0 && (status === 'submitted' || status === 'streaming') && !assistantHasContent);
+    isSetupThinking ||
+    isWaitingForResponse ||
+    (messages.length > 0 && (status === 'submitted' || status === 'streaming') && !assistantHasContent);
   const isLoading = isThinking || isStreaming;
 
   // Get currently running tools from the last assistant message
@@ -643,12 +696,13 @@ const ChatPanel = ({ isOpen, onClose }: ChatPanelProps) => {
 
   // Focus modal input when fullscreen opens
   useEffect(() => {
-    if (isFullscreen && !isLoading) {
-      setTimeout(() => {
+    if (isOpen && isFullscreen && !isLoading) {
+      const timer = setTimeout(() => {
         modalInputRef.current?.focus();
       }, 100);
+      return () => clearTimeout(timer);
     }
-  }, [isFullscreen, isLoading]);
+  }, [isOpen, isFullscreen, isLoading]);
 
   // Handle escape key to close
   useEffect(() => {
@@ -657,23 +711,24 @@ const ChatPanel = ({ isOpen, onClose }: ChatPanelProps) => {
         onClose();
       }
       // Focus input on CMD+I or CTRL+I
-      if ((e.metaKey || e.ctrlKey) && e.key === 'i' && isOpen) {
+      if ((e.metaKey || e.ctrlKey) && !e.altKey && !e.shiftKey && e.key.toLowerCase() === 'i' && isOpen) {
         e.preventDefault();
-        inputRef.current?.focus();
+        (isFullscreen ? modalInputRef : inputRef).current?.focus();
       }
     };
     document.addEventListener('keydown', handleEscape);
     return () => document.removeEventListener('keydown', handleEscape);
-  }, [isOpen, onClose]);
+  }, [isOpen, isFullscreen, onClose]);
 
   // Focus input when opened and not loading
   useEffect(() => {
-    if (isOpen && !isLoading) {
-      setTimeout(() => {
+    if (isOpen && !isFullscreen && !isLoading) {
+      const timer = setTimeout(() => {
         inputRef.current?.focus();
       }, 100);
+      return () => clearTimeout(timer);
     }
-  }, [isOpen, isLoading]);
+  }, [isOpen, isFullscreen, isLoading]);
 
   // Add/remove padding to main application and header when sidebar panel is open
   useEffect(() => {
@@ -686,7 +741,7 @@ const ChatPanel = ({ isOpen, onClose }: ChatPanelProps) => {
     elements.forEach((el) => {
       // Add transition if not already present
       if (!el.style.transition) {
-        el.style.transition = 'padding-right 800ms cubic-bezier(0.16, 1, 0.3, 1)';
+        el.style.transition = 'padding-right 420ms cubic-bezier(0.16, 1, 0.3, 1)';
       }
 
       // Only add padding when panel is open AND not in fullscreen mode
@@ -722,11 +777,48 @@ const ChatPanel = ({ isOpen, onClose }: ChatPanelProps) => {
     (text: string) => {
       if (!text.trim() || isLoading) return;
       setInputValue('');
+      if (!configured) {
+        setMessages((previous) => [...previous, { id: crypto.randomUUID(), role: 'user', parts: [{ type: 'text', text }] }]);
+        setIsSetupThinking(true);
+        setupReplyTimer.current = setTimeout(() => {
+          setMessages((previous) => [
+            ...previous,
+            {
+              id: crypto.randomUUID(),
+              role: 'assistant',
+              parts: [
+                {
+                  type: 'text',
+                  text: offlineReplyText,
+                },
+              ],
+            },
+          ]);
+          setupReplyTimer.current = null;
+          setIsSetupThinking(false);
+        }, 1200);
+        return;
+      }
       setIsWaitingForResponse(true);
       sendMessage({ text });
     },
-    [isLoading, sendMessage]
+    [configured, isLoading, sendMessage, setMessages]
   );
+
+  const stopResponse = useCallback(() => {
+    if (setupReplyTimer.current !== null) {
+      clearTimeout(setupReplyTimer.current);
+      setupReplyTimer.current = null;
+    }
+    setIsSetupThinking(false);
+    setIsWaitingForResponse(false);
+    stop();
+  }, [stop]);
+
+  const clearMessages = useCallback(() => {
+    stopResponse();
+    setMessages([]);
+  }, [stopResponse, setMessages]);
 
   // Handle suggested action clicks
   const handleSuggestedAction = useCallback(
@@ -738,7 +830,7 @@ const ChatPanel = ({ isOpen, onClose }: ChatPanelProps) => {
 
   // Handle input enter key
   const handleInputKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLInputElement>) => {
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
       if (e.key === 'Enter' && !e.shiftKey) {
         e.preventDefault();
         submitMessage(inputValue);
@@ -769,13 +861,17 @@ const ChatPanel = ({ isOpen, onClose }: ChatPanelProps) => {
       {/* Panel - hidden when fullscreen modal is open */}
       {!isFullscreen && (
         <div
-          className="fixed top-0 right-0 h-[100vh] z-[200] border-l border-[rgb(var(--ec-page-border))] flex flex-col overflow-hidden"
+          ref={(element) => {
+            element?.toggleAttribute('inert', !isOpen);
+          }}
+          aria-hidden={!isOpen}
+          className="ec-chat-surface fixed top-0 right-0 h-[100dvh] z-[200] border-l border-[rgb(var(--ec-page-border))] flex flex-col overflow-hidden"
           style={{
-            width: `${PANEL_WIDTH}px`,
-            transform: isOpen ? 'translateX(0)' : `translateX(${PANEL_WIDTH}px)`,
-            transition: 'transform 800ms cubic-bezier(0.16, 1, 0.3, 1)',
+            width: `min(${PANEL_WIDTH}px, 100vw)`,
+            transform: isOpen ? 'translateX(0)' : 'translateX(100%)',
+            transition: 'transform 420ms cubic-bezier(0.16, 1, 0.3, 1)',
             background: `
-              radial-gradient(ellipse 100% 40% at 50% 100%, rgb(var(--ec-accent) / 0.15) 0%, transparent 100%),
+              radial-gradient(ellipse 100% 40% at 50% 100%, rgb(var(--ec-accent) / 0.045) 0%, transparent 100%),
               rgb(var(--ec-page-bg))
             `,
           }}
@@ -784,8 +880,8 @@ const ChatPanel = ({ isOpen, onClose }: ChatPanelProps) => {
           <div className="flex-none shrink-0 border-b border-[rgb(var(--ec-page-border))]">
             <div className="flex items-center justify-between px-4 py-3">
               <div className="flex items-center space-x-2">
-                <BookOpen size={16} className="text-[rgb(var(--ec-accent))]" />
-                <span className="font-medium text-[rgb(var(--ec-header-text))] text-sm">EventCatalog Assistant</span>
+                <Sparkles size={16} className="text-[rgb(var(--ec-accent))]" />
+                <span className="font-medium text-[rgb(var(--ec-header-text))] text-sm">Assistant</span>
               </div>
               <div className="flex items-center space-x-1">
                 {tools.length > 0 && (
@@ -838,7 +934,7 @@ const ChatPanel = ({ isOpen, onClose }: ChatPanelProps) => {
                 </button>
                 {hasMessages && (
                   <button
-                    onClick={() => setMessages([])}
+                    onClick={clearMessages}
                     className="p-2 rounded-lg hover:bg-[rgb(var(--ec-header-border))] text-[rgb(var(--ec-icon-color))] hover:text-[rgb(var(--ec-header-text))] transition-colors"
                     aria-label="Clear chat"
                     title="Clear chat"
@@ -855,21 +951,6 @@ const ChatPanel = ({ isOpen, onClose }: ChatPanelProps) => {
                 </button>
               </div>
             </div>
-            {/* Thinking indicator */}
-            {isThinking && (
-              <div className="px-4 pb-2 flex items-center gap-2">
-                <div className="w-1.5 h-1.5 bg-[rgb(var(--ec-accent))] rounded-full animate-pulse" />
-                <span className="text-xs text-[rgb(var(--ec-icon-color))]">
-                  {runningTools.length > 0 ? (
-                    <>
-                      Using <span className="font-medium text-[rgb(var(--ec-accent))]">{runningTools[0]}</span>...
-                    </>
-                  ) : (
-                    'Thinking...'
-                  )}
-                </span>
-              </div>
-            )}
           </div>
 
           {/* Content */}
@@ -886,23 +967,23 @@ const ChatPanel = ({ isOpen, onClose }: ChatPanelProps) => {
                   >
                     {/* Icon with circular background */}
                     <div className="relative mb-6">
-                      <div className="w-32 h-32 rounded-full bg-[rgb(var(--ec-accent)/0.15)] flex items-center justify-center">
-                        <MessageSquare size={56} className="text-[rgb(var(--ec-accent))]" strokeWidth={1.5} />
+                      <div className="ec-chat-avatar w-24 h-24 rounded-full flex items-center justify-center">
+                        <MessageSquare size={42} className="text-[rgb(var(--ec-accent))]" strokeWidth={1.5} />
                       </div>
                     </div>
-                    <h2 className="text-lg font-semibold text-[rgb(var(--ec-accent))] mb-1">{greeting}</h2>
+                    <h2 className="text-lg font-medium text-[rgb(var(--ec-page-text))] mb-1">{greeting}</h2>
                     <p className="text-sm font-normal text-[rgb(var(--ec-content-text))]">
                       I'm here to help with your architecture
                     </p>
                   </div>
 
                   {/* Suggested questions - pill style */}
-                  <div className="flex-none space-y-2">
+                  <div className="flex-none flex flex-col items-start gap-2">
                     {suggestedQuestions.map((question, index) => (
                       <button
                         key={index}
                         onClick={() => handleSuggestedAction(question.prompt)}
-                        className="w-full text-left px-4 py-2.5 text-xs text-[rgb(var(--ec-page-text-muted))] hover:text-[rgb(var(--ec-page-text))] bg-[rgb(var(--ec-page-text)/0.05)] hover:bg-[rgb(var(--ec-accent)/0.15)] rounded-full transition-all duration-200"
+                        className="ec-chat-suggestion text-left px-3 py-2 text-xs text-[rgb(var(--ec-page-text-muted))] hover:text-[rgb(var(--ec-page-text))] bg-[rgb(var(--ec-accent)/0.04)] hover:bg-[rgb(var(--ec-accent)/0.09)] rounded-full transition-all duration-200"
                         style={isOpen ? fadeInStyles.getQuestionStyle(index) : undefined}
                       >
                         {question.label}
@@ -919,11 +1000,16 @@ const ChatPanel = ({ isOpen, onClose }: ChatPanelProps) => {
                     const completedTools = message.role === 'assistant' ? getCompletedTools(message) : [];
                     const isLastMessage = messageIndex === messages.length - 1;
                     return (
-                      <div key={message.id} className={`flex flex-col ${message.role === 'user' ? 'items-end' : 'items-start'}`}>
+                      <div
+                        key={message.id}
+                        className={`ec-chat-message ${!configured && message.role === 'assistant' ? 'ec-chat-setup' : ''} flex flex-col ${message.role === 'user' ? 'items-end' : 'items-start'}`}
+                      >
                         {message.role === 'user' ? (
                           <div className="max-w-[85%] rounded-2xl rounded-br-md px-4 py-2.5 bg-[rgb(var(--ec-page-text)/0.05)]">
                             <p className="text-sm font-normal whitespace-pre-wrap text-[rgb(var(--ec-page-text))]">{content}</p>
                           </div>
+                        ) : !configured ? (
+                          <OfflineReply />
                         ) : (
                           <>
                             {/* Tools used indicator */}
@@ -956,7 +1042,7 @@ const ChatPanel = ({ isOpen, onClose }: ChatPanelProps) => {
                                   <button
                                     key={index}
                                     onClick={() => handleSuggestedAction(suggestion)}
-                                    className="px-4 py-2.5 text-xs text-[rgb(var(--ec-page-text-muted))] hover:text-[rgb(var(--ec-page-text))] bg-[rgb(var(--ec-page-text)/0.05)] hover:bg-[rgb(var(--ec-accent)/0.15)] rounded-full transition-all duration-200 text-left"
+                                    className="ec-chat-suggestion px-3 py-2 text-xs text-[rgb(var(--ec-page-text-muted))] hover:text-[rgb(var(--ec-page-text))] bg-[rgb(var(--ec-accent)/0.04)] hover:bg-[rgb(var(--ec-accent)/0.09)] rounded-full transition-all duration-200 text-left"
                                     style={fadeInStyles.getFollowUpStyle(index)}
                                   >
                                     {suggestion}
@@ -973,7 +1059,7 @@ const ChatPanel = ({ isOpen, onClose }: ChatPanelProps) => {
                   {/* Skeleton loading indicator */}
                   {isThinking && (
                     <div className="w-full">
-                      <SkeletonLoader />
+                      <SkeletonLoader label={runningTools.length > 0 ? `Using ${runningTools[0]}…` : undefined} />
                     </div>
                   )}
 
@@ -1008,10 +1094,11 @@ const ChatPanel = ({ isOpen, onClose }: ChatPanelProps) => {
             {/* Input area (Fixed at bottom) */}
             <div className="flex-none px-4 py-3" key={isOpen ? 'input-open' : 'input-closed'}>
               <form onSubmit={handleSubmit}>
-                <div className="relative bg-[rgb(var(--ec-page-bg)/0.5)] backdrop-blur-sm rounded-xl border border-[rgb(var(--ec-accent)/0.3)] focus-within:border-[rgb(var(--ec-accent)/0.5)] focus-within:ring-2 focus-within:ring-[rgb(var(--ec-accent)/0.1)] transition-all">
-                  <input
+                <div className="ec-chat-composer relative bg-[rgb(var(--ec-page-bg)/0.5)] backdrop-blur-sm rounded-xl border border-[rgb(var(--ec-accent)/0.3)] focus-within:border-[rgb(var(--ec-accent)/0.5)] focus-within:ring-2 focus-within:ring-[rgb(var(--ec-accent)/0.1)] transition-all">
+                  <textarea
                     ref={inputRef}
-                    type="text"
+                    rows={2}
+                    aria-label="Ask AI a question"
                     value={inputValue}
                     onChange={(e) => setInputValue(e.target.value)}
                     onKeyDown={handleInputKeyDown}
@@ -1019,11 +1106,21 @@ const ChatPanel = ({ isOpen, onClose }: ChatPanelProps) => {
                     disabled={isLoading}
                     className="w-full px-4 py-3 pr-16 bg-transparent text-[rgb(var(--ec-input-text))] placeholder-[rgb(var(--ec-input-placeholder))] focus:outline-hidden text-sm disabled:opacity-50 rounded-xl"
                   />
-                  <div className="absolute right-2 top-1/2 -translate-y-1/2 z-10">
-                    {isStreaming ? (
+                  <div className="absolute bottom-4 left-4 right-20 truncate text-[10px] text-[rgb(var(--ec-page-text-muted))]">
+                    <span className="mr-1.5 rounded bg-[rgb(var(--ec-accent)/0.08)] px-1 py-0.5 font-medium text-[rgb(var(--ec-accent))]">
+                      AI
+                    </span>
+                    {configured
+                      ? pageContext
+                        ? `Based on ${pageContext.name}`
+                        : 'Your architecture, connected'
+                      : 'Explore your catalog with AI'}
+                  </div>
+                  <div className="ec-chat-composer-actions absolute right-2 z-10">
+                    {isStreaming || isSetupThinking ? (
                       <button
                         type="button"
-                        onClick={() => stop()}
+                        onClick={stopResponse}
                         className="p-2 text-red-500 hover:bg-red-500/10 rounded-lg transition-colors"
                         aria-label="Stop generating"
                       >
@@ -1074,10 +1171,10 @@ const ChatPanel = ({ isOpen, onClose }: ChatPanelProps) => {
         <Dialog.Portal>
           <Dialog.Overlay className="fixed inset-0 bg-black/50 backdrop-blur-sm z-[300]" />
           <Dialog.Content
-            className="fixed inset-y-4 left-1/2 -translate-x-1/2 w-[95%] max-w-4xl md:inset-y-8 rounded-xl shadow-2xl z-[301] flex flex-col overflow-hidden focus:outline-hidden border border-[rgb(var(--ec-page-border))]"
+            className="ec-chat-surface fixed inset-y-4 left-1/2 -translate-x-1/2 w-[95%] max-w-4xl md:inset-y-8 rounded-xl shadow-2xl z-[301] flex flex-col overflow-hidden focus:outline-hidden border border-[rgb(var(--ec-page-border))]"
             style={{
               background: `
-                radial-gradient(ellipse 100% 40% at 50% 100%, rgb(var(--ec-accent) / 0.15) 0%, transparent 100%),
+                radial-gradient(ellipse 100% 40% at 50% 100%, rgb(var(--ec-accent) / 0.045) 0%, transparent 100%),
                 rgb(var(--ec-page-bg))
               `,
             }}
@@ -1086,7 +1183,7 @@ const ChatPanel = ({ isOpen, onClose }: ChatPanelProps) => {
             <div className="flex items-center justify-between px-5 py-3 border-b border-[rgb(var(--ec-page-border))] flex-shrink-0">
               <div className="flex items-center space-x-2.5">
                 <div className="p-1.5 bg-[rgb(var(--ec-accent-subtle))] rounded-lg">
-                  <BookOpen size={18} className="text-[rgb(var(--ec-accent))]" />
+                  <Sparkles size={18} className="text-[rgb(var(--ec-accent))]" />
                 </div>
                 <Dialog.Title className="text-base font-medium text-[rgb(var(--ec-page-text))]">Ask AI</Dialog.Title>
               </div>
@@ -1137,7 +1234,7 @@ const ChatPanel = ({ isOpen, onClose }: ChatPanelProps) => {
                 )}
                 {hasMessages && (
                   <button
-                    onClick={() => setMessages([])}
+                    onClick={clearMessages}
                     className="p-2 rounded-lg hover:bg-[rgb(var(--ec-content-hover))] text-[rgb(var(--ec-icon-color))] hover:text-[rgb(var(--ec-page-text))] transition-colors"
                     aria-label="Clear chat"
                     title="Clear chat"
@@ -1166,22 +1263,6 @@ const ChatPanel = ({ isOpen, onClose }: ChatPanelProps) => {
               </div>
             </div>
 
-            {/* Thinking indicator */}
-            {isThinking && (
-              <div className="px-5 py-2 flex items-center gap-2 border-b border-[rgb(var(--ec-page-border))]">
-                <div className="w-1.5 h-1.5 bg-[rgb(var(--ec-accent))] rounded-full animate-pulse" />
-                <span className="text-sm text-[rgb(var(--ec-page-text-muted))]">
-                  {runningTools.length > 0 ? (
-                    <>
-                      Using <span className="font-medium text-[rgb(var(--ec-accent))]">{runningTools[0]}</span>...
-                    </>
-                  ) : (
-                    'Thinking...'
-                  )}
-                </span>
-              </div>
-            )}
-
             {/* Modal Content */}
             <div className="flex-1 overflow-y-auto px-6 py-6">
               {!hasMessages ? (
@@ -1191,11 +1272,11 @@ const ChatPanel = ({ isOpen, onClose }: ChatPanelProps) => {
                   <div className="flex-1 flex flex-col justify-center items-center text-center">
                     {/* Icon with circular background */}
                     <div className="relative mb-8">
-                      <div className="w-40 h-40 rounded-full bg-[rgb(var(--ec-accent)/0.15)] flex items-center justify-center">
-                        <MessageSquare size={72} className="text-[rgb(var(--ec-accent))]" strokeWidth={1.5} />
+                      <div className="ec-chat-avatar w-28 h-28 rounded-full flex items-center justify-center">
+                        <MessageSquare size={48} className="text-[rgb(var(--ec-accent))]" strokeWidth={1.5} />
                       </div>
                     </div>
-                    <h2 className="text-2xl font-semibold text-[rgb(var(--ec-accent))] mb-2">{greeting}</h2>
+                    <h2 className="text-2xl font-medium text-[rgb(var(--ec-page-text))] mb-2">{greeting}</h2>
                     <p className="font-normal text-[rgb(var(--ec-content-text))] text-center">
                       I'm here to help with your architecture
                     </p>
@@ -1207,7 +1288,7 @@ const ChatPanel = ({ isOpen, onClose }: ChatPanelProps) => {
                       <button
                         key={index}
                         onClick={() => handleSuggestedAction(question.prompt)}
-                        className="px-4 py-2.5 text-xs text-[rgb(var(--ec-page-text-muted))] hover:text-[rgb(var(--ec-page-text))] bg-[rgb(var(--ec-page-text)/0.05)] hover:bg-[rgb(var(--ec-accent)/0.15)] rounded-full transition-all duration-200 text-left"
+                        className="ec-chat-suggestion px-3 py-2 text-xs text-[rgb(var(--ec-page-text-muted))] hover:text-[rgb(var(--ec-page-text))] bg-[rgb(var(--ec-accent)/0.04)] hover:bg-[rgb(var(--ec-accent)/0.09)] rounded-full transition-all duration-200 text-left"
                       >
                         {question.label}
                       </button>
@@ -1223,11 +1304,16 @@ const ChatPanel = ({ isOpen, onClose }: ChatPanelProps) => {
                     const completedTools = message.role === 'assistant' ? getCompletedTools(message) : [];
                     const isLastMessage = messageIndex === messages.length - 1;
                     return (
-                      <div key={message.id} className={`flex flex-col ${message.role === 'user' ? 'items-end' : 'items-start'}`}>
+                      <div
+                        key={message.id}
+                        className={`ec-chat-message ${!configured && message.role === 'assistant' ? 'ec-chat-setup' : ''} flex flex-col ${message.role === 'user' ? 'items-end' : 'items-start'}`}
+                      >
                         {message.role === 'user' ? (
                           <div className="max-w-[75%] rounded-2xl rounded-br-md px-4 py-2.5 bg-[rgb(var(--ec-page-text)/0.05)]">
                             <p className="text-sm font-normal whitespace-pre-wrap text-[rgb(var(--ec-page-text))]">{content}</p>
                           </div>
+                        ) : !configured ? (
+                          <OfflineReply />
                         ) : (
                           <>
                             {/* Tools used indicator */}
@@ -1260,7 +1346,7 @@ const ChatPanel = ({ isOpen, onClose }: ChatPanelProps) => {
                                   <button
                                     key={index}
                                     onClick={() => handleSuggestedAction(suggestion)}
-                                    className="px-4 py-2.5 text-xs text-[rgb(var(--ec-page-text-muted))] hover:text-[rgb(var(--ec-page-text))] bg-[rgb(var(--ec-page-text)/0.05)] hover:bg-[rgb(var(--ec-accent)/0.15)] rounded-full transition-all duration-200 text-left"
+                                    className="ec-chat-suggestion px-3 py-2 text-xs text-[rgb(var(--ec-page-text-muted))] hover:text-[rgb(var(--ec-page-text))] bg-[rgb(var(--ec-accent)/0.04)] hover:bg-[rgb(var(--ec-accent)/0.09)] rounded-full transition-all duration-200 text-left"
                                     style={fadeInStyles.getFollowUpStyle(index)}
                                   >
                                     {suggestion}
@@ -1276,7 +1362,7 @@ const ChatPanel = ({ isOpen, onClose }: ChatPanelProps) => {
 
                   {isThinking && (
                     <div className="w-full max-w-md">
-                      <SkeletonLoader />
+                      <SkeletonLoader label={runningTools.length > 0 ? `Using ${runningTools[0]}…` : undefined} />
                     </div>
                   )}
 
@@ -1300,10 +1386,11 @@ const ChatPanel = ({ isOpen, onClose }: ChatPanelProps) => {
             {/* Modal Input area */}
             <div className="flex-shrink-0 px-6 py-4">
               <form onSubmit={handleSubmit} className="max-w-3xl mx-auto">
-                <div className="relative bg-[rgb(var(--ec-page-bg)/0.5)] backdrop-blur-sm rounded-xl border border-[rgb(var(--ec-accent)/0.3)] focus-within:border-[rgb(var(--ec-accent)/0.5)] focus-within:ring-2 focus-within:ring-[rgb(var(--ec-accent)/0.1)] transition-all">
-                  <input
+                <div className="ec-chat-composer relative bg-[rgb(var(--ec-page-bg)/0.5)] backdrop-blur-sm rounded-xl border border-[rgb(var(--ec-accent)/0.3)] focus-within:border-[rgb(var(--ec-accent)/0.5)] focus-within:ring-2 focus-within:ring-[rgb(var(--ec-accent)/0.1)] transition-all">
+                  <textarea
                     ref={modalInputRef}
-                    type="text"
+                    rows={2}
+                    aria-label="Ask AI a question"
                     value={inputValue}
                     onChange={(e) => setInputValue(e.target.value)}
                     onKeyDown={handleInputKeyDown}
@@ -1311,11 +1398,21 @@ const ChatPanel = ({ isOpen, onClose }: ChatPanelProps) => {
                     disabled={isLoading}
                     className="w-full px-4 py-3.5 pr-20 bg-transparent text-[rgb(var(--ec-input-text))] placeholder-[rgb(var(--ec-input-placeholder))] focus:outline-hidden text-sm disabled:opacity-50 rounded-xl"
                   />
-                  <div className="absolute right-2 top-1/2 -translate-y-1/2 z-10">
-                    {isStreaming ? (
+                  <div className="absolute bottom-4 left-4 right-20 truncate text-[10px] text-[rgb(var(--ec-page-text-muted))]">
+                    <span className="mr-1.5 rounded bg-[rgb(var(--ec-accent)/0.08)] px-1 py-0.5 font-medium text-[rgb(var(--ec-accent))]">
+                      AI
+                    </span>
+                    {configured
+                      ? pageContext
+                        ? `Based on ${pageContext.name}`
+                        : 'Your architecture, connected'
+                      : 'Explore your catalog with AI'}
+                  </div>
+                  <div className="ec-chat-composer-actions absolute right-2 z-10">
+                    {isStreaming || isSetupThinking ? (
                       <button
                         type="button"
-                        onClick={() => stop()}
+                        onClick={stopResponse}
                         className="p-2 text-red-500 hover:bg-red-500/10 rounded-lg transition-colors"
                         aria-label="Stop generating"
                       >

--- a/packages/core/eventcatalog/src/components/ChatPanel/ChatPanel.tsx
+++ b/packages/core/eventcatalog/src/components/ChatPanel/ChatPanel.tsx
@@ -738,31 +738,23 @@ const ChatPanel = ({ isOpen, onClose, configured = false }: ChatPanelProps) => {
 
     const elements = [appEl, headerEl].filter(Boolean) as HTMLElement[];
 
-    elements.forEach((el) => {
-      // Add transition if not already present
-      if (!el.style.transition) {
-        el.style.transition = 'padding-right 420ms cubic-bezier(0.16, 1, 0.3, 1)';
-      }
-
-      // Only add padding when panel is open AND not in fullscreen mode
-      if (isOpen && !isFullscreen) {
-        el.style.paddingRight = `${PANEL_WIDTH}px`;
-      } else {
-        el.style.paddingRight = '0';
-      }
-    });
-
-    // Hide docs sidebar when chat panel is open
-    if (docsSidebarEl) {
-      if (isOpen && !isFullscreen) {
-        docsSidebarEl.style.display = 'none';
-      } else {
-        docsSidebarEl.style.display = '';
-      }
-    }
+    const desktop = window.matchMedia('(min-width: 1024px)');
+    const updateLayout = () => {
+      const pushContent = desktop.matches && isOpen && !isFullscreen;
+      elements.forEach((el) => {
+        if (!el.style.transition) {
+          el.style.transition = 'padding-right 420ms cubic-bezier(0.16, 1, 0.3, 1)';
+        }
+        el.style.paddingRight = pushContent ? `${PANEL_WIDTH}px` : '0';
+      });
+      if (docsSidebarEl) docsSidebarEl.style.display = pushContent ? 'none' : '';
+    };
+    updateLayout();
+    desktop.addEventListener('change', updateLayout);
 
     // Cleanup on unmount
     return () => {
+      desktop.removeEventListener('change', updateLayout);
       elements.forEach((el) => {
         el.style.paddingRight = '0';
       });

--- a/packages/core/eventcatalog/src/components/ChatPanel/ChatPanelButton.tsx
+++ b/packages/core/eventcatalog/src/components/ChatPanel/ChatPanelButton.tsx
@@ -1,9 +1,15 @@
-import { useState, useEffect } from 'react';
-import { BookOpen } from 'lucide-react';
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { Sparkles } from 'lucide-react';
 import ChatPanel from './ChatPanel';
 
-const ChatPanelButton = () => {
+const ChatPanelButton = ({ configured = false }: { configured?: boolean }) => {
   const [isOpen, setIsOpen] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const closePanel = useCallback(() => {
+    setIsOpen(false);
+    buttonRef.current?.focus();
+  }, []);
+  const [shortcut, setShortcut] = useState('⌘I');
 
   // Listen for custom event to open chat panel from other components
   useEffect(() => {
@@ -11,22 +17,36 @@ const ChatPanelButton = () => {
       setIsOpen(true);
     };
 
+    setShortcut(/Mac|iPhone|iPad/.test(navigator.platform) ? '⌘I' : 'Ctrl I');
+    const handleShortcut = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && !event.altKey && !event.shiftKey && event.key.toLowerCase() === 'i') {
+        event.preventDefault();
+        setIsOpen(true);
+      }
+    };
+    window.addEventListener('keydown', handleShortcut);
     window.addEventListener('eventcatalog:open-chat', handleOpenChat);
-    return () => window.removeEventListener('eventcatalog:open-chat', handleOpenChat);
+    return () => {
+      window.removeEventListener('keydown', handleShortcut);
+      window.removeEventListener('eventcatalog:open-chat', handleOpenChat);
+    };
   }, []);
 
   return (
     <>
       <button
+        ref={buttonRef}
         onClick={() => setIsOpen(true)}
-        className="flex items-center gap-1.5 px-4 py-1.5 rounded-md bg-[rgb(var(--ec-card-bg))] hover:bg-[rgb(var(--ec-content-hover))] ring-1 ring-inset ring-[rgb(var(--ec-page-border))] shadow-xs transition-colors text-sm ml-[-1px]"
+        className="flex h-9 shrink-0 items-center justify-center gap-1.5 whitespace-nowrap px-4 rounded-md bg-[rgb(var(--ec-card-bg))] hover:bg-[rgb(var(--ec-content-hover))] ring-1 ring-inset ring-[rgb(var(--ec-page-border))] shadow-xs transition-colors text-sm"
         aria-label="Open AI Assistant"
+        aria-keyshortcuts="Meta+i Control+i"
+        title={`Open Event Catalog Assistant (${shortcut})`}
       >
-        <BookOpen size={14} className="text-[rgb(var(--ec-accent))]" />
-        <span className="font-light text-[rgb(var(--ec-page-text-muted))]">Ask</span>
+        <Sparkles size={16} className="shrink-0 text-gray-500" aria-hidden="true" />
+        <span className="font-light text-gray-500">Ask</span>
       </button>
 
-      <ChatPanel isOpen={isOpen} onClose={() => setIsOpen(false)} />
+      <ChatPanel configured={configured} isOpen={isOpen} onClose={closePanel} />
     </>
   );
 };

--- a/packages/core/eventcatalog/src/components/ChatPanel/OfflineReply.tsx
+++ b/packages/core/eventcatalog/src/components/ChatPanel/OfflineReply.tsx
@@ -1,0 +1,45 @@
+import { ArrowUpRight } from 'lucide-react';
+import { buildUrl } from '@utils/url-builder';
+
+const setupUrl = 'https://www.eventcatalog.dev/docs/development/ask-your-architecture/eventcatalog-assistant/configuration';
+const introduction = 'Your whole catalog, connected to your AI.';
+const description =
+  'Bring your own model and I can help you understand your services, trace how events flow, and explore the impact of a change across your whole catalog.';
+const privacy = 'You choose where your data is processed: on your own infrastructure or with a model provider you trust.';
+const setup = 'I’m not connected to a model yet. Your catalog owner can connect one to get started.';
+
+export const offlineReplyText = `${introduction}\n\n${description}\n\n${privacy}\n\n${setup}`;
+
+export default function OfflineReply() {
+  return (
+    <div className="ec-chat-offline w-full space-y-4 py-2 text-[13px] leading-relaxed text-[rgb(var(--ec-content-text))]">
+      <div className="space-y-2">
+        <p className="text-base font-medium leading-snug text-[rgb(var(--ec-page-text))]">{introduction}</p>
+        <p>{description}</p>
+      </div>
+      <div className="space-y-3 rounded-xl border border-[rgb(var(--ec-accent)/0.15)] bg-[rgb(var(--ec-accent)/0.04)] p-4">
+        <div className="space-y-1">
+          <p className="font-medium text-[rgb(var(--ec-page-text))]">Your model. Your control.</p>
+          <p className="text-[rgb(var(--ec-page-text-muted))]">{privacy}</p>
+        </div>
+        <p>{setup}</p>
+        <a
+          href={setupUrl}
+          target="_blank"
+          rel="noreferrer"
+          className="inline-flex items-center gap-2 rounded-lg bg-[rgb(var(--ec-accent))] px-3 py-2 text-xs font-medium text-white transition-colors hover:bg-[rgb(var(--ec-accent-hover))] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[rgb(var(--ec-accent))]"
+        >
+          Connect your model
+          <ArrowUpRight size={14} aria-hidden="true" />
+        </a>
+      </div>
+      <p className="text-xs leading-relaxed text-[rgb(var(--ec-page-text-muted))]">
+        Don’t need the assistant?{' '}
+        <a href={buildUrl('/settings/assistant')} className="underline underline-offset-2 hover:text-[rgb(var(--ec-page-text))]">
+          Turn off Event Catalog Assistant
+        </a>{' '}
+        or set <code className="text-[11px]">chat.enabled: false</code> in your catalog configuration.
+      </p>
+    </div>
+  );
+}

--- a/packages/core/eventcatalog/src/components/ChatPanel/__tests__/ChatPanel.test.ts
+++ b/packages/core/eventcatalog/src/components/ChatPanel/__tests__/ChatPanel.test.ts
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+import { createElement, act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import ChatPanel from '../ChatPanel';
+import ChatPanelButton from '../ChatPanelButton';
+
+vi.mock('@utils/url-builder', () => ({ buildUrl: (url: string) => url }));
+
+// Keep syntax highlighting out of these interaction tests.
+vi.mock('react-syntax-highlighter', () => ({ Prism: () => null }));
+vi.mock('react-syntax-highlighter/dist/cjs/styles/prism', () => ({ oneDark: {} }));
+
+describe('Ask AI setup experience', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ tools: [] })));
+    vi.stubGlobal('fetch', fetchMock);
+    Element.prototype.scrollIntoView = vi.fn();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('answers a suggested question with setup guidance without making an API request when unconfigured', async () => {
+    await act(async () => root.render(createElement(ChatPanel, { isOpen: true, onClose: vi.fn(), configured: false })));
+    const question = Array.from(container.querySelectorAll('button')).find((button) => button.textContent?.includes('?'));
+    expect(question).toBeDefined();
+    await act(async () => question!.click());
+    expect(container.textContent).not.toContain('Your whole catalog, connected to your AI.');
+    expect(container.querySelector('button[aria-label="Stop generating"]')).not.toBeNull();
+    await act(async () => vi.advanceTimersByTime(1200));
+    expect(container.textContent).toContain('Your whole catalog, connected to your AI.');
+    expect(container.textContent).toContain('I’m not connected to a model yet.');
+    expect(container.textContent).toContain('Bring your own model');
+    expect(container.textContent).toContain('You choose where your data is processed');
+    expect(container.querySelector('a[href="/settings/assistant"]')?.textContent).toBe('Turn off Event Catalog Assistant');
+    expect(container.querySelector('a[href$="/eventcatalog-assistant/configuration"]')?.textContent).toBe('Connect your model');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it.each(['Stop generating', 'Clear chat'])('cancels the delayed reply when the user clicks %s', async (label) => {
+    await act(async () => root.render(createElement(ChatPanel, { isOpen: true, onClose: vi.fn(), configured: false })));
+    const question = Array.from(container.querySelectorAll('button')).find((button) => button.textContent?.includes('?'));
+    await act(async () => question!.click());
+    const cancelButton = container.querySelector<HTMLButtonElement>(`button[aria-label="${label}"]`);
+    expect(cancelButton).not.toBeNull();
+    await act(async () => cancelButton!.click());
+    await act(async () => vi.advanceTimersByTime(2000));
+    expect(container.textContent).not.toContain('Your whole catalog, connected to your AI.');
+    expect(container.querySelector('button[aria-label="Stop generating"]')).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it.each(['metaKey', 'ctrlKey'])('opens Ask and focuses its input with %s + I', async (modifier) => {
+    await act(async () => root.render(createElement(ChatPanelButton, { configured: false })));
+    const shortcut = new KeyboardEvent('keydown', { key: 'i', [modifier]: true, bubbles: true, cancelable: true });
+    await act(async () => document.dispatchEvent(shortcut));
+    await act(async () => vi.advanceTimersByTime(100));
+    const input = container.querySelector('textarea');
+    expect(shortcut.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(input);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('makes the closed sidebar inert and restores focus to Ask when closed', async () => {
+    await act(async () => root.render(createElement(ChatPanelButton, { configured: false })));
+    const panel = container.querySelector('.ec-chat-surface')!;
+    const trigger = container.querySelector<HTMLButtonElement>('button[aria-label="Open AI Assistant"]')!;
+    expect(panel.hasAttribute('inert')).toBe(true);
+    expect(panel.getAttribute('aria-hidden')).toBe('true');
+
+    await act(async () => trigger.click());
+    await act(async () => vi.advanceTimersByTime(100));
+    expect(panel.hasAttribute('inert')).toBe(false);
+    expect(panel.getAttribute('aria-hidden')).toBe('false');
+    expect(document.activeElement).toBe(container.querySelector('textarea'));
+
+    await act(async () => document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })));
+    expect(panel.hasAttribute('inert')).toBe(true);
+    expect(panel.getAttribute('aria-hidden')).toBe('true');
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it('does not move focus back into the sidebar when it closes before the focus timer runs', async () => {
+    await act(async () => root.render(createElement(ChatPanelButton, { configured: false })));
+    const trigger = container.querySelector<HTMLButtonElement>('button[aria-label="Open AI Assistant"]')!;
+    await act(async () => trigger.click());
+    await act(async () => container.querySelector<HTMLButtonElement>('button[aria-label="Close chat panel"]')!.click());
+    await act(async () => vi.advanceTimersByTime(100));
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it('loads available tools when the configured assistant opens', async () => {
+    await act(async () => root.render(createElement(ChatPanel, { isOpen: true, onClose: vi.fn(), configured: true })));
+    expect(fetchMock).toHaveBeenCalledWith('/api/chat');
+    expect(container.textContent).not.toContain('Your whole catalog, connected to your AI.');
+  });
+});

--- a/packages/core/eventcatalog/src/components/ChatPanel/__tests__/ChatPanel.test.ts
+++ b/packages/core/eventcatalog/src/components/ChatPanel/__tests__/ChatPanel.test.ts
@@ -17,6 +17,10 @@ describe('Ask AI setup experience', () => {
 
   beforeEach(() => {
     vi.useFakeTimers();
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn(() => ({ matches: true, addEventListener: vi.fn(), removeEventListener: vi.fn() }))
+    );
     vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
     fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ tools: [] })));
     vi.stubGlobal('fetch', fetchMock);
@@ -100,6 +104,32 @@ describe('Ask AI setup experience', () => {
     await act(async () => container.querySelector<HTMLButtonElement>('button[aria-label="Close chat panel"]')!.click());
     await act(async () => vi.advanceTimersByTime(100));
     expect(document.activeElement).toBe(trigger);
+  });
+
+  it('opens from a page action on mobile without squeezing the page, and adapts when resized', async () => {
+    const media = { matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() };
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn(() => media)
+    );
+    const app = document.createElement('div');
+    app.id = 'eventcatalog-application';
+    document.body.appendChild(app);
+    try {
+      await act(async () => root.render(createElement(ChatPanelButton, { configured: false })));
+      await act(async () => window.dispatchEvent(new CustomEvent('eventcatalog:open-chat')));
+      expect(container.querySelector('.ec-chat-surface')?.hasAttribute('inert')).toBe(false);
+      expect(app.style.paddingRight).toBe('0px');
+      const updateLayout = media.addEventListener.mock.calls.at(-1)![1];
+      media.matches = true;
+      await act(async () => updateLayout());
+      expect(app.style.paddingRight).toBe('400px');
+      media.matches = false;
+      await act(async () => updateLayout());
+      expect(app.style.paddingRight).toBe('0px');
+    } finally {
+      app.remove();
+    }
   });
 
   it('loads available tools when the configured assistant opens', async () => {

--- a/packages/core/eventcatalog/src/components/Header.astro
+++ b/packages/core/eventcatalog/src/components/Header.astro
@@ -39,8 +39,8 @@ const repositoryUrl = catalog?.repositoryUrl || 'https://github.com/event-catalo
 >
   <div class="px-6">
     <div class="flex justify-between items-center gap-4">
-      <div class="hidden lg:flex min-w-0 flex-1 items-center gap-3">
-        <div class="min-w-0 flex-1 max-w-xl">
+      <div class="flex min-w-0 flex-1 items-center gap-3">
+        <div class="hidden lg:block min-w-0 flex-1 max-w-xl">
           <Search />
         </div>
         {isEventCatalogChatVisible() && <ChatPanelButton configured={isEventCatalogChatEnabled()} client:idle />}

--- a/packages/core/eventcatalog/src/components/Header.astro
+++ b/packages/core/eventcatalog/src/components/Header.astro
@@ -2,7 +2,12 @@
 import catalog from '@utils/eventcatalog-config/catalog';
 import Search from '@components/Search/Search.astro';
 import { buildUrl } from '@utils/url-builder';
-import { showEventCatalogBranding, showCustomBranding, isEventCatalogChatEnabled } from '@utils/feature';
+import {
+  showEventCatalogBranding,
+  showCustomBranding,
+  isEventCatalogChatVisible,
+  isEventCatalogChatEnabled,
+} from '@utils/feature';
 import { getSession } from 'auth-astro/server';
 import { isAuthEnabled, isSSR } from '@utils/feature';
 import { EnvironmentDropdown } from './EnvironmentDropdown';
@@ -33,15 +38,15 @@ const repositoryUrl = catalog?.repositoryUrl || 'https://github.com/event-catalo
     : 'left: var(--ec-vertical-nav-width, 14rem);'}
 >
   <div class="px-6">
-    <div class="flex justify-between items-center">
-      <div class="hidden lg:flex flex-grow items-center">
-        <div class="w-full max-w-xl">
+    <div class="flex justify-between items-center gap-4">
+      <div class="hidden lg:flex min-w-0 flex-1 items-center gap-3">
+        <div class="min-w-0 flex-1 max-w-xl">
           <Search />
         </div>
-        {isEventCatalogChatEnabled() && <ChatPanelButton client:idle />}
+        {isEventCatalogChatVisible() && <ChatPanelButton configured={isEventCatalogChatEnabled()} client:idle />}
       </div>
 
-      <div class="hidden md:block w-3/12">
+      <div class="hidden md:block shrink-0 ml-auto">
         {
           session ? (
             <div class="flex items-center space-x-4 justify-end pr-2">

--- a/packages/core/eventcatalog/src/components/MDX/Design/Design.astro
+++ b/packages/core/eventcatalog/src/components/MDX/Design/Design.astro
@@ -7,10 +7,10 @@ import AstroNodeGraph from '../NodeGraph/AstroNodeGraph';
 // Visualiser styles ship in the page head so ClientRouter navigations keep them (see NodeGraph.astro).
 import '@eventcatalog/visualiser/styles-core.css';
 
-import { isVisualiserEnabled, isEventCatalogChatEnabled, isDevMode } from '@utils/feature';
+import { isVisualiserEnabled, isEventCatalogChatVisible, isDevMode } from '@utils/feature';
 import { loadSavedLayout, applyLayoutToNodes, buildResourceKey } from '@utils/node-graphs/layout-persistence';
 
-const isChatEnabled = isEventCatalogChatEnabled();
+const isChatEnabled = isEventCatalogChatVisible();
 
 let design: any;
 let id = 'design';

--- a/packages/core/eventcatalog/src/components/MDX/EntityMap/EntityMap.astro
+++ b/packages/core/eventcatalog/src/components/MDX/EntityMap/EntityMap.astro
@@ -7,10 +7,10 @@ import AstroNodeGraph from '../NodeGraph/AstroNodeGraph';
 import '@eventcatalog/visualiser/styles-core.css';
 import { getVersionFromCollection } from '@utils/collections/versions';
 import { getServices } from '@utils/collections/services';
-import { isEventCatalogChatEnabled, isDevMode } from '@utils/feature';
+import { isEventCatalogChatVisible, isDevMode } from '@utils/feature';
 import { loadSavedLayout, applyLayoutToNodes, buildResourceKey } from '@utils/node-graphs/layout-persistence';
 
-const isChatEnabled = isEventCatalogChatEnabled();
+const isChatEnabled = isEventCatalogChatVisible();
 
 const { id, version = 'latest', maxHeight, includeKey = true, entities, collection = 'domains', ...rest } = Astro.props;
 let resource = null;

--- a/packages/core/eventcatalog/src/components/MDX/Flow/Flow.astro
+++ b/packages/core/eventcatalog/src/components/MDX/Flow/Flow.astro
@@ -6,12 +6,12 @@ import AstroNodeGraph from '../NodeGraph/AstroNodeGraph';
 // Visualiser styles ship in the page head so ClientRouter navigations keep them (see NodeGraph.astro).
 import '@eventcatalog/visualiser/styles-core.css';
 import { getVersionFromCollection } from '@utils/collections/versions';
-import { isVisualiserEnabled, isEventCatalogChatEnabled, isDevMode } from '@utils/feature';
+import { isVisualiserEnabled, isEventCatalogChatVisible, isDevMode } from '@utils/feature';
 import { loadSavedLayout, applyLayoutToNodes, buildResourceKey } from '@utils/node-graphs/layout-persistence';
 import { randomUUID } from 'node:crypto';
 import { parseMdxBooleanProp } from '@utils/markdown';
 
-const isChatEnabled = isEventCatalogChatEnabled();
+const isChatEnabled = isEventCatalogChatVisible();
 
 const { id, version = 'latest', maxHeight, mode = 'simple' } = Astro.props;
 const includeKey = parseMdxBooleanProp(Astro.props.legend ?? Astro.props.includeKey, true);

--- a/packages/core/eventcatalog/src/components/MDX/NodeGraph/NodeGraph.astro
+++ b/packages/core/eventcatalog/src/components/MDX/NodeGraph/NodeGraph.astro
@@ -29,11 +29,11 @@ import { pageDataLoader } from '@utils/page-loaders/page-data-loader';
 import { getNodesAndEdges as getNodesAndEdgesForContainer } from '@utils/node-graphs/container-node-graph';
 import { getNodesAndEdges as getNodesAndEdgesForChannel } from '@utils/node-graphs/channel-node-graph';
 import config from '@config';
-import { isEventCatalogChatEnabled, isDevMode } from '@utils/feature';
+import { isEventCatalogChatVisible, isDevMode } from '@utils/feature';
 import { loadSavedLayout, applyLayoutToNodes, buildResourceKey } from '@utils/node-graphs/layout-persistence';
 import { compactVisualiserGraph } from '@utils/node-graphs/compact-visualiser-graph';
 
-const isChatEnabled = isEventCatalogChatEnabled();
+const isChatEnabled = isEventCatalogChatVisible();
 
 interface Props {
   id: string;

--- a/packages/core/eventcatalog/src/components/Search/Search.astro
+++ b/packages/core/eventcatalog/src/components/Search/Search.astro
@@ -4,18 +4,25 @@ import SearchModal from './SearchModal.tsx';
 ---
 
 <div>
-  <div class="relative flex items-center w-full pr-4 ml-1">
+  <div class="relative flex min-w-0 items-center w-full">
     <input
       id="search-dummy-input"
       type="text"
       name="search"
       placeholder="Search EventCatalog"
       autocomplete="off"
-      class="block w-full rounded-md caret-transparent border-0 py-1.5 pr-14 pl-10! text-[rgb(var(--ec-header-text))] bg-[rgb(var(--ec-header-bg))] shadow-xs ring-1 ring-inset ring-[rgb(var(--ec-dropdown-border))] placeholder:text-[rgb(var(--ec-icon-color))] font-light sm:text-sm sm:leading-6"
+      class="block h-9 min-w-0 w-full rounded-md caret-transparent border-0 py-1.5 pr-20 pl-10! text-[rgb(var(--ec-header-text))] bg-[rgb(var(--ec-header-bg))] shadow-xs ring-1 ring-inset ring-[rgb(var(--ec-dropdown-border))] placeholder:text-gray-400 font-light sm:text-sm sm:leading-6"
     />
     <MagnifyingGlassIcon className="absolute inset-y-0 left-0 h-9 w-8 flex items-center pl-4 text-[rgb(var(--ec-icon-color))]" />
-    <div class="absolute inset-y-0 right-0 flex py-1.5 pr-6">
-      <kbd class="inline-flex items-center rounded px-1 font-sans text-xs text-[rgb(var(--ec-icon-color))]">⌘K</kbd>
+    <div class="absolute inset-y-0 right-0 flex items-center gap-1 pr-2 pointer-events-none">
+      <kbd
+        class="inline-flex h-6 min-w-6 items-center justify-center rounded-lg border border-[rgb(var(--ec-dropdown-border))] bg-[rgb(var(--ec-card-bg))] px-1 font-sans text-xs font-normal text-[rgb(var(--ec-icon-color))] shadow-xs"
+        >⌘</kbd
+      >
+      <kbd
+        class="inline-flex h-6 min-w-6 items-center justify-center rounded-lg border border-[rgb(var(--ec-dropdown-border))] bg-[rgb(var(--ec-card-bg))] px-1 font-sans text-xs font-normal text-[rgb(var(--ec-icon-color))] shadow-xs"
+        >K</kbd
+      >
     </div>
   </div>
 </div>

--- a/packages/core/eventcatalog/src/components/Settings/AssistantSettingsForm.tsx
+++ b/packages/core/eventcatalog/src/components/Settings/AssistantSettingsForm.tsx
@@ -76,34 +76,39 @@ export const AssistantSettingsForm = ({ canEdit, initial, chatAvailable, hasPlan
       <Row
         title="Assistant Agent"
         description="Assistant agent that answers questions about your architecture directly in your catalog."
-        canEdit={canEdit && chatAvailable}
+        canEdit={canEdit}
         dirty={dirty}
         saving={saving}
-        onSave={chatAvailable ? save : undefined}
+        onSave={save}
       >
-        {chatAvailable ? (
-          <div className="space-y-3">
-            <ToggleRow
-              icon={<MessageSquare className="h-4 w-4" aria-hidden />}
-              label={chatEnabled ? 'Enabled' : 'Disabled'}
-              hint={chatEnabled ? 'Chat is available to readers of this catalog.' : 'Chat is hidden from the catalog.'}
-              checked={chatEnabled}
-              disabled={!canEdit}
-              onChange={setChatEnabled}
-            />
-            {chatEnabled && <ConfigurationRequired />}
-          </div>
-        ) : !hasPlan ? (
-          <UpgradeRequired
-            tier="Starter and Scale"
-            blurb="The EventCatalog Assistant is part of our paid plans. Upgrade to give your team a built-in AI agent that answers questions about your architecture."
-            docsUrl={ASSISTANT_DOCS_URL}
+        <div className="space-y-3">
+          <ToggleRow
+            icon={<MessageSquare className="h-4 w-4" aria-hidden />}
+            label={chatEnabled ? 'Enabled' : 'Disabled'}
+            hint={
+              chatEnabled
+                ? 'Event Catalog Assistant is visible in this catalog.'
+                : 'Event Catalog Assistant is hidden from this catalog.'
+            }
+            checked={chatEnabled}
+            disabled={!canEdit}
+            onChange={setChatEnabled}
           />
-        ) : !inSSR ? (
-          <AssistantNeedsSSR />
-        ) : !hasChatConfigFile ? (
-          <AssistantNeedsConfigFile />
-        ) : null}
+          {chatEnabled &&
+            (chatAvailable ? (
+              <ConfigurationRequired />
+            ) : !hasPlan ? (
+              <UpgradeRequired
+                tier="Starter and Scale"
+                blurb="The EventCatalog Assistant is part of our paid plans. Upgrade to give your team a built-in AI agent that answers questions about your architecture."
+                docsUrl={ASSISTANT_DOCS_URL}
+              />
+            ) : !inSSR ? (
+              <AssistantNeedsSSR />
+            ) : !hasChatConfigFile ? (
+              <AssistantNeedsConfigFile />
+            ) : null)}
+        </div>
       </Row>
     </form>
   );

--- a/packages/core/eventcatalog/src/enterprise/custom-documentation/pages/docs/custom/index.astro
+++ b/packages/core/eventcatalog/src/enterprise/custom-documentation/pages/docs/custom/index.astro
@@ -21,7 +21,7 @@ import {
   isVisualiserEnabled,
   isMarkdownDownloadEnabled,
   isRSSEnabled,
-  isEventCatalogChatEnabled,
+  isEventCatalogChatVisible,
   isArchitectureGraphEnabled,
 } from '@utils/feature';
 
@@ -152,11 +152,11 @@ const editUrl =
                 client:only="react"
                 variant="toolbar"
                 schemas={[]}
-                chatEnabled={isEventCatalogChatEnabled()}
+                chatEnabled={isEventCatalogChatVisible()}
                 markdownDownloadEnabled={isMarkdownDownloadEnabled()}
                 rssFeedEnabled={isRSSEnabled()}
                 editUrl={editUrl}
-                preferChatAsDefault={isEventCatalogChatEnabled()}
+                preferChatAsDefault={isEventCatalogChatVisible()}
               />
             </div>
           </div>

--- a/packages/core/eventcatalog/src/pages/diagrams/[id]/[version]/index.astro
+++ b/packages/core/eventcatalog/src/pages/diagrams/[id]/[version]/index.astro
@@ -7,7 +7,7 @@ import config from '@config';
 import { buildUrl } from '@utils/url-builder';
 import { GitCompare, X, AlignLeft, HistoryIcon } from 'lucide-react';
 import CopyAsMarkdown from '@components/CopyAsMarkdown';
-import { isLLMSTxtEnabled, isEventCatalogChatEnabled } from '@utils/feature';
+import { isLLMSTxtEnabled, isEventCatalogChatVisible } from '@utils/feature';
 
 import { Page } from './_index.data';
 
@@ -21,7 +21,7 @@ const pageTitle = `Diagram | ${props.data.name}`;
 const currentVersion = props.data.version;
 const allVersions = props.allVersions || [currentVersion];
 const hasMultipleVersions = allVersions.length > 1;
-const chatEnabled = isEventCatalogChatEnabled();
+const chatEnabled = isEventCatalogChatVisible();
 const markdownDownloadEnabled = isLLMSTxtEnabled();
 const chatQuery = `Tell me about the "${props.data.name}" diagram (version ${props.data.version})`;
 ---

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/[docType]/[docId]/[docVersion]/index.astro
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/[docType]/[docId]/[docVersion]/index.astro
@@ -8,7 +8,7 @@ import CopyAsMarkdown from '@components/CopyAsMarkdown';
 import Badge from '@components/Badge.astro';
 import { buildUrl } from '@utils/url-builder';
 import { AlignLeftIcon, HistoryIcon } from 'lucide-react';
-import { isEventCatalogChatEnabled, isMarkdownDownloadEnabled, isResourceDocsEnabled } from '@utils/feature';
+import { isEventCatalogChatVisible, isMarkdownDownloadEnabled, isResourceDocsEnabled } from '@utils/feature';
 import { getResourceDocTypeLabel } from '@utils/collections/resource-docs';
 import { getIcon } from '@utils/badges';
 import { collectionToResourceMap } from '@utils/collections/util';
@@ -37,7 +37,7 @@ const docsBasePath = `/docs/${props.data.resourceCollection}/${props.data.resour
 const singularResourceName =
   collectionToResourceMap[props.data.resourceCollection as keyof typeof collectionToResourceMap] ??
   props.data.resourceCollection.slice(0, props.data.resourceCollection.length - 1);
-const chatEnabled = isEventCatalogChatEnabled();
+const chatEnabled = isEventCatalogChatVisible();
 const chatQuery = `Tell me about the ${props.data.type} doc "${title}" for ${props.data.resourceId} (version ${props.data.version})`;
 
 const pagefindAttributes =
@@ -69,7 +69,9 @@ const pagefindAttributes =
           {
             badges.length > 0 && (
               <div class="flex flex-wrap gap-1.5 pt-4">
-                {badges.map((badge: any) => <Badge badge={badge} />)}
+                {badges.map((badge: any) => (
+                  <Badge badge={badge} />
+                ))}
               </div>
             )
           }

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/[docType]/[docId]/index.astro
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/[docType]/[docId]/index.astro
@@ -8,7 +8,7 @@ import CopyAsMarkdown from '@components/CopyAsMarkdown';
 import Badge from '@components/Badge.astro';
 import { buildUrl } from '@utils/url-builder';
 import { AlignLeftIcon, HistoryIcon } from 'lucide-react';
-import { isEventCatalogChatEnabled, isMarkdownDownloadEnabled, isResourceDocsEnabled } from '@utils/feature';
+import { isEventCatalogChatVisible, isMarkdownDownloadEnabled, isResourceDocsEnabled } from '@utils/feature';
 import { getIcon } from '@utils/badges';
 import { collectionToResourceMap } from '@utils/collections/util';
 import { getResourceDocTypeLabel } from '@utils/collections/resource-docs';
@@ -38,7 +38,7 @@ const singularResourceName =
   collectionToResourceMap[props.data.resourceCollection as keyof typeof collectionToResourceMap] ??
   props.data.resourceCollection.slice(0, props.data.resourceCollection.length - 1);
 const typeLabel = getResourceDocTypeLabel(props.data.type);
-const chatEnabled = isEventCatalogChatEnabled();
+const chatEnabled = isEventCatalogChatVisible();
 const chatQuery = `Tell me about the ${props.data.type} doc "${title}" for ${props.data.resourceId} (version ${props.data.version})`;
 
 const pagefindAttributes =
@@ -60,11 +60,17 @@ const pagefindAttributes =
             <span class="text-xs md:text-sm font-semibold text-[rgb(var(--ec-accent))] capitalize">{typeLabel}</span>
             <h2 id="doc-page-header" class="text-2xl md:text-4xl font-bold text-[rgb(var(--ec-page-text))]">{title}</h2>
           </div>
-          {props.data.summary && <p class="text-base pt-4 text-[rgb(var(--ec-page-text-muted))] font-light">{props.data.summary}</p>}
+          {
+            props.data.summary && (
+              <p class="text-base pt-4 text-[rgb(var(--ec-page-text-muted))] font-light">{props.data.summary}</p>
+            )
+          }
           {
             badges.length > 0 && (
               <div class="flex flex-wrap gap-1.5 pt-4">
-                {badges.map((badge: any) => <Badge badge={badge} />)}
+                {badges.map((badge: any) => (
+                  <Badge badge={badge} />
+                ))}
               </div>
             )
           }

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/asyncapi/[filename].astro
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/asyncapi/[filename].astro
@@ -12,7 +12,7 @@ import js from '@asyncapi/react-component/browser/standalone/without-parser.js?u
 import { AsyncApiComponentWP, type ConfigInterface } from '@asyncapi/react-component';
 import VerticalSideBarLayout from '@layouts/VerticalSideBarLayout.astro';
 import CopyAsMarkdown from '@components/CopyAsMarkdown';
-import { isEventCatalogChatEnabled } from '@utils/feature';
+import { isEventCatalogChatVisible } from '@utils/feature';
 import Config from '@utils/eventcatalog-config/catalog';
 import { Page } from './_[filename].data';
 import { getAbsoluteFilePathForAstroFile } from '@utils/files';
@@ -148,7 +148,7 @@ const renderedComponent = renderToString(component);
 const pageTitle = `${collection} | ${data.name} | AsyncApi Spec`.replace(/^\w/, (c) => c.toUpperCase());
 
 // Chat configuration
-const chatEnabled = isEventCatalogChatEnabled();
+const chatEnabled = isEventCatalogChatVisible();
 const chatQuery = `Tell me about the AsyncAPI specification for "${data.name}" (version ${data.version})`;
 
 // Index only the latest version

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/index.astro
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/index.astro
@@ -61,7 +61,7 @@ import { getIcon } from '@utils/badges';
 import { buildUrl, buildEditUrlForResource } from '@utils/url-builder';
 import { isIconPath, resolveIconUrl } from '@utils/icon';
 import {
-  isEventCatalogChatEnabled,
+  isEventCatalogChatVisible,
   isMarkdownDownloadEnabled,
   isVisualiserEnabled,
   isRSSEnabled,
@@ -479,11 +479,11 @@ if (!isAdrPage && !hasCurrentFlowEmbed && !hasCurrentPageNodeGraph) {
                 variant="toolbar"
                 schemas={schemasForResource}
                 chatQuery={generatePromptForResource(props)}
-                chatEnabled={isEventCatalogChatEnabled()}
+                chatEnabled={isEventCatalogChatVisible()}
                 markdownDownloadEnabled={isMarkdownDownloadEnabled()}
                 rssFeedEnabled={isRSSEnabled()}
                 editUrl={editUrl}
-                preferChatAsDefault={isEventCatalogChatEnabled()}
+                preferChatAsDefault={isEventCatalogChatVisible()}
                 mcpServerUrl={mcpServerUrl}
                 resourceName={props.data.name}
                 mcpResourceType={mcpResourceType}

--- a/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/spec/[filename].astro
+++ b/packages/core/eventcatalog/src/pages/docs/[type]/[id]/[version]/spec/[filename].astro
@@ -5,7 +5,7 @@ import OpenAPISpec from './_OpenAPI.tsx';
 import { DocumentMinusIcon } from '@heroicons/react/24/outline';
 import VerticalSideBarLayout from '@layouts/VerticalSideBarLayout.astro';
 import CopyAsMarkdown from '@components/CopyAsMarkdown';
-import { isEventCatalogChatEnabled } from '@utils/feature';
+import { isEventCatalogChatVisible } from '@utils/feature';
 import './_styles.css';
 import { Page } from './_[filename].data.ts';
 import { getAbsoluteFilePathForAstroFile } from '@utils/files';
@@ -31,7 +31,7 @@ let content = '';
 const pageTitle = `${collection} | ${data.name} | OpenAPI Spec`.replace(/^\w/, (c) => c.toUpperCase());
 
 // Chat configuration
-const chatEnabled = isEventCatalogChatEnabled();
+const chatEnabled = isEventCatalogChatVisible();
 const chatQuery = `Tell me about the OpenAPI specification for "${data.name}" (version ${data.version})`;
 
 // Index only the latest version

--- a/packages/core/eventcatalog/src/pages/visualiser/designs/[id]/index.astro
+++ b/packages/core/eventcatalog/src/pages/visualiser/designs/[id]/index.astro
@@ -4,11 +4,11 @@ import AstroNodeGraph from '@components/MDX/NodeGraph/AstroNodeGraph';
 import '@eventcatalog/visualiser/styles-core.css';
 import { ClientRouter } from 'astro:transitions';
 import VerticalSideBarLayout from '@layouts/VerticalSideBarLayout.astro';
-import { isEventCatalogChatEnabled } from '@utils/feature';
+import { isEventCatalogChatVisible } from '@utils/feature';
 
 import { Page } from './_index.data';
 
-const isChatEnabled = isEventCatalogChatEnabled();
+const isChatEnabled = isEventCatalogChatVisible();
 
 export const prerender = Page.prerender;
 export const getStaticPaths = Page.getStaticPaths;

--- a/packages/core/eventcatalog/src/utils/__tests__/features.spec.ts
+++ b/packages/core/eventcatalog/src/utils/__tests__/features.spec.ts
@@ -5,6 +5,7 @@ import {
   isCustomDocsEnabled,
   isResourceDocsEnabled,
   isEventCatalogChatEnabled,
+  isEventCatalogChatVisible,
   isEventCatalogUpgradeEnabled,
   isCustomLandingPageEnabled,
   isMarkdownDownloadEnabled,
@@ -131,6 +132,34 @@ describe('features', () => {
       delete process.env.EVENTCATALOG_STARTER;
       delete process.env.EVENTCATALOG_SCALE;
       expect(isResourceDocsEnabled()).toBe(false);
+    });
+  });
+
+  describe('isEventCatalogChatVisible', () => {
+    const originalChat = config.chat;
+
+    afterEach(() => {
+      config.chat = originalChat;
+    });
+
+    it('shows Ask AI by default without a plan, server mode, or configuration file', () => {
+      delete process.env.EVENTCATALOG_STARTER;
+      delete process.env.EVENTCATALOG_SCALE;
+      config.output = 'static';
+      config.chat = undefined;
+      expect(isEventCatalogChatVisible()).toBe(true);
+      expect(isEventCatalogChatEnabled()).toBe(false);
+    });
+
+    it('shows Ask AI when chat settings omit enabled', () => {
+      config.chat = {};
+      expect(isEventCatalogChatVisible()).toBe(true);
+    });
+
+    it('hides Ask AI when explicitly disabled', () => {
+      config.chat = { enabled: false };
+      expect(isEventCatalogChatVisible()).toBe(false);
+      expect(isEventCatalogChatEnabled()).toBe(false);
     });
   });
 

--- a/packages/core/eventcatalog/src/utils/feature.ts
+++ b/packages/core/eventcatalog/src/utils/feature.ts
@@ -1,6 +1,7 @@
 import config from '../../eventcatalog.config.js';
 
 // Open-source feature flags
+export const isEventCatalogChatVisible = () => config?.chat?.enabled ?? true;
 export const isSSR = () => config?.output === 'server';
 export const isVisualiserEnabled = () => config?.visualiser?.enabled ?? true;
 // Opt-in while in beta — building the whole-catalog graph is unproven on very large catalogs


### PR DESCRIPTION
## Motivation

Make Event Catalog Assistant discoverable in new and existing catalogs before a model is configured. Ask now appears by default and responds locally with bring-your-own-model guidance, a setup link, and a link to turn the assistant off. No AI requests are made by the unconfigured experience.

## Changes Overview

- Separate UI visibility from the existing licensed, server-side chat readiness checks. Keep `chat.enabled: false` as the opt-out and allow the Assistant settings toggle before setup.
- Refresh the sidebar, search field, and Ask button; add a short setup-response delay, subtle animations, and reduced-motion support.
- Add Cmd+I / Ctrl+I to open and focus the assistant. Make the closed sidebar inert, return focus to Ask on close, and cancel pending focus timers.
- Include the current default-example configuration updates: explicitly enable chat and select the forest theme.
- Add an `@eventcatalog/core` patch changeset.

## How It Works

The header passes chat readiness to the client while the visibility flag controls Ask entry points throughout the catalog. Unconfigured questions receive a local setup reply; configured catalogs retain the existing chat transport and API gating.

## Validation

- `pnpm run format`: passed across all nine packages.
- Focused feature and chat interaction suites: 48 tests passed.
- `git diff --check`: passed.
- Earlier static catalog verification built 970 pages and checked 592 files with zero errors. The final iteration was not rebuilt at the user's request.
- Earlier visual checks covered the welcome, composer, and offline reply in the running catalog.

## Breaking Changes

None to configuration or API contracts. Ask is now visible unless explicitly disabled.

## Additional Notes

- Review follow-up: the assistant host is now available on mobile, with overlay behavior on smaller screens and a responsive layout regression test.
- A real configured-model conversation has not been tested end to end.
