### PR TITLE
ci(core): sync bundled docs during release

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,5 +1,0 @@
-#!/bin/sh
-set -eu
-
-node scripts/sync-core-docs.mjs
-git add packages/core/docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,30 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Verify docs repository access is configured
+        env:
+          DOCS_REPOSITORY_TOKEN: ${{ secrets.DOCS_REPOSITORY_TOKEN }}
+        run: |
+          if [ -z "$DOCS_REPOSITORY_TOKEN" ]; then
+            echo "::error::DOCS_REPOSITORY_TOKEN must have read-only Contents access to event-catalog/website"
+            exit 1
+          fi
+
+      - name: Checkout EventCatalog docs
+        uses: actions/checkout@v4
+        with:
+          repository: event-catalog/website
+          ref: main
+          path: .eventcatalog-docs
+          sparse-checkout: docs
+          persist-credentials: false
+          token: ${{ secrets.DOCS_REPOSITORY_TOKEN }}
+
+      - name: Sync EventCatalog docs
+        env:
+          EVENTCATALOG_DOCS_SOURCE: ${{ github.workspace }}/.eventcatalog-docs/docs
+        run: node scripts/sync-core-docs.mjs
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,9 @@ jobs:
           EVENTCATALOG_DOCS_SOURCE: ${{ github.workspace }}/.eventcatalog-docs/docs
         run: node scripts/sync-core-docs.mjs
 
+      - name: Remove docs checkout
+        run: rm -rf .eventcatalog-docs
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
 


### PR DESCRIPTION
## Motivation

Core package documentation was being synchronized by a local pre-commit hook, which could unexpectedly add a large generated docs diff to unrelated pull requests.

This removes the hook and moves synchronization into the trusted release workflow. The workflow checks out only the `docs` directory from the private `event-catalog/website` repository using the read-only `DOCS_REPOSITORY_TOKEN`, then runs the existing sync script before building release artifacts.

## Validation

- Confirmed the branch differs from `main` by only the hook removal and release workflow update
- Confirmed the workflow fails clearly when `DOCS_REPOSITORY_TOKEN` is not configured
- Confirmed checkout credentials are not persisted